### PR TITLE
Allow services to set a queue_name for VM provisioning.

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -51,7 +51,12 @@ class MiqProvision < MiqProvisionTask
 
   def execute_queue
     super(:zone        => my_zone,
+          :queue_name  => my_queue_name,
           :msg_timeout => CLONE_SYNCHRONOUS ? CLONE_TIME_LIMIT : MiqQueue::TIMEOUT)
+  end
+
+  def my_queue_name
+    source.ext_management_system&.queue_name_for_ems_operations
   end
 
   def placement_auto

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -188,6 +188,29 @@ RSpec.describe MiqProvision do
 
           @vm_prov.my_zone
         end
+
+        it "#execute_queue" do
+          tracking_label = "r#{@pr.id}_miq_provision_#{@vm_prov.id}"
+          miq_callback = {
+            :class_name  => 'MiqProvision',
+            :instance_id => @vm_prov.id,
+            :method_name => :execute_callback
+          }
+          allow(@pr).to receive(:approved?).and_return(true)
+          expect(MiqQueue).to receive(:put).with(
+            :class_name     => 'MiqProvision',
+            :instance_id    => @vm_prov.id,
+            :method_name    => 'execute',
+            :role           => 'ems_operations',
+            :tracking_label => tracking_label,
+            :msg_timeout    => MiqQueue::TIMEOUT,
+            :queue_name     => @vm_prov.my_queue_name,
+            :zone           => @vm_prov.my_zone,
+            :deliver_on     => nil,
+            :miq_callback   => miq_callback
+          )
+          @vm_prov.execute_queue
+        end
       end
     end
   end


### PR DESCRIPTION
Followup of https://github.com/ManageIQ/manageiq/pull/19479

https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/12424

cc @agrare @tinaafitz 