### PR TITLE
Move the OrchestrationStack collections to CloudManager

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -30,6 +30,57 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def orchestration_stacks_resources
+          add_properties(
+            :model_class                  => ::OrchestrationStackResource,
+            :parent_inventory_collections => %i(orchestration_stacks)
+          )
+        end
+
+        def orchestration_stacks_outputs
+          add_properties(
+            :model_class                  => ::OrchestrationStackOutput,
+            :parent_inventory_collections => %i(orchestration_stacks)
+          )
+        end
+
+        def orchestration_stacks_parameters
+          add_properties(
+            :model_class                  => ::OrchestrationStackParameter,
+            :parent_inventory_collections => %i(orchestration_stacks)
+          )
+        end
+
+        def orchestration_templates
+          # TODO(lsmola) do refactoring, we shouldn't need this custom saving block\
+          orchestration_templates_save_block = lambda do |_ems, inventory_collection|
+            hashes = inventory_collection.data.map(&:attributes)
+
+            templates = inventory_collection.model_class.find_or_create_by_contents(hashes)
+            inventory_collection.data.zip(templates).each do |inventory_object, template|
+              inventory_object.id = template.id
+            end
+          end
+
+          add_properties(
+            :custom_save_block => orchestration_templates_save_block
+          )
+        end
+
+        def orchestration_stack_ancestry
+          skip_auto_inventory_attributes
+          skip_model_class
+
+          add_properties(
+            :custom_save_block => orchestration_stack_ancestry_save_block
+          )
+
+          add_dependency_attributes(
+            :orchestration_stacks           => ->(persister) { [persister.collections[:orchestration_stacks]] },
+            :orchestration_stacks_resources => ->(persister) { [persister.collections[:orchestration_stacks_resources]] }
+          )
+        end
+
         def vm_and_template_labels
           # TODO(lsmola) make a generic CustomAttribute IC and move it to base class
           add_properties(
@@ -82,6 +133,32 @@ module ManageIQ::Providers
       end
 
       private
+
+      def orchestration_stack_ancestry_save_block
+        lambda do |_ems, inventory_collection|
+          stacks_inventory_collection = inventory_collection.dependency_attributes[:orchestration_stacks].try(:first)
+
+          return if stacks_inventory_collection.blank?
+
+          stacks_parents = stacks_inventory_collection.data.each_with_object({}) do |x, obj|
+            parent_id = x.data[:parent].try(:load).try(:id)
+            obj[x.id] = parent_id if parent_id
+          end
+
+          model_class = stacks_inventory_collection.model_class
+
+          stacks_parents_indexed = model_class.select(%i(id ancestry))
+                                              .where(:id => stacks_parents.values).find_each.index_by(&:id)
+
+          ActiveRecord::Base.transaction do
+            model_class.select(%i(id ancestry))
+                       .where(:id => stacks_parents.keys).find_each do |stack|
+              parent = stacks_parents_indexed[stacks_parents[stack.id]]
+              stack.update_attribute(:parent, parent)
+            end
+          end
+        end
+      end
 
       def vm_and_miq_template_ancestry_save_block
         lambda do |_ems, inventory_collection|

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -144,87 +144,10 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       add_common_default_values
     end
 
-    def orchestration_stacks_resources
-      add_properties(
-        :model_class                  => ::OrchestrationStackResource,
-        :parent_inventory_collections => %i(orchestration_stacks)
-      )
-    end
-
-    def orchestration_stacks_outputs
-      add_properties(
-        :model_class                  => ::OrchestrationStackOutput,
-        :parent_inventory_collections => %i(orchestration_stacks)
-      )
-    end
-
-    def orchestration_stacks_parameters
-      add_properties(
-        :model_class                  => ::OrchestrationStackParameter,
-        :parent_inventory_collections => %i(orchestration_stacks)
-      )
-    end
-
-    def orchestration_templates
-      # TODO(lsmola) do refactoring, we shouldn't need this custom saving block\
-      orchestration_templates_save_block = lambda do |_ems, inventory_collection|
-        hashes = inventory_collection.data.map(&:attributes)
-
-        templates = inventory_collection.model_class.find_or_create_by_contents(hashes)
-        inventory_collection.data.zip(templates).each do |inventory_object, template|
-          inventory_object.id = template.id
-        end
-      end
-
-      add_properties(
-        :custom_save_block => orchestration_templates_save_block
-      )
-    end
-
-    def orchestration_stack_ancestry
-      skip_auto_inventory_attributes
-      skip_model_class
-
-      add_properties(
-        :custom_save_block => orchestration_stack_ancestry_save_block
-      )
-
-      add_dependency_attributes(
-        :orchestration_stacks           => ->(persister) { [persister.collections[:orchestration_stacks]] },
-        :orchestration_stacks_resources => ->(persister) { [persister.collections[:orchestration_stacks_resources]] }
-      )
-    end
-
     protected
 
     def add_common_default_values
       add_default_values(:ems_id => ->(persister) { persister.manager.id })
-    end
-
-    def orchestration_stack_ancestry_save_block
-      lambda do |_ems, inventory_collection|
-        stacks_inventory_collection = inventory_collection.dependency_attributes[:orchestration_stacks].try(:first)
-
-        return if stacks_inventory_collection.blank?
-
-        stacks_parents = stacks_inventory_collection.data.each_with_object({}) do |x, obj|
-          parent_id = x.data[:parent].try(:load).try(:id)
-          obj[x.id] = parent_id if parent_id
-        end
-
-        model_class = stacks_inventory_collection.model_class
-
-        stacks_parents_indexed = model_class.select(%i(id ancestry))
-                                            .where(:id => stacks_parents.values).find_each.index_by(&:id)
-
-        ActiveRecord::Base.transaction do
-          model_class.select(%i(id ancestry))
-                     .where(:id => stacks_parents.keys).find_each do |stack|
-            parent = stacks_parents_indexed[stacks_parents[stack.id]]
-            stack.update_attribute(:parent, parent)
-          end
-        end
-      end
     end
 
     def relationship_save_block(relationship_key:, relationship_type: :ems_metadata, parent_type: nil)


### PR DESCRIPTION
These collections are very different from the ones used by InfraManagers.  OpenShift Infra depends on these behaving like the cloud manager which is causing those tests to fail.

Adding orchestration templates to the infra manager collections started causing the openstack tests to fail because it expects to use a custom saver where VMware uses the standard ems_id+ems_ref.

https://travis-ci.com/github/ManageIQ/manageiq-providers-openstack/jobs/375836445#L2419

Dependent: https://github.com/ManageIQ/manageiq-providers-openstack/pull/627