### PR TITLE
Rewrote Ansible Credential Types using DDF

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -1,28 +1,41 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Access Key'),
-      :help_text => N_('AWS Access Key for this credential'),
-      :required  => true
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Access Key'),
+      :helperText => N_('AWS Access Key for this credential'),
+      :name       => 'userid',
+      :id         => 'userid',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Secret Key'),
-      :help_text => N_('AWS Secret Key for this credential'),
-      :required  => true
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Secret Key'),
+      :helperText => N_('AWS Secret Key for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
-  EXTRA_ATTRIBUTES = {
-    :security_token => {
-      :type       => :password,
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'password-field',
       :label      => N_('STS Token'),
-      :help_text  => N_('Security Token Service(STS) Token for this credential'),
-      :max_length => 1024
-    }
-  }.freeze
+      :helperText => N_('Security Token Service(STS) Token for this credential'),
+      :name       => 'security_token',
+      :id         => 'security_token',
+      :type       => 'password',
+      :maxLength  => 1024,
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :type       => 'cloud',

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -1,45 +1,60 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('The username to use to connect to the Microsoft Azure account')
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('The username to use to connect to the Microsoft Azure account'),
+      :name       => 'userid',
+      :id         => 'userid',
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password'),
-      :help_text => N_('The password to use to connect to the Microsoft Azure account')
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('The password to use to connect to the Microsoft Azure account'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+    },
+  ].freeze
 
-  EXTRA_ATTRIBUTES = {
-    :subscription => {
-      :type       => :string,
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
       :label      => N_('Subscription ID'),
-      :help_text  => N_('The Subscription UUID for the Microsoft Azure account'),
-      :max_length => 1024,
-      :required   => true
+      :helperText => N_('The Subscription ID for the Microsoft Azure account'),
+      :name       => 'subscription',
+      :id         => 'subscription',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :tenant       => {
-      :type       => :string,
+    {
+      :component  => 'text-field',
       :label      => N_('Tenant ID'),
-      :help_text  => N_('The Tenant ID for the Microsoft Azure account'),
-      :max_length => 1024
+      :helperText => N_('The Tenant ID for the Microsoft Azure account'),
+      :name       => 'tenant',
+      :id         => 'tenant',
+      :maxLength  => 1024,
     },
-    :secret       => {
-      :type       => :password,
+    {
+      :component  => 'password-field',
       :label      => N_('Client Secret'),
-      :help_text  => N_('The Client Secret for the Microsoft Azure account'),
-      :max_length => 1024,
+      :helperText => N_('The Client Secret for the Microsoft Azure account'),
+      :name       => 'secret',
+      :id         => 'secret',
+      :type       => 'password',
+      :maxLength  => 1024,
     },
-    :client       => {
-      :type       => :string,
+    {
+      :component  => 'text-field',
       :label      => N_('Client ID'),
-      :help_text  => N_('The Client ID for the Microsoft Azure account'),
-      :max_length => 128
+      :helperText => N_('The Client ID for the Microsoft Azure account'),
+      :name       => 'client',
+      :id         => 'client',
+      :maxLength  => 128,
     },
-  }.freeze
+  ].freeze
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :type       => 'cloud',

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -1,35 +1,45 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  COMMON_ATTRIBUTES = {
-    :userid => {
-      :type      => :email,
-      :label     => N_('Service Account Email Address'),
-      :help_text => N_('The email address assigned to the Google Compute Engine service account'),
-      :required  => true
-    }
-  }.freeze
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Service Account Email Address'),
+      :helperText => N_('The email address assigned to the Google Compute Engine service account'),
+      :name       => 'userid',
+      :id         => 'userid',
+      :type       => 'email',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
   # rubocop:disable Layout/AlignHash
   #
   # looks better to align the nested keys to the same distance, instead of
   # scope just for the hash in question (which is what rubocop does.
-  EXTRA_ATTRIBUTES = {
-    :ssh_key_data => {
-      :type       => :password,
-      :multiline  => true,
-      :label      => N_('RSA Private Key'),
-      :help_text  => N_('Contents of the PEM file associated with the service account email'),
-      :required   => true
+  EXTRA_ATTRIBUTES = [
+    {
+      :component      => 'password-field',
+      :label          => N_('RSA Private Key'),
+      :helperText     => N_('Contents of the PEM file associated with the service account email'),
+      :componentClass => 'textarea',
+      :name           => 'ssh_key_data',
+      :id             => 'ssh_key_data',
+      :type           => 'password',
+      :isRequired     => true,
+      :validate       => [{:type => 'required'}],
     },
-    :project      => {
-      :type       => :string,
+    {
+      :component  => 'text-field',
       :label      => N_('Project'),
-      :help_text  => N_('The GCE assigned identification. It is constructed as two words followed by a three digit number, such as: squeamish-ossifrage-123'),
-      :max_length => 100,
-    }
-  }.freeze
+      :helperText => N_('The GCE assigned identification. It is constructed as two words followed by a three digit number, such as: squeamish-ossifrage-123'),
+      :name       => 'project',
+      :id         => 'project',
+      :maxLength  => 100,
+    },
+  ].freeze
   # rubocop:enable Layout/AlignHash
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :type       => 'cloud',

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -1,55 +1,89 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential')
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('Username for this credential'),
+      :name       => 'userid',
+      :id         => 'userid',
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password'),
-      :help_text => N_('Password for this credential')
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('Password for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+    },
+  ].freeze
 
   # rubocop:disable Layout/AlignHash
   #
   # looks better to align the nested keys to the same distance, instead of
   # scope just for the hash in question (which is what rubocop does.
-  EXTRA_ATTRIBUTES = {
-    :ssh_key_data => {
-      :type       => :password,
-      :multiline  => true,
-      :label      => N_('Private key'),
-      :help_text  => N_('RSA or DSA private key to be used instead of password')
+  EXTRA_ATTRIBUTES = [
+    {
+      :component      => 'password-field',
+      :label          => N_('Private key'),
+      :helperText     => N_('RSA or DSA private key to be used instead of password'),
+      :componentClass => 'textarea',
+      :name           => 'ssh_key_data',
+      :id             => 'ssh_key_data',
+      :type           => 'password',
     },
-    :ssh_key_unlock => {
-      :type       => :password,
+    {
+      :component  => 'password-field',
       :label      => N_('Private key passphrase'),
-      :help_text  => N_('Passphrase to unlock SSH private key if encrypted'),
-      :max_length => 1024
+      :helperText => N_('Passphrase to unlock SSH private key if encrypted'),
+      :name       => 'ssh_key_unlock',
+      :id         => 'ssh_key_unlock',
+      :maxLength  => 1024,
+      :type       => 'password',
     },
-    :become_method => {
-      :type       => :choice,
-      :label      => N_('Privilege Escalation'),
-      :help_text  => N_('Privilege escalation method'),
-      :choices    => ['', 'sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'pmrun', 'runas', 'enable', 'ksu', 'sesu', 'machinectl']
+    {
+      :component        => 'select',
+      :label            => N_('Privilege Escalation'),
+      :helperText       => N_('Privilege escalation method'),
+      :name             => 'become_method',
+      :id               => 'become_method',
+      :type             => 'choice',
+      :isClearable      => true,
+      :options          => %w[
+        sudo
+        su
+        pbrum
+        pfexec
+        doas
+        dzdo
+        pmrun
+        runas
+        enable
+        ksu
+        sesu
+        machinectl
+      ].map { |item| {:label => item, :value => item} },
     },
-    :become_username => {
-      :type       => :string,
+    {
+      :component  => 'text-field',
       :label      => N_('Privilege Escalation Username'),
-      :help_text  => N_('Privilege escalation username'),
-      :max_length => 1024
+      :helperText => N_('Privilege escalation username'),
+      :name       => 'become_username',
+      :id         => 'become_username',
+      :maxLength  => 1024,
     },
-    :become_password => {
-      :type       => :password,
+    {
+      :component  => 'password-field',
       :label      => N_('Privilege Escalation Password'),
-      :help_text  => N_('Password for privilege escalation method'),
-      :max_length => 1024
-    }
-  }.freeze
+      :helperText => N_('Password for privilege escalation method'),
+      :name       => 'become_password',
+      :id         => 'become_password',
+      :maxLength  => 1024,
+      :type       => 'password',
+    },
+  ].freeze
   # rubocop:enable Layout/AlignHash
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :label      => N_('Machine'),

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -1,49 +1,71 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential'),
-      :required  => true
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('Username for this credential'),
+      :name       => 'userid',
+      :id         => 'userid',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password'),
-      :help_text => N_('Password for this credential'),
-      :required  => true
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('Password for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
   # rubocop:disable Layout/AlignHash
   #
   # looks better to align the nested keys to the same distance, instead of
   # scope just for the hash in question (which is what rubocop does).
-  EXTRA_ATTRIBUTES = {
-    :authorize      => {
-      :type         => :boolean,
-      :label        => N_('Authorize'),
-      :help_text    => N_('Whether to use the authorize mechanism')
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'switch',
+      :label      => N_('Authorize'),
+      :helperText => N_('Whether to use the authorize mechanism'),
+      :name       => 'authorize',
+      :id         => 'authorize',
+      :onText     => 'Yes',
+      :offText    => 'No',
+      :type       => 'boolean',
     },
-    :authorize_password => {
-      :type         => :password,
-      :label        => N_('Authorize password'),
-      :help_text    => N_('Password used by the authorize mechanism')
+    {
+      :component  => 'password-field',
+      :label      => N_('Authorize password'),
+      :helperText => N_('Password used by the authorize mechanism'),
+      :name       => 'authorize_password',
+      :id         => 'authorize_password',
+      :type       => 'password',
     },
-    :ssh_key_data   => {
-      :type         => :password,
-      :multiline    => true,
-      :label        => N_('SSH key'),
-      :help_text    => N_('RSA or DSA private key to be used instead of password')
+    {
+      :component      => 'password-field',
+      :label          => N_('SSH key'),
+      :componentClass => 'textarea',
+      :helperText     => N_('RSA or DSA private key to be used instead of password'),
+      :name           => 'ssh_key_data',
+      :id             => 'ssh_key_data',
+      :type           => 'password',
     },
-    :ssh_key_unlock => {
-      :type         => :password,
-      :label        => N_('Private key passphrase'),
-      :help_text    => N_('Passphrase to unlock SSH private key if encrypted'),
-      :max_length   => 1024
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Private key passphrase'),
+      :helperText => N_('Passphrase to unlock SSH private key if encrypted'),
+      :name       => 'ssh_key_unlock',
+      :id         => 'ssh_key_unlock',
+      :type       => 'password',
+      :maxLength  => 1024,
+    },
+  ].freeze
   # rubocop:enable Layout/AlignHash
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :label      => N_('Network'),

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -1,42 +1,58 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('The username to use to connect to OpenStack'),
-      :required  => true
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('The username to use to connect to OpenStack'),
+      :name       => 'userid',
+      :id         => 'userid',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password (API Key)'),
-      :help_text => N_('The password or API key to use to connect to OpenStack'),
-      :required  => true
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password (API Key)'),
+      :helperText => N_('The password or API key to use to connect to OpenStack'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
-  EXTRA_ATTRIBUTES = {
-    :host    => {
-      :type       => :string,
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
       :label      => N_('Host (Authentication URL)'),
-      :help_text  => N_('The host to authenticate with. For example, https://openstack.business.com/v2.0'),
-      :max_length => 1024,
-      :required   => true
+      :helperText => N_('The host to authenticate with. For example, https://openstack.business.com/v2.0'),
+      :name       => 'host',
+      :id         => 'host',
+      :maxLength  => 1024,
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :project => {
-      :type       => :string,
+    {
+      :component  => 'text-field',
       :label      => N_('Project (Tenant Name)'),
-      :help_text  => N_('This is the tenant name. This value is usually the same as the username'),
-      :max_length => 100,
-      :required   => true
+      :helperText => N_('This is the tenant name. This value is usually the same as the username'),
+      :name       => 'project',
+      :id         => 'project',
+      :maxLength  => 100,
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :domain  => {
-      :type       => :string,
+    {
+      :component  => 'text-field',
       :label      => N_('Domain Name'),
-      :help_text  => N_('OpenStack domains define administrative boundaries. It is only needed for Keystone v3 authentication URLs'),
-      :max_length => 100
-    }
-  }.freeze
+      :helperText => N_('OpenStack domains define administrative boundaries. It is only needed for Keystone v3 authentication URLs'),
+      :name       => 'domain',
+      :id         => 'domain',
+      :maxLength  => 100,
+    },
+  ].freeze
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :type       => 'cloud',

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
@@ -1,27 +1,36 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential')
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('Username for this credential'),
+      :name       => 'userid',
+      :id         => 'userid',
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password'),
-      :help_text => N_('Password for this credential')
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('Password for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+    },
+  ].freeze
 
-  EXTRA_ATTRIBUTES = {
-    :host => {
-      :type       => :string,
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
       :label      => N_('Host'),
-      :help_text  => N_('The host to authenticate with'),
-      :max_length => 1024,
-      :required   => true
-    }
-  }.freeze
+      :helperText => N_('The host to authenticate with'),
+      :name       => 'host',
+      :id         => 'host',
+      :maxLength  => 1024,
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :label      => N_('Red Hat Virtualization'),

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
@@ -1,37 +1,49 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential')
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('Username for this credential'),
+      :name       => 'userid',
+      :id         => 'userid',
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password'),
-      :help_text => N_('Password for this credential')
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('Password for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+    },
+  ].freeze
 
   # rubocop:disable Layout/AlignHash
   #
   # looks better to align the nested keys to the same distance, instead of
   # scope just for the hash in question (which is what rubocop does.
-  EXTRA_ATTRIBUTES = {
-    :ssh_key_unlock => {
-      :type       => :password,
-      :label      => N_('Private key passphrase'),
-      :help_text  => N_('Passphrase to unlock SSH private key if encrypted'),
-      :max_length => 1024
+  EXTRA_ATTRIBUTES = [
+    {
+      :component      => 'password-field',
+      :label          => N_('Private key'),
+      :helperText     => N_('RSA or DSA private key to be used instead of password'),
+      :componentClass => 'textarea',
+      :name           => 'ssh_key_data',
+      :id             => 'ssh_key_data',
+      :type           => 'password',
     },
-    :ssh_key_data => {
-      :type       => :password,
-      :multiline  => true,
-      :label      => N_('Private key'),
-      :help_text  => N_('RSA or DSA private key to be used instead of password')
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Private key passphrase'),
+      :helperText => N_('Passphrase to unlock SSH private key if encrypted'),
+      :name       => 'ssh_key_unlock',
+      :id         => 'ssh_key_unlock',
+      :maxLength  => 1024,
+      :type       => 'password',
+    },
+  ].freeze
   # rubocop:enable Layout/AlignHash
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :label      => N_('Scm'),

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
@@ -1,16 +1,19 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
-  COMMON_ATTRIBUTES = {}.freeze
+  COMMON_ATTRIBUTES = [].freeze
 
-  EXTRA_ATTRIBUTES = {
-    :vault_password => {
-      :type       => :password,
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'password-field',
       :label      => N_('Vault password'),
-      :help_text  => N_('Vault password'),
-      :max_length => 1024
-    }
-  }.freeze
+      :helperText => N_('Vault password'),
+      :name       => 'vault_password',
+      :id         => 'vault_password',
+      :maxLength  => 1024,
+      :type       => 'password',
+    },
+  ].freeze
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :label      => N_('Vault'),

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
@@ -1,29 +1,40 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  COMMON_ATTRIBUTES = {
-    :userid   => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential'),
-      :required  => true
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('Username for this credential'),
+      :name       => 'userid',
+      :id         => 'userid',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
     },
-    :password => {
-      :type      => :password,
-      :label     => N_('Password'),
-      :help_text => N_('Password for this credential'),
-      :required  => true
-    }
-  }.freeze
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('Password for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password',
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
-  EXTRA_ATTRIBUTES = {
-    :host => {
-      :type       => :string,
+  EXTRA_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
       :label      => N_('vCenter Host'),
-      :help_text  => N_('The hostname or IP address of the vCenter Host'),
-      :max_length => 1024,
-      :required   => true
-    }
-  }.freeze
+      :helperText => N_('The hostname or IP address of the vCenter Host'),
+      :name       => 'host',
+      :id         => 'host',
+      :maxLength  => 1024,
+      :isRequired => true,
+      :validate   => [{:type => 'required'}],
+    },
+  ].freeze
 
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  API_ATTRIBUTES = (COMMON_ATTRIBUTES + EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
     :label      => N_('VMware'),


### PR DESCRIPTION
The constants are defining form fields for angular to render, but since we're changing the form into React, it's more straightforward to store them as DDF instead of an on-the-fly conversion.

Required for: https://github.com/ManageIQ/manageiq-ui-classic/pull/7324