### PR TITLE
use uniqueness when changed for service template transformation plan

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -43,7 +43,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     nil
   end
 
-  validates :name, :presence => true, :uniqueness => {:scope => [:tenant_id]}
+  validates :name, :presence => true, :uniqueness_when_changed => {:scope => [:tenant_id]}
 
   # create ServiceTemplate and supporting ServiceResources and ResourceActions
   # options

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -258,6 +258,11 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
   let(:miq_requests) { [FactoryBot.create(:service_template_transformation_plan_request, :request_state => "finished")] }
   let(:miq_requests_with_in_progress_request) { [FactoryBot.create(:service_template_transformation_plan_request, :request_state => "active")] }
 
+  it "doesn’t access database when unchanged model is saved" do
+    f1 = described_class.create!(:name => 'f1')
+    expect { f1.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe '#validate_order' do
     let(:service_template) { described_class.create_catalog_item(catalog_item_options) }
 

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
 
   it "doesn’t access database when unchanged model is saved" do
     f1 = described_class.create!(:name => 'f1')
-    expect { f1.valid? }.to make_database_queries(:count => 1)
+    expect { f1.valid? }.not_to make_database_queries
   end
 
   describe '#validate_order' do


### PR DESCRIPTION
use uniqueness_when_changed for `service template transformation plan` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of soon to be almost four weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 

