### PR TITLE
use uniqueness_when_changed for miq ae namespace

### DIFF
--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -16,9 +16,9 @@ class MiqAeNamespace < ApplicationRecord
            :foreign_key => :namespace_id, :dependent => :destroy, :inverse_of => :ae_namespace
 
   validates :name,
-            :format     => {:with => /\A[\w\.\-\$]+\z/i, :message => N_("may contain only alphanumeric and _ . - $ characters")},
-            :presence   => true,
-            :uniqueness => {:scope => :ancestry, :case_sensitive => false}
+            :format                  => {:with => /\A[\w\.\-\$]+\z/i, :message => N_("may contain only alphanumeric and _ . - $ characters")},
+            :presence                => true,
+            :uniqueness_when_changed => {:scope => :ancestry, :case_sensitive => false}
 
   alias_attribute :fqname_sans_domain, :relative_path
   virtual_has_many :ae_namespaces

--- a/spec/models/miq_ae_namespace_spec.rb
+++ b/spec/models/miq_ae_namespace_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MiqAeNamespace do
   it "doesn’t access database when unchanged model is saved" do
     domain = FactoryBot.create(:miq_ae_domain)
     ns1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => domain)
-    expect { ns1.valid? }.to make_database_queries(:count => 1)
+    expect { ns1.valid? }.not_to make_database_queries
   end
 
   describe "name attribute validation" do

--- a/spec/models/miq_ae_namespace_spec.rb
+++ b/spec/models/miq_ae_namespace_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe MiqAeNamespace do
+  it "doesn’t access database when unchanged model is saved" do
+    domain = FactoryBot.create(:miq_ae_domain)
+    ns1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => domain)
+    expect { ns1.valid? }.to make_database_queries(:count => 1)
+  end
+
   describe "name attribute validation" do
     subject { described_class.new }
 


### PR DESCRIPTION
use uniqueness_when_changed for `miq ae namespace` to reduce queries (1 to 0) performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of soon to be almost four weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
