### PR TITLE
add changed to miq ae field name uniqueness validation 

### DIFF
--- a/app/models/miq_ae_field.rb
+++ b/app/models/miq_ae_field.rb
@@ -7,7 +7,7 @@ class MiqAeField < ApplicationRecord
   has_many   :ae_values,  :class_name => "MiqAeValue",  :foreign_key => :field_id, :dependent => :destroy,
                           :inverse_of => :ae_field
 
-  validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
+  validates :name, :uniqueness => {:scope => [:class_id, :method_id], :case_sensitive => false}, :if => :name_changed?
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[\w]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ characters")

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe MiqAeField do
       end
     end
 
+    it "doesn't access database when unchanged model is saved" do
+      m = described_class.create
+      expect { m.save }.to make_database_queries(:count => 4)
+    end
+
     it "should process boolean fields properly" do
       fname1 = "TEST_EVALUATE"
       f1 = @c1.ae_fields.build(:name => fname1)

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe MiqAeField do
       end
     end
 
-    it "doesn't access database when unchanged model is saved" do
-      m = described_class.create
-      expect { m.save }.to make_database_queries(:count => 4)
+    it "doesn't access database (either via name uniqueness or set_user_info validation) when unchanged model is saved" do
+      miq_ae_field = described_class.create!(:name => "display_name")
+      expect { miq_ae_field.save }.to make_database_queries(:count => 2)
     end
 
     it "should process boolean fields properly" do


### PR DESCRIPTION
name uniqueness on miq ae fields adds an extra query on `save!` and i'm not sure we need it 

@miq-bot add_label performance
@miq-bot assign @kbrock 

the second commit, at the time of this writing, is ~~3: https://github.com/ManageIQ/manageiq/pull/20500 + savepoint & release~~ 2 since 20500 was just merged, thanks KB