### PR TITLE
add tests for aggregation mixin methods on resource pools and folders

### DIFF
--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -3,6 +3,35 @@ RSpec.describe EmsFolder do
 
   include_examples "MiqPolicyMixin"
 
+  describe "AggregationMixin methods" do
+    let(:host) { FactoryBot.create(:host) }
+    let(:rp) { FactoryBot.create(:resource_pool) }
+    let(:vm) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 2048)) }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 1024)) }
+
+    before do
+      subject.with_relationship_type("ems_metadata") { subject.set_parent host }
+      vm.with_relationship_type("ems_metadata") { vm.set_parent subject }
+      vm2.with_relationship_type("ems_metadata") { vm2.set_parent subject }
+    end
+
+    it "aggregate_vm_memory" do
+      expect(subject.aggregate_vm_memory).to eq(3072)
+    end
+
+    it "aggregate_vm_cpus" do
+      expect(subject.aggregate_vm_cpus).to eq(4)
+    end
+
+    it "all_storages" do
+      expect(subject.all_storages).to eq([])
+    end
+
+    it "returns zero for nonexistent associations" do
+      expect(subject.aggregate_cpu_total_cores).to eq(0)
+    end
+  end
+
   context "with folder tree" do
     before do
       @root = FactoryBot.create(:ems_folder, :name => "root")

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -3,6 +3,35 @@ RSpec.describe ResourcePool do
 
   include_examples "MiqPolicyMixin"
 
+  describe "AggregationMixin methods" do
+    let(:host) { FactoryBot.create(:host, :storage) }
+    let(:rp) { FactoryBot.create(:resource_pool) }
+    let(:vm) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 2048)) }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 1024)) }
+
+    before do
+      rp.with_relationship_type("ems_metadata") { rp.set_parent host }
+      vm.with_relationship_type("ems_metadata") { vm.set_parent rp }
+      vm2.with_relationship_type("ems_metadata") { vm2.set_parent rp }
+    end
+
+    it "aggregate_vm_memory" do
+      expect(rp.aggregate_vm_memory).to eq(3072)
+    end
+
+    it "aggregate_vm_cpus" do
+      expect(rp.aggregate_vm_cpus).to eq(4)
+    end
+
+    it "all_storages" do
+      expect(rp.all_storages).to eq([Storage.first])
+    end
+
+    it "returns zero for nonexistent associations" do
+      expect(rp.aggregate_cpu_total_cores).to eq(0)
+    end
+  end
+
   context "Testing VM count virtual columns" do
     before do
       @rp1 = FactoryBot.create(:resource_pool, :name => "RP 1")


### PR DESCRIPTION
Specs for resource pools and folders were promised for the recent adding back in of the aggregation methods for folders and resource pools (https://github.com/ManageIQ/manageiq/pull/20423). 

Not using the existing shared aggregation mixin specs for these because these rely on `with_relationship_type("ems_metadata")` and the others do not so the shared specs aren't particularly applicable. The methods that rely on a host association here (which is nonexistent<sup>1</sup>) will return 0 so I'm only testing one of them to show that which should be okay since the idea behind these specs is merely to show that we're not breaking anything by removing the linked module in the future.

~~I'll add these same tests for folders once I get approval for these.~~

@miq-bot assign @kbrock 
@miq-bot add_label test


[1]
``` ruby
> ResourcePool.first.hosts
...
Traceback (most recent call last):
...
NoMethodError (undefined method `hosts' for #<ResourcePool:0x00007f80719ec3b8>)
> ResourcePool.first.all_hosts
...
 => []
```