### PR TITLE
[AuthenticationMixin] Fix .authentication_status

### DIFF
--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -785,6 +785,28 @@ RSpec.describe AuthenticationMixin do
       end
     end
 
+    context "with an unrelated and existing valid authentication" do
+      let(:id_start_point)        { [Host.order(:id).last&.id.to_i, ExtManagementSystem.order(:id).last&.id.to_i].max }
+      let(:host)                  { FactoryBot.create(:host, :id => ext_management_system.id) }
+      let(:ext_management_system) { FactoryBot.create(:ext_management_system, :authtype => "default", :id => id_start_point + 1) }
+
+      before { host }
+
+      it "is nil with sql" do
+        expect(virtual_column_sql_value(Host, "authentication_status")).to be_nil
+      end
+
+      it "is 'None' with pure ruby (via relations)" do
+        expect(host.authentication_status).to eq("None")
+      end
+
+      it "is 'None' when accessed via ruby, but fetched via sql" do
+        fetched_host = Host.select(:id, :authentication_status).first
+        expect(fetched_host.attributes[:authentication_status]).to be_nil
+        expect(fetched_host.authentication_status).to eq("None")
+      end
+    end
+
     context "with a valid authentication" do
       before { valid_auth }
 


### PR DESCRIPTION
Addresses https://github.com/ManageIQ/manageiq/issues/20115

Also, a **HUGE** thanks to @mzazrivec and @lpichler for the preliminary research in that issue that probably saved me a ton of time in diagnosing the issue (which I [ultimately repeated](https://github.com/ManageIQ/manageiq/issues/20115#issuecomment-682061236) because my brain is dumb)

Background:
-----------

As mentioned in the **lengthy** comment in `AuthenticationMixin`, this ensures that there is the following stanza in the WHERE clause:

```
'"authentications"."relationship_type" = ?'
```

Specifically, when `.authentication_status` is used in the `.select` of a `ActiveRecord` query.

Previously, it would generate something like this (using Host as the example class here):

```
SELECT "hosts".*,
       (SELECT  "authentications"."status"
        FROM "authentications"
        WHERE "authentications"."resource_id" = "hosts"."id"
        ORDER BY CASE
                   WHEN LOWER("authentications"."status") = ''            THEN -1
                   WHEN LOWER("authentications"."status") = 'valid'       THEN 0
                   WHEN LOWER("authentications"."status") = 'none'        THEN 1
                   WHEN LOWER("authentications"."status") = 'incomplete'  THEN 1
                   WHEN LOWER("authentications"."status") = 'error'       THEN 2
                   WHEN LOWER("authentications"."status") = 'unreachable' THEN 2
                   WHEN LOWER("authentications"."status") = 'invalid'     THEN 3
                   ELSE -1
                 END DESC
        LIMIT 1) AS "authentication_status"
FROM "hosts"
WHERE "hosts"."type" IN ('ManageIQ::Providers::Redhat::InfraManager::Host')
  AND (hosts.id IN (2))
  ```

Where you will see the nested `SELECT` matches on `resource_id`, but not `resource_type`.  In this case, if there was a EMS with the same id as the host in question, it's `Authentication` record could be returned instead of what is associated with the Host.  In particular, if the Host happened to have 0 Authentication records, it means that when doing this particular query, it could appear to be given a status of "None" in one case (the default when there are no records), and a say "Valid" state when the query is used via a nested `SELECT` and EMS's `Authentication` record is "Valid".

* * *

The only side effect of this approach (aside from the ugly code it produces) is that there are now cases where the `resource_type` check happens twice within the same query.  Since they results should be equivalent, this shouldn't matter besides slightly increasing the query string length length sent to Postgres (which shouldn't ultimately matter).


TODO
----

* [ ] Add specs

(Note:  The QA steps below basically will outline the kind of test that will be written)

Links
-----

* Issue Addressed: https://github.com/ManageIQ/manageiq/issues/20115
* PR adding this `virtual_delegate`:  https://github.com/ManageIQ/manageiq/pull/18196


Steps for Testing/QA
--------------------

I have some comments starting here that can provide some background:

https://github.com/ManageIQ/manageiq/issues/20115#issuecomment-681096691

But effectively, you need any single provider/EMS with

- least a single "Valid" `Authentication` record
- couple of associated `Host` records with no `Authentication` records

When using the script in the comment above, the `Host` record with the ID that matches the EMS will show "None" when executing `.authentication_status` directly, but "Valid" when executing via a query for it that used a nested `SELECT`.

A reduced form of the script in a Rails console is just testing the following two queries:

```ruby
irb(main):001:0> my_ems_id = ExtManagementSystem.first # change this as needed for your DB
irb(main):002:0> Host.find(my_ems_id).authentication_status
#=> "None"
irb(main):004:0> Host.where(:id => my_ems_id).select(:id, :authentication_status).first.authentication_status
#=> "Valid"
```

With the fix in, both results should return "None".