### PR TITLE
Invalidate MiqProductFeature cache when saving a Tenant record

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -61,6 +61,7 @@ class Tenant < ApplicationRecord
 
   before_save :nil_blanks
   after_create :create_tenant_group, :create_miq_product_features_for_tenant_nodes
+  after_save -> { MiqProductFeature.invalidate_caches }
   before_destroy :ensure_can_be_destroyed
 
   def self.scope_by_tenant?


### PR DESCRIPTION
This is for now called explicitly using a ui controller endpoint when creating/updating a Tenant. According to @Fryguy it should be done in the backend.

Closes https://github.com/ManageIQ/manageiq-api/issues/928