### PR TITLE
Move duplicated tag_mapper logic into the base Persister class

### DIFF
--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Inventory::Persister
   require 'yaml'
   require_nested :Builder
 
-  attr_reader :manager, :target, :collections
+  attr_reader :manager, :target, :collections, :tag_mapper
 
   include ::ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
 
@@ -103,6 +103,11 @@ class ManageIQ::Providers::Inventory::Persister
 
   def initialize_inventory_collections
     # can be implemented in a subclass
+  end
+
+  def initialize_tag_mapper
+    @tag_mapper ||= ContainerLabelTagMapping.mapper
+    collections[:tags_to_resolve] = @tag_mapper.tags_to_resolve_collection
   end
 
   # @return [Hash] entire Persister object serialized to hash


### PR DESCRIPTION
Initializing the tag mapper was duplicated by a number of providers, this consolidates it into the base persister class while still maintaining the same `#initialize_tag_mapper` logic.

Follow-ups to this:
- [ ] Rename the model from `ContainerLabelTagMapping` to something more general e.g.: `ProviderTagMapping`
- [ ] Make the tag_mapper just another inventory_collection in the persister builder

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/170

Dependents:
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/650
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/411
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/399