### PR TITLE
Fix for vmware content-library missing ems_id

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -268,6 +268,10 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def orchestration_templates
+          add_common_default_values
+        end
+
         def root_folder_relationship
           skip_auto_inventory_attributes
           skip_model_class


### PR DESCRIPTION
Content Library templates on VMware should have an ems_id and ems_ref

cc @lfu 