### PR TITLE
[IVANCHUK] Add type for add disk in vm_reconfigure_task methods in app/models.

### DIFF
--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -30,7 +30,7 @@ class VmReconfigureTask < MiqRequestTask
     new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" if req_obj.options[:number_of_sockets].present?
     new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" if req_obj.options[:cores_per_socket].present?
     new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" if req_obj.options[:number_of_cpus].present?
-    new_settings << "Add Disks: #{req_obj.options[:disk_add].length} : #{req_obj.options[:disk_add].collect { |d| d["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) }.join(", ")} " if req_obj.options[:disk_add].present?
+    new_settings << "Add Disks: #{req_obj.options[:disk_add].length} : #{req_obj.options[:disk_add].collect { |d| disk_info(d) }.join(", ")} " if req_obj.options[:disk_add].present?
     new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" if req_obj.options[:disk_remove].present?
     new_settings << "Resize Disks: #{req_obj.options[:disk_resize].length}" if req_obj.options[:disk_resize].present?
     new_settings << "Add Network Adapters: #{req_obj.options[:network_adapter_add].length}" if req_obj.options[:network_adapter_add].present?
@@ -38,6 +38,10 @@ class VmReconfigureTask < MiqRequestTask
     new_settings << "Attach CD/DVDs: #{req_obj.options[:cdrom_connect].length}" if req_obj.options[:cdrom_connect].present?
     new_settings << "Detach CD/DVDs: #{req_obj.options[:cdrom_disconnect].length}" if req_obj.options[:cdrom_disconnect].present?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
+  end
+
+  def self.disk_info(disk)
+    disk["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) + ", Type: " + disk["type"].to_s
   end
 
   def after_request_task_create

--- a/spec/models/vm_reconfigure_task_spec.rb
+++ b/spec/models/vm_reconfigure_task_spec.rb
@@ -9,7 +9,7 @@ describe VmReconfigureTask do
   let(:request) do
     VmReconfigureRequest.create(:requester    => user,
                                 :options      => {:src_ids  => [vm.id],
-                                                  :disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}]},
+                                                  :disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true", "type" => "thin"}]},
                                 :request_type => 'vm_reconfigure')
   end
 
@@ -28,7 +28,8 @@ describe VmReconfigureTask do
 
     describe "#self.get_description" do
       it "should get the task description" do
-        expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} ")
+        expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
+          "Type: #{request.options[:disk_add][0]["type"]} ")
       end
     end
 
@@ -44,15 +45,15 @@ describe VmReconfigureTask do
     let(:request) do
       VmReconfigureRequest.create(:requester    => user,
                                   :options      => {:src_ids  => [vm.id],
-                                                    :disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"},
-                                                                  {"disk_size_in_mb" => "44", "persistent" => "true"}]},
+                                                    :disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true", "type" => "thin"},
+                                                                  {"disk_size_in_mb" => "44", "persistent" => "true", "type" => "thick"}]},
                                   :request_type => 'vm_reconfigure')
     end
 
     describe "#self.get_description" do
       it "should get the task description" do
         expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
-          "#{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} ")
+          "Type: #{request.options[:disk_add][0]["type"]}, #{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, Type: #{request.options[:disk_add][1]["type"]} ")
       end
     end
 


### PR DESCRIPTION
Change a really long and moved to a method as requested.

Added disk type to line and updated test.

Master PR: https://github.com/ManageIQ/manageiq/pull/20081
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1630858