### PR TITLE
remove the default distro setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-dist: xenial
 language: ruby
 rvm:
 - 2.5.8


### PR DESCRIPTION
xenial is the default and, as such, we don't need to specify it as we should only list the distro when it's necessary.

@miq-bot add_label cleanup
@miq-bot assign @kbrock