### PR TITLE
For User, don't query groups if the groups did not change

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
   validates :userid, :unique_within_region => {:match_case => false}
   validates :email, :format => {:with => MoreCoreExtensions::StringFormats::RE_EMAIL,
                                 :allow_nil => true, :message => "must be a valid email address"}
-  validates_inclusion_of  :current_group, :in => proc { |u| u.miq_groups }, :allow_nil => true
+  validates :current_group, :inclusion => {:in => proc { |u| u.miq_groups }, :allow_nil => true, :if => :current_group_id_changed?}
 
   # use authenticate_bcrypt rather than .authenticate to avoid confusion
   # with the class method of the same name (User.authenticate)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,8 +16,19 @@ RSpec.describe User do
       expect(FactoryBot.build(:user, :email => nil)).to be_valid
     end
 
+    it "should validate current_group with a value of nil" do
+      user = FactoryBot.build(:user, :current_group_id => nil)
+      expect(user).to be_valid
+      expect(user.current_group_id).to be_nil
+    end
+
     it "should save proper email address" do
       expect(FactoryBot.build(:user, :email => "that.guy@manageiq.com")).to be_valid
+    end
+
+    it "doesn't validate fields that did not change. specifically group, tenant, and userid" do
+      u = FactoryBot.create(:user)
+      expect { u.update(:lastlogon => Time.zone.now) }.to make_database_queries(:count => 1, :matching => /(select|update)/i)
     end
   end
 
@@ -269,8 +280,13 @@ RSpec.describe User do
         expect(@user.valid?).to be_truthy
       end
 
-      it "when assigning to a group not under the user" do
+      it "when assigning to a group not under the user via object" do
         @user.current_group = @group3
+        expect(@user.valid?).to be_falsey
+      end
+
+      it "when assigning to a group not under the user via group_id" do
+        @user.current_group_id = @group3.id
         expect(@user.valid?).to be_falsey
       end
 


### PR DESCRIPTION
We were fetching all groups every time we saved.
Not such a big deal for a typical loaded user object. but for a simple
update query, this added a lot of overhead

used matching on the query count spec to avoid the save points counting towards queries

Alternative to #20471

/cc @NickLaMuro 