### PR TITLE
Add IBM vendor type

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -44,6 +44,7 @@ class VmOrTemplate < ApplicationRecord
     "openstack"   => "OpenStack",
     "google"      => "Google",
     "kubevirt"    => "KubeVirt",
+    "ibm"         => "IBM",
     "unknown"     => "Unknown"
   }
 


### PR DESCRIPTION
Add IBM vendor type in `VmOrTemplate` class to enable IBM Cloud plugins.