### PR TITLE
log warning if creation of task to generate widget was skipped

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -202,11 +202,12 @@ class MiqWidget < ApplicationRecord
       end
     else
       timeout_stalled_task
-      unless MiqTask.exists?(:name   => "Generate Widget: '#{title}'",
-                             :userid => User.current_userid || 'system',
-                             :state  => %w(Queued Active))
+      if MiqTask.exists?(:name   => "Generate Widget: '#{title}'",
+                         :userid => User.current_userid || 'system',
+                         :state  => %w[Queued Active])
+        _log.warn("#{log_prefix} Skipping task creation for widget content generation. Task with name \"Generate Widget: '#{title}' already exists\"")
+      else
         task = create_task(group_hash.length)
-
         _log.info("#{log_prefix} Queueing Content Generation")
         group_hash.each do |g, u|
           options = generate_content_options(g, u)
@@ -336,9 +337,11 @@ class MiqWidget < ApplicationRecord
       generate_content(*options)
     else
       timeout_stalled_task
-      unless MiqTask.exists?(:name   => "Generate Widget: '#{title}'",
-                             :userid => user.userid,
-                             :state  => %w(Queued Active))
+      if MiqTask.exists?(:name   => "Generate Widget: '#{title}'",
+                         :userid => user.userid,
+                         :state  => %w[Queued Active])
+        _log.warn("#{log_prefix} Skipping task creation for widget content generation. Task with name \"Generate Widget: '#{title}' already exists\"")
+      else
         create_task(1, user.userid)
         queue_generate_content_for_users_or_group(*options)
       end

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -316,7 +316,14 @@ RSpec.describe MiqWidget do
       }
     end
 
-    it "returns MiqTask id if successful" do
+    it "skips task creation and records warn message if MiqTask for generating widget content exists and not finished" do
+      MiqTask.create(:name => "Generate Widget: '#{@widget.title}'", :state => "Queued", :status => "Ok", :userid => "system")
+      expect($log).to receive(:warn).with(skip_message(@widget))
+      @widget.queue_generate_content
+    end
+
+    it "returns MiqTask id if successful and not records warn message" do
+      expect($log).not_to receive(:warn).with(skip_message(@widget))
       return_value = @widget.queue_generate_content
       expect(return_value).to equal(MiqTask.where(:name => "Generate Widget: '#{@widget.title}'",
                                                   :id   => @widget.reload.miq_task_id).first.id)
@@ -627,6 +634,13 @@ RSpec.describe MiqWidget do
     it "with single user" do
       expect { @widget.create_initial_content_for_user(@user) }.not_to raise_error
     end
+
+    it "skips task creation and record warn message if MiqTask for generating widget content exists and not finished" do
+      MiqTask.create(:name => "Generate Widget: '#{@widget.title}'", :state => "Queued", :status => "Ok", :userid => @user.userid)
+      allow(@widget).to receive(:contents_for_user).and_return(nil)
+      expect($log).to receive(:warn).with(skip_message(@widget))
+      @widget.create_initial_content_for_user(@user)
+    end
   end
 
   context "multiple groups" do
@@ -836,4 +850,8 @@ RSpec.describe MiqWidget do
       expect(widget.status_message).to eq("message")
     end
   end
+end
+
+RSpec::Matchers.define :skip_message do |widget|
+  match { |actual| actual.include?("Skipping task creation for widget content generation. Task with name \"Generate Widget: '#{widget.title}' already exists\"") }
 end


### PR DESCRIPTION
**ISSUE**:
All attempts (from schedule) to add new task for widget content generation will be **_quietly_** skipped if there is already exists queued/active task to generate widget content.

**AFTER**:
log warn message if there is possible stale task for widget content generation:

```
[2020-09-01T04:00:13.585778 #14248:330f68]  WARN -- : MIQ(MiqWidget#queue_generate_content) Widget: [Tenant Quota MC] ID: [1000000000025] Skipping task creation for widget content generation. Task with name "Generate Widget: 'Tenant Quota MC' already exists"
```


BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1861046

@miq-bot add-label ivanchuk/yes, jansa/yes?

