### PR TITLE
fix find_by deprecation warning

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -98,7 +98,7 @@ class Classification < ApplicationRecord
   # rubocop:disable Style/NumericPredicate
 
   def self.classify(obj, category_name, entry_name, is_request = true)
-    cat = Classification.find_by_name(category_name, obj.region_id)
+    cat = Classification.lookup_by_name(category_name, obj.region_id)
     return " - FAILED. Tag category '#{category_name}' not found in region #{obj.region_id}" if cat.nil?
 
     ent = cat.find_entry_by_name(entry_name, obj.region_id)


### PR DESCRIPTION
find_by I think should be lookup_by if our deprecation warning's correct? unless this is the wrong way to do this and i just don't know what the right one is which is entirely possible.
