### PR TITLE
Save the provider if it is present in create_from_params

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -61,6 +61,7 @@ class ExtManagementSystem < ApplicationRecord
       endpoints.each { |endpoint| ems.assign_nested_endpoint(endpoint) }
       authentications.each { |authentication| ems.assign_nested_authentication(authentication) }
 
+      ems.provider.save! if ems.provider.present? && ems.provider.changed?
       ems.save!
     end
   end
@@ -157,6 +158,7 @@ class ExtManagementSystem < ApplicationRecord
         ems.endpoints = endpoints.map(&method(:assign_nested_endpoint))
         ems.authentications = authentications.map(&method(:assign_nested_authentication))
 
+        ems.provider.save! if ems.provider.present? && ems.provider.changed?
         ems.save!
       end
     end


### PR DESCRIPTION
More and more provider plugins have a parent `Provider` above 1..N managers, with these managers delegating authentications/endpoints/zone/etc... to the provider.  This means that we need to save the provider along with the manager when creating or updating via the API.  This is normally done by using autosave on the relation (which is what https://github.com/ManageIQ/manageiq/pull/20318) but there are still some tough to solve specs failing on that PR.

This allows us to get rid of the overridden create_with_params/edit_from_params methods on each manager that belongs to a parent Provider until we can solve the provider autosave issue

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/167

Required for:
- [ ] https://github.com/ManageIQ/manageiq-providers-foreman/pull/68
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/234