### PR TITLE
[WIP] [POC] [Integration ENV] Database Cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ content/ansible_consolidated
 db/*.sqlite3
 db/schema.rb
 db/fixtures/ae_datastore/ManageIQ/.manifest.yaml
+lib/manageiq/integration/seed_config.yml
 
 # log/
 log/*.gz

--- a/Gemfile
+++ b/Gemfile
@@ -257,7 +257,6 @@ unless ENV["APPLIANCE"]
     gem "capybara",          "~>2.5.0",  :require => false
     gem "coveralls",         "~>0.8.23", :require => false
     gem "db-query-matchers", "~>0.10.0"
-    gem "factory_bot",       "~>5.1",    :require => false
 
     # TODO: faker is used for url generation in git repository factory and the lenovo
     # provider, via a xclarity_client dependency
@@ -267,8 +266,9 @@ unless ENV["APPLIANCE"]
     gem "webmock",           "~>3.7",    :require => false
   end
 
-  group :development, :test do
+  group :development, :test, :integration do
+    gem "factory_bot",      "~>5.1",    :require => false
     gem "parallel_tests"
-    gem "rspec-rails", "~>3.9.0"
+    gem "rspec-rails",      "~>3.9.0"
   end
 end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -306,6 +306,11 @@ class MiqWorker::Runner
   end
 
   def config_out_of_date?
+    # Skip config syncing if in integration_env
+    #
+    # TODO:  Handle this better for single worker versus appliance
+    return false if Rails.env.integration?
+
     @my_last_config_change ||= Time.now.utc
 
     last_config_change = server_last_change(:last_config_change)

--- a/config/database.pg.yml
+++ b/config/database.pg.yml
@@ -24,6 +24,10 @@ development:
   database: vmdb_development
   min_messages: notice
 
+integration:
+  <<: *base
+  database: vmdb_integration
+
 production:
   <<: *base
   database: vmdb_production

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -1,0 +1,113 @@
+# Settings for integration testings.  A mix between development and production,
+# using production as a base and pulling in specific options from development
+# where appropriate.
+#
+Vmdb::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  config.eager_load_paths = []
+
+  # Code is not reloaded between requests unless CYPRESS_DEV is set
+  #
+  # Idea borrowed from:
+  #
+  #   https://blog.simplificator.com/2019/10/11/setting-up-cypress-with-rails/
+  #
+  # We want this to be "production-like" unless CYPRESS_DEV is present
+  config.cache_classes = ENV['CYPRESS_DEV'].blank?
+  config.eager_load = false
+
+  # Log error messages when you accidentally call methods on nil.
+  #
+  # Pulled from `config/environment/development.rb`, but only enable if
+  # ENV['CYPRESS_DEV']
+  #
+  config.whiny_nils = true if ENV['CYPRESS_DEV'].present?
+
+  # Full error reports are disabled and caching is turned on
+  #
+  # Same in development and production
+  config.consider_all_requests_local       = false
+
+  # Enable caching by default, but disable it when running with CYPRESS_DEV
+  #
+  # Same default as production, setting CYPRESS_DEV sets it to development-like
+  config.action_controller.perform_caching = ENV['CYPRESS_DEV'].blank?
+
+  # Don't care if the mailer can't send
+  #
+  # Matching development here, commented out on production
+  config.action_mailer.raise_delivery_errors = false
+
+  # Print deprecation notices to the Rails logger.
+  #
+  # Same in development and production
+  config.active_support.deprecation = :log
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  #
+  # Using production environment variable, and added headers addition from
+  # test.rb (`.enabled` should default to `true` in `Rails.env.development?`)
+  if ENV['RAILS_SERVE_STATIC_FILES'].present?
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
+  end
+
+  # Compress JavaScripts and CSS
+  #
+  # Production defaults this to true, so matching that.  Development and test
+  # are both `false`, so CYPRESS_DEV=1 will match that.
+  config.assets.compress = ENV['CYPRESS_DEV'].blank?
+
+  # This setting has a confusing name...
+  #
+  # if false:  Do not fallback to assets pipeline if an asset is missing.
+  # if true:   Use assets pipeline if an asset is missing.
+  #
+  # Defaults to true in `sprockets-rails`:
+  #
+  #   https://github.com/rails/sprockets-rails/blob/df46170c/lib/sprockets/railtie.rb#L120
+  #
+  # Matches for production by default, configurable to true via CYPRESS_DEV
+  config.assets.compile = ENV['CYPRESS_DEV'].present?
+
+  # Generate digests for assets URLs
+  #
+  # Defaults to true in `sprockets-rails`:
+  #
+  #   https://github.com/rails/sprockets-rails/blob/df46170c/lib/sprockets/railtie.rb#L121
+  #
+  # Matches for production by default
+  config.assets.digest = true
+
+  # Include miq_debug in the list of assets here because it is only used in development
+  #
+  # Pulled from development.  Doesn't hurt being in regardless
+  config.assets.precompile << 'miq_debug.js'
+  config.assets.precompile << 'miq_debug.css'
+
+  # See everything in the log.  Default is :debug I think...
+  #
+  #   https://github.com/rails/rails/blob/7b5cc5a5/railties/lib/rails/application/configuration.rb#L40
+  #
+  config.log_level = :debug
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found)
+  #
+  # Copied from production
+  config.i18n.fallbacks = [I18n.default_locale]
+
+  # Do not include all helpers for all views
+  #
+  # Shared across test/development/production
+  config.action_controller.include_all_helpers = false
+
+  # The test environment has this disabled, but matching development/production
+  # makes the most sense when dealing with the UI.
+  config.action_controller.allow_forgery_protection = true
+
+  # Copied from production.  Not set in test/development environments
+  config.assets.css_compressor = :sass
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-if ENV['RAILS_USE_MEMORY_STORE'] || (!Rails.env.development? && !Rails.env.production?)
+if ENV['RAILS_USE_MEMORY_STORE'] || Rails.env.test? || Rails.env.integration?
   Vmdb::Application.config.session_store(:memory_store)
 else
   session_store =

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Vmdb::Application.routes.draw do
     logger.level = Logger.const_get(::Settings.log.level_remote_console.upcase)
     mount RemoteConsole::RackServer.new(:logger => logger) => '/ws/console'
   end
+
+  mount ManageIQ::Integration::Engine, :at => "/" if Rails.env.integration?
 end

--- a/config/settings/integration.yml
+++ b/config/settings/integration.yml
@@ -1,0 +1,7 @@
+---
+:log:
+  :level_rails: debug
+:webservices:
+  :url: http://localhost:4000
+:server:
+  :session_store: memory

--- a/lib/manageiq/integration.rb
+++ b/lib/manageiq/integration.rb
@@ -1,6 +1,7 @@
 require_relative 'integration/environment'
 require_relative 'integration/foreman_manager'
 require_relative 'integration/cypress_rake_task'
+require_relative 'integration/database_cleaner'
 
 module ManageIQ
   module Integration

--- a/lib/manageiq/integration.rb
+++ b/lib/manageiq/integration.rb
@@ -2,6 +2,7 @@ require_relative 'integration/environment'
 require_relative 'integration/foreman_manager'
 require_relative 'integration/cypress_rake_task'
 require_relative 'integration/database_cleaner'
+require_relative 'integration/engine'
 
 module ManageIQ
   module Integration

--- a/lib/manageiq/integration.rb
+++ b/lib/manageiq/integration.rb
@@ -1,0 +1,9 @@
+require_relative 'integration/environment'
+require_relative 'integration/foreman_manager'
+require_relative 'integration/cypress_rake_task'
+
+module ManageIQ
+  module Integration
+
+  end
+end

--- a/lib/manageiq/integration/Procfile.example.erb
+++ b/lib/manageiq/integration/Procfile.example.erb
@@ -1,1 +1,5 @@
 ui: env PORT=$PORT <%= Gem.ruby %> <%= Environment.run_single_worker_bin %> MiqUiWorker
+
+<% extra_workers.each do |worker_type| -%>
+<%= worker_type.downcase %>: env PORT=$PORT <%= Gem.ruby %> <%= Environment.run_single_worker_bin %> <%= worker_type %>
+<% end -%>

--- a/lib/manageiq/integration/Procfile.example.erb
+++ b/lib/manageiq/integration/Procfile.example.erb
@@ -1,0 +1,1 @@
+ui: env PORT=$PORT <%= Gem.ruby %> <%= Environment.run_single_worker_bin %> MiqUiWorker

--- a/lib/manageiq/integration/cypress_rake_task.rb
+++ b/lib/manageiq/integration/cypress_rake_task.rb
@@ -1,0 +1,130 @@
+require "rake/tasklib"
+
+module ManageIQ
+  module Integration
+    # A Rake TaskLib for building tasks to run cypress for a given manageiq plugin
+    #
+    # When defining, provide a namespace, usually indicative of the plugin you
+    # are testing, and if needed, you can override the @ui_engine_root
+    #
+    class CypressRakeTask < Rake::TaskLib
+
+      # Namespace for the cypress tasks to live under
+      attr_accessor :cypress_namespace
+
+      # Root directory location for ManageIQ::UI::Classic
+      attr_accessor :ui_engine_root
+
+      def initialize(cypress_namespace)
+        @cypress_namespace = cypress_namespace
+        @ui_engine_root    = ManageIQ::UI::Classic::Engine.root
+
+        yield self if block_given?
+
+        define
+      end
+
+      def define
+        namespace :cypress do
+          desc "Run cypress #{cypress_namespace} tests"
+          task cypress_namespace => ":#{cypress_namespace}run"
+
+          define_cypress_namespace
+        end
+      end
+
+      private
+
+      def define_cypress_namespace
+        namespace cypress_namespace do
+          desc "Seed database/configure assets for cypress specs"
+          task :seed do
+            Rake::Task["#{app_prefix}integration:seed"].invoke
+          end
+
+          desc "Interactively run cypress tests"
+          task :open => ["#{cypress_namespace}:setup"] do
+            sh "#{yarn_cmd} cypress:open"
+          end
+
+          desc "Run headless cypress tests"
+          task :run, [:spec_file] => ["#{cypress_namespace}:setup"] do |t, args|
+            args.with_defaults :spec_file => nil
+
+            cmd  = "#{yarn_cmd} cypress:run:ci"
+            cmd << " --spec #{args.spec_file}" if args.spec_file
+
+            sh cmd
+          end
+
+          desc "Stop the backend Rails server"
+          task :stop do
+            Rake::Task["#{app_prefix}integration:stop_server"].invoke
+          end
+
+          task :setup => cypress_env_file do
+            Rake::Task["#{app_prefix}integration:start_server"].invoke
+          end
+
+          define_cypress_env_file_task
+          define_cypress_dev_tasks
+        end
+      end
+
+      def define_cypress_env_file_task
+        file cypress_env_file do |cypress_env_json_file|
+          unless File.exist?(cypress_env_file)
+            cypress_dir         = File.dirname(cypress_env_file)
+            cypress_env_example = ".cypress.dev.env.json"
+            cypress_env_example = ".cypress.ci.env.json" if ENV["CI"] || ENV["TRAVIS"]
+
+            cp File.join(cypress_dir, cypress_env_example), cypress_env_json_file.name
+          end
+        end
+      end
+
+      def define_cypress_dev_tasks
+        desc "Run cypress tests in 'development' mode"
+        task :dev => "dev:run"
+
+        # Aliases for running with CYPRESS_DEV
+        namespace :dev do
+          desc "'Development Mode' for cypress:#{cypress_namespace}:seed"
+          task :seed => [:env, "cypress:#{cypress_namespace}:seed"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:open"
+          task :open => [:env, "cypress:#{cypress_namespace}:open"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:run"
+          task :run => [:env, "cypress:#{cypress_namespace}:run"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:setup"
+          task :setup => [:env, "cypress:#{cypress_namespace}:setup"]
+
+          desc "'Development Mode' for cypress:#{cypress_namespace}:stop"
+          task :stop => [:env, "cypress:#{cypress_namespace}:stop"]
+
+          # Helper task to defaulte the CYPRESS_DEV env var to "1"
+          task :env do
+            ENV["CYPRESS_DEV"] = "1"
+          end
+        end
+      end
+
+      def yarn_cmd
+        cmd  = "yarn"
+        cmd += " --cwd #{@ui_engine_root}" unless defined?(ENGINE_ROOT)
+
+        cmd
+      end
+
+      def cypress_env_file
+        File.expand_path("cypress.env.json", @ui_engine_root)
+      end
+
+      def app_prefix
+        defined?(ENGINE_ROOT) ? "app:" : ""
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/database_cleaner.rb
+++ b/lib/manageiq/integration/database_cleaner.rb
@@ -1,0 +1,227 @@
+require "fileutils"
+
+module ManageIQ
+  module Integration
+    class DatabaseCleaner
+      SEED_CONFIG_FILENAME = File.expand_path("seed_config.yml", __dir__)
+
+      ACTIVE_RECORD_INTERNAL_TABLES = %w[
+        ar_internal_metadata
+        schema_migrations
+        schema_migrations_ran
+      ]
+
+      # TODO:  Determine if users/miq_user_roles can be truncated
+      #
+      #   miq_user_roles users ?
+      #
+      SKIPABLE_TABLES = %w[
+        assigned_server_roles
+        miq_servers
+        miq_workers
+        miq_databases
+        server_roles
+      ]
+
+      attr_reader :seeded_tables, :skipable_tables, :truncated_tables
+
+      # Clean the database and reset to a freshly seeded state
+      def self.clean
+        new.clean
+      end
+
+      # Run after a `db:seed` to generate an config that is accurate for the
+      #
+      # This is destructive and will drop the existing template DB.  Don't do
+      # if database has been modified post seed.
+      #
+      def self.setup!(force: false)
+        FileUtils.rm_rf(SEED_CONFIG_FILENAME) if force
+        new.prepare
+      end
+
+      def initialize
+        load_seed_config
+      end
+
+      def clean
+        truncate_tables
+        reseed
+      end
+
+      def prepare
+        drop_template_db
+        create_template_db
+        enable_postgres_fdw
+      end
+
+      # Generates a configuration that is created after a db:seed to determine
+      # what tables are seeded, as well as include tables that can't be dropped
+      # mid test run (miq_servers, miq_workers, etc.) since they are currently
+      # being used by the running processes for state.
+      #
+      # Key types include:
+      #
+      # - seeded_tables:      Tables that are seedable (need data after truncate)
+      # - skipable_tables:    Tables that can't be dropped (name pending)
+      # - truncatable_tables: Tables that can be dropped
+      #
+      def generate_seed_config
+        return if File.exist?(SEED_CONFIG_FILENAME)
+
+        require 'yaml'
+
+        File.write(SEED_CONFIG_FILENAME, seed_config.to_yaml)
+      end
+
+      def load_seed_config
+        if File.exist?(SEED_CONFIG_FILENAME)
+          @seed_config        = YAML.load_file(SEED_CONFIG_FILENAME)
+          @seeded_tables      = @seed_config[:seeded_tables]
+          @skipable_tables    = @seed_config[:skipable_tables]
+          @truncatable_tables = @seed_config[:truncatable_tables]
+        else
+          generate_seed_config
+        end
+      end
+
+      private
+
+      def seed_config
+        @seed_config ||= {
+          :seeded_tables      => determine_seeded_tables,
+          :skipable_tables    => skipable_tables,
+          :truncatable_tables => truncatable_tables
+        }
+      end
+
+      def pg_conn
+        ActiveRecord::Base.connection
+      end
+
+      def template_dbname
+        "#{ActiveRecord::Base.connection_config[:database]}_template"
+      end
+
+      def create_template_db
+        create_config = {
+          :owner     => ActiveRecord::Base.connection_config[:username],
+          :encodiing => ActiveRecord::Base.connection_config[:encoding],
+          :template  => ActiveRecord::Base.connection_config[:database]
+        }
+
+        pg_conn.create_database(template_dbname, create_config)
+      end
+
+      def drop_template_db
+        pg_conn.drop_database(template_dbname)
+      end
+
+      # Creates enables the extension for PostgreSQL's Foreign Data Wrapper
+      # (named 'seed_server') and creates a connection to the template server
+      # to import the base data after each test run.
+      #
+      #   https://www.postgresql.org/docs/10/postgres-fdw.html
+      #
+      # Also creates a SCHEMA namsed 'seed_tables'
+      #
+      def enable_postgres_fdw
+        pg_conn.enable_extension("postgres_fdw")
+
+        data_wrapper_server_options = {
+          :host   => ActiveRecord::Base.connection_config[:host] || 'localhost',
+          :dbname => template_dbname
+        }.delete_nils.map { |k, v| "#{k} '#{v}'" }.join(", ")
+
+        data_wrapper_user_auth_options = {
+          :user     => ActiveRecord::Base.connection_config[:username],
+          :password => ActiveRecord::Base.connection_config[:password]
+        }.delete_nils.map { |k, v| "#{k} '#{v}'" }.join(", ")
+
+        pg_conn.execute <<~QUERY
+
+          DROP   SERVER IF EXISTS seed_server CASCADE;
+          CREATE SERVER seed_server
+                FOREIGN DATA WRAPPER postgres_fdw
+                OPTIONS (#{data_wrapper_server_options});
+
+          CREATE USER MAPPING FOR CURRENT_USER
+               SERVER seed_server
+              OPTIONS (#{data_wrapper_user_auth_options});
+
+
+          DROP   SCHEMA IF EXISTS seed_tables;
+          CREATE SCHEMA seed_tables;
+
+          IMPORT FOREIGN SCHEMA public
+            FROM SERVER seed_server
+            INTO seed_tables;
+        QUERY
+      end
+
+      def truncate_tables
+        query = truncatable_tables.map { |table| "TRUNCATE TABLE public.#{table} RESTART IDENTITY" }
+                                  .join(";\n")
+
+        pg_conn.execute(query)
+        # truncatable_tables.each { |table| pg_conn.truncate(table) }
+      end
+
+      def reseed
+        @reseed_query ||= seeded_tables.map { |table|
+                            columns = pg_conn.columns(:miq_sets).map(&:name).join(", ")
+                            "INSERT INTO public.#{table} SELECT * FROM seed_tables.#{table};"
+                          }.join("\n")
+
+        pg_conn.execute(@reseed_query)
+      end
+
+      def all_tables
+        @all_tables ||= pg_conn.tables
+      end
+
+      # Fetch the counts for all of the tables for this MIQ database (ignoring
+      # ones that generated by ActiveRecord) and then rejecting ones that empty
+      # (count of 0).
+      def determine_seeded_tables
+        return @seeded_tables if @seeded_tables
+
+        query          = table_counts_query(truncatable_tables)
+        @seeded_tables = pg_conn.select_all(query)
+                                .rows.to_h
+                                .reject { |_,v| v == 0 }
+                                .keys
+      end
+
+      # Tables that are seeded, but will need to remain unchanged in the
+      # database so the MiqServer can remain functional between specs
+      #
+      def skipable_tables
+        @skipable_tables ||= SKIPABLE_TABLES
+      end
+
+      # Tables that can be truncated
+      #
+      def truncatable_tables
+        return @truncatable_tables if @truncatable_tables
+
+        @truncatable_tables  = all_tables
+        @truncatable_tables -= ACTIVE_RECORD_INTERNAL_TABLES
+        @truncatable_tables -= SKIPABLE_TABLES
+      end
+
+      # Generate a query to get an accurate count of all of the of the tables
+      # in the database by creating a "UNION query" of the table_name + COUNT.
+      #
+      # Note:  Not using pg_class for this since it is documented that
+      # `reltuples` is only an estimate:
+      #
+      #   https://www.postgresql.org/docs/10/catalog-pg-class.html
+      #
+      def table_counts_query(tables = all_tables)
+        tables.map { |table| "SELECT '#{table}' as table, COUNT(id) count FROM #{table}" }
+              .join("\n  UNION\n")
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/engine.rb
+++ b/lib/manageiq/integration/engine.rb
@@ -1,0 +1,72 @@
+# Simple engine config for routes to access factories and such from the
+# frontend via API calls (`cypress`, etc.)
+#
+# Inspired heavily from the following blog post:
+#
+#   https://blog.simplificator.com/2019/10/11/setting-up-cypress-with-rails/
+#
+
+require Rails.root.join("spec/support/factory_bot_helper")
+
+module ManageIQ
+  module Integration
+    class Engine < ::Rails::Engine
+      routes.draw do
+        namespace :miq do
+          namespace :db do
+            delete "clean", :to => "/manageiq/integration/db#clean"
+          end
+
+          namespace :factory do
+            post "create", :to => "/manageiq/integration/factory#create"
+          end
+        end
+      end
+
+    end
+
+    # Database cleaner controller
+    #
+    class DbController < ActionController::Base
+      # Class variable with a memoized instance of DatabaseCleaner
+      #
+      # Lazy loaded so it isn't instanciated on Engine load
+      #
+      def self.cleaner
+        @cleaner ||= DatabaseCleaner.new
+      end
+
+      ##
+      # Run Factory.create for a Factory of :name
+      #
+      # See ManageIQ::Integration::DatabaseCleaner for more info
+      #
+      # @path [DELETE] /miq/db/clean
+      #
+      def clean
+        self.class.cleaner.clean
+
+        head :ok
+      end
+    end
+
+    # FactoryBot via HTTP controller
+    #
+    class FactoryController < ActionController::Base
+      ##
+      # Run Factory.create for a Factory of :name
+      #
+      # @path [POST] /miq/factory/create
+      #
+      # @parameter name(required) [string]  Name of the Factory
+      # @parameter attributes     [hash]    Attributes of the Factory to override
+      #
+      def create
+        create_opts = params.permit(:name, :attributes => {})
+        factory     = FactoryBot.create(create_opts[:name], create_opts[:attributes])
+
+        render :json => factory
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/environment.rb
+++ b/lib/manageiq/integration/environment.rb
@@ -1,0 +1,25 @@
+module ManageIQ
+  module Integration
+    class Environment
+      def self.tmp_dir
+        Rails.root.join('tmp', 'integration')
+      end
+
+      def self.run_single_worker_bin
+        Rails.root.join('lib', 'workers', 'bin', 'run_single_worker.rb')
+      end
+
+      def self.ui_host
+        @ui_host = "localhost"
+      end
+
+      def self.ui_port
+        @ui_port = 3000
+      end
+
+      def self.ui_ping_route
+        @ui_ping_route = "/api/ping"
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/foreman_manager.rb
+++ b/lib/manageiq/integration/foreman_manager.rb
@@ -1,0 +1,208 @@
+require "fileutils"
+
+# A wrapper around the foreman utility for running ManageIQ in the integration
+# environment, with either the server acting more "dev like" or "prod like"
+# depending on the scenario (local development versus CI).
+#
+module ManageIQ
+  module Integration
+    class ForemanManager
+      def self.pid_filename
+        @pid_filename ||= Environment.tmp_dir.join('foreman.pid')
+      end
+
+      def self.log_file
+        Rails.root.join("log", "integration.foreman.log")
+      end
+
+      def self.procfile
+        @procfile ||= Environment.tmp_dir.join('Procfile')
+      end
+
+      def self.procfile_template_data
+        require 'erb'
+        template_path = File.expand_path('Procfile.example.erb', __dir__)
+
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(2.6)
+          ERB.new(File.read(template_path), trim_mode: "-").result(binding)
+        else
+          ERB.new(File.read(template_path), nil, "-").result(binding)
+        end
+      end
+
+      def self.setup
+        FileUtils.mkdir_p(Environment.tmp_dir)
+        FileUtils.rm_f(procfile)
+
+        File.write(procfile, procfile_template_data)
+      end
+
+      def self.run
+        if process_alive?
+          warn "foreman process already running with pid: #{server_pid} from #{pid_filename}"
+        elsif ui_ping
+          ui_server_host = "#{Environment.ui_host}:#{Environment.ui_port}"
+          warn <<~WARN
+            Existing process for #{ui_server_host} exist already!  Cowardly refusing to kill it...
+
+            Unless you "absolutely know what you are doing", make sure this
+            environment is running in `integration` mode, or restart this test
+            run after you have closed that server down so this task can execute
+            an isolated process for you.  Otherwise test will likely fail due
+            to missing resources that only exist in the integration ENV.
+
+          WARN
+        else
+          foreman_cmd = %W[
+            foreman start --port=3000
+                          --root=#{Rails.root}
+                          --procfile=#{procfile}
+          ].join(" ")
+
+          pid = Process.spawn(foreman_cmd, [:out, :err] => [log_file, "a"])
+          Process.detach(pid)
+          File.write(pid_filename, pid)
+        end
+      end
+
+      def self.stop
+        PidFile.new(pid_filename).terminate
+      end
+
+      # Simple status check:
+      #
+      # - Checks for existing pid file
+      # - If the process is running
+      # - If the UI is responding to a request
+      #
+      def self.status
+        if server_pid
+          puts "Server PID##{server_pid}: ".ljust(18) + (process_alive? ? "running" : "stopped")
+        else
+          puts "Server PID#NA:    PID file (#{pid_filename}) doesn't exist..."
+        end
+        puts "UI running?:      #{ui_ping}"
+      end
+
+      def self.process_alive?
+        PidFile.new(pid_filename).running?
+      end
+
+      def self.server_pid
+        PidFile.new(pid_filename).pid
+      end
+
+      def self.ui_ping
+        require 'net/http'
+
+        net_http = Net::HTTP.new(Environment.ui_host, Environment.ui_port)
+        net_http.request_head(Environment.ui_ping_route).code == "200"
+      rescue Errno::ECONNREFUSED
+        false
+      end
+
+      def self.ui_running?
+        ui_ready = false
+        wait_num = ENV["CI"] ? 60 : 15
+
+        wait_num.times do
+          break if (ui_ready = ui_ping)
+
+          sleep 2
+        end
+
+        unless ui_ready
+          raise "ERR: UI server was not able to start or start properly" \
+                " (after waiting ~#{wait_num * 2 / 60.0} minutes)"
+        end
+      rescue => err
+        if ENV["CI"]
+          stop
+          sleep 5 # allow server to stop and flush logs
+
+          debug_output_for_server_logs
+          debug_server_boot
+        end
+
+        raise err
+      end
+
+      def self.debug_output_for_server_logs
+        integration_log_file = Rails.root.join("log", "integration.log")
+        evm_log_file         = Rails.root.join("log", "evm.log")
+
+        puts <<~DEBUGGING_OUTPUT
+
+          ***************************************************
+          *     Printing Debugging log info for server:     *
+          ***************************************************
+
+          Procfile contents
+          -----------------
+
+          #{File.read(procfile)}
+
+
+          last 100 lines of '#{log_file}':
+          #{'-' * (21 + log_file.to_s.length)}
+
+          #{tail_file(log_file)}
+
+
+          last 100 lines of 'log/integration.log':
+          ----------------------------------------
+
+          #{tail_file(integration_log_file)}
+
+
+          last 100 lines of 'log/evm.log':
+          --------------------------------
+
+          #{tail_file(evm_log_file)}
+
+
+        DEBUGGING_OUTPUT
+      end
+
+      def self.debug_server_boot
+        log_file  = Rails.root.join("log", "integration.debug.log")
+        test_boot = "#{Gem.ruby} #{Environment.run_single_worker_bin} MiqUiWorker"
+        pid       = Process.spawn(test_boot, [:out, :err] => [log_file, 'w'])
+
+        puts "running inline ruby server to test for errors..."
+        puts
+        puts "  cmd: #{test_boot}"
+        puts
+
+        Timeout.timeout(30) { Process.waitpid(pid) }
+      rescue Timeout::Error => e
+        Process.kill("TERM", pid)
+      ensure
+        sleep 5 # give a few seconds for the logs output to flush to log_file
+
+        puts File.read(log_file)
+        puts
+        puts
+      end
+
+      def self.tail_file(filename, num_lines = 100)
+        require 'elif'
+
+        line_buffer = []
+
+        Elif.open(filename) do |log_io|
+          num_lines.times do
+            log_line = log_io.readline
+            break if log_line.nil?
+            line_buffer.unshift log_io.readline
+          rescue EOFError
+            # if we reach then end of a file, just end the loop
+          end
+        end
+
+        # new lines are already included, so just convert to a string
+        line_buffer.join
+      end
+    end
+  end
+end

--- a/lib/manageiq/integration/foreman_manager.rb
+++ b/lib/manageiq/integration/foreman_manager.rb
@@ -30,6 +30,14 @@ module ManageIQ
         end
       end
 
+      def self.extra_workers
+        if (worker_string = ENV["FOREMAN_INTEGRATION_EXTRA_WORKERS"])
+          worker_string.split(",")
+        else
+          []
+        end
+      end
+
       def self.setup
         FileUtils.mkdir_p(Environment.tmp_dir)
         FileUtils.rm_f(procfile)

--- a/lib/pid_file.rb
+++ b/lib/pid_file.rb
@@ -42,4 +42,13 @@ class PidFile
 
     true
   end
+
+  def terminate(regexp = nil)
+    if pid && running?(regexp)
+      Process.kill("TERM", pid)
+      FileUtils.rm(@fname)
+    else
+      warn "PID file for server (#{@fname}) or matching process doesn't exist... moving on"
+    end
+  end
 end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -108,10 +108,11 @@ namespace :evm do
   task :compile_assets => 'evm:assets:compile'
   namespace :assets do
     desc "Compile assets (clobber and precompile)"
-    task :compile do
+    task :compile do |rake_task|
+      app_prefix = rake_task.name.chomp('evm:assets:compile')
       EvmRakeHelper.with_dummy_database_url_configuration do
-        Rake::Task["assets:clobber"].invoke
-        Rake::Task["assets:precompile"].invoke
+        Rake::Task["#{app_prefix}assets:clobber"].invoke
+        Rake::Task["#{app_prefix}assets:precompile"].invoke
       end
     end
   end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -4,16 +4,20 @@ require 'evm_rake_helper'
 
 namespace :evm do
   namespace :foreman do
-    task :start => [:environment, 'db:seed'] do
+    task :seed => [:environment, 'db:seed'] do
       server = MiqServer.my_server
 
       # Assign and activate the default roles
       server.ensure_default_roles
       server.activate_roles(server.server_role_names)
+    end
 
+    task :setup => [:environment] do
       # Mark the server as started
-      server.update(:status => "started")
+      MiqServer.my_server(true).starting_server_record
+    end
 
+    task :start => [:seed, :setup] do
       # start the workers using foreman
       exec("foreman start --port=3000")
     end

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -4,8 +4,14 @@ namespace :integration do
 
   namespace :seed do
     task :all    => [:db, :assets]
-    task :db     => [:env, "test:vmdb:setup", "evm:foreman:seed"]
+    task :db     => [:env, "test:vmdb:setup", "evm:foreman:seed", :setup_db_cleaner]
     task :assets => [:env, "test:initialize", :compile_assets]
+
+    # Internal task:  call via integration:seed:db
+    task :setup_db_cleaner => :load_manager do
+      puts "Setting up ManageIQ::Integration::DatabaseCleaner..."
+      ManageIQ::Integration::DatabaseCleaner.setup!(force: true)
+    end
 
     task :compile_assets do |rake_task|
       app_prefix = rake_task.name.chomp('integration:seed:compile_assets')

--- a/lib/tasks/integration.rake
+++ b/lib/tasks/integration.rake
@@ -1,0 +1,69 @@
+namespace :integration do
+  desc "Seed the database and configure assets for integration tests"
+  task :seed => ['seed:all']
+
+  namespace :seed do
+    task :all    => [:db, :assets]
+    task :db     => [:env, "test:vmdb:setup", "evm:foreman:seed"]
+    task :assets => [:env, "test:initialize", :compile_assets]
+
+    task :compile_assets do |rake_task|
+      app_prefix = rake_task.name.chomp('integration:seed:compile_assets')
+      if ENV["CYPRESS_DEV"]
+        Rake::Task["#{app_prefix}update:ui"].invoke
+      else
+        Rake::Task["#{app_prefix}evm:compile_assets"].invoke
+      end
+    end
+  end
+
+  desc "Setup the database for integration tests"
+  task :setup => [:db_setup, "evm:foreman:setup"] do
+    ManageIQ::Integration::ForemanManager.setup
+  end
+
+  desc "Run a foreman server in the background for integration tests"
+  task :run_server => [:setup] do
+    ManageIQ::Integration::ForemanManager.run
+  end
+
+  desc "Start and wait for an integration server to boot"
+  task :start_server => [:run_server, :ui_ready] do
+    MiqServer.my_server.update(:status => "started")
+  end
+
+  desc "Stop server for integration tests"
+  task :stop_server => [:load_manager] do
+    ManageIQ::Integration::ForemanManager.stop
+  end
+
+  desc "Status of the currently running process"
+  task :server_status => [:load_manager] do
+    ManageIQ::Integration::ForemanManager.status
+  end
+
+  # Check if a UI worker is running
+  task :ui_ready => :run_server do
+    ManageIQ::Integration::ForemanManager.ui_running?
+  end
+
+  # For tasks that don't need the full Rails ENV, but need the
+  # ManageIQ::Integration file loaded (:stop_server).
+  task :load_manager do
+    require File.expand_path(File.join("..", "manageiq", "integration"), __dir__)
+  end
+
+  task :env do
+    ENV["RAILS_ENV"] = "integration"
+    ENV["RAILS_SERVE_STATIC_FILES"] = "true"
+    Rails.env = ENV["RAILS_ENV"] if defined?(Rails)
+  end
+
+  task :db_setup => [:env, :environment] do
+    # Reset Rails.env and database config to make sure we are using the
+    # integration environment
+    Rails.env = ENV["RAILS_ENV"]
+    ActiveRecord::Base.remove_connection
+    ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
+  end
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -3,11 +3,13 @@ require_relative './evm_test_helper'
 if defined?(RSpec)
 namespace :test do
   task :initialize do
-    if ENV['RAILS_ENV'] && ENV["RAILS_ENV"] != "test"
+    if ENV['RAILS_ENV'] && !%w[test integration].include?(ENV["RAILS_ENV"])
       warn "Warning: RAILS_ENV is currently set to '#{ENV["RAILS_ENV"]}'. Forcing to 'test' for this run."
+      ENV['RAILS_ENV'] = "test"
+    elsif ENV['RAILS_ENV'].blank?
+      ENV['RAILS_ENV'] = "test"
     end
-    ENV['RAILS_ENV'] = "test"
-    Rails.env = 'test' if defined?(Rails)
+    Rails.env = ENV['RAILS_ENV'] if defined?(Rails)
 
     ENV['VERBOSE'] ||= "false"
   end


### PR DESCRIPTION
Provides a possible solution for cleaning the database in our integration environment (as well as Factory support).

Built on top of https://github.com/ManageIQ/manageiq/pull/20350 , and currently the last two commits of this PR are the relevant ones.  A link for easy diff viewing can be found below:

https://github.com/NickLaMuro/manageiq/compare/integration_env-database_cleaning%5E%5E...integration_env-database_cleaning


Architecture
------------

### `ManageIQ::Integration::DatabaseCleaner`

A singleton class in charge of managing state post `db:seed` (keeping track of tables that had data seeded into them), and contains the logic for `.clean` (mass `TRUNCATE` + `INSERT`).

Makes use a duplicate database that is created after right after an initial `db:seed`, and all `INSERT` statements for the `.clean` do a copy from that "template" database.


### `ManageIQ::Integration::Engine`

A single file `Rails::Engine` that has two controllers built in:

- `DbController`:  Provides the route `/miq/db/clean` that is used to reset the DB to a "post seed" state (uses `ManageIQ::Integration::DatabaseCleaner` for this)
- `FactoryController`:  Provides the route `/miq/factory/create` which can be used by the end user to create arbitrary factories based on our definitions.


Links
-----

* Proposal for https://github.com/ManageIQ/manageiq/issues/20453
* Postgres Doc Links:
  - https://www.postgresql.org/docs/10/manage-ag-templatedbs.html
  - https://www.postgresql.org/docs/10/sql-createdatabase.html
  - https://www.postgresql.org/docs/10/postgres-fdw.html
  - https://www.postgresql.org/docs/10/sql-importforeignschema.html
  - https://www.postgresql.org/docs/10/sql-createschema.html
  - https://www.postgresql.org/docs/10/sql-createserver.html
  - https://www.postgresql.org/docs/10/sql-insert.html (info on doing a `INSERT` with data from a `SELECT`)
* https://thoughtbot.com/blog/postgres-foreign-data-wrapper


Steps for Testing/QA
--------------------

I was testing a lot of this code manually (and will eventually integrate it into https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/150 ), but for now, you can try this out by doing the following in a console (by testing the enduser routes I created:

```console
$ rake integration:seed:db
$ RAILS_ENV=integration bin/rails c
irb> app.post "/miq/factory/create", params: {:name => "vm_vmware", :attributes => {}}
irb> app.post "/miq/factory/create", params: {:name => "vm_vmware", :attributes => {}}
irb> app.delete "/miq/db/clean"
irb> Vm.count
```