### PR TITLE
remove unused dialog field type

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -54,7 +54,6 @@ class DialogField < ApplicationRecord
     :dialog_field_text_area_box,
     :dialog_field_check_box,
     :dialog_field_drop_down_list,
-    :dialog_field_button,
     :dialog_field_tag_control,
     :dialog_field_radio_button,
     # Enable when UI support is available
@@ -66,8 +65,6 @@ class DialogField < ApplicationRecord
     "DialogFieldTextAreaBox"     => N_("Text Area Box"),
     "DialogFieldCheckBox"        => N_("Check Box"),
     "DialogFieldDropDownList"    => N_("Drop Down List"),
-    # Commented out next to field types until they can be implemented
-    #    "DialogFieldButton" => "Button",
     "DialogFieldTagControl"      => N_("Tag Control"),
     "DialogFieldDateControl"     => N_("Date Control"),
     "DialogFieldDateTimeControl" => N_("Date/Time Control"),

--- a/spec/factories/dialog_field.rb
+++ b/spec/factories/dialog_field.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     name { "Dialog Field" }
   end
 
-  factory :dialog_field_button,      :parent => :dialog_field, :class => "DialogFieldButton"
   factory :dialog_field_sorted_item, :parent => :dialog_field, :class => "DialogFieldSortedItem"
   factory :dialog_field_tag_control, :parent => :dialog_field, :class => "DialogFieldTagControl"
   factory :dialog_field_text_box,    :parent => :dialog_field, :class => "DialogFieldTextBox"

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -167,20 +167,15 @@ RSpec.describe Dialog do
       @dialog_group.reload
       expect(@dialog_group.dialog_fields.size).to eq(2)
 
-      button = FactoryBot.create(:dialog_field_button, :label => 'button', :name => 'button')
-      @dialog_group.dialog_fields << button
-      @dialog_group.reload
-      expect(@dialog_group.dialog_fields.size).to eq(3)
-
       check_box = FactoryBot.create(:dialog_field_text_box, :label => 'check box', :name => "check_box")
       @dialog_group.dialog_fields << check_box
       @dialog_group.reload
-      expect(@dialog_group.dialog_fields.size).to eq(4)
+      expect(@dialog_group.dialog_fields.size).to eq(3)
 
       drop_down_list = FactoryBot.create(:dialog_field_drop_down_list, :label => 'drop down list', :name => "drop_down_1")
       @dialog_group.dialog_fields << drop_down_list
       @dialog_group.reload
-      expect(@dialog_group.dialog_fields.size).to eq(5)
+      expect(@dialog_group.dialog_fields.size).to eq(4)
     end
   end
 


### PR DESCRIPTION
we have never used Dialog Field Buttons and i doubt we're about to start anytime soon, maybe we can call this a tech debt removal like the PR skateman opened last year that does much the same thing on a different one of these? 

@miq-bot assign @tinaafitz 