### PR TITLE
Added storage_service SupportedFeature.

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -269,6 +269,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_cinder_volume_types, :type => :boolean
   virtual_column :supports_volume_availability_zones, :type => :boolean
   virtual_column :supports_create_security_group, :type => :boolean
+  virtual_column :supports_storage_services, :type => :boolean
 
   virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
   virtual_aggregate :total_memory, :hosts, :sum, :ram_size
@@ -786,6 +787,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_create_security_group
     supports_create_security_group?
+  end
+
+  def supports_storage_services
+    supports_storage_services?
   end
 
   def get_reserve(field)

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -143,6 +143,7 @@ module SupportsFeatureMixin
     :update_security_group               => 'Security Group Update',
     :upgrade_cluster                     => 'Cluster Upgrade',
     :block_storage                       => 'Block Storage',
+    :storage_services                    => 'Storage Services',
     :object_storage                      => 'Object Storage',
     :vm_import                           => 'VM Import',
     :volume_multiattachment              => 'Volume Multiattachment',


### PR DESCRIPTION
A new `supported-feature` called storage service. 
It's meant to differentiate between EMSs that use StorageService to create cloud-volumes and those that don't.
The differentiation is needed because different fields are required for volume creation based on whether a storage-service is involved or not.

