### PR TITLE
New operation for cloud-volume: safe-delete

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -159,6 +159,39 @@ class CloudVolume < ApplicationRecord
     raise NotImplementedError, _("raw_delete_volume must be implemented in a subclass")
   end
 
+  # ========================================== safe-delete ==========================================
+
+  def safe_delete_volume_queue(userid)
+    task_opts = {
+      :action => "Safe deleting Cloud Volume for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'safe_delete_volume',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def safe_delete_volume
+    raw_safe_delete_volume
+  end
+
+  def raw_safe_delete_volume
+    raise NotImplementedError, _("raw_safe_delete_volume must be implemented in a subclass")
+  end
+
+  def validate_safe_delete_volume
+    validate_unsupported("Safe Delete Volume Operation")
+  end
+
   def available_vms
     raise NotImplementedError, _("available_vms must be implemented in a subclass")
   end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -127,6 +127,7 @@ module SupportsFeatureMixin
     :resize                              => 'Resizing',
     :retire                              => 'Retirement',
     :revert_to_snapshot                  => 'Revert Snapshot Operation',
+    :safe_delete                         => 'CloudVolume safe delete',
     :smartstate_analysis                 => 'Smartstate Analysis',
     :snapshot_create                     => 'Create Snapshot',
     :snapshots                           => 'Snapshots',


### PR DESCRIPTION
Safe-delete operation for cloud-volume is similar to the existing delete operation. 
The difference is that safe-delete isn't supposed to actually delete the volume. Instead it puts the volume on a watch list.
After a per-determined period (safe delete wait timeout) the volume is deleted if there was no IO operations during the period on the volume.
