### PR TITLE
use uniqueness_when_changed for miq_ae_field

### DIFF
--- a/app/models/miq_ae_field.rb
+++ b/app/models/miq_ae_field.rb
@@ -7,10 +7,9 @@ class MiqAeField < ApplicationRecord
   has_many   :ae_values,  :class_name => "MiqAeValue",  :foreign_key => :field_id, :dependent => :destroy,
                           :inverse_of => :ae_field
 
-  validates :name, :uniqueness => {:scope => [:class_id, :method_id], :case_sensitive => false}, :if => :name_changed?
-  validates_presence_of   :name
-  validates_format_of     :name, :with    => /\A[\w]+\z/i,
-                                 :message => N_("may contain only alphanumeric and _ characters")
+  validates :name, :uniqueness_when_changed => {:scope => [:class_id, :method_id], :case_sensitive => false},
+                   :presence                => true,
+                   :format                  => {:with => /\A[\w]+\z/i, :message => N_("may contain only alphanumeric and _ characters")}
 
   validates_inclusion_of  :substitute, :in => [true, false]
 


### PR DESCRIPTION
introduce uniqueness_when_changed for `miq_ae_field` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query and adds tests around the name format validation.
follow up to https://github.com/ManageIQ/manageiq/pull/20501, since we have the validator we should use it rather than an `if_changed?` check

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 

