### PR TITLE
use unique when changed validation for endpoint

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -6,7 +6,7 @@ class Endpoint < ApplicationRecord
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
   validates :port, :numericality => {:only_integer => true, :allow_nil => true, :greater_than => 0}
-  validates :url, :uniqueness => true, :allow_blank => true, :unless => :allow_duplicate_url?
+  validates :url, :uniqueness_when_changed => true, :allow_blank => true, :unless => :allow_duplicate_url?
   validate :validate_certificate_authority
 
   after_create  :endpoint_created

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe Endpoint do
   let(:endpoint) { FactoryBot.build(:endpoint) }
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:endpoint, :url => 'thing1')
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe "#verify_ssl" do
     context "when non set" do
       it "is default to verify ssl" do

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Endpoint do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:endpoint, :url => 'thing1')
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe "#verify_ssl" do


### PR DESCRIPTION
introduce uniqueness_when_changed for `endpoint` to reduce queries performed when an unchanged record is saved.

This relies upon the uniqueness_when_changed to remove 1 query.

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
