### PR TITLE
get_policies should maybe return policies in the set as well as the set itself

### DIFF
--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -31,7 +31,7 @@ module MiqPolicyMixin
       .map { |t| t.split("/").first(2) }
       .group_by(&:first)
       .select { |klass, _ids| ["miq_policy", "miq_policy_set"].include?(klass) }
-      .flat_map { |klass, ids| klass.camelize.constantize.where(:id => ids).to_a }
+      .flat_map { |klass, ids| klass.camelize.constantize.where(:id => ids.map(&:last)).to_a }
   end
 
   def resolve_policies(list, event = nil)

--- a/spec/support/examples_group/shared_examples_for_miq_policy_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_miq_policy_mixin.rb
@@ -2,7 +2,9 @@
 shared_examples_for "MiqPolicyMixin" do
   context "MiqPolicyMixin methods" do
     let(:policy) { FactoryBot.create(:miq_policy) }
+    let(:policy2) { FactoryBot.create(:miq_policy) }
     let(:policy_set) { FactoryBot.create(:miq_policy_set).tap { |ps| ps.add_member(policy) } }
+    let(:policy_set) { FactoryBot.create(:miq_policy_set).tap { |ps| ps.add_member(policy2) } }
 
     describe "#get_policies" do
       it "supports no policies" do
@@ -15,8 +17,10 @@ shared_examples_for "MiqPolicyMixin" do
       end
 
       it "supports policy sets" do
+        subject.add_policy(policy)
+        subject.add_policy(policy2)
         subject.add_policy(policy_set)
-        expect(subject.get_policies).to eq([policy_set])
+        expect(subject.get_policies).to contain_exactly(policy_set, policy, policy2)
       end
     end
 


### PR DESCRIPTION
I think `get_policies` was previously returning the set and all set elements. 
broken in https://github.com/ManageIQ/manageiq/pull/20381 

and https://github.com/ManageIQ/manageiq-api/pull/881 will fix the remaining two api specs that are failing (but 881 can be merged anytime, it doesn't require this PR in any way)

the cross repo : https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/159 


edit — the reason we need to do this is because `User.where(:id => [["user", User.first.id.to_s], ["user", User.last.id.to_s]])` will always return an empty set if there are multiple. `User.where(:id => [["user", User.first.id.to_s]])` works fine. Any policy set with policy count > 1 will return the policy set but nothing else. Certainly no fault of Keenan's. 