### PR TITLE
use uniqueness when changed validator for miq search 

### DIFF
--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -4,11 +4,11 @@ class MiqSearch < ApplicationRecord
   include_concern 'ImportExport'
   include YAMLImportExportMixin
 
-  validates_uniqueness_of :name, :scope => "db"
+  validates :name, :uniqueness_when_changed => {:scope => "db"}
 
   # validate if the name of a new filter is unique in Global Filters
-  validates :description, :uniqueness => { :scope => "db", :conditions => -> { where.not(:search_type => 'user') },
-                          :if => proc { |miq_search| miq_search.search_type == 'global' } }
+  validates :description, :uniqueness_when_changed => {:scope => "db", :conditions => -> { where.not(:search_type => 'user') },
+                          :if => proc { |miq_search| miq_search.search_type == 'global' }}
 
   has_many  :miq_schedules
 

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe MiqSearch do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:miq_search)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe "#results" do
     it "respects filter" do
       all_vms

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe MiqSearch do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_search)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe "#results" do


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq search` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 
