### PR TITLE
Remove ServerRole.to_role

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -102,14 +102,12 @@ module MiqServer::RoleManagement
   end
 
   def is_master_for_role?(server_role)
-    server_role = ServerRole.to_role(server_role)
-    assigned    = assigned_server_roles.find_by(:server_role_id => server_role.id)
+    assigned = assigned_server_roles.find_by(:server_role_id => server_role.id)
     return false if assigned.nil?
     assigned.priority == 1
   end
 
   def set_master_for_role(server_role)
-    server_role = ServerRole.to_role(server_role)
     if server_role.master_supported?
       zone.miq_servers.reject { |s| s.id == id }.each do |server|
         assigned = server.assigned_server_roles.find_by(:server_role_id =>  server_role.id)
@@ -121,7 +119,7 @@ module MiqServer::RoleManagement
   end
 
   def remove_master_for_role(server_role)
-    assign_role(ServerRole.to_role(server_role), 2)
+    assign_role(server_role, 2)
   end
 
   def check_server_roles
@@ -178,7 +176,6 @@ module MiqServer::RoleManagement
   end
 
   def assign_role(server_role, priority = nil)
-    server_role          = ServerRole.to_role(server_role)
     assigned_server_role = assigned_server_roles.find_or_create_by(:server_role_id => server_role.id)
     if assigned_server_role.priority.nil? || (priority.kind_of?(Numeric) && assigned_server_role.priority != priority)
       priority ||= AssignedServerRole::DEFAULT_PRIORITY

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -32,13 +32,6 @@ class ServerRole < ApplicationRecord
     FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end
 
-  def self.to_role(server_role)
-    # server_role can either be a Role Name (string or symbol) or an instance of a ServerRole
-    return server_role if server_role.kind_of?(ServerRole)
-    role_name = server_role.to_s.strip.downcase
-    ServerRole.find_by(:name => role_name) || raise(_("Role <%{name}> not defined in server_roles table") % {:name => role_name})
-  end
-
   def self.all_names
     order(:name).pluck(:name)
   end

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -38,28 +38,27 @@ RSpec.describe "Server Role Management" do
 
     context "role=" do
       it "normal case" do
-        @miq_server.assign_role('ems_operations', 1)
-        expect(@miq_server.server_role_names).to eq(['ems_operations'])
+        @miq_server.assign_role(ServerRole.find_by(:name => 'ems_operations'), 1)
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations])
 
-        desired = 'event,scheduler,user_interface'
-        @miq_server.role = desired
-        expect(@miq_server.server_role_names).to eq(desired.split(","))
+        @miq_server.role = 'event,scheduler,user_interface'
+        expect(@miq_server.server_role_names).to eq(%w[event scheduler user_interface])
       end
 
       it "with a duplicate existing role" do
-        @miq_server.assign_role('ems_operations', 1)
+        @miq_server.assign_role(ServerRole.find_by(:name => 'ems_operations'), 1)
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations])
 
-        desired = 'ems_operations,ems_operations,scheduler'
-        @miq_server.role = desired
-        expect(@miq_server.server_role_names).to eq(%w( ems_operations scheduler ))
+        @miq_server.role = 'ems_operations,ems_operations,scheduler'
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
       end
 
       it "with duplicate new roles" do
-        @miq_server.assign_role('event', 1)
+        @miq_server.assign_role(ServerRole.find_by(:name => 'event'), 1)
+        expect(@miq_server.server_role_names).to eq(%w[event])
 
-        desired = 'ems_operations,scheduler,scheduler'
-        @miq_server.role = desired
-        expect(@miq_server.server_role_names).to eq(%w( ems_operations scheduler ))
+        @miq_server.role = 'ems_operations,scheduler,scheduler'
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
       end
 
       it "with an invalid role name" do
@@ -69,27 +68,26 @@ RSpec.describe "Server Role Management" do
 
     context "server_role_names=" do
       it "normal case" do
-        @miq_server.assign_role('ems_operations', 1)
-        expect(@miq_server.server_role_names).to eq(['ems_operations'])
+        @miq_server.assign_role(ServerRole.find_by(:name => 'ems_operations'), 1)
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations])
 
-        desired = %w[event scheduler user_interface]
-        @miq_server.server_role_names = desired
-        expect(@miq_server.server_role_names).to eq(desired)
+        @miq_server.server_role_names = %w[event scheduler user_interface]
+        expect(@miq_server.server_role_names).to eq(%w[event scheduler user_interface])
       end
 
       it "with a duplicate existing role" do
-        @miq_server.assign_role('ems_operations', 1)
+        @miq_server.assign_role(ServerRole.find_by(:name => 'ems_operations'), 1)
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations])
 
-        desired = %w[ems_operations ems_operations scheduler]
-        @miq_server.server_role_names = desired
+        @miq_server.server_role_names = %w[ems_operations ems_operations scheduler]
         expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
       end
 
       it "with duplicate new roles" do
-        @miq_server.assign_role('event', 1)
+        @miq_server.assign_role(ServerRole.find_by(:name => 'event'), 1)
+        expect(@miq_server.server_role_names).to eq(%w[event])
 
-        desired = %w[ems_operations scheduler scheduler]
-        @miq_server.server_role_names = desired
+        @miq_server.server_role_names = %w[ems_operations scheduler scheduler]
         expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
       end
 
@@ -101,7 +99,7 @@ RSpec.describe "Server Role Management" do
     it "should assign role properly when requested" do
       @roles = [['ems_operations', 1], ['event', 2], ['ems_metrics_coordinator', 1], ['scheduler', 1], ['reporting', 1]]
       @roles.each do |role, priority|
-        asr = @miq_server.assign_role(role, priority)
+        asr = @miq_server.assign_role(ServerRole.find_by(:name => role), priority)
         expect(asr.priority).to eq(priority)
         expect(asr.server_role.name).to eq(role)
       end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe Vm do
       vm = FactoryBot.create(:vm_openstack, :ext_management_system => @ems)
       allow(vm).to receive_messages(:ipaddresses => ["10.0.0.1"])
       server = FactoryBot.create(:miq_server, :ipaddress => "10.0.0.2", :has_active_cockpit_ws => true, :zone => @zone)
-      server.assign_role('cockpit_ws', 1)
+      server.assign_role(ServerRole.find_by(:name => 'cockpit_ws'), 1)
       server.activate_roles('cockpit_ws')
       expect(vm.cockpit_url).to eq(URI.parse("https://10.0.0.2/cws/=10.0.0.1"))
     end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Zone do
 
       it "server when enabled" do
         server = FactoryBot.create(:miq_server, :has_active_cockpit_ws => true, :zone => @zone)
-        server.assign_role('cockpit_ws', 1)
+        server.assign_role(ServerRole.find_by(:name => 'cockpit_ws'), 1)
         server.activate_roles('cockpit_ws')
         expect(@zone.remote_cockpit_ws_miq_server).to eq(server)
       end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -24,8 +24,8 @@ module EvmSpecHelper
   def self.assign_embedded_ansible_role(miq_server = nil)
     MiqRegion.seed
     miq_server ||= local_miq_server
-    ServerRole.find_by(:name => "embedded_ansible") || FactoryBot.create(:server_role, :name => 'embedded_ansible', :max_concurrent => 0)
-    miq_server.assign_role('embedded_ansible').update(:active => true)
+    role = ServerRole.find_by(:name => "embedded_ansible") || FactoryBot.create(:server_role, :name => 'embedded_ansible', :max_concurrent => 0)
+    miq_server.assign_role(role).update(:active => true)
   end
 
   # Clear all EVM caches


### PR DESCRIPTION
~~Built on #20731~~

This method is not necessary since it is only called in a few specific
locations and all of those locations are passed literal ServerRole
objects.  Otherwise, it is a convenience for specs, and so is not
necessary.

@jrafanie Please review.