### PR TITLE
Redis sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem "rack-attack",                      "~>6.5.0",           :require => false
 gem "rails",                            "~>6.0.3", ">=6.0.3.7"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
+gem "redis-rails",                                           :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false
 gem "ripper_ruby_parser",               "~>1.5.1",           :require => false
 gem "ruby-progressbar",                 "~>1.7.0",           :require => false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,6 +4,7 @@ session_store ||= case Settings.server.session_store
                   when "sql"    then :active_record_store
                   when "memory" then :memory_store
                   when "cache"  then :mem_cache_store
+                  when "redis"  then :redis_store
                   end
 
 ManageIQ::Session.store = session_store

--- a/lib/extensions/redis_store_patch.rb
+++ b/lib/extensions/redis_store_patch.rb
@@ -1,0 +1,9 @@
+module RedisStorePatch
+  def delete_sessions(session_ids)
+    session_ids.each do |session_id|
+      delete_session(ManageIQ::Session.fake_request, session_id, :drop => true)
+    end
+  end
+end
+
+ActionDispatch::Session::RedisStore.prepend(RedisStorePatch)

--- a/lib/manageiq/session/redis_store_adapter.rb
+++ b/lib/manageiq/session/redis_store_adapter.rb
@@ -1,0 +1,18 @@
+module ManageIQ
+  module Session
+    class RedisStoreAdapter < AbstractStoreAdapter
+      def type
+        :redis_store
+      end
+
+      def session_options
+        opts = super
+        opts.merge(
+          :servers      => ::Settings.session.redis_url,
+          :expire_after => 24.hours,
+          :key          => "_vmdb_session"
+        )
+      end
+    end
+  end
+end

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -42,6 +42,11 @@ class TokenStore
         ActiveSupport::Cache::MemCacheStore.new(MiqMemcached.server_address, options).tap do |store|
           store.extend KeyValueHelpers
         end
+      when "redis"
+        require "redis-store"
+        ActiveSupport::Cache::RedisStore.new(redis_url, options).tap do |store|
+          store.extend KeyValueHelpers
+        end
       else
         raise "unsupported session store type: #{::Settings.server.session_store}"
       end
@@ -56,4 +61,9 @@ class TokenStore
     }
   end
   private_class_method :cache_store_options
+
+  def self.redis_url
+    # e.g.: redis://:secrets@example.com:1234/9?foo=bar&baz=qux'
+    ENV["REDIS_URL"].presence || ::Settings.session.redis_url
+  end
 end

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -125,9 +125,9 @@ module Vmdb
           end
         end
 
-        if keys.include?(:session_store) && !%w(sql memory cache).include?(data.session_store)
+        if keys.include?(:session_store) && %w[sql memory cache redis].exclude?(data.session_store)
           valid = false
-          errors << [:session_store, "session_store, \"#{data.session_store}\", invalid. Should be one of \"sql\", \"memory\", \"cache\""]
+          errors << [:session_store, "session_store, \"#{data.session_store}\", invalid. Should be one of \"sql\", \"memory\", \"cache\", \"redis\""]
         end
 
         if keys.include?(:zone)


### PR DESCRIPTION
Add the ability to use redis as the session store. Currently alternatives
include memcached, sql, and in-memory.

Changing the session store is done in settings:

```yaml
:server:
  :session_store: redis
:session:
  :redis_url: redis://127.0.0.1/2
```

The url is of the form: `redis://[:password@]host[:port][/db-number]`
