### PR TITLE
Don't allow kafka exceptions to cause EmsEvent.add_queue to fail

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -274,6 +274,9 @@ class EmsEvent < EventStream
       :event   => event[:event_type],
       :payload => event
     )
+  rescue => err
+    _log.warn("Failed to publish event [#{ems_id}] [#{event[:event_type]}]: #{err}")
+    _log.log_backtrace(err)
   end
 
   private_class_method :publish_event


### PR DESCRIPTION
If there are issues publishing events to kafka we shouldn't allow them to cause the main MiqQueue EmsEvent.add to fail

cc @abellotti 

https://github.com/ManageIQ/manageiq-pods/issues/607