### PR TITLE
MiqSmartProxyWorker not running in Podified

### DIFF
--- a/app/models/miq_smart_proxy_worker.rb
+++ b/app/models/miq_smart_proxy_worker.rb
@@ -1,8 +1,14 @@
 class MiqSmartProxyWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.required_roles       = ["smartproxy"]
   self.default_queue_name   = "smartproxy"
+
+  def self.supports_container?
+    true
+  end
 
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_SMART_PROXY_WORKERS


### PR DESCRIPTION
SmartState jobs aren't getting started on podified, no MiqSmartProxyWorker is running so the start signal never gets run.