### PR TITLE
use unique when changed validator for miq schedules

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -4,7 +4,7 @@ class MiqSchedule < ApplicationRecord
   include YAMLImportExportMixin
   deprecate_attribute :towhat, :resource_type
 
-  validates :name, :uniqueness => {:scope => [:userid, :resource_type]}
+  validates :name, :uniqueness_when_changed => {:scope => [:userid, :resource_type]}
   validates :name, :description, :resource_type, :run_at, :presence => true
   validate  :validate_run_at, :validate_file_depot
 

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe MiqSchedule do
 
     it "doesn't access database when unchanged model is saved" do
       m = FactoryBot.create(:miq_schedule)
-      expect { m.valid? }.to make_database_queries(:count => 1)
+      expect { m.valid? }.not_to make_database_queries
     end
 
     context "MiqReport" do

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe MiqSchedule do
       FactoryBot.create(:miq_schedule, :updated_at => 1.year.ago, :filter => miq_expression, :sched_action => sched_action, :userid => user.userid, :last_run_on => Time.zone.now)
     end
 
+    it "doesn't access database when unchanged model is saved" do
+      m = FactoryBot.create(:miq_schedule)
+      expect { m.valid? }.to make_database_queries(:count => 1)
+    end
+
     context "MiqReport" do
       it "exports to array" do
         miq_schedule_array = MiqSchedule.export_to_array([miq_schedule.id], MiqSchedule).first["MiqSchedule"]


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq schedule` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

relies on the as-yet unmerged 20520 (thanks KB)

@miq-bot add_label performance 

## relies on
- [ ] https://github.com/ManageIQ/manageiq/pull/20520