### PR TITLE
[rails6][Gemfile] Upgrade hamlit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>2.0.1"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
-gem "hamlit",                         "~>2.8.5"
+gem "hamlit",                         "~>2.11.0"
 gem "inifile",                        "~>3.0",         :require => false
 gem "inventory_refresh",              "~>0.2.0",       :require => false
 gem "kubeclient",                     "~>4.0",         :require => false # For scaling pods at runtime


### PR DESCRIPTION
Addresses a deprecation warning:

```
DEPRECATION WARNING: Single arity template handlers are deprecated.
Template handlers must now accept two parameters, the view object and the
source for the view object.
Change:
  >> #<Hamlit::RailsTemplate:0x00007f8e7dbd7dc0>.call(template)
To:
  >> #<Hamlit::RailsTemplate:0x00007f8e7dbd7dc0>.call(template, source)
 (called from <top (required)> at ./manageiq/config/environment.rb:5)
```

Bumping to ~>2.11.0 to get some extra fixes that were included:

* https://github.com/k0kubun/hamlit/blob/master/CHANGELOG.md
* https://github.com/k0kubun/hamlit/compare/v2.8.5...v2.11.0

Links
-----

* MIQ Rails 6 Effort:  https://github.com/ManageIQ/manageiq/issues/19977
* WIP `rails-6` branch: https://github.com/NickLaMuro/manageiq/tree/rails-6