### PR TITLE
fix hashrocket alignment in configuration script source

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -93,12 +93,12 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
       configuration_script_payloads.reload
     end
     update!(:status            => "successful",
-                       :last_updated_on   => Time.zone.now,
-                       :last_update_error => nil)
+            :last_updated_on   => Time.zone.now,
+            :last_update_error => nil)
   rescue => error
     update!(:status            => "error",
-                       :last_updated_on   => Time.zone.now,
-                       :last_update_error => format_sync_error(error))
+            :last_updated_on   => Time.zone.now,
+            :last_update_error => format_sync_error(error))
     raise error
   end
 


### PR DESCRIPTION
It was originally like this even before the change to `update!` but it's ugly. 

@miq-bot add_label cleanup

