### PR TITLE
Remove MiqWorker#supports_container? as every worker but one supports podified

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
@@ -7,10 +7,6 @@ class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqQueueWorkerB
 
   self.required_roles = ["ems_metrics_collector"]
 
-  def self.supports_container?
-    true
-  end
-
   def self.normalized_type
     @normalized_type ||= "ems_metrics_collector_worker"
   end

--- a/app/models/miq_ems_metrics_processor_worker.rb
+++ b/app/models/miq_ems_metrics_processor_worker.rb
@@ -10,10 +10,6 @@ class MiqEmsMetricsProcessorWorker < MiqQueueWorkerBase
     @friendly_name ||= "C&U Metrics Processor"
   end
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_METRICS_PROCESSOR_WORKERS
   end

--- a/app/models/miq_event_handler.rb
+++ b/app/models/miq_event_handler.rb
@@ -6,10 +6,6 @@ class MiqEventHandler < MiqQueueWorkerBase
   self.required_roles       = ["event"]
   self.default_queue_name   = "ems"
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_EVENT_HANDLERS
   end

--- a/app/models/miq_generic_worker.rb
+++ b/app/models/miq_generic_worker.rb
@@ -5,10 +5,6 @@ class MiqGenericWorker < MiqQueueWorkerBase
 
   self.default_queue_name = "generic"
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
   end

--- a/app/models/miq_priority_worker.rb
+++ b/app/models/miq_priority_worker.rb
@@ -9,10 +9,6 @@ class MiqPriorityWorker < MiqQueueWorkerBase
     MiqQueue::HIGH_PRIORITY
   end
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_PRIORITY_WORKERS
   end

--- a/app/models/miq_remote_console_worker.rb
+++ b/app/models/miq_remote_console_worker.rb
@@ -13,10 +13,6 @@ class MiqRemoteConsoleWorker < MiqWorker
   include MiqWebServerWorkerMixin
   include MiqWorker::ServiceWorker
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_REMOTE_CONSOLE_WORKERS
   end

--- a/app/models/miq_reporting_worker.rb
+++ b/app/models/miq_reporting_worker.rb
@@ -6,10 +6,6 @@ class MiqReportingWorker < MiqQueueWorkerBase
   self.required_roles       = ["reporting"]
   self.default_queue_name   = "reporting"
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_REPORTING_WORKERS
   end

--- a/app/models/miq_schedule_worker.rb
+++ b/app/models/miq_schedule_worker.rb
@@ -6,10 +6,6 @@ class MiqScheduleWorker < MiqWorker
 
   self.workers = 1
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_SCHEDULE_WORKERS
   end

--- a/app/models/miq_smart_proxy_worker.rb
+++ b/app/models/miq_smart_proxy_worker.rb
@@ -6,10 +6,6 @@ class MiqSmartProxyWorker < MiqQueueWorkerBase
   self.required_roles       = ["smartproxy"]
   self.default_queue_name   = "smartproxy"
 
-  def self.supports_container?
-    true
-  end
-
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_SMART_PROXY_WORKERS
   end

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -12,10 +12,6 @@ class MiqUiWorker < MiqWorker
   include MiqWebServerWorkerMixin
   include MiqWorker::ServiceWorker
 
-  def self.supports_container?
-    true
-  end
-
   def self.bundler_groups
     %w[manageiq_default ui_dependencies graphql_api]
   end

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -12,10 +12,6 @@ class MiqWebServiceWorker < MiqWorker
   include MiqWebServerWorkerMixin
   include MiqWorker::ServiceWorker
 
-  def self.supports_container?
-    true
-  end
-
   def self.bundler_groups
     # TODO: The api process now looks at the existing UI session as of: https://github.com/ManageIQ/manageiq-api/pull/543
     # ui-classic should not be but is serialializing its classes into session, so we need to have access to them for deserialization

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -286,12 +286,8 @@ class MiqWorker < ApplicationRecord
     end
   end
 
-  def self.supports_container?
-    false
-  end
-
   def self.containerized_worker?
-    MiqEnvironment::Command.is_podified? && supports_container?
+    MiqEnvironment::Command.is_podified?
   end
 
   def containerized_worker?

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -10,10 +10,6 @@ module PerEmsWorkerMixin
   end
 
   module ClassMethods
-    def supports_container?
-      true
-    end
-
     def ems_class
       parent
     end

--- a/lib/miq_cockpit.rb
+++ b/lib/miq_cockpit.rb
@@ -16,6 +16,7 @@ module MiqCockpit
 
     def self.can_start_cockpit_ws?
       MiqEnvironment::Command.is_linux? &&
+        !MiqEnvironment::Command.is_podified? &&
         File.exist?(COCKPIT_WS_PATH) &&
         File.exist?(COCKPIT_SSH_PATH)
     end


### PR DESCRIPTION
Every worker except the Cockpit Worker supports running containerized, having an opt-in `supports_container?` that defaults to false is inefficient and prone to bugs (e.g. #20497)

```
>> MiqWorker.leaf_subclasses.reject(&:supports_container?).map(&:name)
=> ["MiqCockpitWsWorker"]
```

The cockpit web services worker already has logic to control if it can start or not so we can utilize this and check for is_podified? as well