### PR TITLE
Improvement to action_check_compliance to avoid infinite loop.

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -987,6 +987,10 @@ class MiqAction < ApplicationRecord
     end
   end
 
+  def self.allowed_for_policies(mode)
+    mode == 'compliance' ? where.not(:name => 'check_compliance') : all
+  end
+
   def self.fixture_path
     FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -369,6 +369,11 @@ class MiqAction < ApplicationRecord
       return
     end
 
+    if inputs[:policy].mode == 'compliance'
+      MiqPolicy.logger.warn("MIQ(action_check_compliance): Invoking action [#{action.description}] for event [#{inputs[:event].description}] would cause infinite loop, skipping")
+      return
+    end
+
     if inputs[:synchronous]
       MiqPolicy.logger.info("MIQ(action_check_compliance): Now executing [#{action.description}] of #{rec.class.name} [#{rec.name}]")
       rec.check_compliance

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -265,6 +265,25 @@ RSpec.describe MiqAction do
     end
   end
 
+  context '#action_check_compliance' do
+    let(:vm) { FactoryBot.create(:vm_infra) }
+    let(:action) { FactoryBot.create(:miq_action, :name => 'check_compliance', :description => 'Check Host or Vm Compliance') }
+    let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance') }
+    let(:event) { FactoryBot.create(:miq_event_definition, :description => 'vm_compliance_check') }
+
+    it 'will not execute for compliance polices' do
+      expect(vm).not_to receive(:check_compliance)
+      expect(MiqPolicy.logger).to receive(:warn)
+      action.action_check_compliance(action, vm, :policy => policy, :synchronous => true, :event => event)
+    end
+
+    it 'will execute for control polices' do
+      policy.update(:mode => 'control')
+      expect(vm).to receive(:check_compliance)
+      action.action_check_compliance(action, vm, :policy => policy, :synchronous => true, :event => event)
+    end
+  end
+
   context '.create_default_actions' do
     context 'seeding default actions from a file with 3 csv rows and some comments' do
       before do


### PR DESCRIPTION
- Add check to `action_check_compliance` to avoid infinite loop.
- Add helper method `MiqAction.allowed_for_policies`.

Fixes https://github.com/ManageIQ/manageiq/issues/20405

cc @h-kataria 