### PR TITLE
[WIP] Add ServiceAnsiblePlaybook.check_connection

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -25,6 +25,20 @@ class GitRepository < ApplicationRecord
     FileUtils.rm_rf(directory_name)
   end
 
+  # Check the connection for the remote.
+  #
+  # Does not clone a repo or use an existing one, and instead initializes a
+  # repo in a temp path to check the remote to see if it can accept
+  # connections.
+  def check_connection
+    Dir.mktmpdir do |tmp_repo_dir|
+      repo_opts    = worktree_params.merge(:new => true, :path => tmp_repo_dir)
+      tmp_worktree = GitWorktree.new(repo_opts)
+
+      tmp_worktree.check_connection(url)
+    end
+  end
+
   def refresh
     update_repo
     transaction do

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -2,7 +2,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   include AnsibleExtraVarsMixin
   include AnsiblePlaybookMixin
 
-  delegate :playbook, :to => :service_template, :allow_nil => true
+  delegate :playbook, :repository, :to => :service_template, :allow_nil => true
 
   # A chance for taking options from automate script to override options from a service dialog
   def preprocess(action, add_options = {})
@@ -16,6 +16,10 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   def execute(action)
     launch_ansible_job_queue(action)
+  end
+
+  def check_connection(action)
+    repository(action).check_connection
   end
 
   def launch_ansible_job_queue(action)

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -76,6 +76,10 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook.find(config_info[action.downcase.to_sym][:playbook_id])
   end
 
+  def repository(action)
+    GitRepository.find(config_info[action.downcase.to_sym][:repository_id])
+  end
+
   def update_catalog_item(options, auth_user = nil)
     config_info = validate_update_config_info(options)
     unless config_info

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -258,6 +258,14 @@ class GitWorktree
     end
   end
 
+  def check_connection(url)
+    with_remote_options do |remote_options|
+      @repo.remotes
+           .create_anonymous(url)
+           .check_connection(:fetch, remote_options)
+    end
+  end
+
   def with_remote_options
     if @ssh_private_key
       @ssh_private_key_file = Tempfile.new


### PR DESCRIPTION
Allows a `ServiceAnsiblePlaybook` instance to check the remote endpoint for a repo to see if it can connect prior to attempting a clone.

This PR also creates some internals in `GitRepository` and `GitWorktree` to facilitate this and call into the `rugged`/`libgit2` internals (all sharing the same method name: `.check_connection`)


Links
-----

* Partially addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1835226


Steps for Testing/QA
--------------------

I tested this by running it in a jansa VM with this patch applied:

1. From a jansa appliance UI, , and create + run a playbook service
   - Login to the UI
   - Enable `EmbeddedAnsible`
   - Add an Ansible playbook repository (example:  https://github.com/NickLaMuro/ansible-tower-samples.git )
   - Create a catalog and add an Ansible Playbook service (example: 'hello_world.yml')
   - Run the playbook service
2. SSH into the vm, apply the changes, and test in a `rails console`:

```console
$ ssh root@[MIQ_VM]
root@MIQ_VM # vmdb
root@MIQ_VM # git init
root@MIQ_VM # git apply <(curl -L https://github.com/ManageIQ/manageiq/pull/20645.patch)
root@MIQ_VM # bin/rails c
irb> ServiceAnsiblePlaybook.first.check_connection(:provision)
#=> true
```