### PR TITLE
fixed lower_relative_path typo

### DIFF
--- a/app/models/mixins/relative_path_mixin.rb
+++ b/app/models/mixins/relative_path_mixin.rb
@@ -15,7 +15,7 @@ module RelativePathMixin
   end
 
   def lower_relative_path
-    rel_path&.downcase
+    relative_path&.downcase
   end
 
   def domain_name


### PR DESCRIPTION
tried to use this field but it was a syntax error

related to https://github.com/ManageIQ/manageiq-ui-classic/pull/7249