### PR TITLE
Initialize Authentication record with correct class from create_from_params

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -6,10 +6,14 @@ class Authentication < ApplicationRecord
   include NewWithTypeStiMixin
   def self.new(*args, &block)
     if self == Authentication
-      AuthUseridPassword.new(*args, &block)
-    else
-      super
+      args = [{}] if args.empty?
+      h = args.first if args.first.kind_of?(Hash)
+
+      type = h[inheritance_column.to_sym] || h[inheritance_column.to_s]
+      h[inheritance_column.to_sym] = "AuthUseridPassword" if type.nil?
     end
+
+    super
   end
 
   include PasswordMixin

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -443,8 +443,13 @@ module AuthenticationMixin
   end
 
   def assign_nested_authentication(attributes)
-    record = authentications.where(:authtype => attributes['authtype']).first_or_initialize
     klass = authentication_class(attributes)
+    record = authentications.find_by(:authtype => attributes['authtype'])
+    if record.nil?
+      record = klass.new(:resource => self)
+      authentications << record
+    end
+
     record.assign_attributes(attributes.merge(:type => klass.to_s, :name => "#{self.class.name} #{name}"))
     record # `assign_attributes` always returns `nil`
   end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -444,12 +444,7 @@ module AuthenticationMixin
 
   def assign_nested_authentication(attributes)
     klass = authentication_class(attributes)
-    record = authentications.find_by(:authtype => attributes['authtype'])
-    if record.nil?
-      record = klass.new(:resource => self)
-      authentications << record
-    end
-
+    record = authentications.where(:authtype => attributes['authtype']).first_or_initialize(:type => klass.to_s)
     record.assign_attributes(attributes.merge(:type => klass.to_s, :name => "#{self.class.name} #{name}"))
     record # `assign_attributes` always returns `nil`
   end


### PR DESCRIPTION
When creating authentication records for a provider via `#create_from_params` or `#edit_with_params` we have to initialize the authentication record with the proper class so that the `@auth_changed` handling is invoked.

If we set the `:type => "AuthToken"` at the same time as setting the `auth_key=` then we're not setting the subclass until after the record is saved, and thus we are not queueing the initial `authentication_check_types_queue`

Fixes https://github.com/ManageIQ/manageiq/issues/20622