### PR TITLE
Update ibm_cloud_power_virtual_servers spec description

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ExtManagementSystem do
       "gce"                             => "Google Compute Engine",
       "gce_network"                     => "Google Network",
       "ibm_cloud_network"               => "IBM Cloud Networks",
-      "ibm_cloud_power_virtual_servers" => "IBM Cloud",
+      "ibm_cloud_power_virtual_servers" => "IBM Power Systems Virtual Servers",
       "ibm_cloud_storage"               => "IBM Cloud Storage",
       "ibm_terraform_configuration"     => "IBM Terraform Configuration",
       "kubernetes"                      => "Kubernetes",


### PR DESCRIPTION
Updating the ibm_cloud_power_virtual_servers spec description to match
change in
https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/9