### PR TITLE
[Gemfile] Support googleauth change in provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "manageiq-messaging",             "~>0.1.4",       :require => false
 gem "manageiq-password",              "~>0.3",         :require => false
 gem "manageiq-postgres_ha_admin",     "~>3.1",         :require => false
 gem "manageiq-ssh-util",              "~>0.1.1",       :require => false
-gem "memoist",                        "~>0.15.0",      :require => false
+gem "memoist",                        "~>0.16.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
 gem "money",                          "~>6.13.5",      :require => false
 gem "more_core_extensions"                                               # min version should be set in manageiq-gems-pending, not here


### PR DESCRIPTION
With this change in `manageiq-providers-google`:

https://github.com/ManageIQ/manageiq-providers-google/pull/161

It is impossible to `bin/bundle update`, with the following error provided:

```console
$ bin/bundle update
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 2.1.4
Using bundler-inject 1.1.0
Fetching https://github.com/ManageIQ/manageiq-gems-pending.git
Fetching https://github.com/ManageIQ/manageiq-schema
Fetching https://github.com/ManageIQ/manageiq-providers-amazon
Fetching https://github.com/ManageIQ/amazon_ssa_support.git
Fetching https://github.com/ManageIQ/manageiq-providers-ansible_tower
Fetching https://github.com/ManageIQ/manageiq-providers-autosde
Fetching https://github.com/ManageIQ/manageiq-providers-azure
Fetching https://github.com/ManageIQ/manageiq-providers-azure_stack
Fetching https://github.com/ManageIQ/manageiq-providers-foreman
Fetching https://github.com/ManageIQ/manageiq-providers-google
Fetching https://github.com/ManageIQ/manageiq-providers-ibm_cloud
Fetching https://github.com/ManageIQ/manageiq-providers-ibm_terraform
Fetching https://github.com/ManageIQ/manageiq-providers-kubernetes
Fetching https://github.com/ManageIQ/manageiq-providers-kubevirt
Fetching https://github.com/ManageIQ/manageiq-providers-lenovo
Fetching https://github.com/ManageIQ/manageiq-providers-nsxt
Fetching https://github.com/ManageIQ/manageiq-providers-nuage
Fetching https://github.com/ManageIQ/manageiq-providers-redfish
Fetching https://github.com/ManageIQ/manageiq-providers-openshift
Fetching https://github.com/ManageIQ/manageiq-providers-openstack
Fetching https://github.com/ManageIQ/manageiq-providers-ovirt
Fetching https://github.com/ManageIQ/manageiq-providers-scvmm
Fetching https://github.com/ManageIQ/manageiq-providers-vmware
Fetching https://github.com/ManageIQ/manageiq-automation_engine
Fetching https://github.com/ManageIQ/manageiq-api
Fetching https://github.com/ManageIQ/manageiq-graphql
Fetching https://github.com/ManageIQ/manageiq-content
Fetching https://github.com/ManageIQ/manageiq-consumption
Fetching https://github.com/ManageIQ/manageiq-decorators
Fetching https://github.com/ManageIQ/manageiq-ui-classic
Fetching https://github.com/ManageIQ/manageiq-v2v
Fetching source index from https://rubygems.manageiq.org/
Fetching gem metadata from https://rubygems.org/......
Fetching source index from https://rubygems.org/
Resolving dependencies.........
Bundler could not find compatible versions for gem "memoist":
	In Gemfile:
		memoist (~> 0.15.0)

		manageiq-providers-google was resolved to 0.1.0, which depends on
			googleauth (~> 0.11.0) was resolved to 0.11.0, which depends on
				memoist (~> 0.16)
```

Supporting a version of `memoist` that works for both fixes the `bundle` issue, and hopefully our tests still pass...

cc @Fryguy @d-m-u

Links
-----

* Offending PR:  https://github.com/ManageIQ/manageiq-providers-google/pull/161