### PR TITLE
fix uniqueness validation to also handle aliases

### DIFF
--- a/lib/uniqueness_when_changed_validator.rb
+++ b/lib/uniqueness_when_changed_validator.rb
@@ -7,7 +7,7 @@ class UniquenessWhenChangedValidator < ActiveRecord::Validations::UniquenessVali
   # Examples:
   #   validates :name, :uniqueness_when_changed => true
   def validate_each(record, attribute, value)
-    return unless record.changed.include?(attribute.to_s) || record.new_record?
+    return if value.nil? || !record.send("#{attribute}_changed?")
 
     super
   end

--- a/spec/lib/uniqueness_when_changed_validator_spec.rb
+++ b/spec/lib/uniqueness_when_changed_validator_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe UniquenessWhenChangedValidator do
   describe "#uniqueness_when_changed" do
     it "queries for a new record" do
       alert = FactoryBot.build(:miq_alert)
-      expect { alert.valid? }.to make_database_queries(:count => 2)
+      expect { alert.valid? }.to make_database_queries(:count => 1)
     end
 
     it "queries for a changed record" do

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -1,4 +1,34 @@
 RSpec.describe MiqSearch do
+  context "validate name uniqueness" do
+    it "with same name" do
+      miq_search = FactoryBot.create(:miq_search)
+
+      expect { FactoryBot.create(:miq_search, :name => miq_search.name) }
+        .to raise_error(ActiveRecord::RecordInvalid, /Name has already been taken/)
+    end
+
+    it "with different names" do
+      FactoryBot.create(:miq_search)
+
+      expect { FactoryBot.create(:miq_search) }.to_not raise_error
+    end
+  end
+
+  context "validate description uniqueness" do
+    it "with same description" do
+      miq_search = FactoryBot.create(:miq_search, :search_type => 'global')
+
+      expect { FactoryBot.create(:miq_search, :description => miq_search.description, :search_type => 'global') }
+        .to raise_error(ActiveRecord::RecordInvalid, /Description has already been taken/)
+    end
+
+    it "with different descriptions" do
+      FactoryBot.create(:miq_search, :search_type => 'global')
+
+      expect { FactoryBot.create(:miq_search, :search_type => 'global') }.to_not raise_error
+    end
+  end
+
   describe '#descriptions' do
     it "hashes" do
       srchs = [


### PR DESCRIPTION
the uniqueness_when_changed validation won't work currently on attributes with aliases, of which, this is the only one broken by recent changes that is merged. 

Broken in https://github.com/ManageIQ/manageiq/pull/20534, per https://github.com/ManageIQ/manageiq/pull/20526/files#r486391619. 

@miq-bot add_label bug 
@miq-bot assign @kbrock 