### PR TITLE
Validate unique within region only if field has changed

### DIFF
--- a/lib/unique_within_region_validator.rb
+++ b/lib/unique_within_region_validator.rb
@@ -13,7 +13,8 @@
 #
 class UniqueWithinRegionValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if value.nil?
+    return if value.nil? || !record.send("#{attribute}_changed?")
+
     match_case = options.key?(:match_case) ? options[:match_case] : true
     record_base_class = record.class.base_class
     matches =

--- a/spec/lib/unique_within_region_validator_spec.rb
+++ b/spec/lib/unique_within_region_validator_spec.rb
@@ -89,24 +89,24 @@ RSpec.describe UniqueWithinRegionValidator do
 
       it "gracefully handles no name" do
         rec = case_sensitive_class.new
-        expect { rec.valid? }.not_to make_database_queries
+        expect { expect(rec.valid?).to eq(true) }.not_to make_database_queries
       end
 
       it "queries for a new record" do
         rec = case_sensitive_class.new(:name => 'abc')
 
-        expect { rec.valid? }.to make_database_queries(:count => 1)
+        expect { expect(rec.valid?).to eq(true) }.to make_database_queries(:count => 1)
       end
 
       it "queries for a changed record" do
         rec = case_sensitive_class.create!(:name => 'abc')
         rec.name += '2'
-        expect { rec.valid? }.to make_database_queries(:count => 1)
+        expect { expect(rec.valid?).to eq(true) }.to make_database_queries(:count => 1)
       end
 
       it "doesn't query for an unchanged record" do
         rec = case_sensitive_class.create!(:name => 'abc')
-        expect { rec.valid? }.not_to make_database_queries
+        expect { expect(rec.valid?).to eq(true) }.not_to make_database_queries
       end
     end
 

--- a/spec/lib/unique_within_region_validator_spec.rb
+++ b/spec/lib/unique_within_region_validator_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe UniqueWithinRegionValidator do
       let(:test_name)  { "thename" }
 
       let(:in_first_region_id) do
-        case_sensitive_class.create(
+        case_sensitive_class.create!(
           :id    => case_sensitive_class.id_in_region(1, 0),
           :name  => test_name,
         ).id
       end
 
       let(:also_in_first_region_id) do
-        case_sensitive_class.create(
+        case_sensitive_class.create!(
           :id    => case_sensitive_class.id_in_region(2, 0),
           :name  => test_name.upcase,
         ).id
       end
 
       let(:in_second_region_id) do
-        case_sensitive_class.create(
+        case_sensitive_class.create!(
           :id    => case_sensitive_class.id_in_region(2, 1),
           :name  => test_name,
         ).id
@@ -99,13 +99,13 @@ RSpec.describe UniqueWithinRegionValidator do
       end
 
       it "queries for a changed record" do
-        rec = case_sensitive_class.create(:name => 'abc')
+        rec = case_sensitive_class.create!(:name => 'abc')
         rec.name += '2'
         expect { rec.valid? }.to make_database_queries(:count => 1)
       end
 
       it "doesn't query for an unchanged record" do
-        rec = case_sensitive_class.create(:name => 'abc')
+        rec = case_sensitive_class.create!(:name => 'abc')
         expect { rec.valid? }.not_to make_database_queries
       end
     end
@@ -136,14 +136,14 @@ RSpec.describe UniqueWithinRegionValidator do
 
       context "two subclasses" do
         it "raises error with non-unique names in same region" do
-          test_subclass1.create(:name => "foo")
+          test_subclass1.create!(:name => "foo")
 
           expect { test_subclass2.create!(:name => "foo") }
             .to raise_error(ActiveRecord::RecordInvalid, / Name is not unique within region/)
         end
 
         it "doesn't raise error with unique names" do
-          test_subclass1.create(:name => "foo")
+          test_subclass1.create!(:name => "foo")
 
           expect { test_subclass2.create!(:name => "bar") }.to_not raise_error
         end

--- a/spec/lib/unique_within_region_validator_spec.rb
+++ b/spec/lib/unique_within_region_validator_spec.rb
@@ -86,6 +86,28 @@ RSpec.describe UniqueWithinRegionValidator do
 
         expect(also_in_first_region_rec.valid?).to be false
       end
+
+      it "gracefully handles no name" do
+        rec = case_sensitive_class.new
+        expect { rec.valid? }.not_to make_database_queries
+      end
+
+      it "queries for a new record" do
+        rec = case_sensitive_class.new(:name => 'abc')
+
+        expect { rec.valid? }.to make_database_queries(:count => 1)
+      end
+
+      it "queries for a changed record" do
+        rec = case_sensitive_class.create(:name => 'abc')
+        rec.name += '2'
+        expect { rec.valid? }.to make_database_queries(:count => 1)
+      end
+
+      it "doesn't query for an unchanged record" do
+        rec = case_sensitive_class.create(:name => 'abc')
+        expect { rec.valid? }.not_to make_database_queries
+      end
     end
 
     context "class with STI" do

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Zone do
   context "#valid?" do
     it "doesn't query for an unchanged record" do
       zone = FactoryBot.create(:zone)
-      expect { zone.valid? }.to make_database_queries(:count => 1)
+      expect { zone.valid? }.not_to make_database_queries
     end
   end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -327,4 +327,11 @@ RSpec.describe Zone do
       expect(message).to be_nil
     end
   end
+
+  context "#valid?" do
+    it "doesn't query for an unchanged record" do
+      zone = FactoryBot.create(:zone)
+      expect { zone.valid? }.to make_database_queries(:count => 1)
+    end
+  end
 end


### PR DESCRIPTION
Every time we save or validate a record, it ensures that the name is unique within a region.
this is only necessary when a record is created, or when the name has changed.

When the field has changed, `save` makes the same number of queries
When the field has not changed, `save` makes 1 fewer queries. (this use case the by far the most common)

/credit Taken from a comment by @NickLaMuro