### PR TITLE
PERF_ROLLUP_CHILDREN should be an Array, fix and remove calls to #to_miq_a

### DIFF
--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -25,7 +25,7 @@ class AvailabilityZone < ApplicationRecord
     where(arel_table[:type].not_eq("ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull"))
   end
 
-  PERF_ROLLUP_CHILDREN = :vms
+  PERF_ROLLUP_CHILDREN = [:vms]
 
   def perf_rollup_parents(interval_name = nil)
     [ext_management_system].compact unless interval_name == 'realtime'

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -39,7 +39,7 @@ class Container < ApplicationRecord
     end
   end
 
-  PERF_ROLLUP_CHILDREN = nil
+  PERF_ROLLUP_CHILDREN = []
 
   def perf_rollup_parents(_interval_name = nil)
     # No rollups: nodes performance are collected separately

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -79,7 +79,7 @@ class ContainerGroup < ApplicationRecord
     end
   end
 
-  PERF_ROLLUP_CHILDREN = nil
+  PERF_ROLLUP_CHILDREN = []
 
   def perf_rollup_parents(interval_name = nil)
     unless interval_name == 'realtime'

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -72,7 +72,7 @@ class ContainerNode < ApplicationRecord
   end
 
   # TODO: children will be container groups
-  PERF_ROLLUP_CHILDREN = nil
+  PERF_ROLLUP_CHILDREN = []
 
   def perf_rollup_parents(interval_name = nil)
     [ext_management_system] unless interval_name == 'realtime'

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -45,7 +45,7 @@ class ContainerProject < ApplicationRecord
   include EventMixin
   include Metric::CiMixin
 
-  PERF_ROLLUP_CHILDREN = :all_container_groups
+  PERF_ROLLUP_CHILDREN = [:all_container_groups]
 
   delegate :my_zone, :to => :ext_management_system, :allow_nil => true
 

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -21,7 +21,7 @@ class ContainerReplicator < ApplicationRecord
   include EventMixin
   include Metric::CiMixin
 
-  PERF_ROLLUP_CHILDREN = :container_groups
+  PERF_ROLLUP_CHILDREN = [:container_groups]
 
   acts_as_miq_taggable
 

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -30,7 +30,7 @@ class ContainerService < ApplicationRecord
 
   include Metric::CiMixin
 
-  PERF_ROLLUP_CHILDREN = :container_groups
+  PERF_ROLLUP_CHILDREN = [:container_groups]
 
   def perf_rollup_parents(interval_name = nil)
     []

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -248,7 +248,7 @@ class EmsCluster < ApplicationRecord
   # Metric methods
   #
 
-  PERF_ROLLUP_CHILDREN = :hosts
+  PERF_ROLLUP_CHILDREN = [:hosts]
 
   def perf_rollup_parents(interval_name = nil)
     [ext_management_system].compact unless interval_name == 'realtime'

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -793,7 +793,7 @@ class ExtManagementSystem < ApplicationRecord
   # Metric methods
   #
 
-  PERF_ROLLUP_CHILDREN = :hosts
+  PERF_ROLLUP_CHILDREN = [:hosts]
 
   def perf_rollup_parents(interval_name = nil)
     [MiqRegion.my_region].compact unless interval_name == 'realtime'

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1620,7 +1620,7 @@ class Host < ApplicationRecord
   # Metric methods
   #
 
-  PERF_ROLLUP_CHILDREN = :vms
+  PERF_ROLLUP_CHILDREN = [:vms]
 
   def perf_rollup_parents(interval_name = nil)
     if interval_name == 'realtime'

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -19,7 +19,7 @@ class HostAggregate < ApplicationRecord
 
   virtual_total :total_vms, :vms
 
-  PERF_ROLLUP_CHILDREN = :vms
+  PERF_ROLLUP_CHILDREN = [:vms]
 
   def perf_rollup_parents(interval_name = nil)
     # don't rollup to ext_management_system since that's handled through availability zone

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -186,7 +186,7 @@ module Metric::Rollup
 
   def self.rollup_realtime(obj, rt_ts, _interval_name, _time_profile, new_perf, orig_perf)
     # Roll up realtime metrics from child objects
-    children = obj.class::PERF_ROLLUP_CHILDREN.to_miq_a
+    children = obj.class::PERF_ROLLUP_CHILDREN
     children.each { |c| new_perf.merge!(rollup_child_metrics(obj, rt_ts, 'realtime', c)) } unless children.empty?
 
     new_perf.reverse_merge!(orig_perf)
@@ -201,7 +201,7 @@ module Metric::Rollup
     rollup_realtime_perfs(obj, rt_perfs, new_perf)
 
     # Roll up hourly metrics from child objects
-    children = obj.class::PERF_ROLLUP_CHILDREN.to_miq_a
+    children = obj.class::PERF_ROLLUP_CHILDREN
     children.each { |c| new_perf.merge!(rollup_child_metrics(obj, hour, 'hourly', c)) } unless children.empty?
 
     new_perf.reverse_merge!(orig_perf)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -457,7 +457,7 @@ class Service < ApplicationRecord
   # Metric methods
   #
 
-  PERF_ROLLUP_CHILDREN = :vms
+  PERF_ROLLUP_CHILDREN = [:vms]
 
   def perf_rollup_parents(interval_name = nil)
     [] unless interval_name == 'realtime'

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -652,7 +652,7 @@ class Storage < ApplicationRecord
   # Metric methods
   #
 
-  PERF_ROLLUP_CHILDREN = :ext_management_systems
+  PERF_ROLLUP_CHILDREN = [:ext_management_systems]
 
   def perf_rollup_parents(interval_name = nil)
     [MiqRegion.my_region].compact unless interval_name == 'realtime'

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1630,7 +1630,7 @@ class VmOrTemplate < ApplicationRecord
   # Metric methods
   #
 
-  PERF_ROLLUP_CHILDREN = nil
+  PERF_ROLLUP_CHILDREN = []
 
   def perf_rollup_parents(interval_name = nil)
     [host, service].compact unless interval_name == 'realtime'


### PR DESCRIPTION
~~Depends on: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/389~~

These are the only remaining definitions in the org.
https://github.com/search?p=2&q=org%3AManageIQ+PERF_ROLLUP_CHILDREN&type=Code