### PR TITLE
only save generic object property_methods if they're changed

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -137,7 +137,9 @@ class GenericObjectDefinition < ApplicationRecord
   end
 
   def add_property_method(name)
-    properties[:methods] << name.to_s unless properties[:methods].include?(name.to_s)
+    return if properties[:methods].include?(name.to_s)
+
+    properties[:methods] << name.to_s
     save!
   end
 

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe GenericObjectDefinition do
     end
 
     it 'does nothing for existing method' do
-      definition.add_property_method("method1")
+      expect { definition.add_property_method("method1") }.to make_database_queries(count: 11)
       expect(definition.properties).to include(:methods => %w(method1))
     end
   end

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe GenericObjectDefinition do
     end
 
     it 'does nothing for existing method' do
-      expect { definition.add_property_method("method1") }.to make_database_queries(count: 11)
+      expect { definition.add_property_method("method1") }.to make_database_queries(:count => 4..8)
       expect(definition.properties).to include(:methods => %w(method1))
     end
   end


### PR DESCRIPTION
only save generic object def in add_property if changed. to see the difference, view by commit: without the dirty check, we make 11 database hits. with, we'll make between 4 and 8 (the eight is a less often sporadic failure, either way, this is a trivial improvement.)

