### PR TITLE
[WIP] - Use `display` value from original service template when copying a record

### DIFF
--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -5,7 +5,7 @@ module ServiceTemplate::Copy
     if template_valid? && type != 'ServiceTemplateAnsiblePlaybook'
       ActiveRecord::Base.transaction do
         dup.tap do |template|
-          template.update!(:name => new_name, :display => false, :options => {:button_order => []})
+          template.update!(:name => new_name, :options => {:button_order => []})
           service_resources.each { |service_resource| resource_copy(service_resource, template) }
           resource_action_copy(template)
           additional_tenant_copy(template)

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe ServiceTemplate do
     let(:custom_button)                  { FactoryBot.create(:custom_button, :applies_to => service_template) }
     let(:custom_button_for_service)      { FactoryBot.create(:custom_button, :applies_to_class => "Service") }
     let(:custom_button_set)              { FactoryBot.create(:custom_button_set, :owner => service_template, :set_data => set_data) }
-    let(:service_template)               { FactoryBot.create(:service_template) }
-    let(:service_template_ansible_tower) { FactoryBot.create(:service_template_ansible_tower) }
-    let(:service_template_orchestration) { FactoryBot.create(:service_template_orchestration) }
+    let(:service_template)               { FactoryBot.create(:service_template, :display => true) }
+    let(:service_template_ansible_tower) { FactoryBot.create(:service_template_ansible_tower, :display => true) }
+    let(:service_template_orchestration) { FactoryBot.create(:service_template_orchestration, :display => true) }
     let(:set_data)                       { {:applies_to_class => "Service", :button_order => [custom_button.id], :applies_to_id => service_template.id} }
 
     def copy_template(template, name = nil)
@@ -15,7 +15,7 @@ RSpec.describe ServiceTemplate do
       end.to(change { ServiceTemplate.count }.by(1))
       expect(copy.persisted?).to be(true)
       expect(copy.guid).not_to eq(template.guid)
-      expect(copy.display).to be(false)
+      expect(copy.display).to be(true)
       copy
     end
 


### PR DESCRIPTION
Fixes issue where Display in Catalog for copied catalog items was being set to false

before
![before](https://user-images.githubusercontent.com/3450808/87336314-a3b5bf80-c50f-11ea-875e-cd4f9f2add91.png)

after
![after](https://user-images.githubusercontent.com/3450808/87336322-a9aba080-c50f-11ea-87a0-bf7941f65088.png)
