### PR TITLE
use unique when changed on miq event def names

### DIFF
--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -1,10 +1,11 @@
 class MiqEventDefinition < ApplicationRecord
   include UuidMixin
 
-  validates_presence_of     :name
-  validates_uniqueness_of   :name
-  validates_format_of       :name, :with => /\A[a-z0-9_\-]+\z/i,
-    :allow_nil => true, :message => "must only contain alpha-numeric, underscore and hyphen characters without spaces"
+  validates :name, :uniqueness_when_changed => true,
+                   :presence                => true,
+                   :allow_nil               => true,
+                   :format                  => {:with    => /\A[a-z0-9_\-]+\z/i,
+                                                :message => "must only contain alpha-numeric, underscore and hyphen characters without spaces"}
   validates_presence_of     :description
 
   acts_as_miq_set_member

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -3,7 +3,23 @@ RSpec.describe MiqEventDefinition do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_event_definition)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
+  end
+
+  describe "name validation" do
+    it "does allow nil" do
+      expect { FactoryBot.create(:miq_event_definition, :name => nil) }.not_to raise_error
+    end
+
+    it "allows alpha-numeric, underscore and hyphen characters" do
+      expect { FactoryBot.create(:miq_event_definition, :name => 'valid_name-87_539_319') }
+        .not_to raise_error
+    end
+
+    it "doesn't allow spaces" do
+      expect { FactoryBot.create(:miq_event_definition, :name => 'invalid name') }
+        .to raise_error(ActiveRecord::RecordInvalid, / Name must only contain alpha-numeric, underscore and hyphen characters without spaces/)
+    end
   end
 
   describe '.seed_default_events' do

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -1,5 +1,11 @@
 RSpec.describe MiqEventDefinition do
   let(:event_defs) { MiqEventDefinition.all.group_by(&:name) }
+
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:miq_event_definition)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe '.seed_default_events' do
     context 'there are 2 event definition sets' do
       let!(:set1) { create_set!('host_operations') }


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq_event_definition` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query and adds tests around the name format validation.

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
