### PR TITLE
Allow the user to specify the provider type to create when using the provider generator

### DIFF
--- a/lib/generators/manageiq/provider/USAGE
+++ b/lib/generators/manageiq/provider/USAGE
@@ -4,4 +4,4 @@ Description:
 Example:
     rails generate manageiq:provider ManageIQ::Providers::VendorName
     rails generate manageiq:provider ManageIQ::Providers::VendorName --path ~/dev
-    rails generate manageiq:provider ManageIQ::Providers::VendorName --vcr --dummy
+    rails generate manageiq:provider ManageIQ::Providers::VendorName --vcr --dummy --manager-type=cloud

--- a/lib/generators/manageiq/provider/USAGE
+++ b/lib/generators/manageiq/provider/USAGE
@@ -2,6 +2,7 @@ Description:
     Create or update ManageIQ provider plugin
 
 Example:
-    rails generate manageiq:provider ManageIQ::Providers::VendorName
-    rails generate manageiq:provider ManageIQ::Providers::VendorName --path ~/dev
-    rails generate manageiq:provider ManageIQ::Providers::VendorName --vcr --dummy --manager-type=cloud
+    rails generate manageiq:provider ManageIQ::Providers::VendorName --manager-type=cloud
+    rails generate manageiq:provider ManageIQ::Providers::VendorName --manager-type=cloud --path ~/dev
+    rails generate manageiq:provider ManageIQ::Providers::VendorName --manager-type=cloud --vcr
+    rails generate manageiq:provider ManageIQ::Providers::VendorName --no-scaffolding

--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -10,6 +10,24 @@ module ManageIQ
     class_option :dummy, :type => :boolean, :default => false,
                  :desc => "Generate dummy implementations (Default: --no-dummy)"
 
+    class_option :manager_type, :type => :string, :default => "cloud",
+                 :desc => "What type of manager to create (Default: \"cloud\")"
+
+    def self.manager_types
+      @manager_types ||= {
+        "automation"    => "AutomationManager",
+        "cloud"         => "CloudManager",
+        "configuration" => "ConfigurationManager",
+        "container"     => "ContainerManager",
+        "infra"         => "InfraManager",
+        "monitoring"    => "MonitoringManager",
+        "network"       => "NetworkManager",
+        "physical"      => "PhysicalInfraManager",
+        "provisioning"  => "ProvisioningManager",
+        "storage"       => "StorageManager"
+      }
+    end
+
     def create_provider_files
       empty_directory "spec/models/#{plugin_path}"
 
@@ -17,6 +35,7 @@ module ManageIQ
         "[#{match}, 'app:test:providers_common']"
       end
 
+      validate_manager_type!
       create_dummy if options[:dummy]
       create_vcr   if options[:vcr]
     end
@@ -25,23 +44,37 @@ module ManageIQ
 
     alias provider_name file_name
 
+    def validate_manager_type!
+      return unless manager_type.nil?
+
+      raise "Invalid manager_type: #{options[:manager_type]}\nMust be one of #{self.class.manager_types.keys.join(", ")}"
+    end
+
+    def manager_type
+      @manager_type ||= self.class.manager_types[options[:manager_type]]
+    end
+
+    def manager_path
+      manager_type.underscore
+    end
+
     def create_dummy
-      template "app/models/%plugin_path%/cloud_manager/event_catcher/runner.rb"
-      template "app/models/%plugin_path%/cloud_manager/event_catcher/stream.rb"
-      template "app/models/%plugin_path%/cloud_manager/metrics_collector_worker/runner.rb"
-      template "app/models/%plugin_path%/cloud_manager/refresh_worker/runner.rb"
-      template "app/models/%plugin_path%/cloud_manager/event_catcher.rb"
-      template "app/models/%plugin_path%/cloud_manager/metrics_capture.rb"
-      template "app/models/%plugin_path%/cloud_manager/metrics_collector_worker.rb"
-      template "app/models/%plugin_path%/cloud_manager/refresh_worker.rb"
-      template "app/models/%plugin_path%/cloud_manager/refresher.rb"
-      template "app/models/%plugin_path%/cloud_manager/vm.rb"
-      template "app/models/%plugin_path%/inventory/collector/cloud_manager.rb"
-      template "app/models/%plugin_path%/inventory/parser/cloud_manager.rb"
+      template "app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb"
+      template "app/models/%plugin_path%/%manager_path%/event_catcher/stream.rb"
+      template "app/models/%plugin_path%/%manager_path%/metrics_collector_worker/runner.rb"
+      template "app/models/%plugin_path%/%manager_path%/refresh_worker/runner.rb"
+      template "app/models/%plugin_path%/%manager_path%/event_catcher.rb"
+      template "app/models/%plugin_path%/%manager_path%/metrics_capture.rb"
+      template "app/models/%plugin_path%/%manager_path%/metrics_collector_worker.rb"
+      template "app/models/%plugin_path%/%manager_path%/refresh_worker.rb"
+      template "app/models/%plugin_path%/%manager_path%/refresher.rb"
+      template "app/models/%plugin_path%/%manager_path%/vm.rb"
+      template "app/models/%plugin_path%/inventory/collector/%manager_path%.rb"
+      template "app/models/%plugin_path%/inventory/parser/%manager_path%.rb"
       template "app/models/%plugin_path%/inventory/persister/definitions/cloud_collections.rb"
-      template "app/models/%plugin_path%/inventory/persister/cloud_manager.rb"
+      template "app/models/%plugin_path%/inventory/persister/%manager_path%.rb"
       template "app/models/%plugin_path%/inventory/persister.rb"
-      template "app/models/%plugin_path%/cloud_manager.rb"
+      template "app/models/%plugin_path%/%manager_path%.rb"
     end
 
     def create_vcr

--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -23,7 +23,7 @@ module ManageIQ
                  :desc => "Enable VCR cassettes (Default: --no-vcr)"
 
     class_option :scaffolding, :type => :boolean, :default => true,
-                 :desc => "Generate default class scaffolding (Default: true)"
+                 :desc => "Generate default class scaffolding (Default: --scaffolding)"
 
     class_option :manager_type, :type => :string,
                  :desc => "What type of manager to create, required if building scaffolding (Options: #{manager_types.keys.join(", ")})"

--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -4,15 +4,6 @@ module ManageIQ
   class ProviderGenerator < PluginGenerator
     source_root File.expand_path('templates', __dir__)
 
-    class_option :vcr, :type => :boolean, :default => false,
-                 :desc => "Enable VCR cassettes (Default: --no-vcr)"
-
-    class_option :dummy, :type => :boolean, :default => false,
-                 :desc => "Generate dummy implementations (Default: --no-dummy)"
-
-    class_option :manager_type, :type => :string, :default => "cloud",
-                 :desc => "What type of manager to create (Default: \"cloud\")"
-
     def self.manager_types
       @manager_types ||= {
         "automation"    => "AutomationManager",
@@ -28,6 +19,15 @@ module ManageIQ
       }
     end
 
+    class_option :vcr, :type => :boolean, :default => false,
+                 :desc => "Enable VCR cassettes (Default: --no-vcr)"
+
+    class_option :dummy, :type => :boolean, :default => false,
+                 :desc => "Generate dummy implementations (Default: --no-dummy)"
+
+    class_option :manager_type, :type => :string,
+                 :desc => "What type of manager to create (Options: #{manager_types.keys.join(", ")})"
+
     def create_provider_files
       empty_directory "spec/models/#{plugin_path}"
 
@@ -35,7 +35,6 @@ module ManageIQ
         "[#{match}, 'app:test:providers_common']"
       end
 
-      validate_manager_type!
       create_dummy if options[:dummy]
       create_vcr   if options[:vcr]
     end
@@ -59,6 +58,7 @@ module ManageIQ
     end
 
     def create_dummy
+      validate_manager_type!
       template "app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb"
       template "app/models/%plugin_path%/%manager_path%/event_catcher/stream.rb"
       template "app/models/%plugin_path%/%manager_path%/metrics_collector_worker/runner.rb"

--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -22,11 +22,11 @@ module ManageIQ
     class_option :vcr, :type => :boolean, :default => false,
                  :desc => "Enable VCR cassettes (Default: --no-vcr)"
 
-    class_option :dummy, :type => :boolean, :default => false,
-                 :desc => "Generate dummy implementations (Default: --no-dummy)"
+    class_option :scaffolding, :type => :boolean, :default => true,
+                 :desc => "Generate default class scaffolding (Default: true)"
 
     class_option :manager_type, :type => :string,
-                 :desc => "What type of manager to create (Options: #{manager_types.keys.join(", ")})"
+                 :desc => "What type of manager to create, required if building scaffolding (Options: #{manager_types.keys.join(", ")})"
 
     def create_provider_files
       empty_directory "spec/models/#{plugin_path}"
@@ -35,8 +35,8 @@ module ManageIQ
         "[#{match}, 'app:test:providers_common']"
       end
 
-      create_dummy if options[:dummy]
-      create_vcr   if options[:vcr]
+      create_scaffolding if options[:scaffolding]
+      create_vcr         if options[:vcr]
     end
 
     private
@@ -57,7 +57,7 @@ module ManageIQ
       manager_type.underscore
     end
 
-    def create_dummy
+    def create_scaffolding
       validate_manager_type!
       template "app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb"
       template "app/models/%plugin_path%/%manager_path%/event_catcher/stream.rb"

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::CloudManager < ManageIQ::Providers::CloudManager
+class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_type %>
   require_nested :MetricsCapture
   require_nested :MetricsCollectorWorker
   require_nested :Refresher

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher.rb
@@ -1,0 +1,3 @@
+class <%= class_name %>::<%= manager_type %>::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+class <%= class_name %>::<%= manager_type %>::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   def stop_event_monitor
     event_monitor_handle.stop
   end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher/stream.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher/stream.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::CloudManager::EventCatcher::Stream
+class <%= class_name %>::<%= manager_type %>::EventCatcher::Stream
   class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
   end
 

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_capture.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_capture.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+class <%= class_name %>::<%= manager_type %>::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
 
   VIM_STYLE_COUNTERS = {
     "cpu_usage_rate_average"  => {

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_collector_worker.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_collector_worker.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
+class <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
   require_nested :Runner
 
   self.default_queue_name = "<%= provider_name %>"

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_collector_worker/runner.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_collector_worker/runner.rb
@@ -1,0 +1,2 @@
+class <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresh_worker.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresh_worker.rb
@@ -1,0 +1,3 @@
+class <%= class_name %>::<%= manager_type %>::RefreshWorker < MiqEmsRefreshWorker
+  require_nested :Runner
+end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresh_worker/runner.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresh_worker/runner.rb
@@ -1,0 +1,2 @@
+class <%= class_name %>::<%= manager_type %>::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresher.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresher.rb
@@ -1,0 +1,2 @@
+class <%= class_name %>::<%= manager_type %>::Refresher < ManageIQ::Providers::BaseManager::Refresher
+end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/vm.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/vm.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
+class <%= class_name %>::<%= manager_type %>::Vm < ManageIQ::Providers::<%= manager_type %>::Vm
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     # find vm instance via connection and return it

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/event_catcher.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/event_catcher.rb
@@ -1,3 +1,0 @@
-class <%= class_name %>::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/metrics_collector_worker/runner.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/metrics_collector_worker/runner.rb
@@ -1,2 +1,0 @@
-class <%= class_name %>::CloudManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/refresh_worker.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/refresh_worker.rb
@@ -1,3 +1,0 @@
-class <%= class_name %>::CloudManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/refresh_worker/runner.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/refresh_worker/runner.rb
@@ -1,2 +1,0 @@
-class <%= class_name %>::CloudManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/refresher.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/cloud_manager/refresher.rb
@@ -1,2 +1,0 @@
-class <%= class_name %>::CloudManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/collector.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/collector.rb
@@ -1,0 +1,3 @@
+class <%= class_name %>::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
+  require_nested :<%= manager_type %>
+end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector/%manager_path%.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::Inventory::Collector::CloudManager < ManageIQ::Providers::Inventory::Collector
+class <%= class_name %>::Inventory::Collector::<%= manager_type %> < ManageIQ::Providers::Inventory::Collector
   def connection
     @connection ||= manager.connect
   end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser/%manager_path%.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::Inventory::Parser::CloudManager < ManageIQ::Providers::Inventory::Parser
+class <%= class_name %>::Inventory::Parser::<%= manager_type %> < ManageIQ::Providers::Inventory::Parser
   def parse
     vms
   end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister.rb
@@ -1,5 +1,5 @@
 class <%= class_name %>::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
+  require_nested :<%= manager_type %>
 
   def strategy
     nil

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister/%manager_path%.rb
@@ -1,4 +1,4 @@
-class <%= class_name %>::Inventory::Persister::CloudManager < <%= class_name %>::Inventory::Persister
+class <%= class_name %>::Inventory::Persister::<%= manager_type %> < <%= class_name %>::Inventory::Persister
   include <%= class_name %>::Inventory::Persister::Definitions::CloudCollections
 
   def initialize_inventory_collections

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/parser.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/parser.rb
@@ -1,0 +1,3 @@
+class <%= class_name %>::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
+  require_nested :<%= manager_type %>
+end


### PR DESCRIPTION
Currently the provider generator only is able to create CloudManagers. This allows the user to specify the type of manager that they would like to create.

For example: `rails generate manageiq:provider ManageIQ::Providers::SomeVendor --vcr --dummy --manager-type=physical`

Fixes https://github.com/ManageIQ/manageiq/issues/19929