### PR TITLE
It's time to allow PG 11/12 on master

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -11,7 +11,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
       raise msg
     end
 
-    if postgresql_version < 100000 || postgresql_version >= 110000
+    if postgresql_version < 100000 || postgresql_version >= 130000
       raise msg if Rails.env.production? && !ENV["UNSAFE_PG_VERSION"]
       $stderr.puts msg
     end


### PR DESCRIPTION
It's important to note that this doesn't change our default PG version, but allows
running PG 11/12 in production mode while we're developing and testing support for PG 12.

Note, PG 13 was just released: https://www.postgresql.org/docs/release/13.0/

Part of: https://github.com/ManageIQ/manageiq/issues/20580