### PR TITLE
use uniqueness_when_changed validator for miq ae instance

### DIFF
--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -9,10 +9,12 @@ class MiqAeInstance < ApplicationRecord
                          :dependent => :destroy, :autosave => true
 
   before_validation :set_relative_path
-  validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
-  validates               :name, :domain_id, :class_id, :presence => true
-  validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
-                                 :message => N_("may contain only alphanumeric and _ . - characters")
+  validates         :domain_id, :class_id, :presence => true
+  validates         :name, :presence                => true,
+                           :uniqueness_when_changed => {:case_sensitive => false,
+                                                        :scope          => :class_id},
+                           :format                  => {:with    => /\A[\w.-]+\z/i,
+                                                        :message => N_("may contain only alphanumeric and _ . - characters")}
 
   def self.lookup_by_name(name)
     find_by(:lower_name => name.downcase)

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe MiqAeInstance do
-
   it "accesses database once when unchanged model is saved" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1')
     n1 = FactoryBot.create(:miq_ae_namespace, :name => 'n1', :parent => d1)
     c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
-    expect { i1.valid? }.to make_database_queries(:count => 1)
+    expect { i1.valid? }.not_to make_database_queries
   end
 
   context "legacy tests" do

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -1,4 +1,13 @@
 RSpec.describe MiqAeInstance do
+
+  it "accesses database once when unchanged model is saved" do
+    d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1')
+    n1 = FactoryBot.create(:miq_ae_namespace, :name => 'n1', :parent => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
+    expect { i1.valid? }.to make_database_queries(:count => 1)
+  end
+
   context "legacy tests" do
     before do
       @user = FactoryBot.create(:user_with_group)


### PR DESCRIPTION
use uniqueness_when_changed for `miq ae instance` to reduce queries (from 1 to 0) performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of three weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
