### PR TITLE
Add check for invalid roles in server_role_names=

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -139,7 +139,12 @@ module MiqServer::RoleManagement
       if roles.blank?
         server_roles.delete_all
       else
-        desired = (roles == "*" ? ServerRole.all_names : roles.map { |role| role.strip.downcase }.sort)
+        all_roles = ServerRole.all_names
+
+        desired = (roles == "*" ? all_roles : roles.map { |role| role.strip.downcase }.sort)
+        invalid = desired - all_roles
+        raise ArgumentError, _("Roles <%{names}> not defined") % {:names => invalid.join(", ")} if invalid.any?
+
         current = server_role_names
 
         # MiqServer#server_role_names may include database scoped roles, which are managed elsewhere,

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe MiqAlert do
   context "With single server with a single generic worker with the notifier role," do
     before do
-      @miq_server = EvmSpecHelper.local_miq_server(:role => 'notifier')
+      ServerRole.seed
+      @miq_server = EvmSpecHelper.local_miq_server.tap { |s| s.role = "notifier" }
       @worker = FactoryBot.create(:miq_worker, :miq_server_id => @miq_server.id)
       @vm     = FactoryBot.create(:vm_vmware)
 

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe MiqServer, "::ConfigurationManagement" do
     let(:miq_server) { EvmSpecHelper.local_miq_server.tap(&:setup_drb_variables) }
 
     it "reloads the new changes into the settings for the resource" do
+      ServerRole.seed
+
       Vmdb::Settings.save!(miq_server, :some_test_setting => 2)
       expect(Settings.some_test_setting).to be_nil
       expect(miq_server).to receive(:notify_workers_of_config_change)

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe "Server Role Management" do
         @miq_server.role = desired
         expect(@miq_server.server_role_names).to eq(%w( ems_operations scheduler ))
       end
+
+      it "with an invalid role name" do
+        expect { @miq_server.role = 'foo' }.to raise_error(ArgumentError, /not defined/)
+      end
     end
 
     context "server_role_names=" do
@@ -87,6 +91,10 @@ RSpec.describe "Server Role Management" do
         desired = %w[ems_operations scheduler scheduler]
         @miq_server.server_role_names = desired
         expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
+      end
+
+      it "with an invalid role name" do
+        expect { @miq_server.server_role_names = ['foo'] }.to raise_error(ArgumentError, /not defined/)
       end
     end
 


### PR DESCRIPTION
This fixes an issue where invalid roles names are silently ignored.  I think it was expected that `assign_role` call a little below would call `ServerRole.to_role` and raise [this exception](https://github.com/ManageIQ/manageiq/blob/c0a2f92bc459c8f63fafaa5ed6890c96e855232c/app/models/server_role.rb#L39), however the `ServerRole.where` just before it will ignore the invalid roles on querying, and thus assign_role can never be called with a bad role name.

I was thinking of fixing this to call .to_role, but I realize that method is a wasted abstraction and I plan to remove it in a follow up PR.

@jrafanie Please review