### PR TITLE
[WIP] Add integration Rails environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -257,7 +257,6 @@ unless ENV["APPLIANCE"]
     gem "capybara",          "~>2.5.0",  :require => false
     gem "coveralls",         "~>0.8.23", :require => false
     gem "db-query-matchers", "~>0.10.0"
-    gem "factory_bot",       "~>5.1",    :require => false
 
     # TODO: faker is used for url generation in git repository factory and the lenovo
     # provider, via a xclarity_client dependency
@@ -267,8 +266,9 @@ unless ENV["APPLIANCE"]
     gem "webmock",           "~>3.7",    :require => false
   end
 
-  group :development, :test do
+  group :development, :test, :integration do
+    gem "factory_bot",      "~>5.1",    :require => false
     gem "parallel_tests"
-    gem "rspec-rails", "~>3.9.0"
+    gem "rspec-rails",      "~>3.9.0"
   end
 end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -306,6 +306,11 @@ class MiqWorker::Runner
   end
 
   def config_out_of_date?
+    # Skip config syncing if in integration_env
+    #
+    # TODO:  Handle this better for single worker versus appliance
+    return false if Rails.env.integration?
+
     @my_last_config_change ||= Time.now.utc
 
     last_config_change = server_last_change(:last_config_change)

--- a/config/database.pg.yml
+++ b/config/database.pg.yml
@@ -24,6 +24,10 @@ development:
   database: vmdb_development
   min_messages: notice
 
+integration:
+  <<: *base
+  database: vmdb_integration
+
 production:
   <<: *base
   database: vmdb_production

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -1,0 +1,113 @@
+# Settings for integration testings.  A mix between development and production,
+# using production as a base and pulling in specific options from development
+# where appropriate.
+#
+Vmdb::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  config.eager_load_paths = []
+
+  # Code is not reloaded between requests unless CYPRESS_DEV is set
+  #
+  # Idea borrowed from:
+  #
+  #   https://blog.simplificator.com/2019/10/11/setting-up-cypress-with-rails/
+  #
+  # We want this to be "production-like" unless CYPRESS_DEV is present
+  config.cache_classes = ENV['CYPRESS_DEV'].blank?
+  config.eager_load = false
+
+  # Log error messages when you accidentally call methods on nil.
+  #
+  # Pulled from `config/environment/development.rb`, but only enable if
+  # ENV['CYPRESS_DEV']
+  #
+  config.whiny_nils = true if ENV['CYPRESS_DEV'].present?
+
+  # Full error reports are disabled and caching is turned on
+  #
+  # Same in development and production
+  config.consider_all_requests_local       = false
+
+  # Enable caching by default, but disable it when running with CYPRESS_DEV
+  #
+  # Same default as production, setting CYPRESS_DEV sets it to development-like
+  config.action_controller.perform_caching = ENV['CYPRESS_DEV'].blank?
+
+  # Don't care if the mailer can't send
+  #
+  # Matching development here, commented out on production
+  config.action_mailer.raise_delivery_errors = false
+
+  # Print deprecation notices to the Rails logger.
+  #
+  # Same in development and production
+  config.active_support.deprecation = :log
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  #
+  # Using production environment variable, and added headers addition from
+  # test.rb (`.enabled` should default to `true` in `Rails.env.development?`)
+  if ENV['RAILS_SERVE_STATIC_FILES'].present?
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
+  end
+
+  # Compress JavaScripts and CSS
+  #
+  # Production defaults this to true, so matching that.  Development and test
+  # are both `false`, so CYPRESS_DEV=1 will match that.
+  config.assets.compress = ENV['CYPRESS_DEV'].blank?
+
+  # This setting has a confusing name...
+  #
+  # if false:  Do not fallback to assets pipeline if an asset is missing.
+  # if true:   Use assets pipeline if an asset is missing.
+  #
+  # Defaults to true in `sprockets-rails`:
+  #
+  #   https://github.com/rails/sprockets-rails/blob/df46170c/lib/sprockets/railtie.rb#L120
+  #
+  # Matches for production by default, configurable to true via CYPRESS_DEV
+  config.assets.compile = ENV['CYPRESS_DEV'].present?
+
+  # Generate digests for assets URLs
+  #
+  # Defaults to true in `sprockets-rails`:
+  #
+  #   https://github.com/rails/sprockets-rails/blob/df46170c/lib/sprockets/railtie.rb#L121
+  #
+  # Matches for production by default
+  config.assets.digest = true
+
+  # Include miq_debug in the list of assets here because it is only used in development
+  #
+  # Pulled from development.  Doesn't hurt being in regardless
+  config.assets.precompile << 'miq_debug.js'
+  config.assets.precompile << 'miq_debug.css'
+
+  # See everything in the log.  Default is :debug I think...
+  #
+  #   https://github.com/rails/rails/blob/7b5cc5a5/railties/lib/rails/application/configuration.rb#L40
+  #
+  config.log_level = :debug
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found)
+  #
+  # Copied from production
+  config.i18n.fallbacks = [I18n.default_locale]
+
+  # Do not include all helpers for all views
+  #
+  # Shared across test/development/production
+  config.action_controller.include_all_helpers = false
+
+  # The test environment has this disabled, but matching development/production
+  # makes the most sense when dealing with the UI.
+  config.action_controller.allow_forgery_protection = true
+
+  # Copied from production.  Not set in test/development environments
+  config.assets.css_compressor = :sass
+end

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -59,6 +59,7 @@ Vmdb::Application.configure do
   # Production defaults this to true, so matching that.  Development and test
   # are both `false`, so CYPRESS_DEV=1 will match that.
   config.assets.compress = ENV['CYPRESS_DEV'].blank?
+  config.assets.gzip     = false
 
   # This setting has a confusing name...
   #

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-if ENV['RAILS_USE_MEMORY_STORE'] || (!Rails.env.development? && !Rails.env.production?)
+if ENV['RAILS_USE_MEMORY_STORE'] || Rails.env.test? || Rails.env.integration?
   Vmdb::Application.config.session_store(:memory_store)
 else
   session_store =

--- a/config/settings/integration.yml
+++ b/config/settings/integration.yml
@@ -1,0 +1,7 @@
+---
+:log:
+  :level_rails: debug
+:webservices:
+  :url: http://localhost:4000
+:server:
+  :session_store: memory

--- a/lib/manageiq/integration.rb
+++ b/lib/manageiq/integration.rb
@@ -1,0 +1,9 @@
+require_relative 'integration/environment'
+require_relative 'integration/foreman_manager'
+require_relative 'integration/cypress_rake_task'
+
+module ManageIQ
+  module Integration
+
+  end
+end

--- a/lib/manageiq/integration/Procfile.example.erb
+++ b/lib/manageiq/integration/Procfile.example.erb
@@ -1,1 +1,5 @@
 ui: env PORT=$PORT <%= Gem.ruby %> <%= Environment.run_single_worker_bin %> MiqUiWorker
+
+<% extra_workers.each do |worker_type| -%>
+<%= worker_type.downcase %>: env PORT=$PORT <%= Gem.ruby %> <%= Environment.run_single_worker_bin %> <%= worker_type %>
+<% end -%>

--- a/lib/manageiq/integration/Procfile.example.erb
+++ b/lib/manageiq/integration/Procfile.example.erb
@@ -1,0 +1,1 @@
+ui: env PORT=$PORT <%= Gem.ruby %> <%= Environment.run_single_worker_bin %> MiqUiWorker

--- a/lib/manageiq/integration/cypress_rake_task.rb
+++ b/lib/manageiq/integration/cypress_rake_task.rb
@@ -1,0 +1,130 @@
+require "rake/tasklib"
+
+module ManageIQ
+  module Integration
+    # A Rake TaskLib for building tasks to run cypress for a given manageiq plugin
+    #
+    # When defining, provide a namespace, usually indicative of the plugin you
+    # are testing, and if needed, you can override the @ui_engine_root
+    #
+    class CypressRakeTask < Rake::TaskLib
+
+      # Namespace for the cypress tasks to live under
+      attr_accessor :cypress_namespace
+
+      # Root directory location for ManageIQ::UI::Classic
+      attr_accessor :ui_engine_root
+
+      def initialize(cypress_namespace)
+        @cypress_namespace = cypress_namespace
+        @ui_engine_root    = ManageIQ::UI::Classic::Engine.root
+
+        yield self if block_given?
+
+        define
+      end
+
+      def define
+        namespace :cypress do
+          desc "Run cypress #{cypress_namespace} tests"
+          task cypress_namespace => ":#{cypress_namespace}run"
+
+          define_cypress_namespace
+        end
+      end
+
+      private
+
+      def define_cypress_namespace
+        namespace cypress_namespace do
+          desc "Seed database/configure assets for cypress specs"
+          task :seed do
+            Rake::Task["#{app_prefix}integration:seed"].invoke
+          end
+
+          desc "Interactively run cypress tests"
+          task :open => ["#{cypress_namespace}:setup"] do
+            sh "#{yarn_cmd} cypress:open"
+          end
+
+          desc "Run headless cypress tests"
+          task :run, [:spec_file] => ["#{cypress_namespace}:setup"] do |t, args|
+            args.with_defaults :spec_file => nil
+
+            cmd  = "#{yarn_cmd} cypress:run:ci"
+            cmd << " --spec #{args.spec_file}" if args.spec_file
+
+            sh cmd
+          end
+
+          desc "Stop the backend Rails server"
+          task :stop do
+            Rake::Task["#{app_prefix}integration:stop_server"].invoke
+          end
+
+          task :setup => cypress_env_file do
+            Rake::Task["#{app_prefix}integration:start_server"].invoke
+          end
+
+          define_cypress_env_file_task
+          define_cypress_dev_tasks
+        end
+      end
+
+      def define_cypress_env_file_task
+        file cypress_env_file do |cypress_env_json_file|
+          unless File.exist?(cypress_env_file)
+            cypress_dir         = File.dirname(cypress_env_file)
+            cypress_env_example = ".cypress.dev.env.json"
+            cypress_env_example = ".cypress.ci.env.json" if ENV["CI"] || ENV["TRAVIS"]
+
+            cp File.join(cypress_dir, cypress_env_example), cypress_env_json_file.name
+          end
+        end
+      end
+
+      def define_cypress_dev_tasks
+        desc "Run cypress tests in 'development' mode"
+        task :dev => "dev:run"
+
+        # Aliases for running with CYPRESS_DEV
+        namespace :dev do
+          desc "'Development Mode' for cypress:#{cypress_namespace}:seed"
+          task :seed => [:env, "cypress:#{cypress_namespace}:seed"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:open"
+          task :open => [:env, "cypress:#{cypress_namespace}:open"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:run"
+          task :run => [:env, "cypress:#{cypress_namespace}:run"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:setup"
+          task :setup => [:env, "cypress:#{cypress_namespace}:setup"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:stop"
+          task :stop => [:env, "cypress:#{cypress_namespace}:stop"]
+
+          # Helper task to defaulte the CYPRESS_DEV env var to "1"
+          task :env do
+            ENV["CYPRESS_DEV"] = "1"
+          end
+        end
+      end
+
+      def yarn_cmd
+        cmd  = "yarn"
+        cmd += " --cwd #{@ui_engine_root}" unless defined?(ENGINE_ROOT)
+
+        cmd
+      end
+
+      def cypress_env_file
+        File.expand_path("cypress.env.json", @ui_engine_root)
+      end
+
+      def app_prefix
+        defined?(ENGINE_ROOT) ? "app:" : ""
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/environment.rb
+++ b/lib/manageiq/integration/environment.rb
@@ -1,0 +1,25 @@
+module ManageIQ
+  module Integration
+    class Environment
+      def self.tmp_dir
+        Rails.root.join('tmp', 'integration')
+      end
+
+      def self.run_single_worker_bin
+        Rails.root.join('lib', 'workers', 'bin', 'run_single_worker.rb')
+      end
+
+      def self.ui_host
+        @ui_host = "localhost"
+      end
+
+      def self.ui_port
+        @ui_port = 3000
+      end
+
+      def self.ui_ping_route
+        @ui_ping_route = "/api/ping"
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/foreman_manager.rb
+++ b/lib/manageiq/integration/foreman_manager.rb
@@ -1,0 +1,208 @@
+require "fileutils"
+
+# A wrapper around the foreman utility for running ManageIQ in the integration
+# environment, with either the server acting more "dev like" or "prod like"
+# depending on the scenario (local development versus CI).
+#
+module ManageIQ
+  module Integration
+    class ForemanManager
+      def self.pid_filename
+        @pid_filename ||= Environment.tmp_dir.join('foreman.pid')
+      end
+
+      def self.log_file
+        Rails.root.join("log", "integration.foreman.log")
+      end
+
+      def self.procfile
+        @procfile ||= Environment.tmp_dir.join('Procfile')
+      end
+
+      def self.procfile_template_data
+        require 'erb'
+        template_path = File.expand_path('Procfile.example.erb', __dir__)
+
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(2.6)
+          ERB.new(File.read(template_path), trim_mode: "-").result(binding)
+        else
+          ERB.new(File.read(template_path), nil, "-").result(binding)
+        end
+      end
+
+      def self.setup
+        FileUtils.mkdir_p(Environment.tmp_dir)
+        FileUtils.rm_f(procfile)
+
+        File.write(procfile, procfile_template_data)
+      end
+
+      def self.run
+        if process_alive?
+          warn "foreman process already running with pid: #{server_pid} from #{pid_filename}"
+        elsif ui_ping
+          ui_server_host = "#{Environment.ui_host}:#{Environment.ui_port}"
+          warn <<~WARN
+            Existing process for #{ui_server_host} exist already!  Cowardly refusing to kill it...
+
+            Unless you "absolutely know what you are doing", make sure this
+            environment is running in `integration` mode, or restart this test
+            run after you have closed that server down so this task can execute
+            an isolated process for you.  Otherwise test will likely fail due
+            to missing resources that only exist in the integration ENV.
+
+          WARN
+        else
+          foreman_cmd = %W[
+            foreman start --port=3000
+                          --root=#{Rails.root}
+                          --procfile=#{procfile}
+          ].join(" ")
+
+          pid = Process.spawn(foreman_cmd, [:out, :err] => [log_file, "a"])
+          Process.detach(pid)
+          File.write(pid_filename, pid)
+        end
+      end
+
+      def self.stop
+        PidFile.new(pid_filename).terminate
+      end
+
+      # Simple status check:
+      #
+      # - Checks for existing pid file
+      # - If the process is running
+      # - If the UI is responding to a request
+      #
+      def self.status
+        if server_pid
+          puts "Server PID##{server_pid}: ".ljust(18) + (process_alive? ? "running" : "stopped")
+        else
+          puts "Server PID#NA:    PID file (#{pid_filename}) doesn't exist..."
+        end
+        puts "UI running?:      #{ui_ping}"
+      end
+
+      def self.process_alive?
+        PidFile.new(pid_filename).running?
+      end
+
+      def self.server_pid
+        PidFile.new(pid_filename).pid
+      end
+
+      def self.ui_ping
+        require 'net/http'
+
+        net_http = Net::HTTP.new(Environment.ui_host, Environment.ui_port)
+        net_http.request_head(Environment.ui_ping_route).code == "200"
+      rescue Errno::ECONNREFUSED
+        false
+      end
+
+      def self.ui_running?
+        ui_ready = false
+        wait_num = ENV["CI"] ? 60 : 15
+
+        wait_num.times do
+          break if (ui_ready = ui_ping)
+
+          sleep 2
+        end
+
+        unless ui_ready
+          raise "ERR: UI server was not able to start or start properly" \
+                " (after waiting ~#{wait_num * 2 / 60.0} minutes)"
+        end
+      rescue => err
+        if ENV["CI"]
+          stop
+          sleep 5 # allow server to stop and flush logs
+
+          debug_output_for_server_logs
+          debug_server_boot
+        end
+
+        raise err
+      end
+
+      def self.debug_output_for_server_logs
+        integration_log_file = Rails.root.join("log", "integration.log")
+        evm_log_file         = Rails.root.join("log", "evm.log")
+
+        puts <<~DEBUGGING_OUTPUT
+
+          ***************************************************
+          *     Printing Debugging log info for server:     *
+          ***************************************************
+
+          Procfile contents
+          -----------------
+
+          #{File.read(procfile)}
+
+
+          last 100 lines of '#{log_file}':
+          #{'-' * (21 + log_file.to_s.length)}
+
+          #{tail_file(log_file)}
+
+
+          last 100 lines of 'log/integration.log':
+          ----------------------------------------
+
+          #{tail_file(integration_log_file)}
+
+
+          last 100 lines of 'log/evm.log':
+          --------------------------------
+
+          #{tail_file(evm_log_file)}
+
+
+        DEBUGGING_OUTPUT
+      end
+
+      def self.debug_server_boot
+        log_file  = Rails.root.join("log", "integration.debug.log")
+        test_boot = "#{Gem.ruby} #{Environment.run_single_worker_bin} MiqUiWorker"
+        pid       = Process.spawn(test_boot, [:out, :err] => [log_file, 'w'])
+
+        puts "running inline ruby server to test for errors..."
+        puts
+        puts "  cmd: #{test_boot}"
+        puts
+
+        Timeout.timeout(30) { Process.waitpid(pid) }
+      rescue Timeout::Error => e
+        Process.kill("TERM", pid)
+      ensure
+        sleep 5 # give a few seconds for the logs output to flush to log_file
+
+        puts File.read(log_file)
+        puts
+        puts
+      end
+
+      def self.tail_file(filename, num_lines = 100)
+        require 'elif'
+
+        line_buffer = []
+
+        Elif.open(filename) do |log_io|
+          num_lines.times do
+            log_line = log_io.readline
+            break if log_line.nil?
+            line_buffer.unshift log_io.readline
+          rescue EOFError
+            # if we reach then end of a file, just end the loop
+          end
+        end
+
+        # new lines are already included, so just convert to a string
+        line_buffer.join
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/foreman_manager.rb
+++ b/lib/manageiq/integration/foreman_manager.rb
@@ -30,6 +30,14 @@ module ManageIQ
         end
       end
 
+      def self.extra_workers
+        if (worker_string = ENV["FOREMAN_INTEGRATION_EXTRA_WORKERS"])
+          worker_string.split(",")
+        else
+          []
+        end
+      end
+
       def self.setup
         FileUtils.mkdir_p(Environment.tmp_dir)
         FileUtils.rm_f(procfile)

--- a/lib/pid_file.rb
+++ b/lib/pid_file.rb
@@ -42,4 +42,13 @@ class PidFile
 
     true
   end
+
+  def terminate(regexp = nil)
+    if pid && running?(regexp)
+      Process.kill("TERM", pid)
+      FileUtils.rm(@fname)
+    else
+      warn "PID file for server (#{@fname}) or matching process doesn't exist... moving on"
+    end
+  end
 end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -108,10 +108,11 @@ namespace :evm do
   task :compile_assets => 'evm:assets:compile'
   namespace :assets do
     desc "Compile assets (clobber and precompile)"
-    task :compile do
+    task :compile do |rake_task|
+      app_prefix = rake_task.name.chomp('evm:assets:compile')
       EvmRakeHelper.with_dummy_database_url_configuration do
-        Rake::Task["assets:clobber"].invoke
-        Rake::Task["assets:precompile"].invoke
+        Rake::Task["#{app_prefix}assets:clobber"].invoke
+        Rake::Task["#{app_prefix}assets:precompile"].invoke
       end
     end
   end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -4,16 +4,20 @@ require 'evm_rake_helper'
 
 namespace :evm do
   namespace :foreman do
-    task :start => [:environment, 'db:seed'] do
+    task :seed => [:environment, 'db:seed'] do
       server = MiqServer.my_server
 
       # Assign and activate the default roles
       server.ensure_default_roles
       server.activate_roles(server.server_role_names)
+    end
 
+    task :setup => [:environment] do
       # Mark the server as started
-      server.update(:status => "started")
+      MiqServer.my_server(true).starting_server_record
+    end
 
+    task :start => [:seed, :setup] do
       # start the workers using foreman
       exec("foreman start --port=3000")
     end

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -5,7 +5,7 @@ namespace :integration do
   namespace :seed do
     task :all    => [:db, :assets]
     task :db     => [:env, "test:vmdb:setup", "evm:foreman:seed"]
-    task :assets => [:env, "test:initialize", :compile_assets]
+    task :assets => [:env, :environment, "test:initialize", :compile_assets]
 
     task :compile_assets do |rake_task|
       app_prefix = rake_task.name.chomp('integration:seed:compile_assets')

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -57,6 +57,7 @@ namespace :integration do
     ENV["RAILS_ENV"] = "integration"
     ENV["RAILS_SERVE_STATIC_FILES"] = "true"
     Rails.env = ENV["RAILS_ENV"] if defined?(Rails)
+    Vmdb::Application.config.paths["config/environments"].glob = "#{Rails.env}.rb"
   end
 
   task :db_setup => [:env, :environment] do

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -1,0 +1,69 @@
+namespace :integration do
+  desc "Seed the database and configure assets for integration tests"
+  task :seed => ['seed:all']
+
+  namespace :seed do
+    task :all    => [:db, :assets]
+    task :db     => [:env, "test:vmdb:setup", "evm:foreman:seed"]
+    task :assets => [:env, "test:initialize", :compile_assets]
+
+    task :compile_assets do |rake_task|
+      app_prefix = rake_task.name.chomp('integration:seed:compile_assets')
+      if ENV["CYPRESS_DEV"]
+        Rake::Task["#{app_prefix}update:ui"].invoke
+      else
+        Rake::Task["#{app_prefix}evm:compile_assets"].invoke
+      end
+    end
+  end
+
+  desc "Setup the database for integration tests"
+  task :setup => [:db_setup, "evm:foreman:setup"] do
+    ManageIQ::Integration::ForemanManager.setup
+  end
+
+  desc "Run a foreman server in the background for integration tests"
+  task :run_server => [:setup] do
+    ManageIQ::Integration::ForemanManager.run
+  end
+
+  desc "Start and wait for an integration server to boot"
+  task :start_server => [:run_server, :ui_ready] do
+    MiqServer.my_server.update(:status => "started")
+  end
+
+  desc "Stop server for integration tests"
+  task :stop_server => [:load_manager] do
+    ManageIQ::Integration::ForemanManager.stop
+  end
+
+  desc "Status of the currently running process"
+  task :server_status => [:load_manager] do
+    ManageIQ::Integration::ForemanManager.status
+  end
+
+  # Check if a UI worker is running
+  task :ui_ready => :run_server do
+    ManageIQ::Integration::ForemanManager.ui_running?
+  end
+
+  # For tasks that don't need the full Rails ENV, but need the
+  # ManageIQ::Integration file loaded (:stop_server).
+  task :load_manager do
+    require File.expand_path(File.join("..", "manageiq", "integration"), __dir__)
+  end
+
+  task :env do
+    ENV["RAILS_ENV"] = "integration"
+    ENV["RAILS_SERVE_STATIC_FILES"] = "true"
+    Rails.env = ENV["RAILS_ENV"] if defined?(Rails)
+  end
+
+  task :db_setup => [:env, :environment] do
+    # Reset Rails.env and database config to make sure we are using the
+    # integration environment
+    Rails.env = ENV["RAILS_ENV"]
+    ActiveRecord::Base.remove_connection
+    ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
+  end
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -3,11 +3,13 @@ require_relative './evm_test_helper'
 if defined?(RSpec)
 namespace :test do
   task :initialize do
-    if ENV['RAILS_ENV'] && ENV["RAILS_ENV"] != "test"
+    if ENV['RAILS_ENV'] && !%w[test integration].include?(ENV["RAILS_ENV"])
       warn "Warning: RAILS_ENV is currently set to '#{ENV["RAILS_ENV"]}'. Forcing to 'test' for this run."
+      ENV['RAILS_ENV'] = "test"
+    elsif ENV['RAILS_ENV'].blank?
+      ENV['RAILS_ENV'] = "test"
     end
-    ENV['RAILS_ENV'] = "test"
-    Rails.env = 'test' if defined?(Rails)
+    Rails.env = ENV['RAILS_ENV'] if defined?(Rails)
 
     ENV['VERBOSE'] ||= "false"
   end


### PR DESCRIPTION
The intent of this is to have a separate environment that can be used for integration tests, and can have specific functionality to it that is propose driven to that environment, instead of trying to shoehorn it into `test` or `development` environments.

By default, the environment mirrors production for the most part, but the `$CYPRESS_DEV` var is designed to be able to toggle portions of the configuration to be more "dev-like" (for example:  no compressing assets so TDD can be done while developing integration specs).

There is also included rake tasks to simplify spinning up a server for `cypress` or other integration style tests to run against and other tasks like seeding the database and compiling assets for the environment.


TODO
----

Most likely in separate PRs:

- Add "integration only" routes for `factory_bot`, "database cleaning", and seeding
- Login helpers


Links
-----

* Previous and related efforts:  https://github.com/ManageIQ/manageiq-ui-classic/pull/6683
* Assisting with the "`cypress` travis" effort:  https://github.com/ManageIQ/manageiq-ui-classic/pull/6683
* "pre-fixup" branch (for some context): https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:integration_env_wip