### PR TITLE
use unique when changed validation on miq widget description

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -18,7 +18,7 @@ class MiqWidget < ApplicationRecord
   has_many   :miq_shortcuts, :through => :miq_widget_shortcuts
 
   validates_presence_of   :title, :description
-  validates_uniqueness_of :description
+  validates :description, :uniqueness_when_changed => true
   VALID_CONTENT_TYPES = %w( report chart rss menu )
   validates_inclusion_of :content_type, :in => VALID_CONTENT_TYPES, :message => "should be one of #{VALID_CONTENT_TYPES.join(", ")}"
 

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe MiqWidget do
 
     it "doesn't access database when unchanged model is saved" do
       m = FactoryBot.create(:miq_widget)
-      expect { m.valid? }.to make_database_queries(:count => 1)
+      expect { m.valid? }.not_to make_database_queries
     end
 
     describe "#sync_schedule" do

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe MiqWidget do
       end
     end
 
+    it "doesn't access database when unchanged model is saved" do
+      m = FactoryBot.create(:miq_widget)
+      expect { m.valid? }.to make_database_queries(:count => 1)
+    end
+
     describe "#sync_schedule" do
       let(:schedule) do
         filter = @widget_chart_vendor_and_guest_os.filter_for_schedule


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq widget` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 

