### PR TITLE
use unique when changed validation for service order

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -11,7 +11,7 @@ class ServiceOrder < ApplicationRecord
   has_many :miq_requests, :dependent => :nullify
 
   validates :state, :inclusion => {:in => [STATE_WISH, STATE_CART, STATE_ORDERED]}
-  validates :state, :uniqueness => { :scope => [:user_id, :tenant_id] }, :if => :cart?
+  validates :state, :uniqueness_when_changed => {:scope => [:user_id, :tenant_id]}, :if => :cart?
   validates :name, :presence => true, :on => :update
 
   before_create :assign_user

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe ServiceOrder do
   end
   let(:tenant) { Tenant.seed }
 
-  it "accesses database when unchanged model is saved" do
+  it "doesn't accesse database when unchanged model is saved" do
     service_order
-    expect { service_order.valid? }.to make_database_queries(:count => 1)
+    expect { service_order.valid? }.not_to make_database_queries
   end
 
   it "should add an miq_request properly" do

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe ServiceOrder do
   end
   let(:tenant) { Tenant.seed }
 
+  it "accesses database when unchanged model is saved" do
+    service_order
+    expect { service_order.valid? }.to make_database_queries(:count => 1)
+  end
+
   it "should add an miq_request properly" do
     expect request.service_order == service_order.id
     expect request.process == false


### PR DESCRIPTION
use uniqueness_when_changed for `service order` to reduce queries (1 to 0) performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of soon to be almost four weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 