### PR TITLE
[wip] use built in default values via rails attribute 

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -19,9 +19,9 @@ class MiqPolicy < ApplicationRecord
   include YAMLImportExportMixin
   before_validation :default_name_to_guid, :on => :create
 
-  default_value_for :towhat, 'Vm'
-  default_value_for :active, true
-  default_value_for :mode,   'control'
+  attribute :towhat, :string,  :default => "Vm"
+  attribute :active, :boolean, :default => true
+  attribute :mode,   :string,  :default => "control"
 
   # NOTE: If another class references MiqPolicy through an ActiveRecord association,
   #   particularly has_one and belongs_to, calling .conditions will result in


### PR DESCRIPTION
miq policy defaults are [well tested already](https://github.com/ManageIQ/manageiq/blob/45bab97af2a762d9730718ba3bb1c0500bc5b70e/spec/models/miq_policy_spec.rb#L305) so this is the first of many if it gets approval

Keenan caught it a couple days ago on [September 22, 2020 11:50 AM](https://gitter.im/ManageIQ/manageiq/core?at=5f6a1d3e9930c13c07b5960a)

@kbrock @Fryguy could I get opinions, please? 

@miq-bot add_label refactoring 

it's work in progress until i'm sure that our use cases can sufficiently be satisfied 