### PR TITLE
use unique when changed for chargeback rate

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -19,8 +19,7 @@ class ChargebackRate < ApplicationRecord
 
   has_many :chargeback_rate_details, :dependent => :destroy, :autosave => true
 
-  validates :description, :presence => true
-  validates_uniqueness_of   :description, :scope => :rate_type
+  validates :description, :presence => true, :uniqueness_when_changed => {:scope => :rate_type}
 
   delegate :symbol, :to => :currency, :prefix => true, :allow_nil => true
 

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ChargebackRate do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:chargeback_rate)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context ".validate_rate_type" do

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe ChargebackRate do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:chargeback_rate)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   context ".validate_rate_type" do
     it "handles valid types" do
       [:compute, :storage, 'compute', 'storage', 'Compute', 'Storage'].each do |type|


### PR DESCRIPTION
introduce uniqueness_when_changed for `chargeback rate` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 
