### PR TITLE
Allow VM tag mapping for InfraManagers

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -84,6 +84,10 @@ class ExtManagementSystem < ApplicationRecord
   has_many :disks,             :through => :hardwares
   has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
+  has_many :vm_and_template_labels, :through => :vms_and_templates, :source => :labels
+  # Only taggings mapped from labels, excluding user-assigned tags.
+  has_many :vm_and_template_taggings, -> { joins(:tag).merge(Tag.controlled_by_mapping) }, :through => :vms_and_templates, :source => :taggings
+
   has_many :storages, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",
                                                       :inverse_of => :ext_management_system

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -30,10 +30,6 @@ module ManageIQ::Providers
     has_many :key_pairs,                     :class_name  => "AuthKeyPair", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
     has_one  :source_tenant, :as => :source, :class_name  => 'Tenant'
-    has_many :vm_and_template_labels,        :through     => :vms_and_templates, :source => :labels
-    # Only taggings mapped from labels, excluding user-assigned tags.
-    has_many :vm_and_template_taggings,      -> { joins(:tag).merge(Tag.controlled_by_mapping) },
-                                             :through     => :vms_and_templates, :source => :taggings
 
     virtual_has_many :volume_availability_zones, :class_name => "AvailabilityZone", :uses => :availability_zones
 

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -81,42 +81,6 @@ module ManageIQ::Providers
           )
         end
 
-        def vm_and_template_labels
-          # TODO(lsmola) make a generic CustomAttribute IC and move it to base class
-          add_properties(
-            :model_class                  => ::CustomAttribute,
-            :manager_ref                  => %i(resource name),
-            :parent_inventory_collections => %i(vms miq_templates)
-          )
-
-          add_targeted_arel(
-            lambda do |inventory_collection|
-              manager_uuids = inventory_collection.parent_inventory_collections.collect(&:manager_uuids).map(&:to_a).flatten
-              inventory_collection.parent.vm_and_template_labels.where(
-                'vms' => {:ems_ref => manager_uuids}
-              )
-            end
-          )
-        end
-
-        def vm_and_template_taggings
-          add_properties(
-            :model_class                  => Tagging,
-            :manager_ref                  => %i(taggable tag),
-            :parent_inventory_collections => %i(vms miq_templates)
-          )
-
-          add_targeted_arel(
-            lambda do |inventory_collection|
-              manager_uuids = inventory_collection.parent_inventory_collections.collect(&:manager_uuids).map(&:to_a).flatten
-              ems = inventory_collection.parent
-              ems.vm_and_template_taggings.where(
-                'taggable_id' => ems.vms_and_templates.where(:ems_ref => manager_uuids)
-              )
-            end
-          )
-        end
-
         def vm_and_miq_template_ancestry
           skip_auto_inventory_attributes
           skip_model_class

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -77,8 +77,8 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       # TODO(lsmola) make a generic CustomAttribute IC and move it to base class
       add_properties(
         :model_class                  => ::CustomAttribute,
-        :manager_ref                  => %i(resource name),
-        :parent_inventory_collections => %i(vms miq_templates)
+        :manager_ref                  => %i[resource name],
+        :parent_inventory_collections => %i[vms miq_templates]
       )
 
       add_targeted_arel(
@@ -94,8 +94,8 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     def vm_and_template_taggings
       add_properties(
         :model_class                  => Tagging,
-        :manager_ref                  => %i(taggable tag),
-        :parent_inventory_collections => %i(vms miq_templates)
+        :manager_ref                  => %i[taggable tag],
+        :parent_inventory_collections => %i[vms miq_templates]
       )
 
       add_targeted_arel(

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -73,6 +73,42 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       )
     end
 
+    def vm_and_template_labels
+      # TODO(lsmola) make a generic CustomAttribute IC and move it to base class
+      add_properties(
+        :model_class                  => ::CustomAttribute,
+        :manager_ref                  => %i(resource name),
+        :parent_inventory_collections => %i(vms miq_templates)
+      )
+
+      add_targeted_arel(
+        lambda do |inventory_collection|
+          manager_uuids = inventory_collection.parent_inventory_collections.collect(&:manager_uuids).map(&:to_a).flatten
+          inventory_collection.parent.vm_and_template_labels.where(
+            'vms' => {:ems_ref => manager_uuids}
+          )
+        end
+      )
+    end
+
+    def vm_and_template_taggings
+      add_properties(
+        :model_class                  => Tagging,
+        :manager_ref                  => %i(taggable tag),
+        :parent_inventory_collections => %i(vms miq_templates)
+      )
+
+      add_targeted_arel(
+        lambda do |inventory_collection|
+          manager_uuids = inventory_collection.parent_inventory_collections.collect(&:manager_uuids).map(&:to_a).flatten
+          ems = inventory_collection.parent
+          ems.vm_and_template_taggings.where(
+            'taggable_id' => ems.vms_and_templates.where(:ems_ref => manager_uuids)
+          )
+        end
+      )
+    end
+
     def hardwares
       add_properties(
         :manager_ref                  => %i(vm_or_template),


### PR DESCRIPTION
Move the vm_or_template_{labels/taggings} associations and inventory collections so that they can be shared by all Manager types

Cross-repo test of providers that currently sync tags: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/169

Needed for: https://github.com/ManageIQ/manageiq-providers-vmware/pull/626