### PR TITLE
Implementing remove physical storage

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -55,17 +55,9 @@ class PhysicalStorage < ApplicationRecord
     raw_delete_physical_storage
   end
 
-  supports :delete do
-    unless respond_to?(:delete)
-      unsupported_reason_add(:delete, _("#{ext_management_system.type} provider type does not support deleting. " +
-                                            "#{ext_management_system.name} could not be deleted."))
-    end
-  end
-
   # Delete a storage system as a queued task and return the task id. The queue
   # name and the queue zone are derived from the EMS, and a userid is mandatory.
   def delete_physical_storage_queue(userid)
-
     task_opts = {
       :action => "deleting PhysicalStorage for user #{userid}",
       :userid => userid

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6321,6 +6321,10 @@
       :description: Edit a Physical Storage
       :feature_type: admin
       :identifier: physical_storage_edit
+    - :name: Remove
+      :description: Remove a Physical Storage
+      :feature_type: admin
+      :identifier: physical_storage_delete
 
 # Physical Servers
 - :name: Physical Servers


### PR DESCRIPTION
Adding functionality for deleting supported physical storages via rest-API

<img width="626" alt="22" src="https://user-images.githubusercontent.com/53213107/96684306-1098eb00-1384-11eb-96c5-c9b7be4bd357.png">
<img width="706" alt="11" src="https://user-images.githubusercontent.com/53213107/96684312-11ca1800-1384-11eb-89ed-7218befaaf56.png">


links
-----------
the following are related PRs
https://github.com/ManageIQ/manageiq-api/pull/932
https://github.com/ManageIQ/manageiq-providers-autosde/pull/38
https://github.com/ManageIQ/manageiq-ui-classic/pull/7433