### PR TITLE
Add 'keys_for_volumes' method defining default fields on vol. tab 

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -3,6 +3,10 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   include CloudInitTemplateMixin
   include SysprepTemplateMixin
 
+  def keys_for_volumes
+    [:name, :size, :delete_on_terminate]
+  end
+
   def allowed_availability_zones(_options = {})
     source = load_ar_obj(get_source_vm)
     targets = get_targets_for_ems(source, :cloud_filter, AvailabilityZone, 'availability_zones.available')

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   include CloudInitTemplateMixin
   include SysprepTemplateMixin
 
-  def keys_for_volumes
+  def volume_dialog_keys
     [:name, :size, :delete_on_terminate]
   end
 

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -4,7 +4,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   include SysprepTemplateMixin
 
   def volume_dialog_keys
-    [:name, :size, :delete_on_terminate]
+    %i[name size delete_on_terminate]
   end
 
   def allowed_availability_zones(_options = {})


### PR DESCRIPTION
Add 'keys_for_volumes' method defining default vol. fields in ProvisionWorkflow
   
- setting default fields [name, size, delete_on_terminate] there
  and overriding in IBM Power Virtual Servers provider
    
- as discussed with David H. in this PR:
   https://github.com/ManageIQ/manageiq-ui-classic/pull/7338