### PR TITLE
enable relative paths for directory param in rake export

### DIFF
--- a/lib/task_helpers/exports.rb
+++ b/lib/task_helpers/exports.rb
@@ -18,6 +18,7 @@ module TaskHelpers
         unless abs_path == dir
           options[:directory] = abs_path
         end
+      end
       
       ensure_absolute_path(options[:directory])
   

--- a/lib/task_helpers/exports.rb
+++ b/lib/task_helpers/exports.rb
@@ -12,9 +12,9 @@ module TaskHelpers
         opt :directory, 'Directory to place exported files in', :type => :string, :required => true
         opt :all, 'Export read-only objects', :type => :boolean, :default => false
       end
-      
+
       options[:directory] = File.absolute_path(options[:directory])
-      
+
       error = validate_directory(options[:directory])
       Optimist.die :directory, error if error
 

--- a/lib/task_helpers/exports.rb
+++ b/lib/task_helpers/exports.rb
@@ -12,16 +12,9 @@ module TaskHelpers
         opt :directory, 'Directory to place exported files in', :type => :string, :required => true
         opt :all, 'Export read-only objects', :type => :boolean, :default => false
       end
-
-      def ensure_absolute_path(dir)
-        abs_path = File.absolute_path(dir)
-        unless abs_path == dir
-          options[:directory] = abs_path
-        end
-      end
       
-      ensure_absolute_path(options[:directory])
-  
+      options[:directory] = File.absolute_path(options[:directory])
+      
       error = validate_directory(options[:directory])
       Optimist.die :directory, error if error
 

--- a/lib/task_helpers/exports.rb
+++ b/lib/task_helpers/exports.rb
@@ -13,6 +13,14 @@ module TaskHelpers
         opt :all, 'Export read-only objects', :type => :boolean, :default => false
       end
 
+      def ensure_absolute_path(dir)
+        abs_path = File.absolute_path(dir)
+        unless abs_path == dir
+          options[:directory] = abs_path
+        end
+      
+      ensure_absolute_path(options[:directory])
+  
       error = validate_directory(options[:directory])
       Optimist.die :directory, error if error
 


### PR DESCRIPTION
Currently the evm:export commands require a fully qualified path for the "directory" parameter.  This simple change enables the script to handle relative paths too.