### PR TITLE
Add new 'CloudSubnet' extra attribute column

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -30,9 +30,10 @@ class CloudSubnet < ApplicationRecord
   virtual_column :host_routes,      :type => :string
   virtual_column :ip_version,       :type => :string
   virtual_column :subnetpool_id,    :type => :string
+  virtual_column :network_type,     :type => :string
 
   # Define all getters and setters for extra_attributes related virtual columns
-  %i(allocation_pools host_routes ip_version subnetpool_id).each do |action|
+  %i(allocation_pools host_routes ip_version subnetpool_id network_type).each do |action|
     define_method("#{action}=") do |value|
       extra_attributes_save(action, value)
     end


### PR DESCRIPTION
In 'ManageIQ::Providers::IbmCloud::PowerVirtualServers' subnets are
typed as 'vlan' and 'pub-vlan'. This generic ':network_type' virtual
column in the 'cloud_subnets' 'extra_attributes' table would facilitate
persisting the subnet type.

This patch was suggested by @agrare
https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/77#discussion_r501309990
