### PR TITLE
Fix Authentication.new with non-hash arguments

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -5,9 +5,9 @@ class Authentication < ApplicationRecord
 
   include NewWithTypeStiMixin
   def self.new(*args, &block)
-    if self == Authentication
+    if self == Authentication && (args.empty? || args.first.kind_of?(Hash))
       args = [{}] if args.empty?
-      h = args.first if args.first.kind_of?(Hash)
+      h = args.first
 
       type = h[inheritance_column.to_sym] || h[inheritance_column.to_s]
       h[inheritance_column.to_sym] = "AuthUseridPassword" if type.nil?


### PR DESCRIPTION
When defaulting to `:type => AuthUseridPassword` we have to check if the `args` are a `Hash` type before assigning the type

Follow-up to https://github.com/ManageIQ/manageiq/pull/20635#discussion_r499750295