### PR TITLE
Replace MiqUUID with Digest::UUID

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -211,10 +211,10 @@ class Hardware < ApplicationRecord
   end
 
   def m_bios(_parent, xmlNode, _deletes)
-    new_bios = MiqUUID.clean_guid(xmlNode.attributes["bios"])
+    new_bios = Digest::UUID.clean(xmlNode.attributes["bios"])
     self.bios = new_bios.nil? ? xmlNode.attributes["bios"] : new_bios
 
-    new_bios = MiqUUID.clean_guid(xmlNode.attributes["location"])
+    new_bios = Digest::UUID.clean(xmlNode.attributes["location"])
     self.bios_location = new_bios.nil? ? xmlNode.attributes["location"] : new_bios
   end
 


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/more_core_extensions/pull/81,  where we added `Digest::UUID.clean` in an effort to ultimately remove `MiqUUID.clean_guid` from gems-pending.

Since `more_core_extensions` versioning is now handled via gems-pending, and that was bumped to 4.0 in https://github.com/ManageIQ/manageiq-gems-pending/pull/481, it should be safe to replace this.

