### PR TITLE
use uniqueness_when_changed validation for miq action

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -25,8 +25,8 @@ class MiqAction < ApplicationRecord
              )
   end
 
-  validates_presence_of     :name, :description, :action_type
-  validates_uniqueness_of   :name, :description
+  validates :action_type,        :presence => true
+  validates :name, :description, :presence => true, :uniqueness_when_changed => true
   validates_format_of       :name, :with => /\A[a-z0-9_\-]+\z/i,
     :allow_nil => true, :message => "must only contain alpha-numeric, underscore and hyphen chatacters without spaces"
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe MiqAction do
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.valid? }.to make_database_queries(:count => 2)
+  end
+
   describe "#invoke_or_queue" do
     before do
       @action = MiqAction.new

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe MiqAction do
   it "doesn't access database when unchanged model is saved" do
-    m = described_class.create
-    expect { m.valid? }.to make_database_queries(:count => 2)
+    m = FactoryBot.create(:miq_action)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe "#invoke_or_queue" do


### PR DESCRIPTION
use uniqueness_when_changed for `miq action` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
