### PR TITLE
Remove seed limit from seeding specs

### DIFF
--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe MiqDatabase do
   end
 
   context ".seed" do
-    include_examples ".seed called multiple times"
+    include_examples ".seed called multiple times", 1
 
     context "default values" do
       it "new record" do

--- a/spec/models/miq_dialog/seeding_spec.rb
+++ b/spec/models/miq_dialog/seeding_spec.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 RSpec.describe MiqDialog do
   describe "::Seeding" do
-    include_examples(".seed called multiple times", 20)
+    include_examples ".seed called multiple times"
 
     describe ".seed" do
       let(:tmpdir)     { Pathname.new(Dir.mktmpdir) }

--- a/spec/models/miq_enterprise_spec.rb
+++ b/spec/models/miq_enterprise_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe MiqEnterprise do
-  include_examples ".seed called multiple times"
+  include_examples ".seed called multiple times", 1
 
   let(:enterprise) { FactoryBot.create(:miq_enterprise) }
 

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe MiqRegion do
       MiqRegion.seed
     end
 
-    include_examples ".seed called multiple times"
+    include_examples ".seed called multiple times", 1
 
     it "should have the expected region number" do
       expect(MiqRegion.first.region).to eq(@region_number)

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -2,9 +2,7 @@ require 'fileutils'
 
 RSpec.describe MiqReport do
   describe "::Seeding" do
-    include_examples(".seed called multiple times", begin
-      (Dir.glob(MiqReport::REPORT_DIR.join("**/*.yaml")) + Dir.glob(MiqReport::COMPARE_DIR.join("**/*.yaml"))).count
-    end)
+    include_examples ".seed called multiple times"
 
     describe ".seed" do
       let(:tmpdir)      { Pathname.new(Dir.mktmpdir) }

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MiqServer do
       Zone.seed
     end
 
-    include_examples ".seed called multiple times"
+    include_examples ".seed called multiple times", 1
   end
 
   context "#hostname" do

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,13 +1,11 @@
 RSpec.describe MiqWidget do
-  describe '.seed' do
-    before { [MiqReport].each(&:seed) }
-    include_examples(".seed called multiple times", begin
-      Dir.glob(Rails.root.join(MiqWidget::WIDGET_DIR, "**", "*.yaml")).count
-    end)
-  end
-
   before do
     EvmSpecHelper.local_miq_server
+  end
+
+  context ".seed" do
+    before { MiqReport.seed }
+    include_examples ".seed called multiple times"
   end
 
   context "setup" do

--- a/spec/models/scan_item/seeding_spec.rb
+++ b/spec/models/scan_item/seeding_spec.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 RSpec.describe ScanItem do
   describe "::Seeding" do
-    include_examples(".seed called multiple times", 6)
+    include_examples ".seed called multiple times"
 
     describe ".seed" do
       let(:tmpdir)         { Pathname.new(Dir.mktmpdir) }

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Tenant do
-  include_examples ".seed called multiple times"
+  include_examples ".seed called multiple times", 1
 
   let(:tenant) { described_class.new(:domain => 'x.com', :parent => default_tenant) }
   let(:user_admin) {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -377,11 +377,9 @@ RSpec.describe User do
   end
 
   context ".seed" do
-    include_examples(".seed called multiple times", 1)
-
-    include_examples("seeding users with", [])
-
-    include_examples("seeding users with", [MiqUserRole, MiqGroup])
+    include_examples ".seed called multiple times", 1
+    include_examples "seeding users with", []
+    include_examples "seeding users with", [MiqUserRole, MiqGroup]
   end
 
   context "#accessible_vms" do

--- a/spec/support/examples_group/shared_examples_for_seeding.rb
+++ b/spec/support/examples_group/shared_examples_for_seeding.rb
@@ -1,7 +1,21 @@
-shared_examples_for ".seed called multiple times" do |count = 1|
+shared_examples_for ".seed called multiple times" do |expected_amount = nil|
   it ".seed called multiple times" do
-    3.times { described_class.seed }
-    expect(described_class.count).to eq(count)
+    described_class.seed
+    count = described_class.count
+    max_id = described_class.pluck(Arel.sql("MAX(id)"))
+
+    if expected_amount
+      expect(count).to eq expected_amount
+    else
+      expect(count).to be_positive
+    end
+
+    2.times do
+      described_class.seed
+
+      expect(described_class.count).to eq(count)
+      expect(described_class.pluck(Arel.sql("MAX(id)"))).to eq(max_id)
+    end
   end
 end
 


### PR DESCRIPTION
Hard counts aren't needed as what we are trying to prove is that seeding
simply works, and then prove that it is reentrant and doesn't
delete-then-add any records. We only need to check hard counts for
well-defined, non pluggable things like MiqRegion.

Fixes #19029
