### PR TITLE
Remove SupportsFeatureMixin warnings

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -174,7 +174,7 @@ module SupportsFeatureMixin
   end
 
   def self.reason_or_default(reason)
-    reason.present? ? reason : "Feature not available/supported"
+    reason.present? ? reason : _("Feature not available/supported")
   end
 
   # query instance for the reason why the feature is unsupported

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -174,7 +174,7 @@ module SupportsFeatureMixin
   end
 
   def self.reason_or_default(reason)
-    reason.present? ? reason : _("Feature not available/supported")
+    reason.present? ? reason : "Feature not available/supported"
   end
 
   # query instance for the reason why the feature is unsupported
@@ -259,6 +259,13 @@ module SupportsFeatureMixin
     def define_supports_feature_methods(feature, is_supported: true, reason: nil, &block)
       method_name = "supports_#{feature}?"
       feature = feature.to_sym
+
+      # Since a series of default methods were created upon inclusion, remove them
+      # if they're explicitly redefined.
+      if respond_to?(method_name)
+        singleton_class.undef_method(method_name)
+        undef_method(method_name)
+      end
 
       # defines the method on the instance
       define_method(method_name) do


### PR DESCRIPTION
This is the simplest way I could find to remove the warnings in the `SupportsFeatureMixin` without a fundamental overhaul of the module in general.

This is a followup to https://github.com/ManageIQ/manageiq/issues/20416, and an alternative to https://github.com/ManageIQ/manageiq/pull/20417.

Another simple way to avoid the warnings would be to wrap the relevant code in a `Kernel.silence_warnings` block.