### PR TITLE
use uniqueness_when_changed validation for miq ae class

### DIFF
--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -12,10 +12,10 @@ class MiqAeClass < ApplicationRecord
   has_many   :ae_methods,   :class_name => "MiqAeMethod",    :foreign_key => :class_id,
                             :dependent => :destroy, :inverse_of => :ae_class
 
-  validates :name, :namespace_id, :domain_id, :presence => true
-  validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
-  validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
-                                 :message => N_("may contain only alphanumeric and _ . - characters")
+  validates :namespace_id, :domain_id, :presence => true
+  validates :name, :presence                => true,
+                   :uniqueness_when_changed => {:case_sensitive => false, :scope => :namespace_id},
+                   :format                  => {:with => /\A[\w.-]+\z/i, :message => N_("may contain only alphanumeric and _ . - characters")}
   before_validation :set_relative_path
   after_save :set_children_relative_path
 

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MiqAeClass do
     d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
     n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
     c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
-    expect { c1.valid? }.to make_database_queries(:count => 1)
+    expect { c1.valid? }.not_to make_database_queries
   end
 
   describe "name attribute validation" do

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -1,6 +1,13 @@
 RSpec.describe MiqAeClass do
   include Spec::Support::AutomationHelper
 
+  it "doesn’t access database when unchanged model is saved" do
+    d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
+    n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    expect { c1.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe "name attribute validation" do
     let(:ns) { FactoryBot.create(:miq_ae_namespace) }
     subject { described_class.new(:ae_namespace => ns) }


### PR DESCRIPTION
use uniqueness_when_changed for `miq ae instance` to reduce queries (from 1 to 0) performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of three weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 