### PR TITLE
Handle possibility that EMS doesn't support targeted refresh in EmsEvent#manager_refresh_targets

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -170,8 +170,12 @@ class EmsEvent < EventStream
   end
 
   def manager_refresh_targets
-    require "inventory_refresh"
-    ext_management_system.class::EventTargetParser.new(self).parse
+    if ext_management_system.allows_targeted_refresh?
+      require "inventory_refresh"
+      ext_management_system.class::EventTargetParser.new(self).parse
+    else
+      ext_management_system
+    end
   end
 
   def self.display_name(number = 1)

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -170,7 +170,7 @@ class EmsEvent < EventStream
   end
 
   def manager_refresh_targets
-    if ext_management_system.allows_targeted_refresh?
+    if ext_management_system.allow_targeted_refresh?
       require "inventory_refresh"
       ext_management_system.class::EventTargetParser.new(self).parse
     else

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -477,12 +477,22 @@ RSpec.describe EmsEvent do
     end
   end
 
-  context 'manager refresh', :manager_refresh do
+  context 'manager refresh' do
     let(:ems_azure) { FactoryBot.create(:ems_azure) }
-    let(:ems_event) {
+    let(:ems_event_azure) {
       FactoryBot.create(
         :ems_event,
         :ext_management_system => ems_azure,
+        :event_type => "CloneVM_Task",
+        :full_data  => {"info" => {"task" => "task-5324"}}
+      )
+    }
+
+    let(:ems_openstack_infra) { FactoryBot.create(:ems_openstack_infra) }
+    let(:ems_event_openstack) {
+      FactoryBot.create(
+        :ems_event,
+        :ext_management_system => ems_openstack_infra,
         :event_type => "CloneVM_Task",
         :full_data  => {"info" => {"task" => "task-5324"}}
       )
@@ -498,7 +508,12 @@ RSpec.describe EmsEvent do
       expect(klass).to receive(:new)
       expect(target_parser).to receive(:parse)
 
-      ems_event.manager_refresh_targets
+      ems_event_azure.manager_refresh_targets
+    end
+
+    it 'returns the ems if targeted refresh is not supported' do
+      expect(ems_openstack_infra).to receive(:allow_targeted_refresh?).and_return(false)
+      expect(ems_event_openstack.manager_refresh_targets).to eq(ems_openstack_infra)
     end
   end
 end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -476,4 +476,29 @@ RSpec.describe EmsEvent do
       end
     end
   end
+
+  context 'manager refresh', :manager_refresh do
+    let(:ems_azure) { FactoryBot.create(:ems_azure) }
+    let(:ems_event) {
+      FactoryBot.create(
+        :ems_event,
+        :ext_management_system => ems_azure,
+        :event_type => "CloneVM_Task",
+        :full_data  => {"info" => {"task" => "task-5324"}}
+      )
+    }
+
+    it 'performs a targeted refresh if supported' do
+      klass = ems_azure.class.const_get('EventTargetParser')
+      target_parser = klass.new(ems_azure)
+
+      allow(klass).to receive(:new).and_return(target_parser)
+
+      expect(ems_azure).to receive(:allow_targeted_refresh?).and_return(true)
+      expect(klass).to receive(:new)
+      expect(target_parser).to receive(:parse)
+
+      ems_event.manager_refresh_targets
+    end
+  end
 end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -478,42 +478,42 @@ RSpec.describe EmsEvent do
   end
 
   context 'manager refresh' do
-    let(:ems_azure) { FactoryBot.create(:ems_azure) }
-    let(:ems_event_azure) {
+    let(:ems_cloud) { FactoryBot.create(:ems_cloud) }
+    let(:ems_event_cloud) {
       FactoryBot.create(
         :ems_event,
-        :ext_management_system => ems_azure,
+        :ext_management_system => ems_cloud,
         :event_type => "CloneVM_Task",
         :full_data  => {"info" => {"task" => "task-5324"}}
       )
     }
 
-    let(:ems_openstack_infra) { FactoryBot.create(:ems_openstack_infra) }
-    let(:ems_event_openstack) {
+    let(:ems_infra) { FactoryBot.create(:ems_infra) }
+    let(:ems_event_infra) {
       FactoryBot.create(
         :ems_event,
-        :ext_management_system => ems_openstack_infra,
+        :ext_management_system => ems_infra,
         :event_type => "CloneVM_Task",
         :full_data  => {"info" => {"task" => "task-5324"}}
       )
     }
 
     it 'performs a targeted refresh if supported' do
-      klass = ems_azure.class.const_get('EventTargetParser')
-      target_parser = klass.new(ems_azure)
+      klass = ems_cloud.class.const_get('EventTargetParser')
+      target_parser = klass.new(ems_cloud)
 
       allow(klass).to receive(:new).and_return(target_parser)
 
-      expect(ems_azure).to receive(:allow_targeted_refresh?).and_return(true)
+      expect(ems_cloud).to receive(:allow_targeted_refresh?).and_return(true)
       expect(klass).to receive(:new)
       expect(target_parser).to receive(:parse)
 
-      ems_event_azure.manager_refresh_targets
+      ems_event_cloud.manager_refresh_targets
     end
 
     it 'returns the ems if targeted refresh is not supported' do
-      expect(ems_openstack_infra).to receive(:allow_targeted_refresh?).and_return(false)
-      expect(ems_event_openstack.manager_refresh_targets).to eq(ems_openstack_infra)
+      expect(ems_infra).to receive(:allow_targeted_refresh?).and_return(false)
+      expect(ems_event_infra.manager_refresh_targets).to eq(ems_infra)
     end
   end
 end


### PR DESCRIPTION
At the moment the `EmsEvent#manager_refresh_targets` assumes that the EMS supports targeted refresh. However, if it doesn't then an error like `uninitialized constant ManageIQ::Providers::Openstack::InfraManager::EventTargetParser` will arise when it tries to dynamically generate an EventTargetParser subclass that doesn't exist.

Currently this is happening via automate hooks on an openstack provider, but could potentially happen elsewhere.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1867795
