### PR TITLE
Rename ContainerLabelTagMapping to be more generic

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,4 @@
 app/models/mixins/supports_feature_mixin.rb
 app/models/manager_refresh
-app/models/container_label_tag_mapping.rb
-app/models/container_label_tag_mapping
+app/models/provider_tag_mapping.rb
+app/models/provider_tag_mapping

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -171,7 +171,7 @@ module EmsRefresh::SaveInventory
 
   # Convert all mapped hashes into actual tags and associate them with the object.
   # The collection or collection[:tags] object should be an array of values
-  # created by the ContainerLabelTagMapping::Mapper#map_labels method
+  # created by the ProviderTagMapping::Mapper#map_labels method
   # that should already have ids set by `Mapper#find_or_create_tags` method.
   #
   # The +collection+ argument can either be a Hash, in which case the argument
@@ -180,7 +180,7 @@ module EmsRefresh::SaveInventory
   def save_tags_inventory(object, collection, _target = nil)
     return if collection.nil?
     tags = collection.kind_of?(Hash) ? collection[:tags] : collection
-    ContainerLabelTagMapping.retag_entity(object, tags)
+    ProviderTagMapping.retag_entity(object, tags)
   rescue => err
     raise if EmsRefresh.debug_failures
     _log.error("Auto-tagging failed on #{object.class} [#{object.name}] with error [#{err}].")

--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -106,7 +106,7 @@ class ManageIQ::Providers::Inventory::Persister
   end
 
   def initialize_tag_mapper
-    @tag_mapper ||= ContainerLabelTagMapping.mapper
+    @tag_mapper ||= ProviderTagMapping.mapper
     collections[:tags_to_resolve] = @tag_mapper.tags_to_resolve_collection
   end
 

--- a/app/models/provider_tag_mapping.rb
+++ b/app/models/provider_tag_mapping.rb
@@ -17,10 +17,7 @@
 #
 # All involved tags must also have a Classification.
 #
-# TODO: rename, no longer specific to containers.
-class ContainerLabelTagMapping < ApplicationRecord
-  self.table_name = "provider_tag_mappings"
-
+class ProviderTagMapping < ApplicationRecord
   belongs_to :tag
 
   require_nested :Mapper
@@ -28,10 +25,10 @@ class ContainerLabelTagMapping < ApplicationRecord
   TAG_PREFIXES = %w(amazon azure kubernetes openstack).map { |name| "/managed/#{name}:" }.freeze
   validate :validate_tag_prefix
 
-  # Return ContainerLabelTagMapping::Mapper instance that holds all current mappings,
+  # Return ProviderTagMapping::Mapper instance that holds all current mappings,
   # can compute applicable tags, and create/find Tag records.
   def self.mapper
-    ContainerLabelTagMapping::Mapper.new(in_my_region.all)
+    ProviderTagMapping::Mapper.new(in_my_region.all)
   end
 
   # Assigning/unassigning should be possible without Mapper instance, perhaps in another process.

--- a/app/models/provider_tag_mapping/mapper.rb
+++ b/app/models/provider_tag_mapping/mapper.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
-class ContainerLabelTagMapping
-  # Performs most of the work of ContainerLabelTagMapping - holds current mappings,
+class ProviderTagMapping
+  # Performs most of the work of ProviderTagMapping - holds current mappings,
   # computes applicable tags, and creates/finds Tag records - except actually [un]assigning.
   class Mapper
     # @return [InventoryCollection<Tag>] a collection saving which will find/create (never delete) all
@@ -10,7 +10,7 @@ class ContainerLabelTagMapping
     #   Doesn't require saving, not really interesting.
     attr_reader :specific_tags_collection
 
-    # @param mappings [Array<ContainerLabelTagMapping>] Mapping records to use
+    # @param mappings [Array<ProviderTagMapping>] Mapping records to use
     def initialize(mappings)
       # {[name, type, value] => [tag_id, ...]}
       @mappings = mappings.group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,7 +4,7 @@ class Tag < ApplicationRecord
   has_one :category, :through => :classification, :source => :parent
   virtual_has_one :categorization, :class_name => "Hash"
 
-  has_many :container_label_tag_mappings
+  has_many :provider_tag_mappings
 
   before_destroy :remove_from_managed_filters
 
@@ -151,9 +151,9 @@ class Tag < ApplicationRecord
       end
   end
 
-  # @return [ActiveRecord::Relation] Scope for tags controlled by ContainerLabelTagMapping.
+  # @return [ActiveRecord::Relation] Scope for tags controlled by ProviderTagMapping.
   def self.controlled_by_mapping
-    queries = ContainerLabelTagMapping::TAG_PREFIXES.collect do |prefix|
+    queries = ProviderTagMapping::TAG_PREFIXES.collect do |prefix|
       where(arel_table[:name].matches("#{sanitize_sql_like(prefix)}%", nil, true)) # case sensitive LIKE
     end
     queries.inject(:or).read_only.is_entry

--- a/spec/factories/provider_tag_mapping.rb
+++ b/spec/factories/provider_tag_mapping.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :container_label_tag_mapping do
+  factory :provider_tag_mapping do
     label_name { 'name' }
 
     trait :only_nodes do
@@ -8,7 +8,7 @@ FactoryBot.define do
   end
 
   # Mapping for <All> entities, as created in UI.
-  factory :tag_mapping_with_category, :parent => :container_label_tag_mapping do
+  factory :tag_mapping_with_category, :parent => :provider_tag_mapping do
     transient do
       category_name { "kubernetes::" + Classification.sanitize_name(label_name.tr("/", ":")) }
       category_description { "Mapped #{label_name}" }

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -23,7 +23,7 @@ context "save_tags_inventory" do
     @tag3 = mapped_tag('kubernetes::foo', 'bar') # All entities
   end
 
-  # Simulate what ContainerLabelTagMapping::Mapper.map_labels(...) would return, after resolving to tag ids.
+  # Simulate what ProviderTagMapping::Mapper.map_labels(...) would return, after resolving to tag ids.
   # Note that we don't explicitly test the mapping
   # creation here, the assumption is that these were the generated mappings.
   let(:data) do

--- a/tools/convert_mapped_tags.rb
+++ b/tools/convert_mapped_tags.rb
@@ -25,8 +25,8 @@ end
 puts
 
 ActiveRecord::Base.transaction do
-  condition_for_mapped_tags = ContainerLabelTagMapping::TAG_PREFIXES.map { "tags.name LIKE ?" }.join(' OR ')
-  tag_values = ContainerLabelTagMapping::TAG_PREFIXES.map { |x| "#{x}%:%" }
+  condition_for_mapped_tags = ProviderTagMapping::TAG_PREFIXES.map { "tags.name LIKE ?" }.join(' OR ')
+  tag_values = ProviderTagMapping::TAG_PREFIXES.map { |x| "#{x}%:%" }
 
   Classification.where.not(:id => Classification.region_to_range) # only other regions(not current, we expected that current region is global)
                 .is_category


### PR DESCRIPTION
Tag Mapping isn't only done for Container Labels any more so the mapping table should be more generically named.

Search queries:
- https://github.com/search?p=1&q=org%3AManageIQ+containerlabeltagmapping&type=Code
- https://github.com/search?q=org%3AManageIQ+container_label_tag_mappings&type=code
- https://github.com/search?q=org%3AManageIQ+container_label_tag_mapping&type=code

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/20577
- [x] https://github.com/ManageIQ/manageiq-schema/pull/514
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/638

Merge together
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/651
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7323
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/400

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/173