### PR TITLE
use unique when changed for pxe server names

### DIFF
--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -11,8 +11,8 @@ class PxeServer < ApplicationRecord
 
   acts_as_miq_taggable
 
-  validates_presence_of   :name, :uri
-  validates_uniqueness_of :name
+  validates :uri, :presence => true
+  validates :name, :presence => true, :uniqueness_when_changed => true
 
   has_many :pxe_menus,      :dependent => :destroy
   has_many :pxe_images,     :dependent => :destroy

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PxeServer do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:pxe_server)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context "pxelinux depot" do

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe PxeServer do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:pxe_server)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   context "pxelinux depot" do
     before do
       @pxe_server.pxe_directory = "pxelinux.cfg"


### PR DESCRIPTION
introduce uniqueness_when_changed for `pxe server` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 