### PR TITLE
Update the Ansible::Runner wait_for timeout

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -362,7 +362,7 @@ module Ansible
         File.join(base_dir, "pid")
       end
 
-      def wait_for(path, timeout: 30.seconds)
+      def wait_for(path, timeout: 10.seconds)
         require "listen"
         require "concurrent"
 


### PR DESCRIPTION
Drop the wait_for timeout to 10 seconds to match what has been merged to `jansa` in https://github.com/ManageIQ/manageiq/pull/20670