### PR TITLE
use unique when changed validator for miq user role name

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -7,7 +7,7 @@ class MiqUserRole < ApplicationRecord
 
   virtual_column :vm_restriction,                   :type => :string
 
-  validates :name, :presence => true, :uniqueness => { :case_sensitive => false }
+  validates :name, :presence => true, :uniqueness_when_changed => {:case_sensitive => false}
 
   serialize :settings
 

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MiqUserRole do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_user_role)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context ".seed" do

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -3,6 +3,11 @@ RSpec.describe MiqUserRole do
     @expected_user_role_count = 20
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:miq_user_role)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   context ".seed" do
     it "empty table" do
       MiqUserRole.seed


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq user role` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see #20520 (thanks KB) which got merged tuesday morning of last week

@miq-bot add_label performance 
@miq-bot assign @kbrock 

