### PR TITLE
use uniqueness_when_changed for transformation mapping

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -5,7 +5,7 @@ class TransformationMapping < ApplicationRecord
   has_many :service_resources, :as => :resource, :dependent => :nullify
   has_many :service_templates, :through => :service_resources
 
-  validates :name, :presence => true, :uniqueness => true
+  validates :name, :presence => true, :uniqueness_when_changed => true
 
   def destination(source)
     transformation_mapping_items.find_by(:source => source).try(:destination)

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe TransformationMapping, :v2v do
     end
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = FactoryBot.create(:transformation_mapping)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   context '#destination' do
     it "finds the destination" do
       expect(mapping_redhat.destination(src_cluster_vmware)).to eq(dst_cluster_redhat)

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe TransformationMapping, :v2v do
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:transformation_mapping)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context '#destination' do


### PR DESCRIPTION

use uniqueness_when_changed for `transformation mapping` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
