### PR TITLE
Delete duplicate reconnect blocks from persister

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -128,37 +128,11 @@ module ManageIQ::Providers
 
         def hosts
           add_properties(
-            :attributes_blacklist => %i[parent],
-            :delete_method        => :disconnect_inv
+            :attributes_blacklist   => %i[parent],
+            :delete_method          => :disconnect_inv,
+            :custom_reconnect_block => INVENTORY_RECONNECT_BLOCK
           )
           add_common_default_values
-
-          add_custom_reconnect_block(
-            lambda do |inventory_collection, inventory_objects_index, attributes_index|
-              relation = inventory_collection.model_class.where(:ems_id => nil)
-
-              return if relation.count <= 0
-
-              inventory_objects_index.each_slice(100) do |batch|
-                relation.where(inventory_collection.manager_ref.first => batch.map(&:first)).each do |record|
-                  index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
-
-                  # We need to delete the record from the inventory_objects_index and attributes_index, otherwise it
-                  # would be sent for create.
-                  inventory_object = inventory_objects_index.delete(index)
-                  hash             = attributes_index.delete(index)
-
-                  record.assign_attributes(hash.except(:id, :type))
-                  if !inventory_collection.check_changed? || record.changed?
-                    record.save!
-                    inventory_collection.store_updated_records(record)
-                  end
-
-                  inventory_object.id = record.id
-                end
-              end
-            end
-          )
         end
 
         def vms
@@ -349,34 +323,6 @@ module ManageIQ::Providers
 
         def vm_template_infra_shared_properties
           add_inventory_attributes(%i[resource_pool])
-          add_properties(:custom_reconnect_block => vm_template_infra_reconnect_block)
-        end
-
-        def vm_template_infra_reconnect_block
-          lambda do |inventory_collection, inventory_objects_index, attributes_index|
-            relation = inventory_collection.model_class.where(:ems_id => nil)
-
-            return if relation.count <= 0
-
-            inventory_objects_index.each_slice(100) do |batch|
-              relation.where(inventory_collection.manager_ref.first => batch.map(&:first)).each do |record|
-                index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
-
-                # We need to delete the record from the inventory_objects_index and attributes_index, otherwise it
-                # would be sent for create.
-                inventory_object = inventory_objects_index.delete(index)
-                hash = attributes_index.delete(index)
-
-                record.assign_attributes(hash.except(:id, :type))
-                if !inventory_collection.check_changed? || record.changed?
-                  record.save!
-                  inventory_collection.store_updated_records(record)
-                end
-
-                inventory_object.id = record.id
-              end
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
The two custom_reconnect_blocks for vms and hosts are essentially duplicates of the main one in the shared persister builder module [[ref](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/inventory/persister/builder/shared.rb#L5-L32)]

Cross-repo test of all the infra_managers: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/190