### PR TITLE
remove to_miq_a callers

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -328,7 +328,7 @@ class MiqAlert < ApplicationRecord
           end
         end
       elsif k == :snmp
-        notifications[k].to_miq_a.each do |n|
+        Array.wrap(notifications[k]).each do |n|
           description = "#{k.to_s.titleize} Action for Alert: #{self.description}"
           action_type = "snmp_trap"
           actions << MiqAction.new(

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -319,7 +319,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     unless options[:tag_filters].blank?
       tag_filters = options[:tag_filters].collect(&:to_s)
-      selected_tags = (@values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags].to_miq_a).uniq
+      selected_tags = (Array.wrap(@values[:vm_tags]) + Array.wrap(@values[:pre_dialog_vm_tags])).uniq
       tag_conditions = []
 
       # Collect the filter tags by category
@@ -553,7 +553,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
           domains[domain] = domain
         end
       else
-        @values[:forced_sysprep_domain_name].to_miq_a.each { |d| domains[d] = d }
+        Array.wrap(@values[:forced_sysprep_domain_name]).each { |d| domains[d] = d }
       end
       domains
     end
@@ -661,11 +661,11 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     spec      = cs_data[:spec]
     dialog    = @dialogs.fetch_path(:dialogs, :customize)
 
-    first_adapter = spec['nicSettingMap'].to_miq_a.first
+    first_adapter = Array.wrap(spec['nicSettingMap']).first
     if first_adapter.kind_of?(Hash)
       adapter = first_adapter['adapter']
-      spec_hash[:dns_servers]  = adapter['dnsServerList'].to_miq_a.join(', ')
-      spec_hash[:gateway]      = adapter['gateway'].to_miq_a.join(', ')
+      spec_hash[:dns_servers]  = Array.wrap(adapter['dnsServerList']).join(', ')
+      spec_hash[:gateway]      = Array.wrap(adapter['gateway']).join(', ')
       spec_hash[:subnet_mask]  = adapter['subnetMask'].to_s
       spec_hash[:ip_addr]      = adapter.fetch_path('ip', 'ipAddress').to_s
       # Combine the WINS server fields into 1 comma separated field list
@@ -673,8 +673,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
 
     # In Linux, DNS server settings are global, not per adapter
-    spec_hash[:dns_servers]  = spec.fetch_path('globalIPSettings', 'dnsServerList').to_miq_a.join(', ') if spec_hash[:dns_servers].blank?
-    spec_hash[:dns_suffixes] = spec.fetch_path('globalIPSettings', 'dnsSuffixList').to_miq_a.join(', ')
+    spec_hash[:dns_servers]  = Array.wrap(spec.fetch_path('globalIPSettings', 'dnsServerList')).join(', ') if spec_hash[:dns_servers].blank?
+    spec_hash[:dns_suffixes] = Array.wrap(spec.fetch_path('globalIPSettings', 'dnsSuffixList')).join(', ')
 
     spec_hash[:addr_mode] = spec_hash[:ip_addr].blank? ? 'dhcp' : 'static'
 

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -82,7 +82,7 @@ class MiqReport < ApplicationRecord
     q = joins(:miq_report_results).merge(MiqReportResult.for_groups(miq_group_ids)).distinct
 
     if options[:select]
-      cols = options[:select].to_miq_a
+      cols = Array.wrap(options[:select])
       cols = cols.dup.unshift(:id) unless cols.include?(:id)
       cols.each { |c| q = q.select(arel_table[c]) }
     end

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -356,7 +356,7 @@ class MiqReportResult < ApplicationRecord
   end
 
   def self.delete_by_userid(userids)
-    userids = userids.to_miq_a
+    userids = Array.wrap(userids)
     _log.info("Queuing deletion of report results for the following user ids: #{userids.inspect}")
     MiqQueue.submit_job(
       :class_name  => name,

--- a/app/models/miq_request_workflow/dialog_field_validation.rb
+++ b/app/models/miq_request_workflow/dialog_field_validation.rb
@@ -1,11 +1,11 @@
 # These methods are available for dialog field validation, do not erase.
 module MiqRequestWorkflow::DialogFieldValidation
   def validate_tags(field, values, _dlg, fld, _value)
-    selected_tags_categories = values[field].to_miq_a.collect do |tag_id|
+    selected_tags_categories = Array.wrap(values[field]).collect do |tag_id|
       Classification.find_by(:id => tag_id).parent.name.to_sym
     end
 
-    required_tags = fld[:required_tags].to_miq_a.collect(&:to_sym)
+    required_tags = Array.wrap(fld[:required_tags]).collect(&:to_sym)
     missing_tags = required_tags - selected_tags_categories
     missing_categories_names = missing_tags.collect do |category|
       begin

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -356,7 +356,7 @@ class MiqSchedule < ApplicationRecord
 
   def next_interval_time
     unless self.valid? || errors[:run_at].blank?
-      _log.warn("Invalid schedule [#{id}] [#{name}]: #{errors[:run_at].to_miq_a.join(", ")}")
+      _log.warn("Invalid schedule [#{id}] [#{name}]: #{Array.wrap(errors[:run_at]).join(", ")}")
       return nil
     end
 
@@ -421,7 +421,7 @@ class MiqSchedule < ApplicationRecord
 
   def interval
     unless self.valid? || errors[:run_at].blank?
-      _log.warn("Invalid schedule [#{id}] [#{name}]: #{errors[:run_at].to_miq_a.join(", ")}")
+      _log.warn("Invalid schedule [#{id}] [#{name}]: #{Array.wrap(errors[:run_at]).join(", ")}")
       return nil
     end
 

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -137,7 +137,7 @@ module MiqProvisionMixin
              elsif folder.kind_of?(Array) && folder.length == 2 && folder.first.kind_of?(Integer)
                MiqAeMethodService::MiqAeServiceEmsFolder.find(folder.first)
              else
-               find_path = folder.to_miq_a.join('/')
+               find_path = Array.wrap(folder).join('/')
                found = eligible_resources(:folders).detect do |f|
                  folder_path = f.folder_path(:exclude_root_folder => true, :exclude_non_display_folders => true)
                  folder_path.casecmp(find_path).zero?

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -178,7 +178,7 @@ module ScanningMixin
       Array.wrap(scan_profiles).each do |p|
         p["definition"].each do |d|
           if d["item_type"] == "category"
-            d["definition"]["content"].to_miq_a.each { |item| cat_scan_list << item["target"] }
+            Array.wrap(d["definition"]["content"]).each { |item| cat_scan_list << item["target"] }
           else
             cat_scan_list |= ["profiles"]
           end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -105,8 +105,8 @@ class Relationship < ApplicationRecord
   # This prunes a tree already in memory
   # may be faster to prune the tree before creating the tree
   def self.filter_arranged_rels_by_resource_type(relationships, options)
-    of_type = options[:of_type].to_miq_a
-    except_type = options[:except_type].to_miq_a
+    of_type = Array.wrap(options[:of_type])
+    except_type = Array.wrap(options[:except_type])
     return relationships if of_type.empty? && except_type.empty?
 
     relationships.each_with_object({}) do |(rel, children), h|

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -151,7 +151,7 @@ class EvmServer
   def check_migrations_up_to_date
     up_to_date, *message = SchemaMigration.up_to_date?
     level = up_to_date ? :info : :warn
-    message.to_miq_a.each { |msg| _log.send(level, msg) }
+    Array.wrap(message).each { |msg| _log.send(level, msg) }
     up_to_date
   end
 


### PR DESCRIPTION
Fix `.DEPRECATION WARNING: Object#to_miq_a should be replaced by Array.wrap (called from block (2 levels) in scan_profile_categories at /Users/drewmu/manageiq/app/models/mixins/scanning_mixin.rb:181)`

@miq-bot add_label technical debt


see also https://github.com/ManageIQ/manageiq-smartstate/pull/136 