### PR TITLE
Fix translations for utilization chart headers

### DIFF
--- a/config/locale_task_config.yaml
+++ b/config/locale_task_config.yaml
@@ -28,3 +28,7 @@ yaml_strings_to_extract:
   - title
   - name
   - headers
+  product/charts/miq_reports/*.yaml:
+  - title
+  - name
+  - headers


### PR DESCRIPTION
## Issue Summary
English string occurs in Services - Workloads - VMs and Instances - All VMs and Instances - Monitoring - Utilization

## Issue Details
### Steps to reproduce

1. Click Services - Workloads - VMs and Instances - All VMs and Instances
2. Click one instance "45on510-gl4tj-master-0"
3. Click Monitoring
4. Click Utilization

### Expected behavior
translated string will occur

### What really happened
English string occurs Like Max, Used etc.
<img width="1309" alt="Screen Shot 2020-09-14 at 4 19 45 PM" src="https://user-images.githubusercontent.com/37085529/93134181-62c05f80-f6a6-11ea-8377-f2a27c308b85.png">
