### PR TITLE
Rename the key_pairs collection to match model name

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -10,9 +10,10 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
-        def key_pairs
+        def auth_key_pairs
           add_properties(
-            :model_class => ::ManageIQ::Providers::CloudManager::AuthKeyPair,
+            :name        => :auth_key_pairs,
+            :association => :key_pairs,
             :manager_ref => %i(name)
           )
           add_default_values(

--- a/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
@@ -51,21 +51,21 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
       @vm_data101 = vm_data(101).merge(
         :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
         :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
-        :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+        :key_pairs        => [persister.auth_key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
         :location         => lazy_find_network1,
       )
 
       @vm_data102 = vm_data(102).merge(
         :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
         :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
-        :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+        :key_pairs        => [persister.auth_key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
         :location         => lazy_find_network2,
       )
 
       @vm_data160 = vm_data(160).merge(
         :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
         :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
-        :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+        :key_pairs        => [persister.auth_key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
         :location         => lazy_find_network60,
       )
 

--- a/spec/models/manageiq/providers/inventory/persister/serializing_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/serializing_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
     @vm_data_1 = vm_data(1).merge(
       :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
       :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
-      :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+      :key_pairs        => [persister.auth_key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
       :location         => persister.networks.lazy_find(
         {:hardware => lazy_find_hardware, :description => "public"},
         {:key     => :hostname,

--- a/spec/models/manageiq/providers/inventory/persister/test_persister.rb
+++ b/spec/models/manageiq/providers/inventory/persister/test_persister.rb
@@ -12,7 +12,7 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
       end
     end
 
-    add_key_pairs
+    add_auth_key_pairs
 
     # Child models with references in the Parent InventoryCollections for Cloud
     %i(availability_zones
@@ -76,8 +76,9 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
   private
 
   # Cloud InventoryCollection
-  def add_key_pairs
-    add_collection(cloud, :key_pairs) do |builder|
+  def add_auth_key_pairs
+    add_collection(cloud, :auth_key_pairs) do |builder|
+      builder.add_properties(:model_class => ::ManageIQ::Providers::CloudManager::AuthKeyPair)
       builder.add_properties(:manager_uuids => name_references(:key_pairs))
     end
   end


### PR DESCRIPTION
The model class is called AuthKeyPair and by not having this match the name of the collection it means that the auto_model_class doesn't work, forcing all providers to manually set the model_class.

It is much easier to name the collection to match the model name and just override the association because that doesn't change with provider subclasses.

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/156
Dependent:
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/640
* https://github.com/ManageIQ/manageiq-providers-azure/pull/405
* https://github.com/ManageIQ/manageiq-providers-google/pull/150
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/623