### PR TITLE
Replace thin MiqStats wrappers with Math extensions

### DIFF
--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -64,7 +64,7 @@ module MiqReport::Generator::Trend
     return nil if rec.respond_to?(:inside_time_profile) && rec.inside_time_profile == false
 
     begin
-      val = MiqStats.solve_for_y(rec.send(CHART_X_AXIS_COLUMN_ADJUSTED).to_i, @trend_data[col][:slope], @trend_data[col][:yint])
+      val = Math.slope_y_intercep(rec.send(CHART_X_AXIS_COLUMN_ADJUSTED).to_i, @trend_data[col][:slope], @trend_data[col][:yint])
       return val > 0 ? val : 0
     rescue ZeroDivisionError
       return nil
@@ -143,7 +143,7 @@ module MiqReport::Generator::Trend
       return unknown
     else
       begin
-        result = MiqStats.solve_for_x(limit, trend_data[trend_data_key][:slope], trend_data[trend_data_key][:yint])
+        result = Math.slope_x_intercept(limit, trend_data[trend_data_key][:slope], trend_data[trend_data_key][:yint])
         if result <= 1.year.from_now.to_i
           if Time.at(result).utc <= Time.now.utc
             return Time.at(result).utc.strftime("%m/%d/%Y")

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -64,7 +64,7 @@ module MiqReport::Generator::Trend
     return nil if rec.respond_to?(:inside_time_profile) && rec.inside_time_profile == false
 
     begin
-      val = Math.slope_y_intercep(rec.send(CHART_X_AXIS_COLUMN_ADJUSTED).to_i, @trend_data[col][:slope], @trend_data[col][:yint])
+      val = Math.slope_y_intercept(rec.send(CHART_X_AXIS_COLUMN_ADJUSTED).to_i, @trend_data[col][:slope], @trend_data[col][:yint])
       return val > 0 ? val : 0
     rescue ZeroDivisionError
       return nil

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -473,7 +473,7 @@ module VimPerformanceAnalysis
     return nil if slope.nil?
 
     begin
-      return MiqStats.solve_for_y(timestamp.to_f, slope, yint)
+      return Math.slope_y_intercept(timestamp.to_f, slope, yint)
     rescue RangeError
       return nil
     rescue => err
@@ -487,7 +487,7 @@ module VimPerformanceAnalysis
     return nil if slope.nil?
 
     begin
-      return Time.at(MiqStats.solve_for_x(value.to_f, slope, yint)).utc
+      return Time.at(Math.slope_x_intercept(value.to_f, slope, yint)).utc
     rescue RangeError
       return nil
     rescue => err

--- a/app/models/vim_performance_trend.rb
+++ b/app/models/vim_performance_trend.rb
@@ -139,7 +139,7 @@ class VimPerformanceTrend < ActsAsArModel
       return nil
     else
       begin
-        result = MiqStats.solve_for_x(limit, trend_data[:slope], trend_data[:yint])
+        result = Math.slope_x_intercept(limit, trend_data[:slope], trend_data[:yint])
         return Time.at(result).utc
       rescue RangeError
         return nil


### PR DESCRIPTION
Near as I can tell, the few `MiqStats` methods we use are just very thin wrappers around custom methods that we ourselves defined in the `more_core_extensions` library.

I see no particular advantage to using these, and this will let us remove miq_stats.rb from gems-pending as part of that cleanup.