### PR TITLE
use unique when changed for customization templates

### DIFF
--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -5,7 +5,7 @@ class CustomizationTemplate < ApplicationRecord
   has_many   :pxe_images, :through => :pxe_image_type
 
   validates :pxe_image_type, :presence => true, :unless => :system?
-  validates :name, :uniqueness => {:scope => :pxe_image_type }, :unless => :seeding?
+  validates :name, :uniqueness_when_changed => {:scope => :pxe_image_type }, :unless => :seeding?
 
   scope :with_pxe_image_type_id, ->(pxe_image_type_id) { where(:pxe_image_type_id => pxe_image_type_id) }
   scope :with_system,            ->(bool = true)       { where(:system => bool) }

--- a/spec/models/customization_template_spec.rb
+++ b/spec/models/customization_template_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe CustomizationTemplate do
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:customization_template)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context "unique name validation" do

--- a/spec/models/customization_template_spec.rb
+++ b/spec/models/customization_template_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe CustomizationTemplate do
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:customization_template)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   context "unique name validation" do
     it "doesn't allow same name, same pxe_image_type in same region" do
       pit = FactoryBot.create(:pxe_image_type)


### PR DESCRIPTION
introduce uniqueness_when_changed for `customization templates` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning

@miq-bot add_label performance 
@miq-bot assign @kbrock 
