### PR TITLE
use uniqueness_when_changed validator for chargeable fields

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -16,7 +16,7 @@ class ChargeableField < ApplicationRecord
 
   belongs_to :detail_measure, :class_name => 'ChargebackRateDetailMeasure', :foreign_key => :chargeback_rate_detail_measure_id
 
-  validates :metric, :uniqueness => true, :presence => true
+  validates :metric, :uniqueness_when_changed => true, :presence => true
   validates :group, :source, :presence => true
 
   def showback_measure

--- a/spec/models/chargeable_field_spec.rb
+++ b/spec/models/chargeable_field_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ChargeableField, :type => :model do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:chargeable_field)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe "#cols_on_metric_rollup" do

--- a/spec/models/chargeable_field_spec.rb
+++ b/spec/models/chargeable_field_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe ChargeableField, :type => :model do
     it { is_expected.to eq("#{group}_#{source}") }
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:chargeable_field)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe "#cols_on_metric_rollup" do
     before do
       ChargebackRateDetailMeasure.seed


### PR DESCRIPTION
introduce uniqueness_when_changed for `chargeable fields` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

relies on the as-yet unmerged 20520 (thanks KB)

@miq-bot add_label performance 

## relies on
- [ ] https://github.com/ManageIQ/manageiq/pull/20520