### PR TITLE
[WIP] add ancestry to resource pool

### DIFF
--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -1,4 +1,7 @@
+require 'ancestry'
+
 class ResourcePool < ApplicationRecord
+  has_ancestry
   include NewWithTypeStiMixin
   include TenantIdentityMixin
 


### PR DESCRIPTION
Since resource pools can be nested it makes sense that we need some way of keeping track of the hierarchy. Just as I said in the related schema PR, I don't mean to be jumping the gun on this but I think we might need it and just in case we don't, it's (also) marked as work in progress. I know this adds a bunch of complexity. I don't think that negates the fact that it's going to be necessary. 

@miq-bot assign @kbrock 
(again, sorry Keenan, just not sorry enough to refrain)

https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/154

depends upon https://github.com/ManageIQ/manageiq-schema/pull/495 

edit — yeah, we can't do this anyway because of the relationships part. 