### PR TITLE
Bump manageiq-smartstate to v0.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,7 +208,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.5.3",       :require => false
+  gem "manageiq-smartstate",            "~>0.6.0",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Allow for updating vmware_web_service and rbvmomi gems

Co-Depends: https://github.com/ManageIQ/manageiq-providers-vmware/pull/606
Cross repo test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/157