### PR TITLE
use unique when changed for miq policies

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -36,8 +36,8 @@ class MiqPolicy < ApplicationRecord
 
   virtual_has_many :miq_event_definitions, :uses => {:miq_policy_contents => :miq_event_definition}
 
-  validates :description, :presence => true, :uniqueness => true
-  validates :name, :presence => true, :uniqueness => true
+  validates :description, :presence => true, :uniqueness_when_changed => true
+  validates :name, :presence => true, :uniqueness_when_changed => true
   validates :mode, :inclusion => { :in => %w(compliance control) }
   validates :towhat, :inclusion => { :in      => TOWHAT_APPLIES_TO_CLASSES,
                                      :message => "should be one of #{TOWHAT_APPLIES_TO_CLASSES.join(", ")}" }

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe MiqPolicy do
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:miq_policy)
+    expect { m.valid? }.to make_database_queries(:count => 2)
+  end
+
   context "Testing edge cases on conditions" do
     # The conditions reflection on MiqPolicy is affected when called through a
     # belongs_to or has_one, which is used under the covers in MiqSet.  This

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe MiqPolicy do
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_policy)
-    expect { m.valid? }.to make_database_queries(:count => 2)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context "Testing edge cases on conditions" do


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq policy` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 2 queries.

see 20520 (thanks KB) which got merged tuesday morning of last week

@miq-bot add_label performance 
@miq-bot assign @kbrock 