### PR TITLE
fix product feature query count

### DIFF
--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -369,8 +369,10 @@ RSpec.describe MiqProductFeature do
       f3 = FactoryBot.create(:miq_product_feature, :identifier => "f3", :name => "F3n", :parent_id => f1.id)
       FactoryBot.create(:miq_product_feature, :identifier => "f4", :name => "F4n", :parent_id => f3.id)
       FactoryBot.create(:miq_product_feature, :identifier => "f5", :name => "F5n", :parent_id => f3.id)
+      MiqProductFeature.attribute_names # 0..1 queries
+      Tenant.attribute_names # 0..1 queries
 
-      expect { MiqProductFeature.features }.to make_database_queries(:count => 1)
+      expect { MiqProductFeature.features }.to make_database_queries(:count => 1..2)
       expect { MiqProductFeature.features }.to_not make_database_queries
 
       expect(MiqProductFeature.feature_root).to eq("f1")


### PR DESCRIPTION
we said in https://github.com/ManageIQ/manageiq/commit/67395a0c452c1e938d60d9a92e581ee17c9f1067 that 
loading `MiqProductFeature`s should only use 1 (vs 3) queries:

```ruby
    it "populates parent and children" do
      f1 = FactoryGirl.create(:miq_product_feature, :identifier => "f1", :name => "F1n")
      FactoryGirl.create(:miq_product_feature, :identifier => "f2", :name => "F2n", :parent_id => f1.id)
      f3 = FactoryGirl.create(:miq_product_feature, :identifier => "f3", :name => "F3n", :parent_id => f1.id)
      FactoryGirl.create(:miq_product_feature, :identifier => "f4", :name => "F4n", :parent_id => f3.id)
      FactoryGirl.create(:miq_product_feature, :identifier => "f5", :name => "F5n", :parent_id => f3.id)

      expect { MiqProductFeature.features }.to match_query_limit_of(1)
      expect { MiqProductFeature.features }.to match_query_limit_of(0)
```

and while I do believe that that commit did decrease the number of select miq product features, I do also think we still run more than one query sometimes: 

``` ruby
  1) MiqProductFeature.features populates parent and children
     Failure/Error: expect { MiqProductFeature.features }.to make_database_queries(:count => 1)

       expected 1 query, but 3 were made:
       SELECT "miq_product_features"."id", "miq_product_features"."identifier", "miq_product_features"."name", "miq_product_features"."description", "miq_product_features"."feature_type", "miq_product_features"."hidden", "miq_product_features"."protected", "miq_product_features"."tenant_id", (SELECT "miq_product_features_sub"."identifier" FROM "miq_product_features" "miq_product_features_sub" WHERE "miq_product_features_sub"."id" = "miq_product_features"."parent_id") AS "parent_identifier" FROM "miq_product_features"
       SELECT a.attname
         FROM (
                SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
                  FROM pg_index
                 WHERE indrelid = '"tenants"'::regclass
                   AND indisprimary
              ) i
         JOIN pg_attribute a
           ON a.attrelid = i.indrelid
          AND a.attnum = i.indkey[i.idx]
        ORDER BY i.idx
       SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                            pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
                            c.collname, col_description(a.attrelid, a.attnum) AS comment
                       FROM pg_attribute a
                       LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                       LEFT JOIN pg_type t ON a.atttypid = t.oid
                       LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
                      WHERE a.attrelid = '"tenants"'::regclass
                        AND a.attnum > 0 AND NOT a.attisdropped
                      ORDER BY a.attnum
     # ./spec/models/miq_product_feature_spec.rb:373:in `block (3 levels) in <top (required)>'
     # /Users/drewmu/.rvm/gems/ruby-2.5.5/gems/webmock-3.9.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```
i think this ought to be a range maybe, this'll fix the failure in the core repo on the main branch atm that i also think is [a sporadic failure](https://travis-ci.com/github/ManageIQ/manageiq/jobs/386872414#L707) since the code snippet here is three selects and the linked failure only two.

@miq-bot assign @kbrock 
