### PR TITLE
Updated .gitignore to enable working with git-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .ruby-version
 .sass-cache/
 .tags
+.repo/
 /data/*
 /productization
 /plugins


### PR DESCRIPTION
To allow working with git-repo, I've added it to .gitignore.

git-repo is a popular git orchestration tool https://gerrit.googlesource.com/git-repo/

git-repo creates a .repo folder in the repository, so adding it to .gitignore  is convenient.