### PR TITLE
use uniqueness when changed for miq ae method

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -15,10 +15,11 @@ class MiqAeMethod < ApplicationRecord
   has_many   :inputs,   -> { order(:priority) }, :class_name => "MiqAeField", :foreign_key => :method_id,
                         :dependent => :destroy, :autosave => true
 
-  validates               :name, :scope, :domain_id, :class_id, :presence => true
-  validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
-  validates_format_of     :name, :with    => /\A[\w]+\z/i,
-                                 :message => N_("may contain only alphanumeric and _ characters")
+  validates :scope, :domain_id, :class_id, :presence => true
+  validates :name,  :presence                => true,
+                    :uniqueness_when_changed => {:case_sensitive => false, :scope => [:class_id, :scope]},
+                    :format                  => {:with    => /\A[\w]+\z/i,
+                                                 :message => N_("may contain only alphanumeric and _ characters")}
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe MiqAeMethod do
     expect(MiqAeMethod.lookup_by_class_id_and_name(c1.id, "foo_method")).to eq(f1)
   end
 
+  it "doesn’t access database when unchanged model is saved" do
+    n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    f1 = FactoryBot.create(:miq_ae_method,
+                           :class_id => c1.id,
+                           :name     => "foo_method",
+                           :scope    => "instance",
+                           :language => "ruby",
+                           :location => "inline")
+    expect { f1.valid? }.to make_database_queries(:count => 1)
+  end
+
   context "#copy" do
     let(:d2) { FactoryBot.create(:miq_ae_domain, :name => "domain2", :priority => 2) }
     let(:ns1) { FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent => @d1) }

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe MiqAeMethod do
                            :scope    => "instance",
                            :language => "ruby",
                            :location => "inline")
-    expect { f1.valid? }.to make_database_queries(:count => 1)
+    expect { f1.valid? }.not_to make_database_queries
   end
 
   context "#copy" do


### PR DESCRIPTION
use uniqueness_when_changed for `miq ae method` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of three weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 

the remaining query is ~~from MiqAeSetUserInfoMixin~~ nonexistent when the method's created right to start with 😲 