### PR TITLE
Add cloud_tenants supported feature into the supports mixin

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -264,6 +264,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
   virtual_column :supports_block_storage,  :type => :boolean
+  virtual_column :supports_cloud_tenants,  :type => :boolean
   virtual_column :supports_volume_multiattachment, :type => :boolean
   virtual_column :supports_volume_resizing, :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
@@ -768,6 +769,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_block_storage
     supports_block_storage?
+  end
+
+  def supports_cloud_tenants
+    supports_cloud_tenants?
   end
 
   def supports_volume_multiattachment

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -65,6 +65,7 @@ module SupportsFeatureMixin
     :clone                               => 'Clone',
     # FIXME: this is just a internal helper and should be refactored
     :control                             => 'Basic control operations',
+    :cloud_tenants                       => 'CloudTenant',
     :cloud_tenant_mapping                => 'CloudTenant mapping',
     :cloud_object_store_container_create => 'Create Object Store Container',
     :cloud_object_store_container_clear  => 'Clear Object Store Container',


### PR DESCRIPTION
This should allow us to query providers that support the creation of underlying cloud tenants.

@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare 