### PR TITLE
drop migration from models

### DIFF
--- a/app/models/mixins/cinder_manager_mixin.rb
+++ b/app/models/mixins/cinder_manager_mixin.rb
@@ -18,24 +18,10 @@ module CinderManagerMixin
     private
 
     def ensure_cinder_managers
-      created = ensure_cinder_manager
+      ensure_cinder_manager
       cinder_manager.name            = "#{name} Cinder Manager"
       cinder_manager.zone_id         = zone_id
       cinder_manager.provider_region = provider_region
-
-      return true unless created
-
-      begin
-        cinder_manager.save
-        cinder_manager.reload
-        _log.debug("cinder_manager.id = #{cinder_manager.id}")
-
-        CloudVolume.where(:ems_id => id).update(:ems_id => cinder_manager.id)
-        CloudVolumeBackup.where(:ems_id => id).update(:ems_id => cinder_manager.id)
-        CloudVolumeSnapshot.where(:ems_id => id).update(:ems_id => cinder_manager.id)
-      rescue ActiveRecord::RecordNotFound
-        # In case parent manager is not valid, let its validation fail.
-      end
       true
     end
   end

--- a/app/models/mixins/swift_manager_mixin.rb
+++ b/app/models/mixins/swift_manager_mixin.rb
@@ -15,23 +15,10 @@ module SwiftManagerMixin
     private
 
     def ensure_swift_managers
-      created = ensure_swift_manager
+      ensure_swift_manager
       swift_manager.name            = "#{name} Swift Manager"
       swift_manager.zone_id         = zone_id
       swift_manager.provider_region = provider_region
-
-      return true unless created
-
-      begin
-        swift_manager.save
-        swift_manager.reload
-        _log.debug("swift_manager.id = #{swift_manager.id}")
-
-        CloudObjectStoreContainer.where(:ems_id => id).update(:ems_id => swift_manager.id)
-        CloudObjectStoreObject.where(:ems_id => id).update(:ems_id => swift_manager.id)
-      rescue ActiveRecord::RecordNotFound
-        # In case parent manager is not valid, let its validation fail.
-      end
       true
     end
   end


### PR DESCRIPTION
### Why are we talking about this?

I am in the process of making providers consistent so we can remove edge cases when zone is saved in the maintenance 
state. https://github.com/ManageIQ/manageiq/issues/20676


### What does this code do?

The code looks for cloud volumes and updates their value based upon the ems.
This seems like a data migration that would be better suited in db:migrations

### This is an issue because...

How do we have cloud volumes associated with our ems when we
are in the process of creating our ems and providers in the first place?
This seems like an issue
that would only be seen in a development environment as we iterate through code and get these edge cases.

### Issue 2?

Also, this child manager is not saved because the way zone is setup there is a validation error. Then the reload drops all the changes to the child record. Not a good situation.

I'm assuming that when this was written it did something, but as the code stands this does nothing, and I don't understand how it can do anything ever based upon point 1.

### Issue 3?

The cider_manager references this object (as parent_manager) and needs this object to be saved before it can be saved.
This is all done this object's before create method, so this object (the parent manager) doesn't have an id to go into the child manager. The child manager needs the manager to be saved first. And this needs the child object to be saved to complete before_create and get to the actual create phase. This is cyclical.

### Again, why do I care?

I am moving the initialization code into one spot and the saving code into another.

This method bridges both worlds. And since it seems to only be screwing up things with the reload, I'd like to drop it.
