### PR TITLE
bump virtual attributes to 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
-gem "activerecord-virtual_attributes", "~>2.0.0"
+gem "activerecord-virtual_attributes", "~>3.0.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Hardware do
 
       it "bails database calculation" do
         hardware
-        expect(virtual_column_sql_value(Hardware, "allocated_disk_storage")).to be_nil
+        expect(virtual_column_sql_value(Hardware, "allocated_disk_storage")).to eq(0.0)
       end
     end
 
@@ -174,7 +174,7 @@ RSpec.describe Hardware do
 
       it "bails database calculation" do
         hardware
-        expect(virtual_column_sql_value(Hardware, "used_disk_storage")).to be_nil
+        expect(virtual_column_sql_value(Hardware, "used_disk_storage")).to eq(0.0)
       end
     end
 


### PR DESCRIPTION
virtual_attributes is about to have a new major version cut 
that includes a deprecation of virtual_aggregate


## relies on
~~we need https://github.com/ManageIQ/activerecord-virtual_attributes/pull/80~~ 


we'll want https://github.com/ManageIQ/manageiq/pull/20572 merged right next to this one