### PR TITLE
Remove VimTypes require from CustomizationSpec

### DIFF
--- a/app/models/customization_spec.rb
+++ b/app/models/customization_spec.rb
@@ -1,6 +1,4 @@
 class CustomizationSpec < ApplicationRecord
-  require "VMwareWebService/VimTypes"
-
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
   serialize :spec


### PR DESCRIPTION
Now that we have a [data migration](https://github.com/ManageIQ/manageiq-schema/pull/508) to clear these we no longer need to require VimTypes here for the serialized :spec column
 
https://github.com/ManageIQ/manageiq/pull/20536 was added so that we could backport a fix without a data migration