### PR TITLE
remove deprecation warning about service display being renamed

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -63,7 +63,6 @@ class Service < ApplicationRecord
   include CiFeatureMixin
   include CustomActionsMixin
   include CustomAttributeMixin
-  include DeprecationMixin
   include ExternalUrlMixin
   include LifecycleMixin
   include Metric::CiMixin
@@ -79,6 +78,8 @@ class Service < ApplicationRecord
   include_concern 'Operations'
   include_concern 'ResourceLinking'
   include_concern 'RetirementManagement'
+
+  hide_attribute "display"
 
   virtual_total :v_total_vms, :vms, :arel => aggregate_hardware_arel("v_total_vms", vms_tbl[:id].count, :skip_hardware => true)
 
@@ -108,7 +109,6 @@ class Service < ApplicationRecord
   alias parent_service parent
   alias_attribute :service, :parent
   virtual_belongs_to :service
-  deprecate_attribute :display, :visible
 
   def power_states
     vms.map(&:power_state)


### PR DESCRIPTION
service display was renamed to visible to avoid a name collision with the Kernel#display method (added in https://github.com/ManageIQ/manageiq/pull/19211)
and the rename itself got merged in https://github.com/ManageIQ/manageiq-automation_engine/pull/449
so we no longer need the warning 



