### PR TITLE
Bump the memory limits for metrics and queue workers

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1121,19 +1121,19 @@
     :queue_worker_base:
       :defaults:
         :dequeue_method: :drb
-        :memory_threshold: 500.megabytes
+        :memory_threshold: 600.megabytes
         :poll_method: :normal
         :queue_timeout: 10.minutes
       :ems_metrics_collector_worker:
         :defaults:
           :count: 2
-          :memory_threshold: 400.megabytes
+          :memory_threshold: 600.megabytes
           :nice_delta: 3
           :poll_method: :escalate
         :ems_metrics_collector_worker_google: {}
       :ems_metrics_processor_worker:
         :count: 2
-        :memory_threshold: 600.megabytes
+        :memory_threshold: 800.megabytes
         :nice_delta: 7
         :poll_method: :escalate
       :ems_operations_worker: {}


### PR DESCRIPTION
It has been seen when running in containers that the reported memory usage is a little higher than RSS which is a little higher than PSS.

This means that if we are on the edge on an appliance the same usage will be over the limit on pods.