### PR TITLE
Accept shared networks instead of public networks in mapping

### DIFF
--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -80,7 +80,7 @@ class TransformationMappingItem < ApplicationRecord
     elsif destination.kind_of?(CloudNetwork) # Openstack, lans are of 'CloudNetwork' type
       tmin             = tm.transformation_mapping_items.where(:destination_type => "CloudTenant")
       dst_cluster_lans = tmin.collect(&:destination).flat_map(&:cloud_networks)
-      dst_cluster_lans |= tmin.map(&:destination).map(&:ext_management_system).flat_map(&:cloud_networks).select { |n| n.shared }.uniq
+      dst_cluster_lans |= tmin.map(&:destination).map(&:ext_management_system).flat_map(&:cloud_networks).select(&:shared).uniq
     end
 
     unless dst_cluster_lans.include?(destination_lan)

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -80,11 +80,11 @@ class TransformationMappingItem < ApplicationRecord
     elsif destination.kind_of?(CloudNetwork) # Openstack, lans are of 'CloudNetwork' type
       tmin             = tm.transformation_mapping_items.where(:destination_type => "CloudTenant")
       dst_cluster_lans = tmin.collect(&:destination).flat_map(&:cloud_networks)
-      dst_cluster_lans |= tmin.map(&:destination).map(&:ext_management_system).flat_map(&:public_networks).uniq
+      dst_cluster_lans |= tmin.map(&:destination).map(&:ext_management_system).flat_map(&:cloud_networks).select { |n| n.shared }.uniq
     end
 
     unless dst_cluster_lans.include?(destination_lan)
-      errors.add(:destination, "Destination cluster lans must include destination lan: #{destination_lan}")
+      errors.add(:destination, "Destination cluster lans must include destination lan: #{destination_lan.inspect}")
     end
   end
 end

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -106,10 +106,10 @@ RSpec.describe TransformationMappingItem, :v2v do
   context "Network validation" do
     let(:dst_cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_openstack) }
     let(:other_cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_openstack) }
-    let(:public_cloud_network) { FactoryBot.create(:cloud_network_public_openstack, :cloud_tenant => other_cloud_tenant) }
+    let(:shared_cloud_network) { FactoryBot.create(:cloud_network_private_openstack, :cloud_tenant => other_cloud_tenant, :shared => true) }
 
     before do
-      ems_openstack.network_manager.public_networks << public_cloud_network
+      ems_openstack.network_manager.private_networks << shared_cloud_network
     end
 
     # source network
@@ -129,8 +129,8 @@ RSpec.describe TransformationMappingItem, :v2v do
           tmi = FactoryBot.create(:transformation_mapping_item, :source => src_lan, :destination => dst_cloud_network, :transformation_mapping_id => osp_mapping.id)
           expect(tmi.valid?).to be(true)
         end
-        it "valid mapping with public network" do
-          tmi = FactoryBot.create(:transformation_mapping_item, :source => src_lan, :destination => public_cloud_network, :transformation_mapping_id => osp_mapping.id)
+        it "valid mapping with shared network" do
+          tmi = FactoryBot.create(:transformation_mapping_item, :source => src_lan, :destination => shared_cloud_network, :transformation_mapping_id => osp_mapping.id)
           expect(tmi.valid?).to be(true)
         end
         it "invalid source" do


### PR DESCRIPTION
Follow-up of https://github.com/ManageIQ/manageiq/pull/20238, to allows _shared_ networks instead of _public_ networks.

According to [app/models/manageiq/providers/openstack/inventory/parser/network_manager.rb#L17](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/inventory/parser/network_manager.rb#L17), a public network is a network for which the router has an external gateway and thus allows floating IPs.

In our case, we want to be able to see networks from other projects, as long as they are shared.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1804263