### PR TITLE
use uniqueness_when_changed for server role names

### DIFF
--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -2,7 +2,7 @@ class ServerRole < ApplicationRecord
   has_many :assigned_server_roles
   has_many :miq_servers, :through => :assigned_server_roles
 
-  validates :name, :presence => true, :uniqueness => true
+  validates :name, :presence => true, :uniqueness_when_changed => true
 
   scope :database_roles, -> { where(:role_scope => 'database').order(:name) }
   scope :region_roles,   -> { where(:role_scope => 'region').order(:name) }

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ServerRole do
   it "doesn't access database when unchanged model is saved" do
     m = described_class.create
-    expect { m.valid? }.to make_database_queries(:count => 1)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   context "Without Seeding" do

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe ServerRole do
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.valid? }.to make_database_queries(:count => 1)
+  end
+
   context "Without Seeding" do
     before do
       @server_roles = []


### PR DESCRIPTION
use uniqueness_when_changed for `server role` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of what is now exactly three weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
