### PR TITLE
remove has_parent?

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -144,9 +144,7 @@ class Service < ApplicationRecord
   end
   virtual_attribute :service_id, :integer
 
-  def has_parent?
-    !root?
-  end
+  # has_parent? is from the ancestry mixin
   alias has_parent has_parent?
 
   def request_class


### PR DESCRIPTION
`has_parent?` is from ancestry anyway and does ... this as well, so we don't need it

sorry Keenan but 
@miq-bot assign @kbrock 
