### PR TITLE
Use inotify to wait for ansible-runner pid file creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.2.4", ">=5.2.4.4"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=12.3.3",      :require => false
+gem "rb-inotify",                     "~>0.10.0",      :require => false
 gem "rest-client",                    "~>2.1.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "inifile",                        "~>3.0",         :require => false
 gem "inventory_refresh",              "~>0.2.0",       :require => false
 gem "kubeclient",                     "~>4.0",         :require => false # For scaling pods at runtime
 gem "linux_admin",                    "~>2.0", ">=2.0.1", :require => false
+gem "listen",                         "~>3.2",         :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.3.4",       :require => false
 gem "manageiq-loggers",               "~>0.5.0",       :require => false
@@ -68,7 +69,6 @@ gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.2.4", ">=5.2.4.4"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=12.3.3",      :require => false
-gem "rb-inotify",                     "~>0.10.0",      :require => false
 gem "rest-client",                    "~>2.1.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -362,7 +362,7 @@ module Ansible
         File.join(base_dir, "pid")
       end
 
-      def wait_for(path, timeout: 1.minute)
+      def wait_for(path, timeout: 30.seconds)
         require "listen"
         require "concurrent"
 
@@ -376,7 +376,7 @@ module Ansible
 
         begin
           res = yield
-          path_created.wait(timeout)
+          raise "Timed out waiting for #{path}" unless path_created.wait(timeout)
         ensure
           listener.stop
           thread.join

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Ansible::Runner do
   describe ".run" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
+      allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(playbook).and_return(true)
     end
@@ -171,6 +172,7 @@ RSpec.describe Ansible::Runner do
   describe ".run_async" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
+      allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(playbook).and_return(true)
     end
@@ -219,6 +221,7 @@ RSpec.describe Ansible::Runner do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
     before do
+      allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(role_path).and_return(true)
     end
@@ -275,6 +278,7 @@ RSpec.describe Ansible::Runner do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
     before do
+      allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(role_path).and_return(true)
     end


### PR DESCRIPTION
When using `ansible-runner start` a daemon is forked off and runs the playbook in the background allowing the caller to continue one.  It then provides a method to check if the playbook is still running via the `ansible-runner is-alive` call.

This call checks for the existence of the `private_data_dir/pid` file and sends a `kill(2)` syscall to check that the process is alive.  Once the daemon exits the `pid` file is deleted and `ansible-runner is-alive` returns `1`

If `ansible-runner is-alive` is called _before_ the daemon is forked then the `pid` file hasn't been created yet and `is-alive` returns that the process isn't running which, while technically true, doesn't help a caller who wants to wait until the daemon has started _and_ exited.

Since `ansible-runner is-alive` checks for the `pid` file it isn't safe to issue the `is-alive` check until after this file has been created if the purpose of calling `is-alive` is to check if the daemon has exited.

This can be done very efficiently by using `inotify`/`fs_notify` to catch filesystem events using watches.  We setup a filesystem watch on the `/tmp/ansible-runner` tempdir looking for the `pid` file and as soon as it is created break out and return to the caller.

This makes all subsequent `ansible-runner is-alive` calls safe since it is impossible for the call to be issued before the daemon has started running.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/187