### PR TITLE
Hosts should be disconnected rather than deleted

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -127,7 +127,10 @@ module ManageIQ::Providers
         end
 
         def hosts
-          add_properties(:attributes_blacklist => %i[parent])
+          add_properties(
+            :attributes_blacklist => %i[parent],
+            :delete_method        => :disconnect_inv
+          )
           add_common_default_values
 
           add_custom_reconnect_block(


### PR DESCRIPTION
Hosts are able to be reconnected and thus shouldn't be deleted when they are removed from the provider.

Cross-Repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/186

Dependent: https://github.com/ManageIQ/manageiq-providers-vmware/pull/632