### PR TITLE
Filter 'apikey' in ProviderSdkLogger

### DIFF
--- a/lib/vmdb/loggers/provider_sdk_logger.rb
+++ b/lib/vmdb/loggers/provider_sdk_logger.rb
@@ -19,6 +19,7 @@ module Vmdb::Loggers
         msg = msg.sub(/Bearer(.*?)\"/, 'Bearer [FILTERED] "')
         msg = msg.sub(/SharedKey(.*?)\"/, 'SharedKey [FILTERED] "')
         msg = msg.sub(/client_secret=(.*?)&/, "client_secret=[FILTERED]&")
+        msg = msg.sub(/apikey=(.*?)\"/, 'apikey=[FILTERED]"')
         super(severity, datetime, progname, msg)
       end
     end


### PR DESCRIPTION
The IBM Cloud IAM authentication API uses a payload 'apikey' to request
an auth token. The 'apikey' value is sensitive and should be filtered
from log files.

Reference 'ibm-cloud-ruby-sdk' PR to enable logging IAM calls once this filter is enabled:
https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/39