### PR TITLE
Add cloud_databases to the cloud_manager persister

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -22,6 +22,14 @@ module ManageIQ::Providers
           )
         end
 
+        def cloud_database_flavors
+          add_common_default_values
+        end
+
+        def cloud_databases
+          add_common_default_values
+        end
+
         def vm_and_template_labels
           # TODO(lsmola) make a generic CustomAttribute IC and move it to base class
           add_properties(


### PR DESCRIPTION
Add cloud_databases and cloud_database_flavors to tbe cloud_manager persister inventory collections

Required For: https://github.com/ManageIQ/manageiq-providers-amazon/pull/643