### PR TITLE
replace virtual_aggregate with virtual_sum

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -276,10 +276,10 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_create_security_group, :type => :boolean
   virtual_column :supports_storage_services, :type => :boolean
 
-  virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
-  virtual_aggregate :total_memory, :hosts, :sum, :ram_size
-  virtual_aggregate :total_cloud_vcpus, :vms, :sum, :cpu_total_cores
-  virtual_aggregate :total_cloud_memory, :vms, :sum, :ram_size
+  virtual_sum :total_vcpus,        :hosts, :total_vcpus
+  virtual_sum :total_memory,       :hosts, :ram_size
+  virtual_sum :total_cloud_vcpus,  :vms,   :cpu_total_cores
+  virtual_sum :total_cloud_memory, :vms,   :ram_size
 
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
   alias_attribute :to_s, :name

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -30,8 +30,8 @@ class Hardware < ApplicationRecord
   virtual_column :hostnames,     :type => :string_set, :uses => :networks
   virtual_column :mac_addresses, :type => :string_set, :uses => :nics
 
-  virtual_aggregate :used_disk_storage,      :disks, :sum, :used_disk_storage
-  virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+  virtual_sum :used_disk_storage,      :disks, :used_disk_storage
+  virtual_sum :allocated_disk_storage, :disks, :size
   virtual_total     :num_disks,              :disks
   virtual_total     :num_hard_disks,         :hard_disks
 

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -1,12 +1,12 @@
 module AggregationMixin
   extend ActiveSupport::Concern
   included do
-    virtual_aggregate :aggregate_cpu_speed,       :host_hardwares, :sum, :aggregate_cpu_speed
-    virtual_aggregate :aggregate_cpu_total_cores, :host_hardwares, :sum, :cpu_total_cores
-    virtual_aggregate :aggregate_disk_capacity,   :host_hardwares, :sum, :disk_capacity
-    virtual_aggregate :aggregate_memory,          :host_hardwares, :sum, :memory_mb
-    virtual_aggregate :aggregate_physical_cpus,   :host_hardwares, :sum, :cpu_sockets
-    virtual_aggregate :aggregate_vm_cpus,         :vm_hardwares,   :sum, :cpu_sockets
-    virtual_aggregate :aggregate_vm_memory,       :vm_hardwares,   :sum, :memory_mb
+    virtual_sum :aggregate_cpu_speed,       :host_hardwares, :aggregate_cpu_speed
+    virtual_sum :aggregate_cpu_total_cores, :host_hardwares, :cpu_total_cores
+    virtual_sum :aggregate_disk_capacity,   :host_hardwares, :disk_capacity
+    virtual_sum :aggregate_memory,          :host_hardwares, :memory_mb
+    virtual_sum :aggregate_physical_cpus,   :host_hardwares, :cpu_sockets
+    virtual_sum :aggregate_vm_cpus,         :vm_hardwares,   :cpu_sockets
+    virtual_sum :aggregate_vm_memory,       :vm_hardwares,   :memory_mb
   end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe Zone do
     end
 
     it "hosts in virtual reflections" do
-      expect(described_class.includes(:aggregate_cpu_speed)).not_to be_nil
+      expect(described_class.includes(:total_cpu_speed)).not_to be_nil
     end
 
     it "vms_and_templates in virtual reflections" do
-      expect(described_class.includes(:aggregate_vm_cpus)).not_to be_nil
+      expect(described_class.includes(:total_vm_cpus)).not_to be_nil
     end
   end
 


### PR DESCRIPTION
relies on #20608 

replace `virtual_aggregate` with `virtual_sum`

virtual_attributes is about to have a new major version cut 
that includes a deprecation of virtual_aggregate

we'll presumably want this sometime in the future when we update the version

see https://github.com/ManageIQ/activerecord-virtual_attributes/pull/77#discussion_r488983586

@miq-bot assign @kbrock 
@miq-bot add_label refactoring


