### PR TITLE
Call `column_type` on parsed field to get the actual column type

### DIFF
--- a/app/models/miq_report/generator/sorting.rb
+++ b/app/models/miq_report/generator/sorting.rb
@@ -15,7 +15,7 @@ module MiqReport::Generator::Sorting
     sb_nil_sub = []
     new_sortby.each_with_index do |sb, idx|
       base_col_name = sb.split(SORT_COL_SUFFIX).first
-      ctype = MiqExpression.parse_field_or_tag(col_to_expression_col(base_col_name)).column_type || :string
+      ctype = MiqExpression.parse_field_or_tag(col_to_expression_col(base_col_name)).try(:column_type) || :string
       sb_nil_sub[idx] = case ctype
                         when :string, :text, :boolean             then "00ff".hex.chr   # "\xFF"
                         when :integer, :fixnum, :decimal, :float  then @table.data.collect { |d| d.data[sb] }.compact.max.to_i + 1

--- a/app/models/miq_report/generator/sorting.rb
+++ b/app/models/miq_report/generator/sorting.rb
@@ -15,7 +15,7 @@ module MiqReport::Generator::Sorting
     sb_nil_sub = []
     new_sortby.each_with_index do |sb, idx|
       base_col_name = sb.split(SORT_COL_SUFFIX).first
-      ctype = MiqExpression.parse_field_or_tag(col_to_expression_col(base_col_name)) || :string
+      ctype = MiqExpression.parse_field_or_tag(col_to_expression_col(base_col_name)).column_type || :string
       sb_nil_sub[idx] = case ctype
                         when :string, :text, :boolean             then "00ff".hex.chr   # "\xFF"
                         when :integer, :fixnum, :decimal, :float  then @table.data.collect { |d| d.data[sb] }.compact.max.to_i + 1


### PR DESCRIPTION
Fixes bug where column type was not being detected which caused sorting to fail when sorting by a string column
containing nil values. In this case, the nil value was not getting  substituted with a value that allows for proper sorting
