### PR TITLE
Hide deprecated and duplicate attributes

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,7 @@ class ApplicationRecord < ActiveRecord::Base
   include ArNestedCountBy
   include ArHrefSlug
   include ToModelHash
+  include ArVisibleAttribute
 
   extend ArTableLock
   extend ArReferences

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -4,6 +4,8 @@ class ExtManagementSystem < ApplicationRecord
   include ExternalUrlMixin
   include VerifyCredentialsMixin
 
+  hide_attribute "aggregate_memory" # better to use total_memory (coin toss - they're similar)
+
   def self.with_tenant(tenant_id)
     tenant = Tenant.find(tenant_id)
     where(:tenant_id => tenant.ancestor_ids + [tenant_id])

--- a/app/models/mixins/deprecation_mixin.rb
+++ b/app/models/mixins/deprecation_mixin.rb
@@ -18,6 +18,7 @@ module DeprecationMixin
     def deprecate_attribute(old_attribute, new_attribute)
       deprecate_attribute_methods(old_attribute, new_attribute)
       virtual_attribute(old_attribute, -> { type_for_attribute(new_attribute.to_s) })
+      hide_attribute(old_attribute)
     end
 
     def deprecate_attribute_methods(old_attribute, new_attribute)

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -1,5 +1,6 @@
 class ActsAsArModel
   include Vmdb::Logging
+  include ArVisibleAttribute
 
   def self.connection
     ActiveRecord::Base.connection

--- a/lib/extensions/ar_visible_attribute.rb
+++ b/lib/extensions/ar_visible_attribute.rb
@@ -1,0 +1,22 @@
+module ArVisibleAttribute
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :hidden_attribute_names, :default => []
+  end
+
+  class_methods do
+    # @param [String|Symbol] attribute name of attribute to be hidden from the api and reporting
+    # this attribute is accessible to all ruby methods. But it is not advertised.
+    # we do this when deprecating an attribute or when introducing an internal attribute
+    def hide_attribute(attribute)
+      self.hidden_attribute_names += [attribute.to_s]
+    end
+
+    # @return Array[String] attribute names that can be advertised in the api and reporting
+    # Other attributes are accessible, they are just no longer in our public api (or never were)
+    def visible_attribute_names
+      self.attribute_names - self.hidden_attribute_names
+    end
+  end
+end

--- a/lib/extensions/ar_visible_attribute.rb
+++ b/lib/extensions/ar_visible_attribute.rb
@@ -9,6 +9,8 @@ module ArVisibleAttribute
     # @param [String|Symbol] attribute name of attribute to be hidden from the api and reporting
     # this attribute is accessible to all ruby methods. But it is not advertised.
     # we do this when deprecating an attribute or when introducing an internal attribute
+    #
+    # NOTE: only use in class definitions, or child classes will be broken
     def hide_attribute(attribute)
       self.hidden_attribute_names += [attribute.to_s]
     end
@@ -16,7 +18,7 @@ module ArVisibleAttribute
     # @return Array[String] attribute names that can be advertised in the api and reporting
     # Other attributes are accessible, they are just no longer in our public api (or never were)
     def visible_attribute_names
-      self.attribute_names - self.hidden_attribute_names
+      attribute_names - hidden_attribute_names
     end
   end
 end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -909,7 +909,7 @@ class MiqExpression
     parent[:class_path] ||= model.name
     parent[:assoc_path] ||= model.name
     parent[:root] ||= model.name
-    result = {:columns => model.attribute_names, :parent => parent}
+    result = {:columns => model.visible_attribute_names, :parent => parent}
     result[:reflections] = {}
 
     model.reflections_with_virtual.each do |assoc, ref|

--- a/spec/lib/extensions/ar_visible_attribute_spec.rb
+++ b/spec/lib/extensions/ar_visible_attribute_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe ArVisibleAttribute do
+  # NOTE: ApplicationRecord already included ArVisibleAttribute
+  let(:klass) { Class.new(ApplicationRecord) { self.table_name = "vms" } }
+  let(:other_klass) { Class.new(ApplicationRecord) { self.table_name = "vms" } }
+
+  context ".visible_attribute_names" do
+    it "shows regular attributes" do
+      expect(klass.visible_attribute_names).to include("type")
+    end
+
+    it "hides hidden attributes" do
+      klass.hide_attribute :type
+      expect(klass.visible_attribute_names).not_to include("type")
+    end
+
+    it "only hides for specified class" do
+      klass.hide_attribute :type
+      expect(other_klass.visible_attribute_names).to include("type")
+    end
+  end
+
+  context ".hidden_attribute_names" do
+    it "starts with no hidden attributes" do
+      expect(klass.hidden_attribute_names).to be_empty
+    end
+
+    it "hides hidden attributes" do
+      klass.hide_attribute :type
+      expect(klass.hidden_attribute_names).to include("type")
+    end
+
+    it "only hides for specified class" do
+      klass.hide_attribute :type
+      expect(other_klass.hidden_attribute_names).not_to include("type")
+    end
+  end
+end

--- a/spec/lib/extensions/ar_visible_attribute_spec.rb
+++ b/spec/lib/extensions/ar_visible_attribute_spec.rb
@@ -2,10 +2,22 @@ RSpec.describe ArVisibleAttribute do
   # NOTE: ApplicationRecord already included ArVisibleAttribute
   let(:klass) { Class.new(ApplicationRecord) { self.table_name = "vms" } }
   let(:other_klass) { Class.new(ApplicationRecord) { self.table_name = "vms" } }
+  let(:child_klass) { Class.new(klass) }
 
   context ".visible_attribute_names" do
     it "shows regular attributes" do
       expect(klass.visible_attribute_names).to include("type")
+    end
+
+    it "shows virtual attributes" do
+      klass.virtual_attribute :superb, :string
+      expect(klass.visible_attribute_names).to include("superb")
+    end
+
+    it "hides hidden virtual attributes" do
+      klass.virtual_attribute :superb, :string
+      klass.hide_attribute :superb
+      expect(klass.visible_attribute_names).not_to include("superb")
     end
 
     it "hides hidden attributes" do
@@ -16,6 +28,36 @@ RSpec.describe ArVisibleAttribute do
     it "only hides for specified class" do
       klass.hide_attribute :type
       expect(other_klass.visible_attribute_names).to include("type")
+    end
+
+    context "child class" do
+      it "shows regular attributes" do
+        expect(child_klass.visible_attribute_names).to include("type")
+      end
+
+      it "hides attributes that are hidden in parent class" do
+        klass.hide_attribute :type
+        expect(child_klass.visible_attribute_names).not_to include("type")
+      end
+
+      it "hides virtual attributes that are hidden in the parent class" do
+        klass.virtual_attribute :superb, :string
+        klass.hide_attribute :superb
+        expect(child_klass.visible_attribute_names).not_to include("superb")
+      end
+
+      it "hides attributes that are hidden in class and parent class" do
+        klass.hide_attribute :type
+        child_klass.hide_attribute :name
+        expect(child_klass.visible_attribute_names).not_to include("type")
+        expect(child_klass.visible_attribute_names).not_to include("name")
+      end
+
+      it "hides attribute only for class and below" do
+        child_klass.hide_attribute :name
+        expect(klass.visible_attribute_names).to include("name")
+        expect(child_klass.visible_attribute_names).not_to include("name")
+      end
     end
   end
 
@@ -32,6 +74,24 @@ RSpec.describe ArVisibleAttribute do
     it "only hides for specified class" do
       klass.hide_attribute :type
       expect(other_klass.hidden_attribute_names).not_to include("type")
+    end
+
+    context "child class" do
+      it "starts with no hidden attributes" do
+        expect(child_klass.hidden_attribute_names).to be_empty
+      end
+
+      it "hides attributes that are hidden in parent class" do
+        klass.hide_attribute :type
+        expect(child_klass.hidden_attribute_names).to include("type")
+      end
+
+      it "hides attributes that are hidden in parent class" do
+        klass.hide_attribute :type
+        child_klass.hide_attribute :name
+        expect(child_klass.hidden_attribute_names).to include("type")
+        expect(child_klass.hidden_attribute_names).to include("name")
+      end
     end
   end
 end

--- a/spec/models/mixins/deprecation_mixin_spec.rb
+++ b/spec/models/mixins/deprecation_mixin_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe DeprecationMixin do
       expect(Host.arel_attribute(:address).name).to eq("hostname") # typically this is a symbol. not perfect but it works
     end
   end
+
+  # Host.deprecate_attribute :address, :hostname
+  context ".visible_attribute_names" do
+    it "hides deprecate_attribute columns" do
+      expect(Host.visible_attribute_names).not_to include("address")
+    end
+  end
 end


### PR DESCRIPTION
Hide deprecated and duplicate attributes

Some virtual_attributes are not needed in reporting nor the api.
Some deprecated attributes should not be advertised for customers to start using.

Now, the attributes are still accessible. So nothing will break. But
these attributes are no longer advertised on the public apis (i.e.: report builder and rest api).

This allows us to control which parts of our models are exposed.
So it will fix #18130 and also allows us to introduce attributes in PRs like #20532 because we will not need to expose the newly introduced attribute.

This does modify the report builder, but minimal changes over in the api repo are necessary to plug up this hole over there.
