### PR TITLE
Don't disconnect resource pools in refresh_new_target

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -247,12 +247,12 @@ module EmsRefresh::SaveInventoryInfra
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
 
   def save_resource_pools_inventory(ems, hashes, target = nil, disconnect = true)
-    target = ems if target.nil? && disconnect
+    target = ems if target.nil?
 
     ems.resource_pools.reset
-    deletes = if (target == ems)
+    deletes = if disconnect && target == ems
                 :use_association
-              elsif target.kind_of?(Host)
+              elsif disconnect && target.kind_of?(Host)
                 target.all_resource_pools_with_default
               else
                 []


### PR DESCRIPTION
When saving a new VM using the legacy refresh_new_target we rely on not deleting records that aren't related to the new target for this to work.

The save_resource_pools_inventory method was incorrectly assuming that not setting `target = ems` and then later checking `target == ems` (aka a full refresh) to see what it should delete, but in the case of refresh_new_target the target is already the ems so every resource pool except the one the VM was on was being deleted.

`refresh_new_target` is destined to go away (https://github.com/ManageIQ/manageiq/issues/19999) but this fixes it in the short term.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1846273