### PR TITLE
[WIP] Add method collection_name to OwnershipMixin

### DIFF
--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -1,4 +1,6 @@
 module OwnershipMixin
+  ALLOWED_COLLECTIONS = %i[vms templates orchestration_stacks services service_templates authentications].freeze
+
   extend ActiveSupport::Concern
 
   included do
@@ -48,6 +50,17 @@ module OwnershipMixin
 
       t.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:owning_ldap_group)]).eq(ldap_group))
     end)
+
+    def collection_name
+      collections = Api::ApiConfig[:collections].to_h.slice(*ALLOWED_COLLECTIONS)
+      found_collection = collections.detect do |_, collection|
+        kind_of?(collection[:klass].constantize)
+      end
+
+      raise NotImplementedError, _("Record is not allowed for set ownership screen.") unless found_collection
+
+      found_collection[0] # collection_name
+    end
   end
 
   module ClassMethods

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -20,6 +20,16 @@ shared_examples_for "OwnershipMixin" do
     let!(:user_owned)  { FactoryBot.create(factory, :name => "user_owned",  :evm_owner => user) }
     let!(:user_owned2) { FactoryBot.create(factory, :name => "user_owned2", :evm_owner => user2) }
 
+    describe "#collection_name" do
+      let(:collection_to_klass) do
+        {:service_template => :service_templates, :service => :services, :vm => :vms}
+      end
+
+      it "matches collection based on record" do
+        expect(no_group.collection_name).to eq(collection_to_klass[factory])
+      end
+    end
+
     describe ".user_or_group_owned" do
       let(:user_other_region) do
         other_region_id = ApplicationRecord.id_in_region(1, MiqRegion.my_region_number + 1)


### PR DESCRIPTION
Adds method `collection_name ` for models with OwnershipMixin which return name of collections - which is used in set ownership screens 


Links
-----

* https://github.com/ManageIQ/manageiq-ui-classic/pull/7236

@miq-bot assign @gtanzillo 
@miq-bot add_label enhancement

