### PR TITLE
remove unneeded travis yaml lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: ruby
 rvm:
 - 2.5.7
 - 2.6.5
-sudo: false
-cache:
-  bundler: true
+cache: bundler
 env:
   global:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000


### PR DESCRIPTION
since we're not specifying directories to cache, we can remove the `true` option on the cache line; we can remove sudo:false per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.`

@miq-bot add_label cleanup
@miq-bot add_label developer 
