### PR TITLE
Don't display report results without group

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -380,7 +380,7 @@ class MiqReportResult < ApplicationRecord
 
   def self.with_current_user_groups
     current_user = User.current_user
-    current_user.report_admin_user? ? all : where(:miq_group_id => current_user.miq_group_ids)
+    for_groups(current_user.report_admin_user? ? nil : current_user.miq_group_ids)
   end
 
   def self.with_chargeback

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe MiqReportResult do
         expect(report_result).not_to match_array([@report_result3, @report_result_nil_report_id])
       end
 
-      it "returns report all results, admin user logged" do
+      it "returns report all results with groups, admin user logged" do
         admin_role = FactoryBot.create(:miq_user_role, :features => MiqProductFeature::REPORT_ADMIN_FEATURE, :read_only => false)
         User.current_user.current_group.miq_user_role = admin_role
         report_result = MiqReportResult.with_current_user_groups
-        expected_reports = [@report_result1, @report_result2, @report_result3, @report_result_nil_report_id]
+        expected_reports = [@report_result1, @report_result2, @report_result3]
         expect(report_result).to match_array(expected_reports)
       end
     end


### PR DESCRIPTION

API request with action `request_download` [generates](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report_result.rb#L275) report result. This result is used in endpoint `task` to get downloads([details here](https://github.com/ManageIQ/manageiq-api/pull/839)). 
It sounds like that such results shouldn't be visible in UI or API and basically it is true because such **reports don't have group** _(miq_group==nil)_ and we don't display them thanks to usage [`.for_user`](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report_result.rb#L28) scope everywhere.
 
### Issue

We are not using logic from [`.for_user`](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report_result.rb#L28) or [`.for_groups`](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report_result.rb#L20) in 
`Overview -> Reports` screen  but there is used scope [with_current_user_groups_and_report](with_current_user_groups_and_report) which **returns also results without group.**

<img width="1391" alt="Screenshot 2020-07-20 at 11 16 56" src="https://user-images.githubusercontent.com/14937244/87921315-aa49b700-ca7a-11ea-94ae-f81ae5f780dd.png">

when you click on orange result -error message is displayed because there is used `.for_user` scope which filters out results without group.

<img width="676" alt="Screenshot 2020-07-20 at 11 23 39" src="https://user-images.githubusercontent.com/14937244/87921879-79b64d00-ca7b-11ea-8bcc-c405cb7b9a3c.png">


This change updates `with_current_user_groups_and_report` to return only results with group (for report_admin role).


cc @abellotti 

@miq-bot assign @gtanzillo 

@miq-bot add_label jansa/yes, bug
 
NOTE: This PR pertains only report_admin role. It works as expected for the other roles.





