### PR TITLE
fix brakeman command injection warning

### DIFF
--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -53,10 +53,10 @@ class SystemConsole < ApplicationRecord
       return nil
     end
 
-    command = '/usr/bin/socat', "TCP-LISTEN:#{local_port},fork", "TCP:#{remote_address}:#{remote_port}"
-    _log.info("Running socat proxy command: #{command.join(' ')}")
+    command = AwesomeSpawn::CommandLineBuilder.new.build("/usr/bin/socat", ["TCP-LISTEN:" + local_port + ",fork", "TCP:" + remote_address + ":" + remote_port])
+    _log.info("Running socat proxy command: #{command}")
+    pid = spawn(command)
 
-    pid = spawn(*command)
     Process.detach(pid)
 
     return [local_address, local_port, pid]

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -19,26 +19,6 @@
       "user_input": "MiqReport.view_yaml_filename(db, current_user, options)",
       "confidence": "Medium",
       "note": "Temporarily skipped, found in new brakeman version"
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "921b9f7b353a4de1033addb95d4a7c7efb090a7e60f8acb350ec8c7aea6e84ff",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/models/system_console.rb",
-      "line": 59,
-      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "spawn(*[\"/usr/bin/socat\", \"TCP-LISTEN:#{local_port},fork\", \"TCP:#{remote_address}:#{remote_port}\"])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "SystemConsole",
-        "method": "SystemConsole.launch_proxy"
-      },
-      "user_input": "remote_address",
-      "confidence": "Medium",
-      "note": ""
     }
   ],
   "updated": "2017-11-01 11:16:49 -0400",


### PR DESCRIPTION
system_console has an injection warning that we're ignoring at the moment. 

<sub>ahem, without [a certain PR that's open but currently languishing](https://github.com/ManageIQ/awesome_spawn/pull/32) to do the detach at the moment, we'll have to go with something like this which is sad because the detach is nifty and I'm a fan.</sub>

thanks for the help, @NickLaMuro 
