### PR TITLE
Added path to delegates of default_endpoint in ext_management_system

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -246,7 +246,6 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :hostname,                :type => :string,  :uses => :endpoints
   virtual_column :port,                    :type => :integer, :uses => :endpoints
   virtual_column :security_protocol,       :type => :string,  :uses => :endpoints
-  virtual_column :path,                    :type => :string,  :uses => :endpoints
 
   virtual_column :emstype,                 :type => :string
   virtual_column :emstype_description,     :type => :string

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -232,14 +232,13 @@ class ExtManagementSystem < ApplicationRecord
            :port=,
            :security_protocol,
            :security_protocol=,
-           :path,
-           :path=,
            :verify_ssl,
            :verify_ssl=,
            :certificate_authority,
            :certificate_authority=,
            :to => :default_endpoint,
            :allow_nil => true
+  delegate :path, :path=, :to => :default_endpoint, :prefix => "endpoint", :allow_nil => true
 
   alias_method :address, :hostname # TODO: Remove all callers of address
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -232,6 +232,8 @@ class ExtManagementSystem < ApplicationRecord
            :port=,
            :security_protocol,
            :security_protocol=,
+           :path,
+           :path=,
            :verify_ssl,
            :verify_ssl=,
            :certificate_authority,
@@ -245,6 +247,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :hostname,                :type => :string,  :uses => :endpoints
   virtual_column :port,                    :type => :integer, :uses => :endpoints
   virtual_column :security_protocol,       :type => :string,  :uses => :endpoints
+  virtual_column :path,                    :type => :string,  :uses => :endpoints
 
   virtual_column :emstype,                 :type => :string
   virtual_column :emstype_description,     :type => :string


### PR DESCRIPTION
Added path to delegates of default_endpoint in ext_management_system so the path can be used in provider connections.

In the NSX-T Network Manager the path will be used to selected whether the NSX-T manager is a Federation Global Manager or a Federation Local/Stand-alone Manager.
