### PR TITLE
[JANSA] Bump manageiq-smartstate gem to 0.5.10 for Jansa

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.5.3",       :require => false
+  gem "manageiq-smartstate",            "~>0.5.10",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Fixes:

1. RHEV SSA Fails on VMs with Direct LUNs
2. Fix Symlink Processing so Packages don't Get Missed Sometimes

@agrare @Fryguy @roliveri please review and merge.  Thanks.