### PR TITLE
introduce User.lower_userid to remove some arel across a few repos

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -244,7 +244,7 @@ module Authenticator
 
     def case_insensitive_find_by_userid(username)
       user =  User.lookup_by_userid(username)
-      user || User.in_my_region.where('lower(userid) = ?', username.downcase).order(:lastlogon).last
+      user || User.in_my_region.where(:lower_userid => username.downcase).order(:lastlogon).last
     end
 
     def userid_for(_identity, username)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,13 @@ class User < ApplicationRecord
   singleton_class.send(:alias_method, :find_by_lower_email, :lookup_by_lower_email)
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_lower_email => :lookup_by_lower_email)
 
+  def lower_userid
+    userid&.downcase
+  end
+
+  virtual_attribute :lower_userid, :string, :arel => ->(t) { t.grouping(t[:userid].lower) }
+  hide_attribute :lower_userid
+
   virtual_column :ldap_group, :type => :string, :uses => :current_group
   # FIXME: amazon_group too?
   virtual_column :miq_group_description, :type => :string, :uses => :current_group
@@ -333,7 +340,7 @@ class User < ApplicationRecord
   end
 
   def self.regional_users(user)
-    where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:userid)]).eq(user.userid.downcase)))
+    where(:lower_userid => user.userid.downcase)
   end
 
   def self.super_admin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,11 +109,18 @@ class User < ApplicationRecord
   # often we have the most probably user object onhand. so use that if possible
   def self.lookup_by_lower_email(email, cache = [])
     email = email.downcase
-    Array.wrap(cache).detect { |u| u.email.try(:downcase) == email } || find_by(['lower(email) = ?', email])
+    Array.wrap(cache).detect { |u| u.lower_email == email } || find_by(:lower_email => email)
   end
 
   singleton_class.send(:alias_method, :find_by_lower_email, :lookup_by_lower_email)
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_lower_email => :lookup_by_lower_email)
+
+  def lower_email
+    email&.downcase
+  end
+
+  virtual_attribute :lower_email, :string, :arel => ->(t) { t.grouping(t[:email].lower) }
+  hide_attribute :lower_email
 
   def lower_userid
     userid&.downcase

--- a/lib/token_store/sql_store.rb
+++ b/lib/token_store/sql_store.rb
@@ -47,7 +47,7 @@ class TokenStore
     end
 
     def find_user_by_userid(userid)
-      User.in_my_region.where('lower(userid) = ?', userid.downcase).first
+      User.in_my_region.where(:lower_userid => userid.downcase).first
     end
 
     def find_user_by_id(id)

--- a/tools/miq_config_sssd_ldap/configure_database.rb
+++ b/tools/miq_config_sssd_ldap/configure_database.rb
@@ -74,7 +74,7 @@ module MiqConfigSssdLdap
 
     def find_user(userid)
       user = User.lookup_by_userid(userid)
-      user || User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
+      user || User.in_my_region.where(:lower_userid => userid).order(:lastlogon).last
     end
   end
 end


### PR DESCRIPTION
I noticed a few lowercase comparisons for userid and a lookup by userid method

this allows us to just use active record where instead of the arel junk.

```ruby
# before a
    where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:userid)]).eq(userid.downcase)))
before b
    where('lower(userid) = ?', userid.downcase)
# after
    where(:lower_userid => userid.downcase)
```

I would prefer if we used this instead of `lookup_by_name()` but want a second opinion on that one before moving forward. specifically the in region filter. 

this is developer focused