### PR TITLE
Add has_policies virtual attribute

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -1,4 +1,6 @@
 class ContainerGroup < ApplicationRecord
+  acts_as_miq_taggable
+
   include SupportsFeatureMixin
   include ComplianceMixin
   include CustomAttributeMixin
@@ -64,8 +66,6 @@ class ContainerGroup < ApplicationRecord
 
   include EventMixin
   include Metric::CiMixin
-
-  acts_as_miq_taggable
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -1,4 +1,6 @@
 class ContainerImage < ApplicationRecord
+  acts_as_miq_taggable
+
   include ComplianceMixin
   include MiqPolicyMixin
   include ScanningMixin
@@ -31,7 +33,6 @@ class ContainerImage < ApplicationRecord
   serialize :exposed_ports, Hash
   serialize :environment_variables, Hash
 
-  acts_as_miq_taggable
   virtual_column :display_registry, :type => :string
   virtual_total :total_containers, :containers
 

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -1,4 +1,6 @@
 class ContainerNode < ApplicationRecord
+  acts_as_miq_taggable
+
   include SupportsFeatureMixin
   include ComplianceMixin
   include MiqPolicyMixin
@@ -58,7 +60,6 @@ class ContainerNode < ApplicationRecord
   include EventMixin
   include Metric::CiMixin
   include CustomAttributeMixin
-  acts_as_miq_taggable
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -1,4 +1,6 @@
 class ContainerProject < ApplicationRecord
+  acts_as_miq_taggable
+
   include SupportsFeatureMixin
   include CustomAttributeMixin
   include ArchivedMixin
@@ -52,8 +54,6 @@ class ContainerProject < ApplicationRecord
   def all_container_groups
     ContainerGroup.where(:container_project_id => id).or(ContainerGroup.where(:old_container_project_id => id))
   end
-
-  acts_as_miq_taggable
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -1,4 +1,6 @@
 class ContainerReplicator < ApplicationRecord
+  acts_as_miq_taggable
+
   include SupportsFeatureMixin
   include ComplianceMixin
   include CustomAttributeMixin
@@ -22,8 +24,6 @@ class ContainerReplicator < ApplicationRecord
   include Metric::CiMixin
 
   PERF_ROLLUP_CHILDREN = [:container_groups]
-
-  acts_as_miq_taggable
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -15,8 +15,8 @@ class MiqServer < ApplicationRecord
   include_concern 'UpdateManagement'
 
   include UuidMixin
-  include MiqPolicyMixin
   acts_as_miq_taggable
+  include MiqPolicyMixin
   include RelationshipMixin
 
   alias_attribute :description, :name

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -31,7 +31,7 @@ module MiqPolicyMixin
   end
 
   def has_policies?
-    get_policies.length > 0
+    tag_list(:ns => "/miq_policy", :cat => "assignment").split.length > 0
   end
 
   def resolve_policies(list, event = nil)

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -1,6 +1,10 @@
 module MiqPolicyMixin
   extend ActiveSupport::Concern
 
+  included do
+    tag_attribute :policy, "/miq_policy/assignment"
+  end
+
   def add_policy(policy)
     ns = "/miq_policy"
     cat = "assignment/#{policy.class.to_s.underscore}"
@@ -23,15 +27,11 @@ module MiqPolicyMixin
   end
 
   def get_policies
-    tag_list(:ns => "/miq_policy", :cat => "assignment").split.collect do |t|
+    policy_tags.collect do |t|
       klass, id = t.split("/")
       next unless ["miq_policy", "miq_policy_set"].include?(klass)
       klass.camelize.constantize.find_by(:id => id.to_i)
     end.compact
-  end
-
-  def has_policies?
-    tag_list(:ns => "/miq_policy", :cat => "assignment").split.length > 0
   end
 
   def resolve_policies(list, event = nil)

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -22,14 +22,11 @@ module MiqPolicyMixin
     reload
   end
 
-  def get_policies(mode = nil)
-    ns = "/miq_policy"
-    cat = "assignment"
-    tag_list(:ns => ns, :cat => cat).split.collect do |t|
+  def get_policies
+    tag_list(:ns => "/miq_policy", :cat => "assignment").split.collect do |t|
       klass, id = t.split("/")
       next unless ["miq_policy", "miq_policy_set"].include?(klass)
-      policy = klass.camelize.constantize.find_by(:id => id.to_i)
-      policy if mode.nil? || policy.mode == mode
+      klass.camelize.constantize.find_by(:id => id.to_i)
     end.compact
   end
 

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -27,11 +27,11 @@ module MiqPolicyMixin
   end
 
   def get_policies
-    policy_tags.collect do |t|
-      klass, id = t.split("/")
-      next unless ["miq_policy", "miq_policy_set"].include?(klass)
-      klass.camelize.constantize.find_by(:id => id.to_i)
-    end.compact
+    policy_tags
+      .map { |t| t.split("/").first(2) }
+      .group_by(&:first)
+      .select { |klass, _ids| ["miq_policy", "miq_policy_set"].include?(klass) }
+      .flat_map { |klass, ids| klass.camelize.constantize.where(:id => ids).to_a }
   end
 
   def resolve_policies(list, event = nil)

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -1,4 +1,6 @@
 class PhysicalServer < ApplicationRecord
+  acts_as_miq_taggable
+
   include NewWithTypeStiMixin
   include MiqPolicyMixin
   include TenantIdentityMixin
@@ -7,8 +9,6 @@ class PhysicalServer < ApplicationRecord
   include ProviderObjectMixin
 
   include_concern 'Operations'
-
-  acts_as_miq_taggable
 
   VENDOR_TYPES = {
     # DB        Displayed

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe ContainerGroup do
+  subject { FactoryBot.create(:container_group) }
+
+  include_examples "MiqPolicyMixin"
+
   it "has container volumes and pods" do
     pvc = FactoryBot.create(
       :persistent_volume_claim,

--- a/spec/models/container_image_spec.rb
+++ b/spec/models/container_image_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe ContainerImage do
+  subject { FactoryBot.create(:container_image) }
+
+  include_examples "MiqPolicyMixin"
+
   it "#full_name" do
     image = ContainerImage.new(:name => "fedora")
     expect(image.full_name).to eq("fedora")

--- a/spec/models/container_node_spec.rb
+++ b/spec/models/container_node_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe ContainerNode do
+  subject { FactoryBot.create(:container_node) }
+
+  include_examples "MiqPolicyMixin"
+end

--- a/spec/models/container_project_spec.rb
+++ b/spec/models/container_project_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe ContainerProject do
+  subject { FactoryBot.create(:container_project) }
+
+  include_examples "MiqPolicyMixin"
+end

--- a/spec/models/container_replicator_spec.rb
+++ b/spec/models/container_replicator_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe ContainerReplicator do
+  subject { FactoryBot.create(:container_replicator) }
+
+  include_examples "MiqPolicyMixin"
+end

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe EmsCluster do
+  subject { FactoryBot.create(:ems_cluster) }
+
   include_examples "AggregationMixin"
+  include_examples "MiqPolicyMixin"
+
   context("VMware") do
     before do
       @cluster = FactoryBot.create(:ems_cluster)

--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe EmsFolder do
+  subject { FactoryBot.create(:ems_folder) }
+
+  include_examples "MiqPolicyMixin"
+
   context "with folder tree" do
     before do
       @root = FactoryBot.create(:ems_folder, :name => "root")

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe ExtManagementSystem do
+  subject { FactoryBot.create(:ext_management_system) }
+
   include_examples "AggregationMixin"
+  include_examples "MiqPolicyMixin"
+
   describe ".with_tenant" do
     # tenant_root
     #   \___ tenant_eye_bee_em (service_template_eye_bee_em)

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe Host do
+  subject { FactoryBot.create(:host) }
+
   include_examples "AggregationMixin"
+  include_examples "MiqPolicyMixin"
+
   it "groups and users joins" do
     user1  = FactoryBot.create(:account_user)
     user2  = FactoryBot.create(:account_user)

--- a/spec/models/miq_enterprise_spec.rb
+++ b/spec/models/miq_enterprise_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe MiqEnterprise do
+  subject { enterprise }
+
+  include_examples "MiqPolicyMixin"
   include_examples ".seed called multiple times", 1
 
+  # TODO:  Make this `subject` for consistency
   let(:enterprise) { FactoryBot.create(:miq_enterprise) }
 
   context "with all existing records" do

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe MiqRegion do
+  subject { region }
+
+  include_examples "MiqPolicyMixin"
+
   let(:region) { FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number) }
   # the first id from a region other than ours
   let(:external_region_id) do

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe MiqServer do
+  subject { FactoryBot.create(:miq_server) }
+
+  include_examples "MiqPolicyMixin"
+
   context ".seed" do
     before do
       MiqRegion.seed

--- a/spec/models/mixins/miq_policy_mixin_spec.rb
+++ b/spec/models/mixins/miq_policy_mixin_spec.rb
@@ -1,0 +1,19 @@
+describe MiqPolicyMixin do
+  let(:policy) { FactoryBot.create(:miq_policy) }
+  let(:policy_set) { FactoryBot.create(:miq_policy_set).tap { |ps| ps.add_member(policy) } }
+  subject { TestModel.create }
+
+  before do
+    class TestModel < ApplicationRecord
+      self.table_name = "hosts" # any table really
+      acts_as_miq_taggable
+      include MiqPolicyMixin
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestModel)
+  end
+
+  include_examples "MiqPolicyMixin"
+end

--- a/spec/models/physical_server_spec.rb
+++ b/spec/models/physical_server_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe PhysicalServer do
 
   subject { FactoryBot.create(:physical_server, :with_asset_detail) }
 
+  include_examples "MiqPolicyMixin"
+
   describe '#compatible_firmware_binaries' do
     before { subject.asset_detail.update(**attrs) }
 

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe ResourcePool do
+  subject { FactoryBot.create(:resource_pool) }
+
+  include_examples "MiqPolicyMixin"
+
   context "Testing VM count virtual columns" do
     before do
       @rp1 = FactoryBot.create(:resource_pool, :name => "RP 1")

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe VmOrTemplate do
+  subject { vm }
+
+  include_examples "MiqPolicyMixin"
+
   include Spec::Support::ArelHelper
 
   let(:vm)      { FactoryBot.create(:vm_or_template) }

--- a/spec/support/examples_group/shared_examples_for_miq_policy_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_miq_policy_mixin.rb
@@ -25,6 +25,15 @@ shared_examples_for "MiqPolicyMixin" do
         it "detects no policies in ruby" do
           expect(subject.has_policies?).to eq(false)
         end
+
+        it "detects no policies with preloaded tags in ruby" do
+          subject.tags.load
+          expect(subject.has_policies?).to eq(false)
+        end
+
+        it "detects no policies in SQL" do
+          expect(subject.class.select(:id, :has_policies).find(subject.id).has_policies).to be(false)
+        end
       end
 
       context "with a policy" do
@@ -32,6 +41,16 @@ shared_examples_for "MiqPolicyMixin" do
 
         it "detects policies in ruby" do
           expect(subject.has_policies?).to eq(true)
+        end
+
+        it "detects policies with preloaded tags in ruby" do
+          subject.tags.load
+          expect(subject.has_policies?).to eq(true)
+        end
+
+        it "detects policies in SQL" do
+          result = subject.class.select(:id, :has_policies).find(subject.id)
+          expect(result.has_policies).to be(true)
         end
       end
 
@@ -41,6 +60,32 @@ shared_examples_for "MiqPolicyMixin" do
         it "detects policies in ruby" do
           expect(subject.has_policies?).to eq(true)
         end
+
+        it "detects policies with preloaded tags in ruby" do
+          result = subject.class.select(:id, :has_policies).find(subject.id)
+          expect(result.has_policies).to be(true)
+        end
+
+        it "detects policies in sql" do
+          result = subject.class.select(:id, :has_policies).find(subject.id)
+          expect(result.has_policies).to be(true)
+        end
+      end
+    end
+
+    describe "#policy_tags" do
+      it "supports no policies" do
+        expect(subject.policy_tags).to eq([])
+      end
+
+      it "supports policies" do
+        subject.add_policy(policy)
+        expect(subject.policy_tags).to eq(["#{policy.class.name.underscore}/#{policy.id}"])
+      end
+
+      it "supports policy sets" do
+        subject.add_policy(policy_set)
+        expect(subject.policy_tags).to eq(["#{policy_set.class.name.underscore}/#{policy_set.id}"])
       end
     end
   end

--- a/spec/support/examples_group/shared_examples_for_miq_policy_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_miq_policy_mixin.rb
@@ -1,0 +1,47 @@
+# Note:  This example group uses the `subject` defined by the calling spec
+shared_examples_for "MiqPolicyMixin" do
+  context "MiqPolicyMixin methods" do
+    let(:policy) { FactoryBot.create(:miq_policy) }
+    let(:policy_set) { FactoryBot.create(:miq_policy_set).tap { |ps| ps.add_member(policy) } }
+
+    describe "#get_policies" do
+      it "supports no policies" do
+        expect(subject.get_policies).to eq([])
+      end
+
+      it "supports policies" do
+        subject.add_policy(policy)
+        expect(subject.get_policies).to eq([policy])
+      end
+
+      it "supports policy sets" do
+        subject.add_policy(policy_set)
+        expect(subject.get_policies).to eq([policy_set])
+      end
+    end
+
+    describe "#has_policies" do
+      context "with no policies" do
+        it "detects no policies in ruby" do
+          expect(subject.has_policies?).to eq(false)
+        end
+      end
+
+      context "with a policy" do
+        before { subject.add_policy(policy) }
+
+        it "detects policies in ruby" do
+          expect(subject.has_policies?).to eq(true)
+        end
+      end
+
+      context "with a policy_set" do
+        before { subject.add_policy(policy_set) }
+
+        it "detects policies in ruby" do
+          expect(subject.has_policies?).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an alternative to #20349 @h-kataria.

We want to know if a host has a policy or policy set assigned.

The current method downloads a lot of data. So the goal is to introduce a boolean virtual attribute that tells users if a policy is associated with a host/object.

- Introduce the concept of a virtual attribute that is true when a tag is assigned
- With that new found power, declares a policy attribute for a given tag.

Now this will work:

```ruby
module MiqPolicyMixin
  tag_attribute :policy, "/miq_policy/assignment"
end

Host.select(:id).select(:has_policies).first
```

Which generates

```sql
SELECT  "hosts"."id",
       (SELECT  true
        FROM "taggings"
        INNER JOIN "tags"
        ON "tags"."id" = "taggings"."tag_id"
        WHERE "tags"."name" LIKE '/miq_policy/assignment/%'
        AND "taggings"."taggable_type" = 'Host'
        AND "taggings"."taggable_id" = "hosts"."id" LIMIT 1) AS "has_policies"
FROM "hosts"
ORDER BY "hosts"."id" ASC LIMIT 1
```

NOTE: The sql returns `true` or `null` - but the method it self returns true or false. Not sure if sorting in the database may be a little funky here