### PR TITLE
use uniqueness_when_changed for miq_report

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -31,7 +31,7 @@ class MiqReport < ApplicationRecord
   serialize :display_filter
 
   validates_presence_of     :name, :title, :db, :rpt_group
-  validates :name, :uniqueness => true, :if => :name_changed?
+  validates :name, :uniqueness_when_changed => true
   validates_inclusion_of    :rpt_type, :in => %w( Default Custom )
 
   has_many                  :miq_report_results, :dependent => :destroy

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe MiqReport do
 
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create
-    expect { m.save }.to make_database_queries(:count => 2)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context "#format_row" do


### PR DESCRIPTION
use uniqueness_when_changed for `miq report` to reduce queries performed when an unchanged record is saved.
follow up to https://github.com/ManageIQ/manageiq/pull/20513

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label refactoring 
@miq-bot assign @kbrock 

