### PR TITLE
Display revoke_user_sessions permission for roles

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6615,7 +6615,7 @@
       :identifier: custom_button_events_show_list
   - :name: Revoke Sessions of Other Users
     :description: Revoke Sessions of Other Users
-    :hidden: true
+    :hidden: false
     :feature_type: control
     :identifier: revoke_user_sessions
   - :name: Service Offerings


### PR DESCRIPTION
Follow up of https://github.com/ManageIQ/manageiq/pull/20633.

This feature can be enabled or disabled in UI.

@miq-bot add_label enhancement 
@miq-bot assign @gtanzillo 
