### PR TITLE
[wip] remove extra custom button save queries 

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -12,7 +12,7 @@ class CustomButton < ApplicationRecord
   serialize :visibility
 
   validates :applies_to_class, :presence => true
-  validates :name, :description, :uniqueness => {:scope => [:applies_to_class, :applies_to_id]}, :presence => true
+  validates :name, :description, :uniqueness => {:scope => [:applies_to_class, :applies_to_id]}, :presence => true, :if => :name_or_description_changed?
 
   virtual_attribute :uri_attributes, :string
 
@@ -69,6 +69,10 @@ class CustomButton < ApplicationRecord
     end
 
     where(:applies_to_class => applies_to_class, :applies_to_id => applies_to_id)
+  end
+
+  def name_or_description_changed?
+    name_changed? || description_changed?
   end
 
   def expanded_serializable_hash

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe CustomButton do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.save }.to make_database_queries(:count => 5)
+  end
+
   context "with no buttons" do
     describe '#evaluate_enablement_expression_for' do
       let(:miq_expression) { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => 'vm_1'}) }

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CustomButton do
 
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create
-    expect { m.save }.to make_database_queries(:count => 5)
+    expect { m.save }.to make_database_queries(:count => 3)
   end
 
   context "with no buttons" do


### PR DESCRIPTION
Saving a cb is more expensive than it should be. Two of the five (and two of the remaining three in the second commit) are savepoint/release. It's work in progress cause of the last one on the second commit, I haven't hunted it down yet. Or maybe this idea is a non-starter, I dunno. 

@miq-bot add_label performance
@miq-bot assign @kbrock 