### PR TITLE
Feature changes to go with Control Explorer split

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1858,41 +1858,41 @@
     :description: Everything under Policies
     :protected: true
     :feature_type: node
-    :identifier: policy
+    :identifier: miq_policy
     :children:
     - :name: View
       :description: View Policies
       :feature_type: view
-      :identifier: policy_view
+      :identifier: miq_policy_view
     - :name: Modify
       :description: Modify Policies
       :feature_type: admin
-      :identifier: policy_admin
+      :identifier: miq_policy_admin
       :children:
       - :name: Add
         :description: Add a Policy
         :feature_type: admin
-        :identifier: policy_new
+        :identifier: miq_policy_new
       - :name: Copy
         :description: Copy a Policy
         :feature_type: admin
-        :identifier: policy_copy
+        :identifier: miq_policy_copy
       - :name: Edit
         :description: Edit a Policy
         :feature_type: admin
-        :identifier: policy_edit
+        :identifier: miq_policy_edit
       - :name: Edit Condition Assignment
         :description: Edit Policy's Condition assignments
         :feature_type: admin
-        :identifier: policy_edit_conditions
+        :identifier: miq_policy_edit_conditions
       - :name: Edit Event Assignment
         :description: Edit Policy's Event assignments
         :feature_type: admin
-        :identifier: policy_edit_events
+        :identifier: miq_policy_edit_events
       - :name: Delete
         :description: Delete a Policy
         :feature_type: admin
-        :identifier: policy_delete
+        :identifier: miq_policy_delete
   - :name: Conditions
     :description: Everything under Conditions
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1978,29 +1978,29 @@
     :description: Everything under Policy Alert Profiles
     :protected: true
     :feature_type: node
-    :identifier: alert_profile
+    :identifier: miq_alert_set
     :children:
     - :name: Modify
       :description: Modify Policy Alert Profiles
       :feature_type: admin
-      :identifier: alert_profile_admin
+      :identifier: miq_alert_set_admin
       :children:
       - :name: Add
         :description: Add a Policy Alert Profile
         :feature_type: admin
-        :identifier: alert_profile_new
+        :identifier: miq_alert_set_new
       - :name: Edit
         :description: Edit a Policy Alert Profile
         :feature_type: admin
-        :identifier: alert_profile_edit
+        :identifier: miq_alert_set_edit
       - :name: Edit assignments
         :description: Edit assignments
         :feature_type: admin
-        :identifier: alert_profile_assign
+        :identifier: miq_alert_set_assign
       - :name: Delete
         :description: Delete a Policy Alert Profile
         :feature_type: admin
-        :identifier: alert_profile_delete
+        :identifier: miq_alert_set_delete
   - :name: Alerts
     :description: Everything under Policy Alerts
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1854,10 +1854,6 @@
         :description: Edit a Policy Profile
         :feature_type: admin
         :identifier: miq_policy_set_edit
-      - :name: Edit Policies Assignment
-        :description: Edit Policy Profile's policies assignments
-        :feature_type: admin
-        :identifier: miq_policy_set_assign
   - :name: Policies
     :description: Everything under Policies
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1932,17 +1932,17 @@
     :description: Everything under Policy Events
     :protected: true
     :feature_type: node
-    :identifier: event
+    :identifier: miq_event
     :children:
     - :name: Modify
-      :description: Modify Conditions
+      :description: Modify Events
       :feature_type: admin
-      :identifier: event_admin
+      :identifier: miq_event_admin
       :children:
       - :name: Edit
         :description: Edit Event
         :feature_type: admin
-        :identifier: event_edit
+        :identifier: miq_event_edit
   - :name: Actions
     :description: Everything under Policy Actions
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2005,29 +2005,29 @@
     :description: Everything under Policy Alerts
     :protected: true
     :feature_type: node
-    :identifier: alert
+    :identifier: miq_alert
     :children:
     - :name: Modify
       :description: Modify Policy Alerts
       :feature_type: admin
-      :identifier: alert_admin
+      :identifier: miq_alert_admin
       :children:
       - :name: Add
         :description: Add a Policy Alert
         :feature_type: admin
-        :identifier: alert_new
+        :identifier: miq_alert_new
       - :name: Copy
         :description: Copy a Policy Alert
         :feature_type: admin
-        :identifier: alert_copy
+        :identifier: miq_alert_copy
       - :name: Edit
         :description: Edit a Policy Alert
         :feature_type: admin
-        :identifier: alert_edit
+        :identifier: miq_alert_edit
       - :name: Delete
         :description: Delete a Policy Alert
         :feature_type: admin
-        :identifier: alert_delete
+        :identifier: miq_alert_delete
   - :name: Alerts Statuses
     :description: Everything under Alerts Statuses
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1822,58 +1822,46 @@
   :identifier: rss
 
 # Policy
-- :name: Explorer
-  :description: Control Explorer
+- :name: Control
+  :description: Control
   :feature_type: node
-  :identifier: control_explorer
+  :identifier: control
   :children:
-  - :name: View All Records
-    :description: View all Records in Control Explorer
-    :feature_type: view
-    :hidden: true
-    :identifier: control_explorer_view
   - :name: Policy Profiles
-    :description: Everything under Policy Profiles Accordion
+    :description: Everything under Policy Profiles
     :protected: true
     :feature_type: node
-    :hidden: true
-    :identifier: policy_profile
+    :identifier: miq_policy_set
     :children:
     - :name: View
       :description: View Policy Profiles
       :feature_type: view
-      :identifier: policy_profile_view
+      :identifier: miq_policy_set_view
     - :name: Modify
       :description: Modify Policy Profiles
       :feature_type: admin
-      :hidden: true
-      :identifier: policy_profile_admin
+      :identifier: miq_policy_set_admin
       :children:
       - :name: Add
         :description: Add a Policy Profile
         :feature_type: admin
-        :hidden: true
-        :identifier: profile_new
+        :identifier: miq_policy_set_new
       - :name: Delete
         :description: Delete a Policy Profile
         :feature_type: admin
-        :hidden: true
-        :identifier: profile_delete
+        :identifier: miq_policy_set_delete
       - :name: Edit
         :description: Edit a Policy Profile
         :feature_type: admin
-        :hidden: true
-        :identifier: profile_edit
+        :identifier: miq_policy_set_edit
       - :name: Edit Policies Assignment
         :description: Edit Policy Profile's policies assignments
         :feature_type: admin
-        :hidden: true
-        :identifier: policy_profile_assign
+        :identifier: miq_policy_set_assign
   - :name: Policies
-    :description: Everything under Policies Accordion
+    :description: Everything under Policies
     :protected: true
     :feature_type: node
-    :hidden: true
     :identifier: policy
     :children:
     - :name: View
@@ -1883,111 +1871,91 @@
     - :name: Modify
       :description: Modify Policies
       :feature_type: admin
-      :hidden: true
       :identifier: policy_admin
       :children:
       - :name: Add
         :description: Add a Policy
         :feature_type: admin
-        :hidden: true
         :identifier: policy_new
       - :name: Copy
         :description: Copy a Policy
         :feature_type: admin
-        :hidden: true
         :identifier: policy_copy
       - :name: Edit
         :description: Edit a Policy
         :feature_type: admin
-        :hidden: true
         :identifier: policy_edit
       - :name: Edit Condition Assignment
         :description: Edit Policy's Condition assignments
         :feature_type: admin
-        :hidden: true
         :identifier: policy_edit_conditions
       - :name: Edit Event Assignment
         :description: Edit Policy's Event assignments
         :feature_type: admin
-        :hidden: true
         :identifier: policy_edit_events
       - :name: Delete
         :description: Delete a Policy
         :feature_type: admin
-        :hidden: true
         :identifier: policy_delete
   - :name: Conditions
-    :description: Everything under Conditions Accordion
+    :description: Everything under Conditions
     :protected: true
     :feature_type: node
-    :hidden: true
     :identifier: condition
     :children:
     - :name: Modify
       :description: Modify Conditions
       :feature_type: admin
-      :hidden: true
       :identifier: condition_admin
       :children:
       - :name: Add
         :description: Add a Condition
         :feature_type: admin
-        :hidden: true
         :identifier: condition_new
       - :name: Copy
         :description: Copy a Condition
         :feature_type: admin
-        :hidden: true
         :identifier: condition_copy
       - :name: Copy Condition to specified Policy
         :description: Copy Condition to a new Condition assigned to specified Policy
         :feature_type: admin
-        :hidden: true
         :identifier: condition_policy_copy
       - :name: Edit
         :description: Edit a Condition
         :feature_type: admin
-        :hidden: true
         :identifier: condition_edit
       - :name: Delete
         :description: Delete a Condition
         :feature_type: admin
-        :hidden: true
         :identifier: condition_delete
       - :name: Remove from Policy
         :description: Remove Condition from specified Policy
         :feature_type: admin
-        :hidden: true
         :identifier: condition_remove
   - :name: Events
-    :description: Everything under Policy Events Accordion
+    :description: Everything under Policy Events
     :protected: true
     :feature_type: node
-    :hidden: true
     :identifier: event
     :children:
     - :name: Modify
       :description: Modify Conditions
       :feature_type: admin
-      :hidden: true
       :identifier: event_admin
       :children:
       - :name: Edit
         :description: Edit Event
         :feature_type: admin
-        :hidden: true
         :identifier: event_edit
   - :name: Actions
-    :description: Everything under Policy Actions Accordion
+    :description: Everything under Policy Actions
     :protected: true
     :feature_type: node
-    :hidden: true
     :identifier: action
     :children:
     - :name: Modify
       :description: Modify Policy Actions
       :feature_type: admin
-      :hidden: true
       :identifier: action_admin
       :children:
       - :name: List
@@ -2001,83 +1969,68 @@
       - :name: Add
         :description: Add a Policy Action
         :feature_type: admin
-        :hidden: true
         :identifier: action_new
       - :name: Edit
         :description: Edit a Policy Action
         :feature_type: admin
-        :hidden: true
         :identifier: action_edit
       - :name: Delete
         :description: Delete a Policy Action
         :feature_type: admin
-        :hidden: true
         :identifier: action_delete
   - :name: Alert Profiles
-    :description: Everything under Policy Alert Profiles Accordion
+    :description: Everything under Policy Alert Profiles
     :protected: true
     :feature_type: node
-    :hidden: true
     :identifier: alert_profile
     :children:
     - :name: Modify
       :description: Modify Policy Alert Profiles
       :feature_type: admin
-      :hidden: true
       :identifier: alert_profile_admin
       :children:
       - :name: Add
         :description: Add a Policy Alert Profile
         :feature_type: admin
-        :hidden: true
         :identifier: alert_profile_new
       - :name: Edit
         :description: Edit a Policy Alert Profile
         :feature_type: admin
-        :hidden: true
         :identifier: alert_profile_edit
       - :name: Edit assignments
         :description: Edit assignments
         :feature_type: admin
-        :hidden: true
         :identifier: alert_profile_assign
       - :name: Delete
         :description: Delete a Policy Alert Profile
         :feature_type: admin
-        :hidden: true
         :identifier: alert_profile_delete
   - :name: Alerts
-    :description: Everything under Policy Alerts Accordion
+    :description: Everything under Policy Alerts
     :protected: true
     :feature_type: node
-    :hidden: true
     :identifier: alert
     :children:
     - :name: Modify
       :description: Modify Policy Alerts
       :feature_type: admin
-      :hidden: true
       :identifier: alert_admin
       :children:
       - :name: Add
         :description: Add a Policy Alert
         :feature_type: admin
-        :hidden: true
         :identifier: alert_new
       - :name: Copy
         :description: Copy a Policy Alert
         :feature_type: admin
-        :hidden: true
         :identifier: alert_copy
       - :name: Edit
         :description: Edit a Policy Alert
         :feature_type: admin
-        :hidden: true
         :identifier: alert_edit
       - :name: Delete
         :description: Delete a Policy Alert
         :feature_type: admin
-        :hidden: true
         :identifier: alert_delete
   - :name: Alerts Statuses
     :description: Everything under Alerts Statuses

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1884,11 +1884,15 @@
       - :name: Edit Condition Assignment
         :description: Edit Policy's Condition assignments
         :feature_type: admin
-        :identifier: miq_policy_edit_conditions
+        :identifier: miq_policy_conditions_assignment
       - :name: Edit Event Assignment
         :description: Edit Policy's Event assignments
         :feature_type: admin
-        :identifier: miq_policy_edit_events
+        :identifier: miq_policy_events_assignment
+      - :name: Edit Actions for Policy Event
+        :description: Edit Actions for Policy Event
+        :feature_type: admin
+        :identifier: miq_policy_event_edit
       - :name: Delete
         :description: Delete a Policy
         :feature_type: admin
@@ -1933,16 +1937,6 @@
     :protected: true
     :feature_type: node
     :identifier: miq_event
-    :children:
-    - :name: Modify
-      :description: Modify Events
-      :feature_type: admin
-      :identifier: miq_event_admin
-      :children:
-      - :name: Edit
-        :description: Edit Event
-        :feature_type: admin
-        :identifier: miq_event_edit
   - :name: Actions
     :description: Everything under Policy Actions
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1947,33 +1947,33 @@
     :description: Everything under Policy Actions
     :protected: true
     :feature_type: node
-    :identifier: action
+    :identifier: miq_action
     :children:
     - :name: Modify
       :description: Modify Policy Actions
       :feature_type: admin
-      :identifier: action_admin
+      :identifier: miq_action_admin
       :children:
       - :name: List
         :description: Display All Policy Actions
         :feature_type: view
-        :identifier: action_show_list
+        :identifier: miq_action_show_list
       - :name: Show
         :description: Show MiqAction
         :feature_type: view
-        :identifier: action_show
+        :identifier: miq_action_show
       - :name: Add
         :description: Add a Policy Action
         :feature_type: admin
-        :identifier: action_new
+        :identifier: miq_action_new
       - :name: Edit
         :description: Edit a Policy Action
         :feature_type: admin
-        :identifier: action_edit
+        :identifier: miq_action_edit
       - :name: Delete
         :description: Delete a Policy Action
         :feature_type: admin
-        :identifier: action_delete
+        :identifier: miq_action_delete
   - :name: Alert Profiles
     :description: Everything under Policy Alert Profiles
     :protected: true

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -404,10 +404,40 @@
   :url: /cloud_object_store_object/show_list
   :rbac_feature_name: cloud_object_store_object_show_list
   :startup: true
-- :name: control_explorer
-  :description: Control / Explorer
+- :name: miq_policy_set
+  :description: Control / Policy Profiles
+  :url: /miq_policy_set/explorer
+  :rbac_feature_name: miq_policy_set
+  :startup: true
+- :name: miq_policy
+  :description: Control / Policies
   :url: /miq_policy/explorer
-  :rbac_feature_name: control_explorer_view
+  :rbac_feature_name: miq_policy
+  :startup: true
+- :name: miq_event
+  :description: Control / Events
+  :url: /miq_event/explorer
+  :rbac_feature_name: miq_event
+  :startup: true
+- :name: consdition
+  :description: Control / Conditions
+  :url: /condition/explorer
+  :rbac_feature_name: condition
+  :startup: true
+- :name: miq_action
+  :description: Control / Actions
+  :url: /miq_action/explorer
+  :rbac_feature_name: miq_action
+  :startup: true
+- :name: miq_alert_set
+  :description: Control / Alert Profiles
+  :url: /miq_alert_set/explorer
+  :rbac_feature_name: miq_alert_set
+  :startup: true
+- :name: miq_alert
+  :description: Control / Alerts
+  :url: /miq_alert/explorer
+  :rbac_feature_name: miq_alert
   :startup: true
 - :name: policy_simulation
   :description: Control / Simulation

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -22,7 +22,7 @@
   - cloud_network
   - cloud_object_store_container
   - cloud_object_store_object
-  - control_explorer
+  - control
   - dashboard
   - storage
   - storage_pod
@@ -102,7 +102,7 @@
   - chargeback_reports
   - customization_template_view
   - iso_datastore_view
-  - control_explorer
+  - control
   - dashboard
   - ems_cluster_show
   - ems_cluster_show_list
@@ -196,7 +196,7 @@
   - chargeback_reports
   - customization_template_view
   - iso_datastore_view
-  - control_explorer
+  - control
   - dashboard
   - ems_cluster_view
   - ems_cluster_tag
@@ -490,7 +490,7 @@
   - all_vm_rules
   - chargeback
   - chargeback_reports
-  - control_explorer
+  - control
   - dashboard
   - ems_cluster_show
   - ems_cluster_show_list
@@ -575,7 +575,7 @@
   - all_vm_rules
   - chargeback
   - chargeback_reports
-  - control_explorer
+  - control
   - dashboard
   - ems_cluster_show
   - ems_cluster_show_list
@@ -1031,7 +1031,7 @@
   - ems_configuration
   - configuration_profile
   - configured_system
-  - control_explorer
+  - control
   - dashboard
   - storage
   - ems_cloud
@@ -1092,7 +1092,7 @@
   - ems_configuration
   - configuration_profile
   - configured_system
-  - control_explorer
+  - control
   - dashboard
   - storage
   - ems_cloud
@@ -1151,7 +1151,7 @@
   - consumption
   - chargeback
   - pictures
-  - control_explorer
+  - control
   - generic_object
   - generic_object_definition
   - my_settings

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -205,10 +205,10 @@ RSpec.describe MiqUserRole do
     #   - profile_new (H)
     it "allows hidden child of hidden parent" do
       EvmSpecHelper.seed_specific_product_features(
-        %w(policy_profile_admin profile_new container_dashboard)
+        %w(miq_ae_class_explorer miq_ae_namespace_new container_dashboard)
       )
       user = FactoryBot.create(:user, :features => "container_dashboard")
-      expect(user.role_allows?(:identifier => "profile_new")).to be_truthy
+      expect(user.role_allows?(:identifier => "miq_ae_namespace_new")).to be_truthy
     end
   end
 


### PR DESCRIPTION
Removed hidden attribute from several features under Control Explorer. Renamed feature id's under Policy Profile section to go with UI [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7259). In future commits, will be renaming other sections under control as i continue to split them into their own explorers.

https://github.com/ManageIQ/manageiq-ui-classic/issues/6996
https://github.com/ManageIQ/manageiq-ui-classic/issues/6819

![Screenshot from 2020-08-12 10-34-15](https://user-images.githubusercontent.com/3450808/90028215-6320a180-dc87-11ea-84fa-c97bd2769184.png)
