### PR TITLE
Split extra vars for Ansible playbooks

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -398,7 +398,7 @@ class ConversionHost < ApplicationRecord
       raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: %{auth_type}") % {:auth_type => auth.authtype}
     end
 
-    params << {:extra_vars => "'#{extra_vars.to_json}'"}
+    extra_vars.each { |k, v| params << {:extra_vars= => "#{k}='#{v}'"} }
 
     command = AwesomeSpawn.build_command_line("ansible-playbook", params)
     result = AwesomeSpawn.run(command)


### PR DESCRIPTION
This PR is a rebase of https://github.com/ManageIQ/manageiq/pull/19864.

With #19698, we switched to using AwesomeSpawn to build the command lines, including ansible-playbook. So far, we used a single --extra-vars option with a JSON string, but the command line generated by AwesomeSpawn is broken, probably by too much escaping.

Given that extra_vars is a hash where each value is a string, this pull requests iterates over the hash entries to add them as independent --extra-vars option. This way, there no conflict between the generated JSON string and the escaping of AwesomeSpawn.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1857523