### PR TITLE
Make sure that all model -> name mappings are in singular

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1416,7 +1416,7 @@ en:
     model:
       AuditEvent:                     EVM Audit Event
       AvailabilityZone:               Availability Zone
-      BottleneckEvent:                Bottleneck Events
+      BottleneckEvent:                Bottleneck Event
       HostAggregate:                  Host Aggregate
       ChargebackVm:                   Chargeback for Vms
       ChargebackContainerImage:       Chargeback for Image
@@ -1650,7 +1650,7 @@ en:
       MiqWorker:                EVM Worker
       NetworkPort:              Network Port
       NetworkRouter:            Network Router
-      Network:                  Networks
+      Network:                  Network
       NetworkService:           Network Service
       OrchestrationStack:       Orchestration Stack
       OrchestrationTemplate:    Orchestration Template
@@ -1661,7 +1661,7 @@ en:
       ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate:    vApp Template
       PersistentVolume:         Persistent Volume
       PhysicalChassis:          Physical Chassis
-      PhysicalRack:             Physical Racks
+      PhysicalRack:             Physical Rack
       PhysicalServer:           Physical Server
       PhysicalSwitch:           Physical Switch
       PolicyEvent:              Policy Event


### PR DESCRIPTION
The `ui_lookup` function called with a model should always return an entity name in singular. The strings introduced [here](https://github.com/ManageIQ/manageiq/pull/20699/files#diff-7a2e9358ed6a0532c2127a4b11267e2a59d1747798cca77a26b140d61c31413cR1419-R1664) don't follow this rule and this breaks the CI on `ui-classic`.

FYI @DavidResende0 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_label bug, i18n