### PR TITLE
Include SupportsFeatureMixin in configuration profiles and configured systems models

### DIFF
--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -1,5 +1,7 @@
 class ConfigurationProfile < ApplicationRecord
   include NewWithTypeStiMixin
+  include SupportsFeatureMixin
+
   acts_as_miq_taggable
   belongs_to :manager, :class_name => 'ExtManagementSystem'
   belongs_to :parent, :class_name => 'ConfigurationProfile'

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -1,5 +1,7 @@
 class ConfiguredSystem < ApplicationRecord
   include NewWithTypeStiMixin
+  include SupportsFeatureMixin
+
   acts_as_miq_taggable
   belongs_to :configuration_location
   belongs_to :configuration_organization


### PR DESCRIPTION
This is an enhancement for https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/28. 

In the Confguration Profile and Configured System details page, we would like to add a link back to the provider specific UI page. 

In this PR, we extend the base classes for these two models. Each provider that supports this feature will have to overwrite the implementation and add its own logic.