### PR TITLE
Add '::EmsStorage' alias

### DIFF
--- a/app/models/aliases/ems_storage.rb
+++ b/app/models/aliases/ems_storage.rb
@@ -1,0 +1,1 @@
+::EmsStorage = ::ManageIQ::Providers::StorageManager


### PR DESCRIPTION
Many existing '::ManageIQ::Providers' subclasses have an alias defined. An '::EmsStorage' alias would be helpful for consistency.
