### PR TITLE
fix folders and resource pools no longer having aggregate associations

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -11,6 +11,7 @@ class EmsFolder < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include RelationshipsAggregationMixin
+  include AggregationMixin::Methods
   include MiqPolicyMixin
 
   virtual_has_many :vms_and_templates, :uses => :all_relationships

--- a/app/models/mixins/aggregation_mixin/methods.rb
+++ b/app/models/mixins/aggregation_mixin/methods.rb
@@ -1,0 +1,55 @@
+module AggregationMixin
+  module Methods
+    extend ActiveSupport::Concern
+
+    def aggregate_cpu_speed(targets = nil)
+      aggregate_hardware(:hosts, :aggregate_cpu_speed, targets)
+    end
+
+    def aggregate_cpu_total_cores(targets = nil)
+      aggregate_hardware(:hosts, :cpu_total_cores, targets)
+    end
+
+    def aggregate_physical_cpus(targets = nil)
+      aggregate_hardware(:hosts, :cpu_sockets, targets)
+    end
+
+    def aggregate_memory(targets = nil)
+      aggregate_hardware(:hosts, :memory_mb, targets)
+    end
+
+    def aggregate_vm_cpus(targets = nil)
+      aggregate_hardware(:vms_and_templates, :cpu_sockets, targets)
+    end
+
+    def aggregate_vm_memory(targets = nil)
+      aggregate_hardware(:vms_and_templates, :memory_mb, targets)
+    end
+
+    def aggregate_disk_capacity(targets = nil)
+      aggregate_hardware(:hosts, :disk_capacity, targets)
+    end
+
+    # Default implementations which can be overridden with something more optimized
+
+    def all_storages
+      hosts = all_hosts
+      MiqPreloader.preload(hosts, :storages)
+      hosts.collect(&:storages).flatten.compact.uniq
+    end
+
+    def aggregate_hardware(from, field, targets = nil)
+      from      = from.to_s.singularize
+      select    = field == :aggregate_cpu_speed ? "cpu_total_cores, cpu_speed" : field
+      targets ||= send("all_#{from.pluralize}")
+      hdws      = Hardware.where(from.singularize => targets).select(select)
+      hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
+    end
+
+    def lans
+      hosts = all_hosts
+      MiqPreloader.preload(hosts, :lans)
+      hosts.flat_map(&:lans).compact.uniq
+    end
+  end
+end

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -13,6 +13,7 @@ class ResourcePool < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include RelationshipsAggregationMixin
+  include AggregationMixin::Methods
   include MiqPolicyMixin
   include AsyncDeleteMixin
 


### PR DESCRIPTION
Currently the aggregation methods on resource pools and folders are broken because of changes I made in https://github.com/ManageIQ/manageiq/pull/20149.

See https://gitter.im/ManageIQ/manageiq-providers-ovirt?at=5f2d4a299b76045d5b83c0ed from earlier today. 

I know the point of 20149 was to remove this file, but since resource pools and folders are the only things that need it it doesn't make sense to me to put these methods into the mixin, I think they should stay separate until I figure out a better way to do this (sorry, Keenan, I know you're going to dislike this).

you all can see it's broken with a call to any aggregate function on a resource pool.

https://github.com/ManageIQ/manageiq/pull/20149/files#r429475770 was correct. 
@NickLaMuro sorry but could I ask you to look at this, please, since you caught it? 
