### PR TITLE
Fix template directory due to RPM build changes

### DIFF
--- a/tools/miq_config_sssd_ldap/auth_template_files.rb
+++ b/tools/miq_config_sssd_ldap/auth_template_files.rb
@@ -4,7 +4,7 @@ module MiqConfigSssdLdap
   class AuthTemplateFilesError < StandardError; end
 
   class AuthTemplateFiles
-    TEMPLATE_DIR     = "/var/www/miq/system/TEMPLATE".freeze
+    TEMPLATE_DIR     = "/opt/manageiq/manageiq-appliance/TEMPLATE".freeze
     ALT_TEMPLATE_DIR = "/opt/rh/cfme-appliance/TEMPLATE".freeze
     HTTPD_CONF_DIR   = "/etc/httpd/conf.d".freeze
     PAM_CONF_DIR     = "/etc/pam.d".freeze


### PR DESCRIPTION
The /var/www/miq/system dir no longer exists (it was a leftover symlink from forever ago that is now gone in the move to RPMs.)

Fixes https://github.com/ManageIQ/manageiq/issues/20375

