### PR TITLE
Add IBM Cloud to 'eligible_for_provisioning' list

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -13,9 +13,10 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
 
   def self.eligible_for_provisioning
     super.where(:type => %w(ManageIQ::Providers::Amazon::CloudManager::Template
-                            ManageIQ::Providers::Openstack::CloudManager::Template
                             ManageIQ::Providers::Azure::CloudManager::Template
                             ManageIQ::Providers::Google::CloudManager::Template
+                            ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
+                            ManageIQ::Providers::Openstack::CloudManager::Template
                             ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate
                             ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate))
   end


### PR DESCRIPTION
Add IBM Cloud Power Virtual Servers Template to list of Templates
'eligible_for_provisioning' to enable manageiq-providers-ibm_cloud.

This pluggability issue is already included in #19440