### PR TITLE
Update optional smtp key handling in GenericMailer#set_mailer_smtp

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -184,7 +184,7 @@ class GenericMailer < ActionMailer::Base
     else                  raise ArgumentError, "authentication value #{evm_settings[:authentication].inspect} must be one of: 'none', 'plain', 'login'"
     end
 
-    OPTIONAL_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] if evm_settings[key] }
+    OPTIONAL_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] if evm_settings.key?(key) }
 
     ActionMailer::Base.smtp_settings = am_settings
     log_smtp_settings = am_settings.dup

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -231,4 +231,12 @@ describe GenericMailer do
   it "returns an array of openssl verify modes" do
     expect(GenericMailer.openssl_verify_modes).to eq([["None", "none"], ["Peer", "peer"], ["Client Once", "client_once"], ["Fail If No Peer Cert", "fail_if_no_peer_cert"]])
   end
+
+  it "sets optional smtp keys as expected" do
+    mail = GenericMailer.new
+    options = {:enable_starttls_auto => false, :openssl_verify_mode => :none}
+    mail.send(:set_mailer_smtp, options)
+    options.delete(:authentication) # Deal with current pass by ref issue
+    expect(ActionMailer::Base.smtp_settings).to include(options)
+  end
 end


### PR DESCRIPTION
Currently the optional smtp keys are skipped if they are set to an explicit false, which is what happens if "No" is selected for the `Start TLS Automatically` option in the UI settings.

As a result, the `am_settings[key]` is never changed from its `true` default value. You can see the issue here:

`OPTIONAL_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] if evm_settings[key] }`

Should be changed to:

`OPTIONAL_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] if evm_settings.key?(key) }`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1881201