### PR TITLE
[JANSA][Ansible::Runner] wait on artifacts/ to exist

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -217,6 +217,7 @@ module Ansible
         begin
           fetch_galaxy_roles(playbook_or_role_args)
           result = AwesomeSpawn.run("ansible-runner", :env => env_vars_hash, :params => params)
+          wait_on(File.join(base_dir, "artifacts"))
           res = response(base_dir, ansible_runner_method, result)
         ensure
           # Clean up the tmp dir for the sync method, for async we will clean it up after the job is finished and we've
@@ -376,6 +377,15 @@ module Ansible
 
       def determine_existing_python_paths_for(*paths)
         paths.select { |path| File.exist?(path) }
+      end
+
+      def wait_on(dir)
+        100.times do |i|
+          break if Dir.exist?(dir)
+
+          raise "Timed out waiting for #{dir}" if i >= 99
+          sleep(0.1)
+        end
       end
     end
   end


### PR DESCRIPTION
Before returning a result, wait on the `artifacts/` directory to be created before returning a response object.

This will ensure that calling `.running?` will return `false` properly when the `ansible-runner` has ended, and not before it has even had a chance to start.

Thanks for Jason for the find on this bug.

**Note:  This should only really be a problem in a `docker`/`podified` environment, where launching the process and waiting for a response happens within the same background job.  This isn't something that can happen on an Appliance, since it will have an inherent delay when monitoring the result via a new background job.**


Links
-----

- An arguably worse alternative to https://github.com/ManageIQ/manageiq/pull/20666


Steps for Testing/QA
--------------------

I was using a test script for this in `docker` to run this.

```console
$ docker run --rm -it manageiq/manageiq:latest-jansa /bin/bash
[root@5f4c439ca069 vmdb]# cd /var/www/vmdb/miq
[root@5f4c439ca069 vmdb]# curl -O https://raw.githubusercontent.com/ansible/test-playbooks/master/sleep.yml
[root@5f4c439ca069 vmdb]# cat script.rb
require 'pathname'

class Rails
  def self.root
    Pathname.new("/var/www/miq/vmdb")
  end
end

class Vmdb
  module Logging
  end
end

require 'awesome_spawn'
require 'ansible/runner'
require 'ansible/content'
require 'ansible/runner/response'
require 'ansible/runner/response_async'
require 'tmpdir'
require 'active_support/all'

response = Ansible::Runner.run_async({}, {}, "/var/www/miq/vmdb/hello_world.yml")
puts response.base_dir
puts response.running?

200.times do
  puts response.running?
end
[root@5f4c439ca069 vmdb]# ruby -I lib script.rb
/tmp/ansible-runner20201007-120-2d8yu1
false
false
true
true
...
true
true
false
false
false
false
```

- A good run will return `true` values first... then `false` false values.
- A bad run (where it isn't working correctly) with return some `false` values, followed by some `true` values, and then `false` values.

The idea is that `true` equals the process is running.  If we get `false` prior to receiving some `true` values, we can reliably expect that `.running?` is a good indicator that the `ansible-runner` process was ever running properly.

The example run above shows it _**not**_ working properly, and a correct run would be when the first to `false` output values are omitted.