### PR TITLE
Adding IBM "Aix" and "i" operating systems to the list of MIQ supported OSes

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -28,7 +28,9 @@ class OperatingSystem < ApplicationRecord
     ["linux_coreos",    %w(coreos)],
     ["linux_esx",       %w(vmnixx86 vmwareesxserver esxserver vmwareesxi)],
     ["linux_solaris",   %w(solaris)],
-    ["linux_generic",   %w(linux)]
+    ["linux_generic",   %w(linux)],
+    ["ibm_aix",         %w(aix)],
+    ["ibm_i",           %w(ibmi)],
   ]
 
   def self.add_elements(vm, xmlNode)

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -29,7 +29,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_esx",       %w(vmnixx86 vmwareesxserver esxserver vmwareesxi)],
     ["linux_solaris",   %w(solaris)],
     ["linux_generic",   %w(linux)],
-    ["ibm_aix",         %w(aix)],
+    ["unix_aix",        %w(aix)],
     ["ibm_i",           %w(ibmi)]
   ]
 

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -30,7 +30,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_solaris",   %w(solaris)],
     ["linux_generic",   %w(linux)],
     ["ibm_aix",         %w(aix)],
-    ["ibm_i",           %w(ibmi)],
+    ["ibm_i",           %w(ibmi)]
   ]
 
   def self.add_elements(vm, xmlNode)


### PR DESCRIPTION
- added corresponding data to: app/models/operating_system.rb