### PR TITLE
Add User.revoke_sessions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,6 +220,12 @@ class User < ApplicationRecord
     sessions << Session.find_or_create_by(:session_id => session_id)
   end
 
+  def revoke_sessions
+    current_sessions = Session.where(:user_id => id)
+    ManageIQ::Session.revoke(current_sessions.map(&:session_id))
+    current_sessions.destroy_all
+  end
+
   def self.authenticate_with_http_basic(username, password, request = nil, options = {})
     authenticator(username).authenticate_with_http_basic(username, password, request, options)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -224,6 +224,10 @@ class User < ApplicationRecord
     current_sessions = Session.where(:user_id => id)
     ManageIQ::Session.revoke(current_sessions.map(&:session_id))
     current_sessions.destroy_all
+
+    TokenStore.token_caches.each do |_, token_store|
+      token_store.delete_all_for_user(userid)
+    end
   end
 
   def self.authenticate_with_http_basic(username, password, request = nil, options = {})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
   has_many   :unseen_notification_recipients, -> { unseen }, :class_name => 'NotificationRecipient'
   has_many   :unseen_notifications, :through => :unseen_notification_recipients, :source => :notification
   has_many   :authentications, :foreign_key => :evm_owner_id, :dependent => :nullify, :inverse_of => :evm_owner
+  has_many   :sessions, :dependent => :destroy
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
   scope      :superadmins, lambda {
@@ -206,7 +207,17 @@ class User < ApplicationRecord
   end
 
   def self.authenticate(username, password, request = nil, options = {})
-    authenticator(username).authenticate(username, password, request, options)
+    user = authenticator(username).authenticate(username, password, request, options)
+    user.try(:link_to_session, request)
+
+    user
+  end
+
+  def link_to_session(request)
+    return unless request
+    return unless (session_id = request.session_options[:id])
+
+    sessions << Session.find_or_create_by(:session_id => session_id)
   end
 
   def self.authenticate_with_http_basic(username, password, request = nil, options = {})

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -17,9 +17,9 @@ class TokenManager
     ttl = token_options.delete(:token_ttl_override) || token_ttl
     token_data = {:token_ttl => ttl, :expires_on => Time.now.utc + ttl}
 
-    token_store.write(token,
-                      token_data.merge!(prune_token_options(token_options)),
-                      :expires_in => token_ttl)
+    token_store.create_user_token(token,
+                                  token_data.merge!(prune_token_options(token_options)),
+                                  :expires_in => token_ttl)
     token
   end
 

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -1,6 +1,4 @@
 class TokenStore
-  @token_caches = {} # Hash of Memory/Dalli Store Caches, Keyed by namespace
-
   module KeyValueHelpers
     def delete_all_for_user(userid)
       Array(read("tokens_for_#{userid}")).each do |token|
@@ -22,10 +20,14 @@ class TokenStore
     end
   end
 
+  def self.token_caches
+    @token_caches ||= {} # Hash of Memory/Dalli Store Caches, Keyed by namespace
+  end
+
   # only used by TokenManager.token_store
   # @return a token store for users
   def self.acquire(namespace, token_ttl)
-    @token_caches[namespace] ||= begin
+    token_caches[namespace] ||= begin
       options = cache_store_options(namespace, token_ttl)
       case ::Settings.server.session_store
       when "sql"

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -1,6 +1,27 @@
 class TokenStore
   @token_caches = {} # Hash of Memory/Dalli Store Caches, Keyed by namespace
 
+  module KeyValueHelpers
+    def delete_all_for_user(userid)
+      Array(read("tokens_for_#{userid}")).each do |token|
+        delete(token)
+      end
+
+      delete("tokens_for_#{userid}")
+    end
+
+    def create_user_token(token, data, options)
+      write(token, data, options)
+    ensure
+      if data[:userid]
+        user_tokens_cache_key = "tokens_for_#{data[:userid]}"
+        user_tokens_cache = read(user_tokens_cache_key) || []
+        user_tokens_cache << token
+        write(user_tokens_cache_key, user_tokens_cache)
+      end
+    end
+  end
+
   # only used by TokenManager.token_store
   # @return a token store for users
   def self.acquire(namespace, token_ttl)
@@ -11,10 +32,14 @@ class TokenStore
         SqlStore.new(options)
       when "memory"
         require 'active_support/cache/memory_store'
-        ActiveSupport::Cache::MemoryStore.new(options)
+        ActiveSupport::Cache::MemoryStore.new(options).tap do |store|
+          store.extend KeyValueHelpers
+        end
       when "cache"
         require 'active_support/cache/dalli_store'
-        ActiveSupport::Cache::DalliStore.new(MiqMemcached.server_address, options)
+        ActiveSupport::Cache::DalliStore.new(MiqMemcached.server_address, options).tap do |store|
+          store.extend KeyValueHelpers
+        end
       else
         raise "unsupported session store type: #{::Settings.server.session_store}"
       end

--- a/lib/token_store/sql_store.rb
+++ b/lib/token_store/sql_store.rb
@@ -4,9 +4,14 @@ class TokenStore
       @namespace = options.fetch(:namespace)
     end
 
+    def create_user_token(token, data, options)
+      write(token, data, options)
+    end
+
     def write(token, data, _options = nil)
       record = Session.find_or_create_by(:session_id => session_key(token))
       record.raw_data = data
+      record.user_id = find_user_by_userid(data[:userid]).try(:id) if data[:userid]
       record.save!
     end
 
@@ -28,12 +33,25 @@ class TokenStore
       record.destroy!
     end
 
+    def delete_all_for_user(userid)
+      user = find_user_by_userid(userid)
+      user.sessions.where(Session.arel_table[:session_id].matches("#{@namespace}%", nil, true)).destroy_all
+    end
+
     private
 
     attr_reader :namespace
 
     def session_key(token)
       "#{namespace}:#{token}"
+    end
+
+    def find_user_by_userid(userid)
+      User.in_my_region.where('lower(userid) = ?', userid.downcase).first
+    end
+
+    def find_user_by_id(id)
+      User.in_my_region.where(:id => id).first
     end
   end
 end


### PR DESCRIPTION
Built on top of https://github.com/ManageIQ/manageiq/pull/20477
Requires https://github.com/ManageIQ/manageiq-schema/pull/503

Adds functionality to revoke all sessions (API, UI, etc.) from a given user.


Links
-----

* Part of https://github.com/ManageIQ/manageiq/issues/20476
* https://github.com/ManageIQ/manageiq/pull/20477

Steps for Testing/QA
--------------------

I tested this locally by:

1. Starting up a server
2. Running a collection of API calls, where I first requested a token
3. Looked up the user that was fetching said token
4. Called this new method on that `User` instance (`.revoke_sessions`)