### PR TITLE
use unique when changed for conversion host addresses

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -19,11 +19,11 @@ class ConversionHost < ApplicationRecord
   validates :resource_id, :uniqueness_when_changed => {:scope => :resource_type}
 
   validates :address,
-    :uniqueness => true,
-    :format     => { :with => Resolv::AddressRegex },
-    :inclusion  => { :in => ->(conversion_host) { conversion_host.resource.ipaddresses } },
-    :unless     => ->(conversion_host) { conversion_host.address.blank? || conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? },
-    :presence   => false
+            :uniqueness_when_changed => true,
+            :format                  => {:with => Resolv::AddressRegex},
+            :inclusion               => {:in => ->(conversion_host) { conversion_host.resource.ipaddresses }},
+            :unless                  => ->(conversion_host) { conversion_host.address.blank? || conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? },
+            :presence                => false
 
   validate :resource_supports_conversion_host
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -104,9 +104,22 @@ RSpec.describe ConversionHost, :v2v do
       end
     end
 
-    it "doesn't access database when unchanged model is saved" do
-      m = FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:vm_openstack))
-      expect { m.valid? }.not_to make_database_queries
+    describe "uniqueness_when_changed validation" do
+      context "resource_id validation" do
+        it "doesn't access database when unchanged model is saved" do
+          m = FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:vm_openstack))
+          expect { m.valid? }.not_to make_database_queries
+        end
+      end
+
+      context "address validation" do
+        it "doesn't access database when unchanged model is saved" do
+          conversion_host = FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:vm_openstack), :address => '127.0.0.1')
+          allow(vm).to receive(:ipaddresses).and_return(['10.0.1.1', 'FE80::0202:B3FF:FE1E:3267', '192.168.1.1'])
+
+          expect { conversion_host.valid? }.not_to make_database_queries
+        end
+      end
     end
 
     context "#ipaddress" do


### PR DESCRIPTION
use uniqueness_when_changed for `conversion host` `address` to reduce queries (1 to 0) performed when an unchanged record is saved.

it's two separate prs for this model: https://github.com/ManageIQ/manageiq/pull/20550 was the `resource_id` uniqueness validation change, the `address` validation change was a little more complicated 

see #20520 

@miq-bot add_label performance 
@miq-bot assign @kbrock 
