### PR TITLE
CustomizationSpec#spec may contain VimHashes

### DIFF
--- a/app/models/customization_spec.rb
+++ b/app/models/customization_spec.rb
@@ -1,4 +1,6 @@
 class CustomizationSpec < ApplicationRecord
+  require "VMwareWebService/VimTypes"
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
   serialize :spec


### PR DESCRIPTION
Handle a serialized VimHash in the CustomizationSpec#spec column in a backport-friendly way until a database migration can clean these up

Can be reverted once https://github.com/ManageIQ/manageiq-schema/pull/508 is in

Related: https://github.com/ManageIQ/manageiq-providers-vmware/pull/614