### PR TITLE
use uniqueness_when_changed validator for product feature identifiers

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -17,8 +17,7 @@ class MiqProductFeature < ApplicationRecord
 
   virtual_delegate :identifier, :to => :parent, :prefix => true, :allow_nil => true, :type => :string
 
-  validates_presence_of   :identifier
-  validates_uniqueness_of :identifier
+  validates :identifier, :uniqueness_when_changed => true, :presence => true
 
   DETAIL_ATTRS = [
     :name,

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MiqProductFeature do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_product_feature, :identifier => "some_feature")
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   # - container_dashboard

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe MiqProductFeature do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:miq_product_feature, :identifier => "some_feature")
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   # - container_dashboard
   # - miq_report_widget_editor
   #   - miq_report_widget_admin


### PR DESCRIPTION
introduce uniqueness_when_changed for `MiqProductFeature` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed validator to remove 1 query and condenses the presence and unique validation into one line.

relies on ~~the as-yet unmerged~~ 20520

@miq-bot add_label performance 

## relies on
- [x] https://github.com/ManageIQ/manageiq/pull/20520
