### PR TITLE
The tower provider was moved to the base factory

### DIFF
--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe ServiceTemplateAnsibleTower do
   end
 
   describe '#my_zone' do
-    let(:manager) { FactoryBot.create(:automation_manager_ansible_tower, :provider) }
+    let(:manager) { FactoryBot.create(:automation_manager_ansible_tower) }
     let(:job_template) { FactoryBot.create(:configuration_script, :manager => manager) }
     let(:service_template) { FactoryBot.create(:service_template_ansible_tower, :job_template => job_template) }
 


### PR DESCRIPTION
Don't need to specify a provider trait since the provider has moved to the base ansible_tower automation_manager factory with the proper class.

https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/229