### PR TITLE
add ancestry case to the genealogy parent setter

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -529,9 +529,19 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def genealogy_parent=(parent)
-    @genealogy_parent_object = parent
+    with_relationship_type('genealogy') do
+      if use_ancestry?
+        self.parent = parent
+      else
+        @genealogy_parent_object = parent
+      end
+    end
   end
 
+  # save_genealogy_information is only necessary for relationships using genealogy
+  # when using ancestry, the relationship will be saved after the fact
+  # when not using ancestry, the relationship is saved on assignment, necessitating the prior save of the vm/template record
+  # this variable is used to delay that assignment
   def save_genealogy_information
     if defined?(@genealogy_parent_object) && @genealogy_parent_object
       with_relationship_type('genealogy') { self.parent = @genealogy_parent_object }


### PR DESCRIPTION
the multiplicity of tree like structures and their differences in behavior makes this overly complicated. we've got a few bugs with multiple parents being set and a lot of code written to address that bug in particular. we're trying to simplify all this by removing relationships.

this genealogy_parent setter needs to eventually handle ancestry cases as well. 

when we destroy all relationships, we'll want to just alias this to `parent=`

@miq-bot assign @kbrock 


## relies on 
https://github.com/ManageIQ/manageiq/pull/20274
for the `use_ancestry?` method

