### PR TITLE
zLinux support to build the ManageIQ docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_REF=latest
 ARG ARCH=x86_64
-FROM localhost/manageiq/manageiq-ui-worker:${IMAGE_REF}
+FROM manageiq/manageiq-ui-worker:${IMAGE_REF}
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq
 
 ENV DATABASE_URL=postgresql://root@localhost/vmdb_production?encoding=utf8&pool=5&wait_timeout=5


### PR DESCRIPTION
Adding zLinux support to build the ManageIQ docker image. Adding some packages which are required for s390x architecture and changes are architecture based.