### PR TITLE
add ibm_vpc to list of ems types

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe ExtManagementSystem do
       "ibm_cloud_power_virtual_servers"         => "IBM Power Systems Virtual Servers",
       "ibm_cloud_power_virtual_servers_storage" => "IBM Power Systems Virtual Servers Storage",
       "ibm_terraform_configuration"             => "IBM Terraform Configuration",
+      "ibm_vpc"                                 => "IBM Virtual Private Cloud",
       "kubernetes"                              => "Kubernetes",
       "kubernetes_monitor"                      => "Kubernetes Monitor",
       "kubevirt"                                => "KubeVirt",

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe EmsCloud do
                       ManageIQ::Providers::Openstack::CloudManager,
                       ManageIQ::Providers::Google::CloudManager,
                       ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager,
+                      ManageIQ::Providers::IbmCloud::VPC::CloudManager,
                       ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
     expect(described_class.types).to match_array(expected_types)
   end
@@ -17,6 +18,7 @@ RSpec.describe EmsCloud do
                            ManageIQ::Providers::Openstack::CloudManager,
                            ManageIQ::Providers::Google::CloudManager,
                            ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager,
+                           ManageIQ::Providers::IbmCloud::VPC::CloudManager,
                            ManageIQ::Providers::Vmware::CloudManager]
     expect(described_class.supported_subclasses).to match_array(expected_subclasses)
   end
@@ -28,6 +30,7 @@ RSpec.describe EmsCloud do
                       ManageIQ::Providers::Openstack::CloudManager,
                       ManageIQ::Providers::Google::CloudManager,
                       ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager,
+                      ManageIQ::Providers::IbmCloud::VPC::CloudManager,
                       ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
     expect(described_class.supported_types).to match_array(expected_types)
   end


### PR DESCRIPTION
the addition of the new cloud manager on the ibm provider necessitates a few updated tests

@miq-bot assign @agrare 

``` ruby
Failures:

  1) ExtManagementSystem .types
     Failure/Error: expect(described_class.types).to match_array(all_types_and_descriptions.keys)

       expected collection contained:  ["ansible_tower_automation", "azure", "azure_network", "azure_stack", "azure_stack_network", "cinder"...edhat_network", "rhevm", "s3", "scvmm", "swift", "vmware_cloud", "vmware_cloud_network", "vmwarews"]
       actual collection contained:    ["ansible_tower_automation", "azure", "azure_network", "azure_stack", "azure_stack_network", "cinder"...edhat_network", "rhevm", "s3", "scvmm", "swift", "vmware_cloud", "vmware_cloud_network", "vmwarews"]
       the extra elements were:        ["ibm_vpc"]
     # ./spec/models/ext_management_system_spec.rb:96:in `block (2 levels) in <top (required)>'
     # /Users/drewmu/.rvm/gems/ruby-2.5.5/gems/webmock-3.9.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```