### PR TITLE
Allow providers to override provider_module

### DIFF
--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -95,6 +95,10 @@ class ManageIQ::Providers::Inventory::Persister
     end
   end
 
+  def self.provider_module
+    ManageIQ::Providers::Inflector.provider_module(self).name
+  end
+
   protected
 
   def initialize_inventory_collections

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -208,7 +208,7 @@ module ManageIQ::Providers
       def auto_model_class
         model_class = begin
           # a) Provider specific class
-          provider_module = ManageIQ::Providers::Inflector.provider_module(@persister_class).name
+          provider_module = @persister_class.provider_module
           manager_module = self.class.name.split('::').last
 
           class_name = "#{provider_module}::#{manager_module}::#{@name.to_s.classify}"


### PR DESCRIPTION
Some provider classes don't match exactly the "expected" format and this allows for the auto_model_class to work without forcing the provider to manually set every model_class.