### PR TITLE
fix resource pool not having all_hosts reference

### DIFF
--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -145,7 +145,7 @@ class ResourcePool < ApplicationRecord
   # Overridden from AggregationMixin to provide hosts related to this RP
   def all_hosts
     if p = parent_cluster_or_host
-      p.kind_of?(Host) ? [p] : p.all_hosts
+      p.kind_of?(Host) ? [p] : p.hosts
     else
       []
     end

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -117,4 +117,18 @@ RSpec.describe ResourcePool do
       expect(subject.current_tenant).to eq(Tenant.root_tenant)
     end
   end
+
+  describe "all_hosts" do
+    let(:resource_pool) { FactoryBot.create(:resource_pool) }
+    let(:cluster) { FactoryBot.create(:ems_cluster) }
+    let(:rel) { FactoryBot.create(:relationship, :resource_type => "EmsCluster", :resource_id => cluster.id) }
+
+    it "doesn't call all_hosts on the cluster" do
+      cluster.with_relationship_type("ems_metadata") { cluster.add_child resource_pool }
+
+      expect(cluster).not_to receive(:all_hosts)
+
+      resource_pool.all_hosts
+    end
+  end
 end


### PR DESCRIPTION
Broken in https://github.com/ManageIQ/manageiq/pull/20149 when I removed the `all_*` methods, see https://github.com/ManageIQ/manageiq/pull/20423#issuecomment-672787537 

@miq-bot add_label bug 
