### PR TITLE
manageiq-smartstate gem version 0.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -216,7 +216,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.6.0",       :require => false
+  gem "manageiq-smartstate",            "~>0.6.1",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Release manageiq-smartstate gem version 0.6.1

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1872954

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1872954
* https://github.com/ManageIQ/manageiq-smartstate/pull/141
