### PR TITLE
The cloud_volumes inv collection was missing

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
@@ -2,6 +2,14 @@ module ManageIQ::Providers
   class Inventory::Persister
     class Builder
       class StorageManager < ::ManageIQ::Providers::Inventory::Persister::Builder
+        def cloud_volumes
+          add_common_default_values
+        end
+
+        def cloud_volume_snapshots
+          add_common_default_values
+        end
+
         def cloud_object_store_objects
           add_common_default_values
         end


### PR DESCRIPTION
The inventory collections for cloud volumes and cloud_volume_snapshots weren't present in the core persister definitions which meant that each provider had to define the entire collection not just override parts of it.