### PR TITLE
Add initial log line for run_single_worker

### DIFF
--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -60,6 +60,7 @@ end
 opt_parser.parse!
 worker_class = ARGV[0]
 
+puts "** Booting #{worker_class} with PID: #{Process.pid}#{" and options: #{options.inspect}" if options.any?}..." unless options[:list]
 require File.expand_path("../../../config/environment", __dir__)
 
 if options[:list]


### PR DESCRIPTION
@jrafanie Please review.

As we've seen many times, containers in slow environments can seem to take forever to start with the user staring at "Writing encryption key" and wondering if anything is happening.  At a very minimum, we write this log line before we load the Rails environment to give more feedback.