### PR TITLE
Update Gemfile.lock.release when tagging branch

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -20,13 +20,33 @@ task :release do
   version_file = root.join("VERSION")
   File.write(version_file, version)
 
+  # Update Gemfile.lock if exist
+  lock_release = root.join("Gemfile.lock.release")
+  if lock_release.exist?
+    gemfile_lock = lock_release.to_s.chomp(".release")
+    appliance_dependency = root.join("bundler.d/manageiq-appliance-dependencies.rb")
+
+    FileUtils.ln_s(lock_release, gemfile_lock, :force => true)
+    FileUtils.ln_s(root.join("../manageiq-appliance/manageiq-appliance-dependencies.rb"),
+                   appliance_dependency, :force => true)
+
+    exit $?.exitstatus unless Bundler.unbundled_system({"BUNDLE_IGNORE_CONFIG" => "true", "APPLIANCE" => "true"}, "bundle lock --update --conservative --patch")
+
+    FileUtils.rm([appliance_dependency, gemfile_lock])
+
+    content = lock_release.read
+    lock_release.write(content.gsub("branch: #{branch}", "tag: #{version}"))
+  end
+
   # Change git based gem source to tag reference in Gemfile
   gemfile = root.join("Gemfile")
   content = gemfile.read
   gemfile.write(content.gsub(":branch => \"#{branch}\"", ":tag => \"#{version}\""))
 
   # Commit
-  exit $?.exitstatus unless system("git add #{version_file} #{gemfile}")
+  files_to_update = [version_file, gemfile]
+  files_to_update << lock_release if lock_release.exist?
+  exit $?.exitstatus unless system("git add #{files_to_update.join(" ")}")
   exit $?.exitstatus unless system("git commit -m 'Release #{version}'")
 
   # Tag


### PR DESCRIPTION
Assumption: This will always be called from bin/release_tag.rb in manageiq-release, which means local clones are clean and correct branch is checked out.

RPM build process will be changed to use Gemfile.lock.release if exists (https://github.com/ManageIQ/manageiq-rpm_build/pull/87). For release build, the file is taken as is. For nightly build, plugin revision will be updated during build to pick up the latest changes (the updated file will not be committed back).

Gemfile.lock.release will be committed to jansa branch only.