### PR TITLE
[WIP] Introduce supports_snapshot_memory and expose it as a virtual column

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -130,6 +130,7 @@ module SupportsFeatureMixin
     :revert_to_snapshot                  => 'Revert Snapshot Operation',
     :smartstate_analysis                 => 'Smartstate Analysis',
     :snapshot_create                     => 'Create Snapshot',
+    :snapshot_memory                     => 'Snapshot the Memory',
     :snapshots                           => 'Snapshots',
     :shutdown_guest                      => 'Shutdown Guest Operation',
     :start                               => 'Start',

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -42,6 +42,12 @@ module VmOrTemplate::Operations::Snapshot
         unsupported_reason_add(:revert_to_snapshot, unsupported_reason(:remove_snapshot))
       end
     end
+
+    virtual_column :supports_snapshot_memory, :type => :boolean
+
+    def supports_snapshot_memory
+      supports_snapshot_memory?
+    end
   end
 
   def raw_create_snapshot(name, desc = nil, memory)


### PR DESCRIPTION
We're depending on this feature in the UI, so it should be queryable via the API.

@miq-bot assign @agrare 
@miq-bot add_label enhancement