### PR TITLE
[wip] add ancestry to resource pool

### DIFF
--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -1,8 +1,11 @@
+require 'ancestry'
+
 class ResourcePool < ApplicationRecord
   include NewWithTypeStiMixin
   include TenantIdentityMixin
 
   acts_as_miq_taggable
+  has_ancestry
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many   :miq_events,            :as => :target, :dependent => :destroy


### PR DESCRIPTION
originally part of https://github.com/ManageIQ/manageiq/pull/20392

i'd like to separate this out so i can run cross repo tests on just this model and not also folders 

related: 
https://github.com/ManageIQ/manageiq-schema/pull/510