### PR TITLE
add changed check to user lookup for namespaces

### DIFF
--- a/app/models/mixins/miq_ae_set_user_info_mixin.rb
+++ b/app/models/mixins/miq_ae_set_user_info_mixin.rb
@@ -1,11 +1,15 @@
 module MiqAeSetUserInfoMixin
   extend ActiveSupport::Concern
   included do
-    before_validation  :set_user_info
+    before_validation :set_user_info, :if => :user_info_changed?
   end
 
   def set_user_info
     self.updated_by         = User.current_userid || 'system'
     self.updated_by_user_id = User.current_user.try(:id)
+  end
+
+  def user_info_changed?
+    updated_by_changed? || updated_by_user_id_changed? || new_record?
   end
 end


### PR DESCRIPTION
I don't think we need an extra query every time for users when we save automate namespaces, or miq_ae_fields, or any of these:

```
app/models/miq_ae_class.rb:2:  include MiqAeSetUserInfoMixin
app/models/miq_ae_field.rb:2:  include MiqAeSetUserInfoMixin
app/models/miq_ae_instance.rb:2:  include MiqAeSetUserInfoMixin
app/models/miq_ae_method.rb:4:  include MiqAeSetUserInfoMixin
app/models/miq_ae_namespace.rb:5:  include MiqAeSetUserInfoMixin
app/models/miq_ae_value.rb:2:  include MiqAeSetUserInfoMixin
```


@miq-bot add_label performance
@miq-bot assign @kbrock 