### PR TITLE
use uniqueness when changed for ems name

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -127,7 +127,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :ems_licenses,   :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :ems_extensions, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
 
-  validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
+  validates :name,     :presence => true, :uniqueness_when_changed => {:scope => [:tenant_id]}
   validates :hostname, :presence => true, :if => :hostname_required?
   validates :zone,     :presence => true
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -77,6 +77,11 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
+    it "doesn't accesse database when unchanged model is saved" do
+    r = FactoryBot.create(:ems_vmware)
+    expect { r.valid? }.to make_database_queries(:count => 4)
+  end
+
   it ".ems_infra_discovery_types" do
     expected_types = %w(scvmm rhevm virtualcenter openstack_infra)
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
-    it "doesn't accesse database when unchanged model is saved" do
+  it "does access database when unchanged model is saved" do
     r = FactoryBot.create(:ems_vmware)
-    expect { r.valid? }.to make_database_queries(:count => 4)
+    expect { r.valid? }.to make_database_queries(:count => 3)
   end
 
   it ".ems_infra_discovery_types" do


### PR DESCRIPTION
use uniqueness_when_changed for `ext management system` to reduce queries (4 to 3) performed when an unchanged record is saved.

see #20520 (thanks KB) which got merged tuesday morning of just over four weeks ago

@miq-bot add_label performance 
@miq-bot assign @kbrock 
