### PR TITLE
use uniqueness_when_changed validation for conditions noop save

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -3,7 +3,7 @@ class Condition < ApplicationRecord
   before_validation :default_name_to_guid, :on => :create
 
   validates :name, :description, :expression, :towhat, :presence => true
-  validates :name, :description, :uniqueness => true
+  validates :name, :description, :uniqueness_when_changed => true
 
   acts_as_miq_taggable
   acts_as_miq_set_member

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Condition do
 
     it "doesn't access database when unchanged model is saved" do
       m = FactoryBot.create(:condition)
-      expect { m.valid? }.to make_database_queries(:count => 3)
+      expect { m.valid? }.not_to make_database_queries
     end
 
     context "expression with <find>" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe Condition do
       end
     end
 
+    it "doesn't access database when unchanged model is saved" do
+      m = FactoryBot.create(:condition)
+      expect { m.valid? }.to make_database_queries(:count => 3)
+    end
+
     context "expression with <find>" do
       let(:cluster) { FactoryBot.create(:ems_cluster) }
       let(:host1) { FactoryBot.create(:host, :ems_cluster => cluster) }


### PR DESCRIPTION
introduce uniqueness_when_changed for `Conditions` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

the UUID mixin validation is fixed in 20520

relies on ~~the as-yet unmerged~~ 20520 (thanks KB)

@miq-bot add_label performance 

## relies on
- [x] https://github.com/ManageIQ/manageiq/pull/20520

