### PR TITLE
Move SKIP_TEST_RESET to environment.rb

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -29,7 +29,7 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
       ManageIQ::Environment.seed_database
     end
 
-    ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
+    ManageIQ::Environment.setup_test_environment
     ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
   end
 

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -93,6 +93,8 @@ module ManageIQ
     end
 
     def self.setup_test_environment(task_prefix: '', root: APP_ROOT)
+      return if ENV["SKIP_TEST_RESET"]
+
       puts "\n== Resetting tests =="
       run_rake_task("#{task_prefix}test:vmdb:setup", :root => root)
     end


### PR DESCRIPTION
Allows plugins to use this ENV var as well in CI and local.

Currently using this as part of the `manageiq-cross_repo-tests` runs I am doing here:

https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/150