### PR TITLE
use uniqueness_when_changed validation for service template catalog

### DIFF
--- a/app/models/service_template_catalog.rb
+++ b/app/models/service_template_catalog.rb
@@ -1,7 +1,6 @@
 class ServiceTemplateCatalog < ApplicationRecord
   include TenancyMixin
-  validates_presence_of     :name
-  validates :name, :uniqueness => {:scope => :tenant_id}
+  validates :name, :presence => true, :uniqueness_when_changed => {:scope => :tenant_id}
 
   belongs_to :tenant
   has_many  :service_templates, :dependent => :nullify

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -3,6 +3,11 @@ RSpec.describe ServiceTemplateCatalog do
     Tenant.seed
   end
 
+  it "doesn’t access database when unchanged model is saved" do
+    f1 = described_class.create!(:name => 'f1')
+    expect { f1.valid? }.to make_database_queries(:count => 3)
+  end
+
   describe "#name" do
     it "is unique per tenant" do
       FactoryBot.create(:service_template_catalog, :name => "common", :tenant => root_tenant)

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ServiceTemplateCatalog do
 
   it "doesn’t access database when unchanged model is saved" do
     f1 = described_class.create!(:name => 'f1')
-    expect { f1.valid? }.to make_database_queries(:count => 3)
+    expect { f1.valid? }.to make_database_queries(:count => 2)
   end
 
   describe "#name" do


### PR DESCRIPTION
use uniqueness_when_changed for `service template catalog` to reduce queries performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of soon to be almost four weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 

The remaining queries on this are from the TenancyMixin, which has been the subject of discussion as of late: https://github.com/ManageIQ/manageiq/pull/20447#issuecomment-699101058. 
