### PR TITLE
Fix automate_output_value() for tag control

### DIFF
--- a/app/models/dialog_field_tag_control.rb
+++ b/app/models/dialog_field_tag_control.rb
@@ -85,7 +85,7 @@ class DialogFieldTagControl < DialogFieldSortedItem
   end
 
   def automate_output_value
-    MiqAeEngine.create_automation_attribute_array_value(Classification.where(:id => @value.to_s.split(",")))
+    MiqAeEngine.create_automation_attribute_array_value(Classification.where(:id => @value.kind_of?(String) ? @value.split(',') : @value))
   end
 
   def automate_key_name


### PR DESCRIPTION
1. Create a service dialog, add a Tag control element to it
2. Make sure the selected tag in the above tag control element allows multiple choices
3. Add the above created service dialog to a catalog item (a generic catalog item for example)
4. Order the above created catalog item and select at least two tags in the presented dialog
5. Check the created service, see if it mentions all selected tags

Before (a service using a service dialog with 3 tag controls, first one allowing multiple choices, selected 4 tags):
```
irb(main):008:0> pp Service.find_by(:name => 'bug-1886887-20201013-144146').options
{:dialog=>
  {"Array::dialog_tag_control_1"=>"",
   "Array::dialog_tag_control_2"=>"Classification::19",
   "Array::dialog_tag_control_3"=>"Classification::45",
   "dialog_tag_control_2"=>["prod_ops"],
   "dialog_tag_control_3"=>["engineering"]}}
```

After:
```
irb(main):002:0> pp Service.find_by(:name => 'bug-1886887-20201013-144444').options
{:dialog=>
  {"Array::dialog_tag_control_1"=>
    "Classification::7,Classification::10,Classification::14,Classification::15",
   "Array::dialog_tag_control_2"=>"Classification::19",
   "Array::dialog_tag_control_3"=>"Classification::45",
   "dialog_tag_control_1"=>["desktop", "database", "messaging", "security"],
   "dialog_tag_control_2"=>["prod_ops"],
   "dialog_tag_control_3"=>["engineering"]}}
```

The `@value` variable, as far as I can tell, is an either an array of integers (classification ids) or a string of comma-separated integers (again classification ids).

https://bugzilla.redhat.com/show_bug.cgi?id=1886887