### PR TITLE
add ancestry to folders

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -1,4 +1,7 @@
+require 'ancestry'
+
 class EmsFolder < ApplicationRecord
+  has_ancestry
   include NewWithTypeStiMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"


### PR DESCRIPTION
we're working on getting to the point where we can cleanup ems folders, and in order to do so we'll need ancestry on folders and resource pools.

https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/155
