### PR TITLE
User login scoping (API)

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -243,9 +243,14 @@ module Authenticator
     end
 
     def case_insensitive_find_by_userid(username, lookup_scope: nil)
+      user_key                          = username.downcase
+      @lookup                         ||= {}
+      @lookup[user_key]               ||= {}
+      return @lookup[user_key][lookup_scope] if @lookup[username][lookup_scope]
+
       base =  User.send(User::LOOKUP_SCOPES[lookup_scope])
       user =  base.lookup_by_userid(username)
-      user || User.in_my_region.where(:lower_userid => username.downcase).order(:lastlogon).last
+      @lookup[user_key][lookup_scope] = user || base.in_my_region.where(:lower_userid => user_key).order(:lastlogon).last
     end
 
     def userid_for(_identity, username)

--- a/app/models/authenticator/database.rb
+++ b/app/models/authenticator/database.rb
@@ -10,8 +10,8 @@ module Authenticator
 
     private
 
-    def _authenticate(username, password, _request)
-      user = case_insensitive_find_by_userid(username)
+    def _authenticate(username, password, request: nil, lookup_scope: nil)
+      user = case_insensitive_find_by_userid(username, lookup_scope: lookup_scope)
 
       return [false, _('Your account has been locked due to too many failed login attempts, please contact the administrator.')] if user&.locked?
 

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -66,7 +66,7 @@ module Authenticator
       miq_ldap.normalize(miq_ldap.fqusername(username))
     end
 
-    def _authenticate(username, password, _request)
+    def _authenticate(username, password, request: nil, lookup_scope: nil)
       password.present? &&
         ldap_bind(username, password)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,8 @@ class User < ApplicationRecord
 
   scope :with_same_userid, ->(id) { where(:userid => User.where(:id => id).pluck(:userid)) }
 
+  scope :api_includes, -> { eager_load(:current_group => [:miq_user_role, :tenant]) }
+
   def self.with_roles_excluding(identifier)
     where.not(:id => User.unscope(:select).joins(:miq_groups => :miq_product_features)
                              .where(:miq_product_features => {:identifier => identifier})

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -107,19 +107,19 @@ RSpec.describe Authenticator::Httpd do
     end
 
     it "finds existing users as username" do
-      expect(subject.lookup_by_identity('alice', request)).to eq(alice)
+      expect(subject.lookup_by_identity('alice', request: request)).to eq(alice)
     end
 
     it "finds existing users as UPN" do
-      expect(subject.lookup_by_identity('cheshire', request)).to eq(cheshire)
+      expect(subject.lookup_by_identity('cheshire', request: request)).to eq(cheshire)
     end
 
     it "finds existing users as distinguished name" do
-      expect(subject.lookup_by_identity('towmater', request)).to eq(towmater_dn)
+      expect(subject.lookup_by_identity('towmater', request: request)).to eq(towmater_dn)
     end
 
     it "doesn't create new users" do
-      expect(subject.lookup_by_identity('bob', request)).to be_nil
+      expect(subject.lookup_by_identity('bob', request: request)).to be_nil
     end
   end
 


### PR DESCRIPTION
~~**NOTE:**  Currently built on top of https://github.com/ManageIQ/manageiq/pull/20471~~

~~(though, this probably could be done without, but worth noting the **Benchmarks** included those changes)~~

A collection of tweaks to the `User` and `Authenticator::*` models to enable more effecient querying of `User` and related models

Requires `manageiq-api` changes to take effect:  https://github.com/ManageIQ/manageiq-api/pull/888

Benchmarks
----------

Note:  Improvements are in number of **queries**.


### Before

```
$ bundle exec miqperf benchmark -ac2 "/api/users"
$ bundle exec miqperf report --last
/api/auth
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 5088 |      26 |        183 |   10 |
/api/users
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  267 |      12 |         13 | 1494 |
|   17 |      10 |        3.9 |   12 |
```


### After

```
$ bundle exec miqperf benchmark -ac2 "/api/users"
$ bundle exec miqperf report --last
/api/auth
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 4949 |      12 |        181 |    1 |
/api/users
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  258 |       7 |         12 | 1489 |
|   15 |       5 |        3.3 |    7 |
```


Links
-----

* https://github.com/ManageIQ/manageiq-api/pull/888
* More improvements as part of this effort:  https://github.com/ManageIQ/manageiq-api/issues/880