### PR TITLE
Update relationships to work better with future ancestry

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -400,7 +400,7 @@ module RelationshipMixin
   def grandchild_rels(*args)
     options = args.extract_options!
     rels = relationships.inject(Relationship.none) do |stmt, r|
-      stmt.or(Relationship.where(r.grandchild_conditions))
+      stmt.or(r.grandchildren)
     end
     Relationship.filter_by_resource_type(rels, options)
   end
@@ -412,7 +412,7 @@ module RelationshipMixin
   def child_and_grandchild_rels(*args)
     options = args.extract_options!
     rels = relationships.inject(Relationship.none) do |stmt, r|
-      stmt.or(Relationship.where(r.child_and_grandchild_conditions))
+      stmt.or(r.child_and_grandchildren)
     end
     Relationship.filter_by_resource_type(rels, options)
   end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -193,13 +193,13 @@ class Relationship < ApplicationRecord
   # reminders:
   # - matches("a%", nil, true) is case sensitive matching (i.e.: "like 'a%'") vs default (i.e.: "ilike 'a%'")
   #
-  def grandchild_conditions
+  def grandchildren
     t = self.class.arel_table
-    t.grouping(t[:ancestry].matches("#{child_ancestry}/%", nil, true)
-                           .and(t[:ancestry].does_not_match("#{child_ancestry}/%/%", nil, true)))
+    self.class.where(t[:ancestry].matches("#{child_ancestry}/%", nil, true))
+        .where(t[:ancestry].does_not_match("#{child_ancestry}/%/%", nil, true))
   end
 
-  def child_and_grandchild_conditions
-    grandchild_conditions.or(child_conditions)
+  def child_and_grandchildren
+    grandchildren.or(children)
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -181,7 +181,7 @@ class Service < ApplicationRecord
   virtual_has_many :services
 
   def indirect_service_children
-    descendants.where.not(child_conditions)
+    descendants.where.not(children)
   end
   Vmdb::Deprecation.deprecate_methods(self, :indirect_service_children)
 


### PR DESCRIPTION
Ancestry will no longer support condition clauses (`Model.where(Model.child_conditions)`)
Instead, basic active record where clauses are used (`Model.children`)

this changes our condition clauses to instead use basic AR where clauses

After this, we will be able to upgrade to ancestry 2.0 in https://github.com/ManageIQ/manageiq/pull/20508 

/cc @agrare 