### PR TITLE
use uniqueness_when_changed for tenant quota

### DIFF
--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -37,8 +37,8 @@ class TenantQuota < ApplicationRecord
   NAMES = QUOTA_BASE.keys.map(&:to_s)
 
   validates :name,
-            :inclusion  => {:in => NAMES},
-            :uniqueness => {:scope => :tenant_id, :message => "should be unique per tenant"}
+            :inclusion               => {:in => NAMES},
+            :uniqueness_when_changed => {:scope => :tenant_id, :message => "should be unique per tenant"}
   validates :unit, :value, :presence => true
   validates :value, :numericality => {:greater_than => 0}
   validates :warn_value, :numericality => {:greater_than => 0}, :if => -> { warn_value.present? }

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe TenantQuota do
 
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create(:tenant => tenant, :name => :cpu_allocated, :value => 16)
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe "#valid?" do

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe TenantQuota do
   let(:tenant) { FactoryBot.create(:tenant) }
 
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create(:tenant => tenant, :name => :cpu_allocated, :value => 16)
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe "#valid?" do
     it "rejects invalid name" do
       expect(described_class.new(:name => "XXX")).not_to be_valid


### PR DESCRIPTION
use uniqueness_when_changed for `tenant quota` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 

