### PR TITLE
Rename the container_label_tag_mapping table

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -19,6 +19,8 @@
 #
 # TODO: rename, no longer specific to containers.
 class ContainerLabelTagMapping < ApplicationRecord
+  self.table_name = "provider_tag_mappings"
+
   belongs_to :tag
 
   require_nested :Mapper


### PR DESCRIPTION
Raname the container_label_tag_mappings table to provider_tag_mappings

Must be merged together with https://github.com/ManageIQ/manageiq-schema/pull/514
Cross Repo Test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/176