### PR TITLE
Fix the evm_application_spec for updated tabelize

### DIFF
--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -153,13 +153,13 @@ RSpec.describe EvmApplication do
         expected_output = <<~SERVER_INFO
           Checking EVM status...
            #{header(:Region)  } | #{header(:Zone, :ljust)} | Server                   | Status  | PID | SPID | Workers | Version | #{header(:Started, :ljust)  } | #{header(:Heartbeat, :ljust)  } | MB Usage | Roles
-          -#{line_for(:Region)}-+-#{line_for(:Zone)      }-+--------------------------+---------+-----+------+---------+---------+-#{line_for(:Started)        }-+-#{line_for(:Heartbeat)        }-+----------+-------
+          -#{line_for(:Region)}-|-#{line_for(:Zone)      }-|--------------------------|---------|-----|------|---------|---------|-#{line_for(:Started)        }-|-#{line_for(:Heartbeat)        }-|----------|-------
            #{pad(rgn, :Region)} | #{local.zone.name      } | #{      local.name     } | started |     |      |       1 | 9.9.9.9 | #{local_started_on          } | #{local_heartbeat             } |          |
 
           * marks a master appliance
 
            #{header(:Region)  } | #{header(:Zone, :ljust)} | Type | Status | #{header(:PID)         } | SPID | Server                   | Queue | Started | Heartbeat | MB Usage
-          -#{line_for(:Region)}-+-#{line_for(:Zone)      }-+------+--------+-#{line_for(:PID)       }-+------+--------------------------+-------+---------+-----------+----------
+          -#{line_for(:Region)}-|-#{line_for(:Zone)      }-|------|--------|-#{line_for(:PID)       }-|------|--------------------------|-------|---------|-----------|----------
            #{pad(rgn, :Region)} | #{local.zone.name      } | Ui   | ready  | #{pad(ui.pid, :PID)    } |      | #{      local.name     } |       |         |           |
         SERVER_INFO
 
@@ -178,7 +178,7 @@ RSpec.describe EvmApplication do
         expected_output = <<~SERVER_INFO
           Checking EVM status...
            #{header(:Zone, :ljust)               } | Server                    | Status  | Workers | #{header(:Started, :ljust)  } | #{header(:Heartbeat, :ljust).rstrip}
-          -#{line_for(:Zone)                     }-+---------------------------+---------+---------+-#{line_for(:Started)        }-+-#{line_for(:Heartbeat)}-
+          -#{line_for(:Zone)                     }-|---------------------------|---------|---------|-#{line_for(:Started)        }-|-#{line_for(:Heartbeat)}-
            #{pad(local.zone.name, :Zone, :ljust) } | #{      local.name     }  | started |       1 | #{local_started_on          } | #{local_heartbeat}
            #{pad(remote.zone.name, :Zone, :ljust)} | #{     remote.name     }* | started |       2 | #{remote_started_on         } |
 
@@ -186,7 +186,7 @@ RSpec.describe EvmApplication do
           * marks a master appliance
 
            #{header(:Zone, :ljust)               } | Type          | Status | #{header(:PID)          } | Server
-          -#{line_for(:Zone)                     }-+---------------+--------+-#{line_for(:PID)        }-+--------------------------
+          -#{line_for(:Zone)                     }-|---------------|--------|-#{line_for(:PID)        }-|--------------------------
            #{pad(local.zone.name, :Zone, :ljust) } | Ui            | ready  | #{pad(ui.pid, :PID)     } | #{      local.name     }
            #{pad(remote.zone.name, :Zone, :ljust)} | Base::Refresh | ready  | #{pad(refresh.pid, :PID)} | #{     remote.name     }
            #{pad(remote.zone.name, :Zone, :ljust)} | Generic       | ready  | #{pad(generic.pid, :PID)} | #{     remote.name     }


### PR DESCRIPTION
The tablize format from more_core_extensions changed in the latest release from using '-+-' to '-|-' as the header separator which breaks this evm:status spec.

Caused by: https://github.com/ManageIQ/more_core_extensions/pull/83