### PR TITLE
Remove miq-deep from FixAuth

### DIFF
--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -1,7 +1,6 @@
 require 'active_support/all'
 require 'active_record'
 require 'securerandom'
-require 'util/extensions/miq-deep'
 
 module FixAuth
   class FixAuthentication < ActiveRecord::Base


### PR DESCRIPTION
This PR removes the miq-deep require from tools/fix_auth/models.rb.

Partly because we're trying to remove `miq-deep` from gems-pending, and partly because this file doesn't appear to use any of its methods anyway, i.e. there's no call to `deep_clone` or `deep_delete` inside this file.