### PR TITLE
use uniqueness when changed validation for firmware registries

### DIFF
--- a/app/models/firmware_registry.rb
+++ b/app/models/firmware_registry.rb
@@ -5,7 +5,7 @@ class FirmwareRegistry < ApplicationRecord
   has_one :endpoint, :as => :resource, :dependent => :destroy, :inverse_of => :resource
   has_one :authentication, :as => :resource, :dependent => :destroy, :inverse_of => :resource
 
-  validates :name, :presence => true, :uniqueness => true
+  validates :name, :presence => true, :uniqueness_when_changed => true
 
   def sync_fw_binaries_queue
     MiqQueue.put_unless_exists(

--- a/spec/models/firmware_registry_spec.rb
+++ b/spec/models/firmware_registry_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe FirmwareRegistry do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:firmware_registry)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   it '#sync_fw_binaries_raw' do
     expect { subject.sync_fw_binaries_raw }.to raise_error(NotImplementedError)
   end

--- a/spec/models/firmware_registry_spec.rb
+++ b/spec/models/firmware_registry_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FirmwareRegistry do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:firmware_registry)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   it '#sync_fw_binaries_raw' do


### PR DESCRIPTION
introduce uniqueness_when_changed for `firmware registries` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
