### PR TITLE
Add changed check to report name validation

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -31,7 +31,7 @@ class MiqReport < ApplicationRecord
   serialize :display_filter
 
   validates_presence_of     :name, :title, :db, :rpt_group
-  validates_uniqueness_of   :name
+  validates :name, :uniqueness => true, :if => :name_changed?
   validates_inclusion_of    :rpt_type, :in => %w( Default Custom )
 
   has_many                  :miq_report_results, :dependent => :destroy

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe MiqReport do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.save }.to make_database_queries(:count => 3)
+  end
+
   context "#format_row" do
     let(:row) { {"boot_time" => Time.now.in_time_zone('Moscow'), "name" => "v2v-ubuntu-kk"} }
     let(:report) do

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe MiqReport do
 
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create
-    expect { m.save }.to make_database_queries(:count => 3)
+    expect { m.save }.to make_database_queries(:count => 2)
   end
 
   context "#format_row" do


### PR DESCRIPTION
we can save a (measly) single query on the noop with a changed check on the name uniqueness validation. 

@miq-bot assign @kbrock 
@miq-bot add_label performance 