### PR TITLE
add schemaless option to rspec config to not match schema queries

### DIFF
--- a/spec/support/db_query_matchers.rb
+++ b/spec/support/db_query_matchers.rb
@@ -1,0 +1,3 @@
+DBQueryMatchers.configure do |config|
+  config.schemaless = true
+end


### PR DESCRIPTION
DBQueryMatchers config includes the option to not count schema queries which we should probably be taking advantage of. 

It will not count all the ones like this: 

```
  1) RelationshipMixin#root is self with with no relationships
     Failure/Error:
       expect do
         nodes = host.with_relationship_type(test_rel_type, &:root)
         expect(nodes).to eq(host)
       end.to make_database_queries(:count => 1) # lookup the relationship node

       expected 1 query, but 4 were made:
       SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                            pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
                            c.collname, col_description(a.attrelid, a.attnum) AS comment
                       FROM pg_attribute a
                       LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                       LEFT JOIN pg_type t ON a.atttypid = t.oid
                       LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
                      WHERE a.attrelid = '"relationships"'::regclass
                        AND a.attnum > 0 AND NOT a.attisdropped
                      ORDER BY a.attnum
       SELECT a.attname
         FROM (
                SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
                  FROM pg_index
                 WHERE indrelid = '"relationships"'::regclass
                   AND indisprimary
              ) i
         JOIN pg_attribute a
           ON a.attrelid = i.indrelid
          AND a.attnum = i.indkey[i.idx]
        ORDER BY i.idx
       SHOW search_path
       SELECT  "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3 ORDER BY "relationships"."id" ASC LIMIT $4
     # ./spec/models/mixins/relationship_mixin_spec.rb:349:in `block (3 levels) in <top (required)>'
     # /Users/drewmu/.rvm/gems/ruby-2.5.5/gems/webmock-3.9.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

@miq-bot assign @kbrock 