### PR TITLE
Load environment for store_dictionary_strings rake task

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -1,6 +1,6 @@
 namespace :locale do
   desc "Extract strings from en.yml and store them in a ruby file for gettext:find"
-  task :store_dictionary_strings do
+  task :store_dictionary_strings => :environment do
     output_strings = [
       "# This is automatically generated file (rake locale:store_dictionary_strings).",
       "# The file contains strings extracted from en.yml for gettext to find."


### PR DESCRIPTION
The `store_dictionary_strings` rake tasks extracts strings from `locale/en.yml` dictionary, transforms these strings into gettext strings in a temporary ruby file so that these strings are then found by gettext string extractor.

As a part of the yaml file string extraction, the task also automatically creates plurals for the strings. I just discovered, that the `.pluralize` method behaves differently when `environment` is loaded.

Without loaded `environment`:
```
[1] pry(main)> "VM and Instance".pluralize
=> "VM and Instances"
```

With loaded `environment`:
```
[1] pry(main)> "VM and Instance".pluralize
=> "VMs and Instances"
```

This means that we were lacking some gettext strings (plurals) in the gettext catalog and therefore some strings were shown untranslated in our UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1751148

@miq-bot add_label internationalization