### PR TITLE
add uniqueness when changed validation for generic object definition

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -32,7 +32,7 @@ class GenericObjectDefinition < ApplicationRecord
   has_one   :picture, :dependent => :destroy, :as => :resource
   has_many  :generic_objects
 
-  validates :name, :presence => true, :uniqueness => true
+  validates :name, :presence => true, :uniqueness_when_changed => true
   validate  :validate_property_attributes,
             :validate_property_associations,
             :validate_property_methods,

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GenericObjectDefinition do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:generic_object_definition)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   it 'requires name attribute present' do

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe GenericObjectDefinition do
     )
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:generic_object_definition)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   it 'requires name attribute present' do
     expect(described_class.new).not_to be_valid
   end


### PR DESCRIPTION
introduce uniqueness_when_changed for `generic object definition` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 