### PR TITLE
Remove 'create_security_group' feature

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -76,7 +76,6 @@ module SupportsFeatureMixin
     :conversion_host                     => 'Conversion host capable',
     :create_floating_ip                  => 'Floating IP Creation',
     :create_host_aggregate               => 'Host Aggregate Creation',
-    :create_security_group               => 'Security Group Creation',
     :console                             => 'Remote Console',
     :external_logging                    => 'Launch External Logging UI',
     :swift_service                       => 'Swift storage service',


### PR DESCRIPTION
The feature is currently unused. It was introduced in e949f5335388c40e248c50554223a13eff7629d6 but then removed in 437743078d2ede81b424b025cfe8d8f6d05bc84

@miq-bot add_label technical_debt