### PR TITLE
Introduce Uniqueness only for changed fields validator

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -7,7 +7,7 @@ class MiqAlert < ApplicationRecord
   serialize :hash_expression
   serialize :options
 
-  validates :description, :presence => true, :uniqueness => true
+  validates :description, :presence => true, :uniqueness_when_changed => true
   validate :validate_automate_expressions
   validate :validate_single_expression
   validates :severity, :inclusion => { :in => SEVERITIES }

--- a/lib/uniqueness_when_changed_validator.rb
+++ b/lib/uniqueness_when_changed_validator.rb
@@ -1,0 +1,14 @@
+#
+# Validates whether the value of the specified attributes are unique across the system,
+#   but only applies the validation when those attributes have changed.
+#
+#   See Rails uniqueness validator: https://api.rubyonrails.org/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_uniqueness_of
+class UniquenessWhenChangedValidator < ActiveRecord::Validations::UniquenessValidator
+  # Examples:
+  #   validates :name, :uniqueness_when_changed => true
+  def validate_each(record, attribute, value)
+    return unless record.changed.include?(attribute.to_s) || record.new_record?
+
+    super
+  end
+end

--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -2,7 +2,7 @@ module UuidMixin
   extend ActiveSupport::Concern
   included do
     default_value_for(:guid) { SecureRandom.uuid }
-    validates :guid,  :uniqueness => true, :presence => true
+    validates :guid,  :uniqueness_when_changed => true, :presence => true
   end
 
   def dup

--- a/spec/lib/uniqueness_when_changed_validator_spec.rb
+++ b/spec/lib/uniqueness_when_changed_validator_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe UniquenessWhenChangedValidator do
+  # MiqAlert currently only has one validation for uniqueness
+  describe "#uniqueness_when_changed" do
+    it "queries for a new record" do
+      alert = FactoryBot.build(:miq_alert)
+      expect { alert.valid? }.to make_database_queries(:count => 2)
+    end
+
+    it "queries for a changed record" do
+      alert = FactoryBot.create(:miq_alert)
+      alert.description = alert.description + "_2"
+      expect { alert.valid? }.to make_database_queries(:count => 1)
+    end
+
+    it "doesn't query for an unchanged record" do
+      alert = FactoryBot.create(:miq_alert)
+      expect { alert.valid? }.not_to make_database_queries
+    end
+
+    it "actually does a uniqueness check" do
+      alert = FactoryBot.create(:miq_alert)
+      alert2 = FactoryBot.build(:miq_alert, :description => alert.description)
+      expect(alert2).not_to be_valid
+    end
+  end
+end

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -577,7 +577,7 @@ RSpec.describe MiqAlert do
   describe "#valid?" do
     it "doesn't query for an unchanged record" do
       alert = FactoryBot.create(:miq_alert)
-      expect { alert.valid? }.to make_database_queries(:count => 2)
+      expect { alert.valid? }.not_to make_database_queries
     end
   end
 end

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -573,4 +573,11 @@ RSpec.describe MiqAlert do
       )
     end
   end
+
+  describe "#valid?" do
+    it "doesn't query for an unchanged record" do
+      alert = FactoryBot.create(:miq_alert)
+      expect { alert.valid? }.to make_database_queries(:count => 2)
+    end
+  end
 end


### PR DESCRIPTION
Currently, the uniqueness checks are performed on every validate. Even when the field has not changed.
This new validator only checks uniqueness for new and changed records

At first, we were introducing a validator for `field_changed?` but this caused issues when a presence validator was put in the same `validates` clause.

This approach works with all validators.
`validates :uniqueness` and `validates :uniqueness_in_region` are the main validators that hits the database.

```ruby
  class CoolModel
    # before: 2 queries per unchanged save
    validates :name, :description, :uniqueness => true, :presence => true

    # before: fixed
    validates :name, :uniqueness => true, :if => :name_changed?
    validates :description, :uniqueness => true, :if => :description_changed?
    validates :name, :description, :presence => true

    # after: fixed
    validates :name, :description, :uniqueness_when_changed => true, :presence => true
  end
```


To display the sheer power of this validator, `MiqAlert` was used as a guinea pig.

thanks copilot @d-m-u 