### PR TITLE
[wip] add warning if parent service name is the same as child service name

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -30,6 +30,9 @@ class ServiceRetireTask < MiqRetireTask
     Service.where(:id => options[:src_ids]).each do |parent_svc|
       if create_subtasks?(parent_svc)
         _log.info("- creating service subtasks for service task <#{self.class.name}:#{id}>, service <#{parent_svc.id}>")
+        if parent_svc.children.where(:name => parent_svc.name).exists?
+          _log.info("- retirement requested for service <#{parent_svc.id}> with child of same name (#{parent_svc.name})")
+        end
         create_retire_subtasks(parent_svc, self)
       end
     end


### PR DESCRIPTION
we have no name uniqueness validation on services
it's entirely possibly to call retirement on a bundled parent service
with the same name as the child

wip because i need think about the right way to fix this
don't bother reviewing