### PR TITLE
Filtered the auth key in api.log

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,7 @@ module Vmdb
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password, :verify, :data, :_pwd, :__protected]
+    config.filter_parameters += [:password, :verify, :data, :auth_key, :_pwd, :__protected]
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true


### PR DESCRIPTION
Now attaching ProviderSdkLogger to api.log as we will like to filter out the auth_key before printing the log. Please see below, the snippet from the generated api.log file :
```
[----] I, [2020-09-30T12:35:29.786119 #2846:2731200]  INFO -- : MIQ(Api::ProvidersController.log_request) Parameters:   
  {"action"=>"update", "controller"=>"api/providers", "format"=>"json", "body"=>{"action"=>"verify_credentials", "resource"=>
{"authentications"=>{"default"=>{"auth_key"=>"FILTERED"}}, "uid_ems"=>"473f85b4-c4ba-4425-b495-d26c77365c91", 
"type"=>"ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager", "zone_id"=>"2"}}}
```

and here the the complete api.log
[api.log](https://github.com/ManageIQ/manageiq/files/5307017/api.log)

