### PR TITLE
Just ignore the entire log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,10 +63,7 @@ db/schema.rb
 db/fixtures/ae_datastore/ManageIQ/.manifest.yaml
 
 # log/
-log/*.gz
-log/*.log
-log/*.txt
-log/call_graph_*.html
+log
 
 # product/
 product/automate


### PR DESCRIPTION
Rather than ignore specific files in the `log` subdirectory, just ignore the `log` directory itself. The issue that can be confusing is that when doing local development, any untracked file that you might create will cause the entire `log` directory to show up as an untracked file.

To reproduce:
```
> touch log/evm.bak
> git status
```