### PR TITLE
 widget generate_report_result should work regardless of whether the owner has a group

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -311,7 +311,7 @@ class MiqWidget < ApplicationRecord
     userid_for_result = "widget_id_#{id}|#{name}|schedule"
     MiqReportResult.purge_for_user(:userid => userid_for_result)
 
-    rpt.build_create_results(:userid => userid_for_result, :report_source => WIDGET_REPORT_SOURCE, :timezone => timezone, :miq_group_id => group.id)
+    rpt.build_create_results(:userid => userid_for_result, :report_source => WIDGET_REPORT_SOURCE, :timezone => timezone, :miq_group_id => group&.id)
   end
 
   def find_or_build_contents_for_user(group, user, timezone = nil)


### PR DESCRIPTION
add safe operator to group rather than breaking on the last line if owner has no group

nothing preventing group from being nil, so `rpt.build_create_results(:userid => userid_for_result, :report_source => WIDGET_REPORT_SOURCE, :timezone => timezone, :miq_group_id => group.id)` is pretty fragile

this might inadvertently cause other reporting bugs, i really do not know

previously, anyone who hit this would have to manually assign the user to a group to fix and probably questioned why that is necessary to update a widget

<sub>"tomorrow is a work day btw"</sub>

" MIQ(MiqWidget#generate_one_content_for_user) Widget: [Top Memory Consumers (weekly)] ID: [1000000000017] Failed for [User] [Managed Cloud] with error: [NoMethodError] [undefined method `id' for nil:NilClass]"

https://bugzilla.redhat.com/show_bug.cgi?id=1861046