### PR TITLE
address discrepancies between array wrap and miq to_a

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -319,7 +319,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     unless options[:tag_filters].blank?
       tag_filters = options[:tag_filters].collect(&:to_s)
-      selected_tags = (Array.wrap(@values[:vm_tags]) + Array.wrap(@values[:pre_dialog_vm_tags])).uniq
+      selected_tags = (Array.wrap(@values[:vm_tags].presence) + Array.wrap(@values[:pre_dialog_vm_tags].presence)).uniq
       tag_conditions = []
 
       # Collect the filter tags by category
@@ -553,7 +553,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
           domains[domain] = domain
         end
       else
-        Array.wrap(@values[:forced_sysprep_domain_name]).each { |d| domains[d] = d }
+        Array.wrap(@values[:forced_sysprep_domain_name].split('\n')).each { |d| domains[d] = d }
       end
       domains
     end

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -356,7 +356,7 @@ class MiqReportResult < ApplicationRecord
   end
 
   def self.delete_by_userid(userids)
-    userids = Array.wrap(userids)
+    userids = Array.wrap(userids.presence)
     _log.info("Queuing deletion of report results for the following user ids: #{userids.inspect}")
     MiqQueue.submit_job(
       :class_name  => name,

--- a/app/models/miq_request_workflow/dialog_field_validation.rb
+++ b/app/models/miq_request_workflow/dialog_field_validation.rb
@@ -1,11 +1,11 @@
 # These methods are available for dialog field validation, do not erase.
 module MiqRequestWorkflow::DialogFieldValidation
   def validate_tags(field, values, _dlg, fld, _value)
-    selected_tags_categories = Array.wrap(values[field]).collect do |tag_id|
+    selected_tags_categories = Array.wrap(values[field].split('\n')).collect do |tag_id|
       Classification.find_by(:id => tag_id).parent.name.to_sym
     end
 
-    required_tags = Array.wrap(fld[:required_tags]).collect(&:to_sym)
+    required_tags = Array.wrap(fld[:required_tags].presence).collect(&:to_sym)
     missing_tags = required_tags - selected_tags_categories
     missing_categories_names = missing_tags.collect do |category|
       begin

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -137,7 +137,7 @@ module MiqProvisionMixin
              elsif folder.kind_of?(Array) && folder.length == 2 && folder.first.kind_of?(Integer)
                MiqAeMethodService::MiqAeServiceEmsFolder.find(folder.first)
              else
-               find_path = Array.wrap(folder).join('/')
+               find_path = Array.wrap(folder.presence).join('/')
                found = eligible_resources(:folders).detect do |f|
                  folder_path = f.folder_path(:exclude_root_folder => true, :exclude_non_display_folders => true)
                  folder_path.casecmp(find_path).zero?

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -104,8 +104,8 @@ class Relationship < ApplicationRecord
   # This prunes a tree already in memory
   # may be faster to prune the tree before creating the tree
   def self.filter_arranged_rels_by_resource_type(relationships, options)
-    of_type = Array.wrap(options[:of_type])
-    except_type = Array.wrap(options[:except_type])
+    of_type = Array.wrap(options[:of_type].presence)
+    except_type = Array.wrap(options[:except_type].presence)
     return relationships if of_type.empty? && except_type.empty?
 
     relationships.each_with_object({}) do |(rel, children), h|

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -150,7 +150,7 @@ class EvmServer
   def check_migrations_up_to_date
     up_to_date, *message = SchemaMigration.up_to_date?
     level = up_to_date ? :info : :warn
-    Array.wrap(message).each { |msg| _log.send(level, msg) }
+    Array.wrap(message.presence).each { |msg| _log.send(level, msg) }
     up_to_date
   end
 


### PR DESCRIPTION
my to_miq_a removal introduced bugs where the string case doesn't handle nils or split in the same fashion as array wrap. 


keenan caught it in https://github.com/ManageIQ/manageiq/pull/20433#issuecomment-673162823

@miq-bot add_label bug
@miq-bot assign @kbrock 