### PR TITLE
use uniqueness_when_changed for orchestration_template

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -11,8 +11,8 @@ class OrchestrationTemplate < ApplicationRecord
   default_value_for :orderable, true
 
   validates :md5,
-            :uniqueness => {:scope => :draft, :message => "of content already exists (content must be unique)"},
-            :if         => :unique_md5?
+            :uniqueness_when_changed => {:scope => :draft, :message => "of content already exists (content must be unique)"},
+            :if                      => :unique_md5?
   validates_presence_of :name
 
   scope :orderable, -> { where(:orderable => true) }

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe OrchestrationTemplate do
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe ".find_or_create_by_contents" do

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe OrchestrationTemplate do
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe ".find_or_create_by_contents" do
     context "when the template does not exist" do
       let(:query_hash) { FactoryBot.build(:orchestration_template).as_json.symbolize_keys }


### PR DESCRIPTION
use uniqueness_when_changed for `orchestration_template` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of almost three weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 