### PR TITLE
Add back Cloud Provider Load Balancer Menus

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4273,6 +4273,35 @@
         :feature_type: admin
         :identifier: network_service_entry_delete
 
+# Load Balancer
+- :name: Load Balancers
+  :description: Everything under Load Balancers
+  :feature_type: node
+  :identifier: load_balancer
+  :children:
+  - :name: View
+    :description: View Load Balancers
+    :feature_type: view
+    :identifier: load_balancer_view
+    :children:
+    - :name: List
+      :description: Display Lists of Load Balancers
+      :feature_type: view
+      :identifier: load_balancer_show_list
+    - :name: Show
+      :description: Display Individual Load Balancers
+      :feature_type: view
+      :identifier: load_balancer_show
+  - :name: Operate
+    :description: Perform Operations on Load Balancers
+    :feature_type: control
+    :identifier: load_balancer_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Load Balancer
+      :feature_type: control
+      :identifier: load_balancer_tag
+
 # ContainerGroup
 - :name: Pods
   :description: Everything under Pods

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -354,6 +354,11 @@
   :url: /network_port/show_list
   :rbac_feature_name: network_port_show_list
   :startup: true
+- :name: load_balancers
+  :description: Networks / Load Balancers
+  :url: /load_balancer/show_list
+  :rbac_feature_name: load_balancer_show_list
+  :startup: true
 - :name: network_topology
   :description: Networks / Topology
   :url: /network_topology

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -1039,6 +1039,7 @@
   - ems_infra
   - ems_physical_infra
   - host
+  - load_balancer
   - miq_ae_class_explorer
   - miq_ae_customization_explorer
   - miq_ae_class_import_export
@@ -1284,6 +1285,7 @@
   - infra_topology
   - instance_view
   - iso_datastore_view
+  - load_balancer_view
   - miq_ae_class_log
   - miq_ae_domain_view
   - miq_report_saved_reports_view

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -42,6 +42,7 @@ module Rbac
       HostAggregate
       IsoImage
       Lan
+      LoadBalancer
       MiddlewareDatasource
       MiddlewareDeployment
       MiddlewareDomain
@@ -72,6 +73,7 @@ module Rbac
       CloudNetwork
       CloudSubnet
       FloatingIp
+      LoadBalancer
       NetworkPort
       NetworkRouter
       SecurityGroup

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1026,6 +1026,7 @@ en:
       ems_physical_infras:         Physical Infrastructure Providers
       ems_storage:                 Storage Manager
       floating_ips:                Floating IP
+      load_balancer:               Load Balancer
       network_port:                Network Port
       network_router:              Network Router
       evm_owner:                   EVM Owner

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2019,6 +2019,7 @@ RSpec.describe Rbac::Filterer do
         CloudNetwork
         CloudSubnet
         FloatingIp
+        LoadBalancer
         NetworkPort
         NetworkRouter
         SecurityGroup


### PR DESCRIPTION
This reverts https://github.com/ManageIQ/manageiq/pull/18918 adding back the Load Balancer menus