### PR TITLE
Fixed broken links for provider documentation and added missing link for the Storage Manager

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,13 +87,13 @@
   :product_documentation_direct_link: true
   :product_support_website: https://www.manageiq.org
   :product_support_website_text: ManageIQ.org
-  :ansible_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#adding-an-ansible-tower-provider
-  :cloud_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#cloud_providers
-  :configuration_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#configuration_management_providers
-  :container_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#containers-providers
-  :infra_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#infrastructure_providers
-  :network_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#network_providers
-  :physical_infra_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#infrastructure_providers
+  :ansible_provider: https://manageiq.org/docs/reference/latest/managing_providers/#adding-an-ansible-tower-provider
+  :cloud_provider: https://manageiq.org/docs/reference/latest/managing_providers/#cloud-providers
+  :configuration_provider: https://manageiq.org/docs/reference/latest/managing_providers/#configuration-management-providers
+  :container_provider: https://manageiq.org/docs/reference/latest/managing_providers/#containers-providers
+  :infra_provider: https://manageiq.org/docs/reference/latest/managing_providers/#infrastructure-providers
+  :network_provider: https://manageiq.org/docs/reference/latest/managing_providers/#network-managers
+  :physical_infra_provider: https://www.manageiq.org/docs/reference/latest/managing_providers/#discovering-physical-infrastucture-providers
 
 :drift_states:
   :history:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,7 @@
   :infra_provider: https://manageiq.org/docs/reference/latest/managing_providers/#infrastructure-providers
   :network_provider: https://manageiq.org/docs/reference/latest/managing_providers/#network-managers
   :physical_infra_provider: https://www.manageiq.org/docs/reference/latest/managing_providers/#discovering-physical-infrastucture-providers
+  :storage_manager: https://www.manageiq.org/docs/reference/latest/managing_providers/#storage-managers
 
 :drift_states:
   :history:


### PR DESCRIPTION
@llivne found out that the links accessible from the provider listviews when there are no providers available are broken:
![Screenshot from 2020-10-01 13-36-15](https://user-images.githubusercontent.com/649130/94804467-23ef1100-03eb-11eb-94e4-70f07ab2126a.png)

I fixed these links so they point to the correct location and also added the link for the missing storage manager docs. I'm not sure though about the `storage_manager` as the name, maybeit should be `storage_provider` ...

@miq-bot assign @chessbyte 
@miq-bot add_label bug, documentation, question