### PR TITLE
add uniqueness when changed for conversion hosts

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -16,7 +16,7 @@ class ConversionHost < ApplicationRecord
 
   validates :name, :presence => true
   validates :resource, :presence => true
-  validates :resource_id, :uniqueness => { :scope => :resource_type }
+  validates :resource_id, :uniqueness_when_changed => {:scope => :resource_type}
 
   validates :address,
     :uniqueness => true,

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ConversionHost, :v2v do
 
     it "doesn't access database when unchanged model is saved" do
       m = FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:vm_openstack))
-      expect { m.valid? }.to make_database_queries(:count => 1)
+      expect { m.valid? }.not_to make_database_queries
     end
 
     context "#ipaddress" do

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -104,6 +104,11 @@ RSpec.describe ConversionHost, :v2v do
       end
     end
 
+    it "doesn't access database when unchanged model is saved" do
+      m = FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:vm_openstack))
+      expect { m.valid? }.to make_database_queries(:count => 1)
+    end
+
     context "#ipaddress" do
       it "returns first IP address if 'address' is nil" do
         expect(conversion_host_1.ipaddress).to eq('10.0.0.1')


### PR DESCRIPTION
introduce uniqueness_when_changed for `conversion hosts` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 