### PR TITLE
Allow plugins to bring new Vm vendor_types

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -23,9 +23,17 @@ class Host < ApplicationRecord
     nil               => "Unknown",
   }.freeze
 
+  def self.all_vendor_types
+    @all_vendor_types ||= begin
+      leaf_subclasses.select { |c| c.respond_to?(:vendor_types) }.each_with_object({}) do |c, hash|
+        hash.merge!(c.vendor_types)
+      end.merge(VENDOR_TYPES)
+    end
+  end
+
   validates_presence_of     :name
   validates_inclusion_of    :user_assigned_os, :in => ["linux_generic", "windows_generic", nil]
-  validates_inclusion_of    :vmm_vendor, :in => VENDOR_TYPES.keys
+  validates_inclusion_of    :vmm_vendor, :in => all_vendor_types.keys
 
   belongs_to                :ext_management_system, :foreign_key => "ems_id"
   belongs_to                :ems_cluster
@@ -615,7 +623,7 @@ class Host < ApplicationRecord
   end
 
   def vmm_vendor_display
-    VENDOR_TYPES[vmm_vendor]
+    all_vendor_types[vmm_vendor]
   end
 
   #

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -47,11 +47,19 @@ class VmOrTemplate < ApplicationRecord
     "unknown"     => "Unknown"
   }
 
+  def self.all_vendor_types
+    @all_vendor_types ||= begin
+      leaf_subclasses.select { |c| c.respond_to?(:vendor_types) }.each_with_object({}) do |c, hash|
+        hash.merge!(c.vendor_types)
+      end.merge(VENDOR_TYPES)
+    end
+  end
+
   POWER_OPS = %w(start stop suspend reset shutdown_guest standby_guest reboot_guest)
   REMOTE_REGION_TASKS = POWER_OPS + %w(retire_now)
 
   validates_presence_of     :name, :location
-  validates                 :vendor, :inclusion => {:in => VENDOR_TYPES.keys}
+  validates                 :vendor, :inclusion => {:in => all_vendor_types.keys}
 
   has_one                   :operating_system, :dependent => :destroy
   has_one                   :openscap_result, :as => :resource, :dependent => :destroy
@@ -594,7 +602,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def vendor_display
-    VENDOR_TYPES[vendor]
+    all_vendor_types[vendor]
   end
 
   #

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/vm.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/vm.rb
@@ -7,6 +7,10 @@ class <%= class_name %>::<%= manager_type %>::Vm < ManageIQ::Providers::<%= mana
     OpenStruct.new
   end
 
+  def vendor_types
+    {"<%= provider_name %>" => "<%= provider_name.split('_').map(&:capitalize).join(' ') %>"}
+  end
+
   def raw_start
     with_provider_object(&:start)
     # Temporarily update state for quick UI response until refresh comes along


### PR DESCRIPTION
Currently every provider plugin that refreshes a VM has to add a line to the core VmOrTemplate.VENDOR_TYPES constant array which is obviously not very pluggable.

Not requiring that all vendor types be in this list and allowing subclasses to override `#vendor_display` with their own constant we can allow plugins to work without modifying core

https://github.com/ManageIQ/manageiq/issues/19440