### PR TITLE
change custom button uniqueness validation to use changed validator

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -12,7 +12,7 @@ class CustomButton < ApplicationRecord
   serialize :visibility
 
   validates :applies_to_class, :presence => true
-  validates :name, :description, :uniqueness => {:scope => [:applies_to_class, :applies_to_id]}, :presence => true
+  validates :name, :description, :uniqueness_when_changed => {:scope => [:applies_to_class, :applies_to_id]}, :presence => true
 
   virtual_attribute :uri_attributes, :string
 

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CustomButton do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:custom_button, :applies_to_class => Vm)
-    expect { m.valid? }.to make_database_queries(:count => 3)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context "with no buttons" do

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe CustomButton do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:custom_button, :applies_to_class => Vm)
+    expect { m.valid? }.to make_database_queries(:count => 3)
+  end
+
   context "with no buttons" do
     describe '#evaluate_enablement_expression_for' do
       let(:miq_expression) { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => 'vm_1'}) }


### PR DESCRIPTION
introduce uniqueness_when_changed for `custom button name and description` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

the UUID mixin validation is fixed in 20520

relies on ~~the as-yet unmerged~~ 20520 (thanks KB)

@miq-bot add_label performance 

## relies on
- [x] https://github.com/ManageIQ/manageiq/pull/20520

