### PR TITLE
use unique within region validator for classification 

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -9,12 +9,7 @@ class Classification < ApplicationRecord
   before_save    :save_tag
   before_destroy :delete_tags_and_entries
 
-  validates :description, :presence => true, :length => {:maximum => 255}
-  validates :description, :uniqueness => {:scope => [:parent_id]}, :if => proc { |c|
-    cond = c.class.in_region(region_id).where(:parent_id => c.parent_id, :description => c.description)
-    cond = cond.where.not(:id => c.id) unless c.new_record?
-    cond.exists?
-  }
+  validates :description, :presence => true, :length => {:maximum => 255}, :unique_within_region => {:scope => :parent_id}
 
   NAME_MAX_LENGTH = 50
   validates :name, :presence => true, :length => {:maximum => NAME_MAX_LENGTH}

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe Classification do
     end
   end
 
+  it "validates description uniqueness" do
+    c1 = described_class.create!(:name => "parent", :description => "this is getting annoying")
+    described_class.create!(:name => "child", :description => "cat", :parent => c1)
+    c2 = described_class.new(:name => "child", :description => "cat", :parent => c1)
+
+    expect(c2.valid?).to be(false)
+  end
+
+  it "accesses database once when unchanged model is saved" do
+    c1 = described_class.create!(:name => "parent", :description => "this is getting annoying")
+    c2 = described_class.create!(:name => "child", :description => "cat", :parent => c1)
+
+    expect { expect(c2.valid?).to be(true) }.to make_database_queries(:count => 1)
+  end
+
   context "enforce_policy" do
     let(:tag) { FactoryBot.build(:classification_tag, :parent => FactoryBot.build(:classification)) }
 


### PR DESCRIPTION
validates :description on classification uses the in region logic and should be using the in region validator which happens to have been written with an array to start with. since we currently don't support arrays in scopes in that validator:

```bash
1) UniqueWithinRegionValidator#unique_within_region class without STI applies the passed scopes
     Failure/Error: matches = matches.where(options[:scope] => record.public_send(options[:scope])) if options.key?(:scope)

     TypeError:
       [:email, :last_name] is not a symbol nor a string
...
```

per the last comment on this pr, i'm just removing the array so we can get the classification query count down. 


@miq-bot assign @kbrock 
@miq-bot add_label bug
