### PR TITLE
Add ui_dependencies back to base worker to avoid load errors

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -49,7 +49,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.bundler_groups
-    %w[manageiq_default]
+    %w[manageiq_default ui_dependencies]
   end
 
   def self.kill_priority


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-documentation/issues/1493
Related: https://github.com/ManageIQ/manageiq/issues/20406

Note, the second link isn't resolved. You cannot generate widget content
in console without ui_dependencies.

There are still many modules/classes in ui-classic that could be called
from backend workers, see: #19863 
