### PR TITLE
add ids to the retirement log lines

### DIFF
--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Service Retirement Management" do
     end
 
     it "#finish_retirement" do
-      message = "OrchestrationStack: [#{orchestration_stack.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+      message = "OrchestrationStack: [id:<#{orchestration_stack.id}>, name:<#{orchestration_stack.name}>] with Retires On value: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
       expect(orchestration_stack).to receive(:raise_audit_event).with("orchestration_stack_retired", message, nil)
 
       orchestration_stack.finish_retirement

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe "Service Retirement Management" do
   end
 
   it "#finish_retirement" do
-    message = "Service: [#{@service.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+    message = "Service: [id:<#{@service.id}>, name:<#{@service.name}>] with Retires On value: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
     expect(@service).to receive(:raise_audit_event).with("service_retired", message, nil)
 
     @service.finish_retirement

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe "VM Retirement Management" do
   end
 
   it "#finish_retirement" do
-    message = "Vm: [#{vm2.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+    message = "Vm: [id:<#{vm2.id}>, name:<#{vm2.name}>] with Retires On value: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
     expect(vm2).to receive(:raise_audit_event).with("vm_retired", message, nil)
 
     vm2.finish_retirement


### PR DESCRIPTION
services don't have a uniqueness validation on names (which to be honest I'd love to change but is not exactly low risk). it'd be better to have both the name and id of the object being retired in logs. 


@miq-bot assign @kbrock 
@miq-bot add_label enhancement 


