### PR TITLE
[wip] only set tenant id if the group changed

### DIFF
--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -110,6 +110,6 @@ module OwnershipMixin
   end
 
   def set_tenant_from_group
-    self.tenant_id = miq_group.tenant_id if miq_group
+    self.tenant_id = miq_group.tenant_id if miq_group_id_changed? && miq_group
   end
 end


### PR DESCRIPTION
`set_tenant_from_group` only makes sense to run if the group changed, otherwise we're making extra unnecessary writes for no-op cases

it's a bug if you're on the performance team 
@miq-bot add_label bug
@miq-bot assign @kbrock 


also, i have no idea how to test this. using the last updated_on timestamp won't work for this, nor will the query count, nor will `_changed?`