### PR TITLE
use unique when changed for tranformation mapping items

### DIFF
--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -3,7 +3,7 @@ class TransformationMappingItem < ApplicationRecord
   belongs_to :source,      :polymorphic => true
   belongs_to :destination, :polymorphic => true
 
-  validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type, :destination_type]}
+  validates :source_id, :uniqueness_when_changed => {:scope => [:transformation_mapping_id, :source_type, :destination_type]}
 
   validate :validate_source_cluster,      :if => -> { source.kind_of?(EmsCluster) }
   validate :validate_destination_cluster, :if => -> { destination.kind_of?(EmsCluster) || destination.kind_of?(CloudTenant) }

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe TransformationMappingItem, :v2v do
   let(:ems_openstack) { FactoryBot.create(:ems_openstack) }
   let(:openstack_cluster) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => ems_openstack) }
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:transformation_mapping_item)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   # ---------------------------------------------------------------------------
   # Cluster Validation
   # ---------------------------------------------------------------------------

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TransformationMappingItem, :v2v do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:transformation_mapping_item)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq policy` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see 20520 (thanks KB) which got merged tuesday morning of last week

@miq-bot add_label performance 
@miq-bot assign @kbrock 
