### PR TITLE
Block attempt to create duplicate retire request 

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -135,7 +135,17 @@ module RetirementMixin
       end
     end
 
-    self.class.make_retire_request(id, requester, :initiated_by => 'system') if retirement_due?
+    if retirement_due?
+      if allow_retire_request_creation?
+        self.class.make_retire_request(id, requester, :initiated_by => 'system')
+      else
+        _log.warn("Attempt to create duplicate retirement request has been terminated")
+      end
+    end
+  end
+
+  def allow_retire_request_creation?
+    true
   end
 
   def retire_now(requester = nil)

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -100,6 +100,8 @@ class OrchestrationStack < ApplicationRecord
   def allow_retire_request_creation?
     MiqRequest.with_type("OrchestrationStackRetireRequest").where(:approval_state => "pending_approval").find_each do |request|
       if request.options.try(:[], :src_ids)&.include?(id)
+        next if request.request_state == "finished" || request.status == "Error"
+
         _log.warn("MiqRequest with id:#{request.id} to retire Orchestra tionStack name:'#{name}' id:#{id} already created but not approved yet")
         return false
       end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -97,6 +97,17 @@ class OrchestrationStack < ApplicationRecord
     format.nil? ? try(:raw_stdout) : try(:raw_stdout, format)
   end
 
+  def allow_retire_request_creation?
+    MiqRequest.with_type("OrchestrationStackRetireRequest").where(:approval_state => "pending_approval").find_each do |request|
+      if request.options.try(:[], :src_ids)&.include?(id)
+        _log.warn("MiqRequest with id:#{request.id} to retire Orchestra tionStack name:'#{name}' id:#{id} already created but not approved yet")
+        return false
+      end
+    end
+
+    true
+  end
+
   private :directs_and_indirects
 
   def self.create_stack(orchestration_manager, stack_name, template, options = {})

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -165,6 +165,17 @@ class Service < ApplicationRecord
     parent.present? ? true : type.present?
   end
 
+  def retire_request_exists?
+    MiqRequest.with_type("ServiceRetireRequest").find_each do |request|
+      if request.options.try(:[], :src_ids)&.include?(id)
+        warn_message = "MiqRequest with id:#{request.id} to retire Service name:'#{name}' id:#{id} already created"
+        return true unless allow_retire_request_creation?(request, warn_message)
+      end
+    end
+
+    false
+  end
+
   alias root_service root
   alias services children
   alias direct_service_children children

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -168,6 +168,8 @@ class Service < ApplicationRecord
   def allow_retire_request_creation?
     MiqRequest.with_type("ServiceRetireRequest").where(:approval_state => "pending_approval").find_each do |request|
       if request.options.try(:[], :src_ids)&.include?(id)
+        next if request.request_state == "finished" || request.status == "Error"
+
         _log.warn("MiqRequest with id:#{request.id} to retire Service name:'#{name}' id:#{id} already created but not approved yet")
         return false
       end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -165,15 +165,15 @@ class Service < ApplicationRecord
     parent.present? ? true : type.present?
   end
 
-  def retire_request_exists?
-    MiqRequest.with_type("ServiceRetireRequest").find_each do |request|
+  def allow_retire_request_creation?
+    MiqRequest.with_type("ServiceRetireRequest").where(:approval_state => "pending_approval").find_each do |request|
       if request.options.try(:[], :src_ids)&.include?(id)
-        warn_message = "MiqRequest with id:#{request.id} to retire Service name:'#{name}' id:#{id} already created"
-        return true unless allow_retire_request_creation?(request, warn_message)
+        _log.warn("MiqRequest with id:#{request.id} to retire Service name:'#{name}' id:#{id} already created but not approved yet")
+        return false
       end
     end
 
-    false
+    true
   end
 
   alias root_service root

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -125,6 +125,23 @@ class Vm < VmOrTemplate
     }
   end
 
+  def allow_retire_request_creation?
+    MiqRequest.where(:source_type => "Vm", :source_id => id).with_type("VmRetireRequest").find_each do |r|
+      warn_message = "MiqRequest with id:#{r.id} to retire Vm name:'#{name}' id:#{id} already created"
+      if r.request_pending_approval?
+        _log.warn("#{warn_message} but not approved yet")
+        return false
+      end
+
+      if (r.request_state == 'active' || r.request_state == 'pending') && r.status == 'Ok' && r.process == true
+        _log.warn("#{warn_message}  and retirement is in progress")
+        return false
+      end
+    end
+
+    true
+  end
+
   def self.display_name(number = 1)
     n_('VM and Instance', 'VMs and Instances', number)
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -127,14 +127,11 @@ class Vm < VmOrTemplate
 
   def allow_retire_request_creation?
     MiqRequest.where(:source_type => "Vm", :source_id => id).with_type("VmRetireRequest").find_each do |r|
+      next if r.request_state == "finished" || r.status == "Error"
+
       warn_message = "MiqRequest with id:#{r.id} to retire Vm name:'#{name}' id:#{id} already created"
       if r.request_pending_approval?
         _log.warn("#{warn_message} but not approved yet")
-        return false
-      end
-
-      if (r.request_state == 'active' || r.request_state == 'pending') && r.status == 'Ok' && r.process == true
-        _log.warn("#{warn_message}  and retirement is in progress")
         return false
       end
     end

--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     factory :service_reconfigure_request,        :class => "ServiceReconfigureRequest"
     factory :service_retire_request,             :class => "ServiceRetireRequest"
+    factory :orchestration_stack_retire_request, :class => "OrchestrationStackRetireRequest"
     factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest" do
       source { create(:service_template) }
     end

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe "Service Retirement Management" do
           expect(stack_with_owner.retirement_requester).to eq("admin")
         end
       end
+
+      it "does not create request if existing retirement request is not approved yet" do
+        stack_with_owner.update(:retires_on => Time.zone.today)
+        FactoryBot.create(:orchestration_stack_retire_request, :requester => user, :options => {:src_ids => [stack_with_owner.id]})
+        expect(stack_with_owner.class).not_to receive(:make_retire_request)
+
+        stack_with_owner.retirement_check
+      end
     end
 
     it "#start_retirement" do

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -43,12 +43,30 @@ RSpec.describe "Service Retirement Management" do
         end
       end
 
-      it "does not create request if existing retirement request is not approved yet" do
-        stack_with_owner.update(:retires_on => Time.zone.today)
-        FactoryBot.create(:orchestration_stack_retire_request, :requester => user, :options => {:src_ids => [stack_with_owner.id]})
-        expect(stack_with_owner.class).not_to receive(:make_retire_request)
+      context "preventing creation of duplicate retirement request" do
+        before do
+          stack_with_owner.update(:retires_on => Time.zone.today)
+          @request = FactoryBot.create(:orchestration_stack_retire_request, :requester => user, :options => {:src_ids => [stack_with_owner.id]})
+        end
 
-        stack_with_owner.retirement_check
+        context "retirement request not approved yet" do
+          it "create request if existing request's state is 'finished'" do
+            @request.update(:request_state => 'finished')
+            expect(stack_with_owner.class).to receive(:make_retire_request)
+            stack_with_owner.retirement_check
+          end
+
+          it "create request if existing request's status is 'Error'" do
+            @request.update(:status => 'Error')
+            expect(stack_with_owner.class).to receive(:make_retire_request)
+            stack_with_owner.retirement_check
+          end
+
+          it "does not create request if existing request not finished and status is not 'Error'" do
+            expect(stack_with_owner.class).not_to receive(:make_retire_request)
+            stack_with_owner.retirement_check
+          end
+        end
       end
     end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe "Service Retirement Management" do
         expect(@service.retirement_requester).to eq('admin')
       end
     end
+
+    it "does not create request if existing retirement request is not approved yet" do
+      service_with_owner.update(:retires_on => Time.zone.today)
+      FactoryBot.create(:service_retire_request, :requester => user, :options => {:src_ids => [service_with_owner.id]})
+      expect(service_with_owner.class).not_to receive(:make_retire_request)
+
+      service_with_owner.retirement_check
+    end
   end
 
   it "#start_retirement" do

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -74,70 +74,35 @@ RSpec.describe "VM Retirement Management" do
       end
     end
 
-    context "does not create duplicate retirement request for the same object" do
+    context "preventing creation of duplicate retirement request" do
       before do
         vm_with_owner.update(:retires_on => Time.zone.today)
         @request = FactoryBot.create(:vm_retire_request, :requester => user, :source_id => vm_with_owner.id)
       end
 
-      context "retirement request not approved yet" do
-        it "does not create request if existing retirement request is not approved yet" do
-          expect(vm_with_owner.class).not_to receive(:make_retire_request)
-          vm_with_owner.retirement_check
-        end
+      it "create request if existing request's state is 'finished' regardless approval status" do
+        @request.update(:request_state => 'finished')
+        expect(vm_with_owner.class).to receive(:make_retire_request)
+        vm_with_owner.retirement_check
+
+        @request.update(:approval_state => "approved")
+        expect(vm_with_owner.class).to receive(:make_retire_request)
+        vm_with_owner.retirement_check
       end
 
-      context "retirement request approved" do
-        before do
-          @request.approve(user, "I want to")
-        end
+      it "create request if existing request's status is 'Error' regardless approval status" do
+        @request.update(:status => 'Error')
+        expect(vm_with_owner.class).to receive(:make_retire_request)
+        vm_with_owner.retirement_check
 
-        context "request status is 'Ok'" do
-          before do
-            @request.update(:status => 'Ok')
-          end
+        @request.update(:approval_state => "approved")
+        expect(vm_with_owner.class).to receive(:make_retire_request)
+        vm_with_owner.retirement_check
+      end
 
-          it "does not create request if existing retirement request's state is 'active'" do
-            @request.update(:request_state => 'active')
-            expect(vm_with_owner.class).not_to receive(:make_retire_request)
-            vm_with_owner.retirement_check
-          end
-
-          it "does not create request if existing retirement request's state is 'pending'" do
-            @request.update(:request_state => 'pending')
-            expect(vm_with_owner.class).not_to receive(:make_retire_request)
-            vm_with_owner.retirement_check
-          end
-
-          it "creates request if existing retirement request's 'process' attribute set to false" do
-            @request.update(:request_state => "pending")
-            @request.update(:process => false)
-            expect(vm_with_owner.class).to receive(:make_retire_request)
-            vm_with_owner.retirement_check
-          end
-
-          it "creates request if existing retirement request's state is not 'active' or 'pending'" do
-            @request.update(:request_state => "finished")
-            expect(vm_with_owner.class).to receive(:make_retire_request)
-            vm_with_owner.retirement_check
-          end
-        end
-
-        context "request status is not 'Ok'" do
-          before do
-            @request.update(:status => 'Error')
-          end
-
-          it "create request for any state of existing retirement request" do
-            @request.update(:request_state => 'active')
-            expect(vm_with_owner.class).to receive(:make_retire_request)
-            vm_with_owner.retirement_check
-
-            @request.update(:request_state => 'pending')
-            expect(vm_with_owner.class).to receive(:make_retire_request)
-            vm_with_owner.retirement_check
-          end
-        end
+      it "does not create request if existing request not approved and not finished and status is not 'Error'" do
+        expect(vm_with_owner.class).not_to receive(:make_retire_request)
+        vm_with_owner.retirement_check
       end
     end
   end

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -109,8 +109,6 @@ RSpec.describe "VM Retirement Management" do
             vm_with_owner.retirement_check
           end
 
-          # Is it possible to have retieremnt request for Vm with process = false ?
-          # I am not sure if we should have this expectation....
           it "creates request if existing retirement request's 'process' attribute set to false" do
             @request.update(:request_state => "pending")
             @request.update(:process => false)


### PR DESCRIPTION
**ISSUE:**
If it takes some time to approve retirement request or vm retirement process stuck in "not finished" state than multiple retirement request for the same object can be created.


**AFTER:** rspec output describing logic for
```OrchestrationStack```:
```
    #retirement_check
       preventing creation of duplicate retirement request
         retirement request not approved yet
           create request if existing request's status is 'Error'
           does not create request if existing request not finished and status is not 'Error'
           create request if existing request's state is 'finished'
```
```Service```:
```
  #retirement_check
    preventing creation of duplicate retirement request
      retirement request not approved yet
        create request if existing request's state is 'finished'
        does not create request if existing request not finished and status is not 'Error'
        create request if existing request's status is 'Error'
```
```Vm```:
```
  #retirement_check
    preventing creation of duplicate retirement request
      create request if existing request's state is 'finished' regardless approval status
      create request if existing request's status is 'Error' regardless approval status
      does not create request if existing request not approved and not finished and status is not 'Error'
```
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1851087

/cc @tinaafitz 