### PR TITLE
Add ability to detect and cleanup failed deployments

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -2,6 +2,7 @@ module MiqServer::WorkerManagement::Monitor
   extend ActiveSupport::Concern
 
   include_concern 'Kill'
+  include_concern 'Kubernetes'
   include_concern 'Quiesce'
   include_concern 'Reason'
   include_concern 'Settings'
@@ -68,6 +69,7 @@ module MiqServer::WorkerManagement::Monitor
     clean_worker_records
 
     if podified?
+      cleanup_failed_deployments
     elsif systemd?
       cleanup_failed_systemd_services
     end

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -97,11 +97,8 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
     ch[:container_restarts]    = pod.status.containerStatuses.inject(0) { |sum, cs| sum += cs.restartCount if cs.lastState.terminated; sum }
 
     name = pod.metadata.name
-    if current_pods[name]
-      current_pods[name].merge!(ch)
-    else
-      current_pods[name] = ch
-    end
+    current_pods[name] ||= ch
+    current_pods[name].merge!(ch)
   end
 
   def delete_pod(pod)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -35,8 +35,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def delete_failed_deployments
-    # TODO: We should have a list of worker deployments we'll delete to avoid accidentally killing pg/memcached/orchestrator
-    # See ContainerOrchestrator#get_pods
     failed_deployments.each do |failed|
       orchestrator.delete_deployment(failed)
     end
@@ -51,7 +49,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
       current_pods.clear
       resource_version = collect_initial_pods
 
-      # watch_for_pod_events doesn't return unless an error caused us to break out of it, so we'll reset and start over again
+      # watch_for_pod_events doesn't return unless an error caused us to break out of it, so we'll start over again
       watch_for_pod_events(resource_version)
     end
   end
@@ -70,7 +68,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
       when "deleted"
         delete_pod(event.object)
       when "error"
-        if status = event.object
+        if (status = event.object)
           # ocp 3 appears to return 'ERROR' watch events with the object containing the 410 code and "Gone" reason like below:
           # #<Kubeclient::Resource type="ERROR", object={:kind=>"Status", :apiVersion=>"v1", :metadata=>{}, :status=>"Failure", :message=>"too old resource version: 199900 (27177196)", :reason=>"Gone", :code=>410}>
           log_pod_error_event(status.code, status.message, status.reason)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -65,7 +65,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def watch_for_pod_events
-    watcher = orchestrator.watch_pods(pod_resource_version) do |event|
+    orchestrator.watch_pods(pod_resource_version) do |event|
       case event.type.downcase
       when "added", "modified"
         save_pod(event.object)
@@ -82,8 +82,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
         break
       end
     end
-  ensure
-    watcher.finish if watcher
   end
 
   def log_pod_error_event(code, message, reason)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -65,7 +65,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def watch_for_pod_events
-    orchestrator.watch_pods(pod_resource_version) do |event|
+    orchestrator.watch_pods(pod_resource_version).each do |event|
       case event.type.downcase
       when "added", "modified"
         save_pod(event.object)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -1,0 +1,76 @@
+module MiqServer::WorkerManagement::Monitor::Kubernetes
+  extend ActiveSupport::Concern
+  attr_accessor :pod_resource_version
+
+  def current_pods
+    # TODO: Add mutex around access
+    @current_pods ||= begin
+      # The first call to current_pods will return an empty hash since the newly created collector thread hasn't collected anything yet.
+      collector_thread
+      {}
+    end
+  end
+
+  def cleanup_failed_deployments
+    # TODO: We should have a list of worker deployments we'll delete to avoid accidentally killing pg/memcached/orchestrator
+    # See ContainerOrchestrator#get_pods
+    failed_deployments.each do |failed|
+      orchestrator.delete_deployment(failed)
+    end
+  end
+
+  def failed_deployments(restart_count = 5)
+    # TODO: This logic might flag deployments that are hitting memory/cpu limits or otherwise not really 'failed'
+    current_pods.select { |name, h| h.fetch(:last_state_terminated) && h.fetch(:container_restarts, 0) > restart_count }.collect { |name, h| h[:label_name] }
+  end
+
+  private
+  def collector_thread
+    # TODO: Ensure thread exceptions kill the thread and a new thread is created
+    @collector_thread ||= Thread.new { pod_collector }
+  end
+
+  def orchestrator
+    @orchestrator ||= ContainerOrchestrator.new
+  end
+
+  def pod_collector
+    # TODO: To ensure we're in sync, we might want to break out of the watch, reset the current_pods and run this again
+    collect_initial_pods
+    watch_for_pod_events
+  end
+
+  def collect_initial_pods
+    pods = orchestrator.get_pods
+    pods.each { |p| save_pod(p) }
+    self.pod_resource_version = pods.resourceVersion || 0
+  end
+
+  def watch_for_pod_events
+    orchestrator.watch_pods(self.pod_resource_version) do |event|
+      case event.type.downcase
+      when "added", "modified"
+        save_pod(event.object)
+      when "deleted"
+        delete_pod(event.object)
+      when "error"
+        # TODO
+      end
+    end
+  end
+
+  def save_pod(pod)
+    # TODO: consider a more nuanced data structure if we're going to start using current_pods from sync_workers
+    name = pod.metadata.name
+    current_pods[name] ||= {}
+    current_pods[name][:label_name]            = pod.metadata.labels.name
+    current_pods[name][:last_state_running]    = pod.status.containerStatuses.all? { |cs| !!cs.state.running }
+    current_pods[name][:started_at]            = pod.status.containerStatuses.collect {|cs| cs.state.running && cs.state.running.startedAt }.compact
+    current_pods[name][:last_state_terminated] = pod.status.containerStatuses.any? { |cs| !!cs.lastState.terminated }
+    current_pods[name][:container_restarts]    = pod.status.containerStatuses.inject(0) { |sum, cs| sum += cs.restartCount if cs.lastState.terminated; sum }
+  end
+
+  def delete_pod(pod)
+    current_pods.delete(pod.metadata.name)
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -21,9 +21,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   private
 
   def start_pod_monitor
-    @monitor_thread ||= begin
-      Thread.new { monitor_pods }
-    end
+    @monitor_thread ||= Thread.new { monitor_pods }
   end
 
   def ensure_pod_monitor_started

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -3,8 +3,12 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   attr_accessor :pod_resource_version
 
   def current_pods
-    # TODO: Add mutex around access
-    @current_pods ||= {}
+    @current_pods ||= Concurrent::Hash.new
+  end
+
+  def reset_current_pods
+    @current_pods = nil
+    current_pods
   end
 
   def cleanup_failed_deployments
@@ -25,7 +29,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   private
   def start_pod_monitor
     @monitor_thread ||= begin
-      @current_pods = {}
+      reset_current_pods
       Thread.new { monitor_pods }
     end
   end

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -93,8 +93,8 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
 
     ch = Concurrent::Hash.new
     ch[:label_name]            = pod.metadata.labels.name
-    ch[:last_state_terminated] = pod.status.containerStatuses.any? { |cs| !!cs.lastState.terminated }
-    ch[:container_restarts]    = pod.status.containerStatuses.inject(0) { |sum, cs| sum += cs.restartCount if cs.lastState.terminated; sum }
+    ch[:last_state_terminated] = pod.status.containerStatuses.any? { |cs| cs.lastState.terminated }
+    ch[:container_restarts]    = pod.status.containerStatuses.sum { |cs| cs.restartCount.to_i }
 
     name = pod.metadata.name
     current_pods[name] ||= ch

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -6,7 +6,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
     # TODO: Add mutex around access
     @current_pods ||= begin
       # The first call to current_pods will return an empty hash since the newly created collector thread hasn't collected anything yet.
-      collector_thread
+      start_pod_monitor
       {}
     end
   end
@@ -25,16 +25,16 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   private
-  def collector_thread
+  def start_pod_monitor
     # TODO: Ensure thread exceptions kill the thread and a new thread is created
-    @collector_thread ||= Thread.new { pod_collector }
+    @start_pod_monitor ||= Thread.new { monitor_pods }
   end
 
   def orchestrator
     @orchestrator ||= ContainerOrchestrator.new
   end
 
-  def pod_collector
+  def monitor_pods
     # TODO: To ensure we're in sync, we might want to break out of the watch, reset the current_pods and run this again
     collect_initial_pods
     watch_for_pod_events

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -1,11 +1,10 @@
 module MiqServer::WorkerManagement::Monitor::Kubernetes
   extend ActiveSupport::Concern
   attr_accessor :pod_resource_version
-  attr_reader :current_pods
 
-  def initialize(*args)
-    @current_pods = Concurrent::Hash.new
-    super
+  included do
+    cattr_accessor :current_pods
+    self.current_pods = Concurrent::Hash.new
   end
 
   def cleanup_failed_deployments

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -1,13 +1,11 @@
 module MiqServer::WorkerManagement::Monitor::Kubernetes
   extend ActiveSupport::Concern
   attr_accessor :pod_resource_version
+  attr_reader :current_pods
 
-  def current_pods
-    @current_pods ||= Concurrent::Hash.new
-  end
-
-  def reset_current_pods
-    current_pods.clear
+  def initialize(*args)
+    @current_pods = Concurrent::Hash.new
+    super
   end
 
   def cleanup_failed_deployments
@@ -54,7 +52,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
 
   def monitor_pods
     loop do
-      reset_current_pods
+      current_pods.clear
       collect_initial_pods
 
       # watch_for_pod_events doesn't return unless an error caused us to break out of it, so we'll reset and start over again

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -64,7 +64,7 @@ class ContainerOrchestrator
     kube_connection.get_pods(pod_options)
   end
 
-  def watch_pods(resource_version)
+  def watch_pods(resource_version = 0)
     watcher = kube_connection.watch_pods(pod_options.merge(:resource_version => resource_version))
     watcher.each { |notice| yield notice }
   end

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -59,8 +59,6 @@ class ContainerOrchestrator
   end
 
   def get_pods
-    # TODO: we should set a label for workers we want to monitor so we don't accidentally kill memcached/postgresql pod
-    # :label_selector => "app=manageiq,worker=true"
     kube_connection.get_pods(pod_options)
   end
 
@@ -71,7 +69,7 @@ class ContainerOrchestrator
 
   private
   def pod_options
-    @pod_options ||= {:namespace => my_namespace, :label_selector => "app=#{app_name}"}
+    {:namespace => my_namespace, :label_selector => [app_name_selector, orchestrated_by_selector].join(",")}
   end
 
   def kube_connection

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -63,8 +63,7 @@ class ContainerOrchestrator
   end
 
   def watch_pods(resource_version = nil)
-    watcher = kube_connection.watch_pods(pod_options.merge(:resource_version => resource_version))
-    watcher.each { |notice| yield notice }
+    kube_connection.watch_pods(pod_options.merge(:resource_version => resource_version))
   end
 
   private

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -64,7 +64,7 @@ class ContainerOrchestrator
     kube_connection.get_pods(pod_options)
   end
 
-  def watch_pods(resource_version = 0)
+  def watch_pods(resource_version = nil)
     watcher = kube_connection.watch_pods(pod_options.merge(:resource_version => resource_version))
     watcher.each { |notice| yield notice }
   end

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe ContainerOrchestrator do
       end
 
       it "defaults resource_version" do
-        expect(kube_connection_stub).to receive(:watch_pods).with(hash_including(:resource_version => 0)).and_return([])
+        expect(kube_connection_stub).to receive(:watch_pods).with(hash_including(:resource_version => nil)).and_return([])
         subject.watch_pods
       end
 

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -187,5 +187,34 @@ RSpec.describe ContainerOrchestrator do
         subject.delete_deployment("deploy_name")
       end
     end
+
+    describe "#get_pods" do
+      it "sets namespace and label_selector" do
+        expect(subject).to receive(:app_name).and_return("manageiq")
+        expect(kube_connection_stub).to receive(:get_pods).with(hash_including(:namespace => namespace, :label_selector => "app=manageiq"))
+        subject.get_pods
+      end
+    end
+
+    describe "#watch_pods" do
+      before do
+        expect(subject).to receive(:app_name).and_return("manageiq")
+      end
+
+      it "sets namespace and label_selector" do
+        expect(kube_connection_stub).to receive(:watch_pods).with(hash_including(:namespace => namespace, :label_selector => "app=manageiq")).and_return([])
+        subject.watch_pods
+      end
+
+      it "defaults resource_version" do
+        expect(kube_connection_stub).to receive(:watch_pods).with(hash_including(:resource_version => 0)).and_return([])
+        subject.watch_pods
+      end
+
+      it "accepts provided resource_version" do
+        expect(kube_connection_stub).to receive(:watch_pods).with(hash_including(:resource_version => 100)).and_return([])
+        subject.watch_pods(100)
+      end
+    end
   end
 end

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -151,13 +151,6 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
       double(:object => event_object)
     end
 
-    it "ensures watcher.finish" do
-      watcher = double
-      allow(orchestrator).to receive(:watch_pods).and_return(watcher)
-      expect(watcher).to receive(:finish)
-      server.send(:watch_for_pod_events)
-    end
-
     context "processes event" do
       before do
         allow(orchestrator).to receive(:watch_pods).and_yield(watch_event)

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
 
     context "processes event" do
       before do
-        allow(orchestrator).to receive(:watch_pods).and_yield(watch_event)
+        allow(orchestrator).to receive(:watch_pods).and_return([watch_event])
       end
 
       it "ADDED calls save_pod with event object" do

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
     let(:pods) do
       metadata = double(:name => deployment_name, :labels => double(:name => pod_label))
       state = double(:running => double(:startedAt => started_at))
-      lastState = double(:terminated => nil)
-      status = double(:containerStatuses => [double(:state => state, :lastState => lastState, :restartCount => 0)])
+      last_state = double(:terminated => nil)
+      status = double(:containerStatuses => [double(:state => state, :lastState => last_state, :restartCount => 0)])
       pods = [double(:metadata => metadata, :status => status)]
       allow(pods).to receive(:resourceVersion).and_return(resource_version)
       pods

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
     server.current_pods.clear
   end
 
+  it "#current_pods initialized" do
+    expect(server.current_pods).to_not be_nil
+  end
+
+  it ".current_pods initialized" do
+    expect(server.class.current_pods).to_not be_nil
+  end
+
+  it ".current_pods and #current_pods share the same hash" do
+    expect(server.class.current_pods.object_id).to eql(server.current_pods.object_id)
+    server.current_pods[:a] = :b
+    expect(server.class.current_pods[:a]).to eql(:b)
+  end
+
   context "#cleanup_failed_deployments" do
     context "#ensure_pod_monitor_started" do
       before do

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -1,0 +1,210 @@
+RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
+  let(:server)          { EvmSpecHelper.create_guid_miq_server_zone.second }
+  let(:orchestrator)    { double("ContainerOrchestrator") }
+  let(:deployment_name) { '1-generic-79bb8b8bb5-8ggbg' }
+  let(:pod_label)       { '1-generic' }
+
+  before do
+    # MiqWorkerType.seed
+    allow(server).to receive(:orchestrator).and_return(orchestrator)
+  end
+
+  after do
+    server.reset_current_pods
+  end
+
+  context "#cleanup_failed_deployments" do
+    context "#ensure_pod_monitor_started" do
+      before do
+        allow(server).to receive(:delete_failed_deployments)
+      end
+
+      it "calls start_pod_monitor if nil monitor thread" do
+        expect(server).to receive(:start_pod_monitor)
+        server.instance_variable_set(:@monitor_thread, nil)
+        server.cleanup_failed_deployments
+      end
+
+      it "calls start_pod_monitor if monitor thread terminated normally" do
+        expect(server).to receive(:start_pod_monitor)
+        thread = double(:alive? => false, :status => false)
+        expect(thread).to receive(:join).never
+
+        server.instance_variable_set(:@monitor_thread, thread)
+        server.cleanup_failed_deployments
+      end
+
+      it "joins a dead thread with an exception before calling start_pod_monitor" do
+        expect(server).to receive(:start_pod_monitor)
+        thread = double(:alive? => false, :status => nil)
+        expect(thread).to receive(:join).once
+
+        server.instance_variable_set(:@monitor_thread, thread)
+        server.cleanup_failed_deployments
+      end
+    end
+
+    context "#delete_failed_deployments" do
+      let(:current_pods) do
+        stats = Concurrent::Hash.new
+        stats[:last_state_terminated] = false
+        stats[:container_restarts] = 0
+        stats[:label_name] = pod_label
+
+        h = Concurrent::Hash.new
+        h['1-generic-79bb8b8bb5-8ggbg'] = stats
+        h
+      end
+
+      before do
+        allow(server).to receive(:ensure_pod_monitor_started)
+      end
+
+      context "with no deployments" do
+        it "doesn't call delete_deployment" do
+          allow(server).to receive(:current_pods).and_return(Concurrent::Hash.new)
+          expect(orchestrator).to receive(:delete_deployment).never
+          server.cleanup_failed_deployments
+        end
+      end
+
+      context "with 1 running deployment" do
+        it "doesn't call delete_deployment" do
+          allow(server).to receive(:current_pods).and_return(current_pods)
+          expect(orchestrator).to receive(:delete_deployment).never
+          server.cleanup_failed_deployments
+        end
+      end
+
+      context "with a failed deployment" do
+        it "calls delete_deployment with pod name" do
+          current_pods[deployment_name][:last_state_terminated] = true
+          current_pods[deployment_name][:container_restarts] = 100
+
+          allow(server).to receive(:current_pods).and_return(current_pods)
+          expect(orchestrator).to receive(:delete_deployment).with(pod_label)
+          server.cleanup_failed_deployments
+        end
+      end
+    end
+  end
+
+  context "#collect_initial_pods(private)" do
+    let(:resource_version) { "21943006" }
+    let(:started_at) { "2020-07-22T18:47:08Z" }
+    let(:pods) do
+      metadata = double(:name => deployment_name, :labels => double(:name => pod_label))
+      state = double(:running => double(:startedAt => started_at))
+      lastState = double(:terminated => nil)
+      status = double(:containerStatuses => [double(:state => state, :lastState => lastState, :restartCount => 0)])
+      pods = [double(:metadata => metadata, :status => status)]
+      allow(pods).to receive(:resourceVersion).and_return(resource_version)
+      pods
+    end
+
+    before do
+      allow(orchestrator).to receive(:get_pods).and_return(pods)
+    end
+
+    it "calls save_pod for running pod" do
+      server.send(:collect_initial_pods)
+
+      expect(server.current_pods[deployment_name][:label_name]).to eql(pod_label)
+      expect(server.pod_resource_version).to eql(resource_version)
+      expect(server.current_pods[deployment_name][:last_state_running]).to eql(true)
+      expect(server.current_pods[deployment_name][:started_at]).to eql([started_at])
+      expect(server.current_pods[deployment_name][:last_state_terminated]).to eql(false)
+      expect(server.current_pods[deployment_name][:container_restarts]).to eql(0)
+    end
+
+    it "calls save_pod for terminated pod" do
+      allow(pods.first.status.containerStatuses.first.lastState).to receive(:terminated).and_return(double(:exitCode => 1, :reason => "Error"))
+      allow(pods.first.status.containerStatuses.first.state).to receive(:running).and_return(nil)
+      allow(pods.first.status.containerStatuses.first).to receive(:restartCount).and_return(10)
+      server.send(:collect_initial_pods)
+
+      expect(server.current_pods[deployment_name][:label_name]).to eql(pod_label)
+      expect(server.current_pods[deployment_name][:last_state_running]).to eql(false)
+      expect(server.current_pods[deployment_name][:last_state_terminated]).to eql(true)
+      expect(server.current_pods[deployment_name][:container_restarts]).to eql(10)
+    end
+
+    it "sets get_pods resource_version" do
+      server.send(:collect_initial_pods)
+      expect(server.pod_resource_version).to eql(resource_version)
+    end
+  end
+
+  context "#watch_for_pod_events(private)" do
+    let(:event_object) { double }
+
+    let(:watch_event) do
+      double(:object => event_object)
+    end
+
+    it "defaults pod_resource_version to 0 if not available" do
+      server.pod_resource_version = nil
+      expect(orchestrator).to receive(:watch_pods).with(0)
+      server.send(:watch_for_pod_events)
+    end
+
+    it "ensures watcher.finish" do
+      watcher = double
+      allow(orchestrator).to receive(:watch_pods).and_return(watcher)
+      expect(watcher).to receive(:finish)
+      server.send(:watch_for_pod_events)
+    end
+
+    context "processes event" do
+      before do
+        allow(orchestrator).to receive(:watch_pods).and_yield(watch_event)
+      end
+
+      it "ADDED calls save_pod with event object" do
+        allow(watch_event).to receive(:type).and_return("ADDED")
+        expect(server).to receive(:save_pod).with(event_object)
+        server.send(:watch_for_pod_events)
+      end
+
+      it "MODIFIED calls save_pod with event object" do
+        allow(watch_event).to receive(:type).and_return("MODIFIED")
+        expect(server).to receive(:save_pod).with(event_object)
+        server.send(:watch_for_pod_events)
+      end
+
+      it "DELETED calls delete_pod with event object" do
+        allow(watch_event).to receive(:type).and_return("DELETED")
+        expect(server).to receive(:delete_pod).with(event_object)
+        server.send(:watch_for_pod_events)
+      end
+
+      it "UNKNOWN type isn't saved or deleted" do
+        allow(watch_event).to receive(:type).and_return("UNKNOWN")
+        expect(server).to receive(:save_pod).never
+        expect(server).to receive(:delete_pod).never
+        server.send(:watch_for_pod_events)
+      end
+
+      it "ERROR logs warning, resets pod_resource_version and breaks" do
+        server.pod_resource_version = 1000
+        expected_code = 410
+        expected_message = "too old resource version: 199900 (27177196)"
+        expected_reason = "Gone"
+
+        allow(watch_event).to receive(:type).and_return("ERROR")
+        allow(event_object).to receive(:code).and_return(expected_code)
+        allow(event_object).to receive(:message).and_return(expected_message)
+        allow(event_object).to receive(:reason).and_return(expected_reason)
+
+        allow(server).to receive(:log_pod_error_event) do |code, message, reason|
+          expect(code).to eql(expected_code)
+          expect(message).to eql(expected_message)
+          expect(reason).to eql(expected_reason)
+        end
+
+        server.send(:watch_for_pod_events)
+        expect(server.pod_resource_version).to eql(0)
+      end
+    end
+  end
+end

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
   end
 
   after do
-    server.reset_current_pods
+    server.current_pods.clear
   end
 
   context "#cleanup_failed_deployments" do

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -151,12 +151,6 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
       double(:object => event_object)
     end
 
-    it "defaults pod_resource_version to 0 if not available" do
-      server.pod_resource_version = nil
-      expect(orchestrator).to receive(:watch_pods).with(0)
-      server.send(:watch_for_pod_events)
-    end
-
     it "ensures watcher.finish" do
       watcher = double
       allow(orchestrator).to receive(:watch_pods).and_return(watcher)
@@ -212,7 +206,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
         end
 
         server.send(:watch_for_pod_events)
-        expect(server.pod_resource_version).to eql(0)
+        expect(server.pod_resource_version).to eql(nil)
       end
     end
   end


### PR DESCRIPTION
What this PR does:
* pods are labeled with the orchestrator pod that manages them
* for this orchestrator's pods, a collector thread gets the initial pod information and monitors for updates
* deployments with 1+ terminated container(s) and sum of restarts > 5 are "killed"

The easiest way to recreate this:
* Add an amazon cloud provider in the manageiq UI.
* Wait a few seconds for `oc get pods` to show new amazon-cloud-event-catcher and amazon-cloud-refresh worker pods creating/starting:

```
$ oc get pods
NAME                                              READY   STATUS              RESTARTS   AGE
1-amazon-cloud-event-catcher-2-7bd6479946-84c8n   0/1     ContainerCreating   0          2s
1-amazon-cloud-refresh-2-3-4-5548695867-9qkzx     0/1     ContainerCreating   0          1s
```
* Delete the amazon cloud provider in the manageiq UI before the new pods finish starting.
* The new worker pods will continually start/restart/fail/backoff until it reaches 6 restarts and gets killed.

TODO:

- [x] Mutex around read/writes
- [x] Ensure the pod collector thread is running/restarted
- [x] Guard against monitoring/killing deployments for things such as postgresql, memcached, httpd, etc. To do this, we'll label all of the worker pods that are managed by the orchestrator so the orchestrator will only monitor and kill failed pods it's monitoring.  This will require new images to be tested to ensure the labels are set correctly and that the orchestrator can monitor this subset of pods that it's managing as represented by this label.
- [x] Fix some thread safety issues identified below.
- [x] ~~More nuanced detection of failed deployments (5+ restarts and terminated status) as we might flag pods that often hit memory/cpu limits over days/months.~~. This is basic and doesn't conflict with liveness checks failures since those will be restarted, and not remain in terminated lastState.  Any pod that has 5 or more container restarts and remains in terminated state will get removed as a deployment.
- [x] Manual tests are great but we'll need some tests
Fixes: https://github.com/ManageIQ/manageiq/issues/20147

Here's an example of the events indicating two failed worker pods and their subsequent automatic removal:

![image](https://user-images.githubusercontent.com/19339/92658554-ca506680-f2c4-11ea-8e2e-f83fe50e8fa9.png)



Side effect bonus:

* Each pod's labels show which orchestrator they're managed by:
![image](https://user-images.githubusercontent.com/19339/92645722-493ca380-f2b3-11ea-9f33-f4c4e49a161e.png)

* By filtering by the orchestrator, such as`manageiq-orchestrated-by orchestrator-5f89795bcc-89ztg`, we can see all of the deployments managed by that orchestrator (or any orchestator pod if you filter by `manageiq-orchestrated-by`) and therefore which ones we're monitoring and will get killed if they continually fail:
![image](https://user-images.githubusercontent.com/19339/92645571-0b3f7f80-f2b3-11ea-9e3e-09226d7a03be.png)

