### PR TITLE
use uniqueness when changed for system console

### DIFF
--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -4,7 +4,7 @@ class SystemConsole < ApplicationRecord
 
   default_value_for :opened, false
 
-  validates :url_secret, :uniqueness => true
+  validates :url_secret, :uniqueness_when_changed => true
 
   def connection_params
     {

--- a/spec/models/system_console_spec.rb
+++ b/spec/models/system_console_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe SystemConsole do
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+end

--- a/spec/models/system_console_spec.rb
+++ b/spec/models/system_console_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe SystemConsole do
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 end


### PR DESCRIPTION
use uniqueness_when_changed for `system console` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of two weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 