### PR TITLE
Add a memory and cpu limits on deployments 

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -48,10 +48,9 @@ class MiqWorker
       return {} if !Settings.server.worker_monitor.enforce_resource_constraints || (mem_threshold.nil? && cpu_threshold.nil?)
 
       {:limits => {}}.tap do |h|
-        h[:limits][:memory] = "#{mem_threshold / 1.megabyte}Mi" if mem_threshold
+        h[:limits][:memory] = format_memory_threshold(mem_threshold) if mem_threshold
         if cpu_threshold
-          millicores = ((cpu_threshold / 100.0) * 1000).to_i
-          h[:limits][:cpu] = "#{millicores}m"
+          h[:limits][:cpu] = format_cpu_threshold(cpu_threshold)
         end
       end
     end
@@ -78,6 +77,16 @@ class MiqWorker
         deployment_name << "-#{Array(ems_id).map { |id| ApplicationRecord.split_id(id).last }.join("-")}" if respond_to?(:ems_id)
         "#{deployment_prefix}#{deployment_name.underscore.dasherize.tr("/", "-")}"
       end
+    end
+
+    private
+
+    def format_memory_threshold(value)
+      "#{value / 1.megabyte}Mi"
+    end
+
+    def format_cpu_threshold(value)
+      "#{((value / 100.0) * 1000).to_i}m"
     end
   end
 end

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -42,16 +42,19 @@ class MiqWorker
     end
 
     def resource_constraints
-      mem_threshold = self.class.worker_settings[:memory_threshold]
-      cpu_threshold = self.class.worker_settings[:cpu_threshold_percent]
+      return {} unless Settings.server.worker_monitor.enforce_resource_constraints
 
-      return {} if !Settings.server.worker_monitor.enforce_resource_constraints || (mem_threshold.nil? && cpu_threshold.nil?)
+      mem_limit = self.class.worker_settings[:memory_threshold]
+      cpu_limit = self.class.worker_settings[:cpu_threshold_percent]
+      mem_request   = self.class.worker_settings[:memory_request]
+      cpu_request   = self.class.worker_settings[:cpu_request_percent]
 
-      {:limits => {}}.tap do |h|
-        h[:limits][:memory] = format_memory_threshold(mem_threshold) if mem_threshold
-        if cpu_threshold
-          h[:limits][:cpu] = format_cpu_threshold(cpu_threshold)
-        end
+      {}.tap do |h|
+        h.store_path(:limits, :memory, format_memory_threshold(mem_limit)) if mem_limit
+        h.store_path(:limits, :cpu, format_cpu_threshold(cpu_limit)) if cpu_limit
+
+        h.store_path(:defaultRequest, :memory, format_memory_threshold(mem_request)) if mem_request
+        h.store_path(:defaultRequest, :cpu, format_cpu_threshold(cpu_request)) if cpu_request
       end
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1077,10 +1077,12 @@
   :worker_base:
     :defaults:
       :count: 1
+      :cpu_request_percent: 25
       :cpu_threshold_percent: 50
       :gc_interval: 15.minutes
       :heartbeat_freq: 10.seconds
       :heartbeat_timeout: 2.minutes
+      :memory_request: 250.megabytes
       :memory_threshold: 400.megabytes
       :nice_delta: 10
       :parent_time_threshold: 3.minutes

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -173,6 +173,39 @@ RSpec.describe MiqWorker::ContainerCommon do
         }
         expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
       end
+
+      it "returns default cpu when it is set" do
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:cpu_request_percent => 10)
+        constraints = {
+          :defaultRequest => {
+            :cpu => "100m"
+          }
+        }
+        expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
+      end
+
+      it "returns default memory when it is set" do
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_request => 250.megabytes)
+        constraints = {
+          :defaultRequest => {
+            :memory => "250Mi",
+          }
+        }
+        expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
+      end
+
+      it "returns memory pair when set" do
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_request => 250.megabytes, :memory_threshold => 600.megabytes)
+        constraints = {
+          :defaultRequest => {
+            :memory => "250Mi",
+          },
+          :limits         => {
+            :memory => "600Mi",
+          }
+        }
+        expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
+      end
     end
 
     context "when not allowing resource constraints" do


### PR DESCRIPTION
For kubernetes, stating a threshold without a minimum infers that the maximum is also the minimum.
So a maximum memory of 2GB states that it requires 2GB to startup - and we required way too much memory.

If neither is declared, then the min/max from the pod is used.

This adds support for declaring a default memory threshold


https://github.com/ManageIQ/manageiq/issues/20589