### PR TITLE
Make the WebMKS console client nonblocking, improve cleanup

### DIFF
--- a/lib/remote_console/client_adapter/web_mks.rb
+++ b/lib/remote_console/client_adapter/web_mks.rb
@@ -21,8 +21,9 @@ module RemoteConsole
         # This callback should be set just once, yielding with the parsed message
         @driver.on(:message) { |msg| yield(msg.data) } if @driver.listeners(:message).length.zero?
 
-        data = @ssl.sysread(length) # Read from the socket
-        @driver.parse(data) # Parse the incoming data, run the callback from above
+        data = @ssl.send(:sysread_nonblock, length, :exception => false)
+        # Parse the incoming data, run the callback from above
+        @driver.parse(data) if data != :wait_readable
       end
 
       def issue(data)

--- a/lib/remote_console/rack_server.rb
+++ b/lib/remote_console/rack_server.rb
@@ -82,6 +82,9 @@ module RemoteConsole
         ws_sock = env['rack.hijack'].call # Hijack the socket from the incoming HTTP connection
         console_sock = TCPSocket.open(record.host_name, record.port) # Open a TCP connection to the remote endpoint
 
+        ws_sock.autoclose = false
+        console_sock.autoclose = false
+
         # These adapters will be used for reading/writing from/to the particular sockets
         @adapters[console_sock] = ClientAdapter.new(record, console_sock)
         @adapters[ws_sock] = ServerAdapter.new(record, env, ws_sock)
@@ -108,13 +111,13 @@ module RemoteConsole
         @logger.send(log_level, message % {:vm_id => record.vm_id})
       end
 
+      @proxy.pop(sock_a, sock_b) unless sock_a.nil? || sock_b.nil?
+
       # Close the sockets if they aren't closed yet
       [sock_a, sock_b].each do |sock|
         sock.try(:close)
         @adapters.delete(sock)
       end
-
-      @proxy.pop(sock_a, sock_b) unless sock_a.nil? || sock_b.nil?
     end
 
     # Primitive same-origin policy checking in production


### PR DESCRIPTION
WebMKS uses SSL on the client side of the remote console proxy, the regular non-ssl socket gets wrapped into one. Unfortunately, `surro-gate` cannot wait on an SSL socket and so we are waiting for the underlying regular one upon `@proxy.select`. This can sometimes get us into situations when the underlying socket is readable, but the SSL wrapper is not as there are not enough incoming data to be decrypted. To bypass this problem, I am using a blocking select when we are reading from the SSL socket, which seemed to work fine as the blocking is kinda rare.

However, the blocking wait can crash if the socket gets closed while the wait operation is pending on it. This caused a deadlock in certain conditions which stops any further proxying. As a workaround I replaced the blocking read with a non-blocking one (ugly private method call) and if it would block, I'm throwing away the result. It's not an ideal solution, but it looks like it fixes the problem and doesn't decrease the overall performance. A longer-term solution would be to teach `surro-gate` to wait on the wrapping SSL socket instead.

Fixes https://github.com/ManageIQ/manageiq/issues/20584