### PR TITLE
[WIP] Use `.update_attribute` over `.save!` for User login

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -111,8 +111,7 @@ module Authenticator
       end
 
       if user_or_taskid.kind_of?(User)
-        user_or_taskid.lastlogon = Time.now.utc
-        user_or_taskid.save!
+        user_or_taskid.update_attribute(:lastlogon, Time.now.utc) # rubocop:disable Rails/SkipsModelValidations
       end
 
       user_or_taskid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,11 +175,11 @@ class User < ApplicationRecord
   end
 
   def unlock!
-    update!(:failed_login_attempts => 0)
+    update_attribute(:failed_login_attempts, 0) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def fail_login!
-    update!(:failed_login_attempts => failed_login_attempts + 1)
+    update_attribute(:failed_login_attempts, failed_login_attempts + 1) # rubocop:disable Rails/SkipsModelValidations
 
     unlock_queue if locked?
   end


### PR DESCRIPTION
For the two columns in question:

- Updating `:failed_login_attempts`
- Updating `:lastlogin`

Doing a full set of user validations is unnecessary, and ends up triggering some extra quries thanks to the `UniqueWithinRegionValidator`:

https://github.com/ManageIQ/manageiq/blob/cadc08a7/lib/unique_within_region_validator.rb

Since neither of these column updates have any relevance to that uniqueness check, there is no need to validate, and in turn, make extra queries as part of ~~every API request~~ each login request.

Similar fixes in the future will be addressing `User` authentication in the API further, but this is a simple and succinct set of changes to start that effort.


Benchmarks
----------

tl; dr:  There is ~17% reduction in queries (26 -> 20) with this change, but that isn't reflected in `ms` in my environment due to nearly zero latency between app and DB.

~~This has been tested to reduce queries when using based token auth in the API.~~ I was mistaken with this statement... and these particular fixes only affects `/api/auth` routes.

Both the **Before** and **After** benchmarks were taken with two runs of the same command from `manageiq-performance`:

```console
$ bundle exec miqperf benchmark -ac 5 "/api/users"
D, [2020-08-21T11:38:21.658079 #79425] DEBUG -- : --> logging in...
D, [2020-08-21T11:38:22.012845 #79425] DEBUG -- : --> making GET request: /api/users
D, [2020-08-21T11:38:22.107294 #79425] DEBUG -- : --> making GET request: /api/users
D, [2020-08-21T11:38:22.198779 #79425] DEBUG -- : --> making GET request: /api/users
D, [2020-08-21T11:38:22.291756 #79425] DEBUG -- : --> making GET request: /api/users
D, [2020-08-21T11:38:22.383895 #79425] DEBUG -- : --> making GET request: /api/users
```

The reporting for `manageiq-performance` splits out the requests based URL, so the first `/api/auth` command is then associated with first 5 `/api/users` calls, and the second `/api/auth` is with the last 5 `/api/users` calls.

Note:  the savings is only in the number of queries for `/api/auth`, and not for any of the `/api/users` calls (though some separate fixes to address that will be added in the future), and the first request of the **Before** and **After** are slow because the server process just booted (so autoloading).


### Before

```
/api/auth
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 5115 |      26 |        187 |   10 |
|  261 |      26 |        9.6 |   10 |
/api/users
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  140 |      12 |         12 | 1494 |
|   53 |      10 |        3.8 |   12 |
|   17 |      10 |        3.6 |   12 |
|   15 |      10 |        3.1 |   12 |
|   16 |      10 |        3.3 |   12 |
|   16 |      10 |        3.3 |   12 |
|   16 |      10 |        3.3 |   12 |
|   16 |      10 |        3.5 |   12 |
|   16 |      10 |        3.1 |   12 |
|   15 |      10 |        3.3 |   12 |
```


### After

```
/api/auth
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 5148 |      20 |        185 |    8 |
|  256 |      20 |        7.4 |    8 |
/api/users
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  140 |      12 |         12 | 1494 |
|   18 |      10 |        3.9 |   12 |
|   17 |      10 |        4.2 |   12 |
|   15 |      10 |        3.3 |   12 |
|   14 |      10 |        3.2 |   12 |
|   16 |      10 |        3.4 |   12 |
|   16 |      10 |        3.1 |   12 |
|   16 |      10 |        3.1 |   12 |
|   16 |      10 |        3.3 |   12 |
|   16 |      10 |        3.0 |   12 |
```


Links
-----

* Helping speed up the API:  https://github.com/ManageIQ/manageiq-api/issues/880
* The extra `.update!` calls were introduced in https://github.com/ManageIQ/manageiq/pull/20087