### PR TITLE
use uniqueness when changed for tenant

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -43,14 +43,14 @@ class Tenant < ApplicationRecord
   belongs_to :default_miq_group, :class_name => "MiqGroup", :dependent => :destroy
   belongs_to :source, :polymorphic => true
 
-  validates :subdomain, :uniqueness => true, :allow_nil => true
-  validates :domain,    :uniqueness => true, :allow_nil => true
+  validates :subdomain, :uniqueness_when_changed => true, :allow_nil => true
+  validates :domain,    :uniqueness_when_changed => true, :allow_nil => true
   validate  :validate_only_one_root
   validates :description, :presence => true
-  validates :name, :presence => true, :unless => :use_config_for_attributes?
-  validates :name, :uniqueness => {:scope      => :ancestry,
-                                   :conditions => -> { in_my_region },
-                                   :message    => "should be unique per parent"}
+  validates :name, :presence                  => true, :unless => :use_config_for_attributes?,
+                   :uniqueness_when_changed   => {:scope      => :ancestry,
+                                                  :conditions => -> { in_my_region },
+                                                  :message    => "should be unique per parent"}
   validate :validate_default_tenant, :on => :update, :if => :saved_change_to_default_miq_group_id?
 
   scope :all_tenants,  -> { where(:divisible => true) }

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Tenant do
     Tenant.seed
   end
 
+  it "doesn't access database when unchanged model is saved" do
+    m = described_class.create
+    expect { m.valid? }.to make_database_queries(:count => 2)
+  end
+
   describe "#default_tenant" do
     it "has a default tenant" do
       expect(default_tenant).to be_truthy

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Tenant do
   end
 
   it "doesn't access database when unchanged model is saved" do
-    m = described_class.create
-    expect { m.valid? }.to make_database_queries(:count => 2)
+    m = described_class.create!(:parent => described_class.create!)
+    expect { m.valid? }.not_to make_database_queries
   end
 
   describe "#default_tenant" do


### PR DESCRIPTION
use uniqueness_when_changed for `tenant` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of three weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
