### PR TITLE
consistent child manager saves

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -29,6 +29,19 @@ module ManageIQ::Providers
       self.class.http_proxy_uri
     end
 
+    # copy my attributes to a child manager
+    # child managers need to be in lock step with this manager
+    def propagate_child_manager_attributes(child, name = nil)
+      child.name                 = name if name
+      child.zone_id              = zone_id
+      child.zone_before_pause_id = zone_before_pause_id
+      child.enabled              = enabled
+      child.provider_region      = provider_region
+      child.tenant_id            = tenant_id
+
+      child
+    end
+
     def self.http_proxy_uri
       VMDB::Util.http_proxy_uri(ems_type.try(:to_sym)) || VMDB::Util.http_proxy_uri
     end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -42,6 +42,7 @@ module ManageIQ::Providers
 
     validates_presence_of :zone
 
+    # TODO: remove and have each manager include this
     include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
 

--- a/app/models/manageiq/providers/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager.rb
@@ -9,7 +9,6 @@ class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::
            :authentication_status_ok?,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :cinder_service,
            :connect,
            :verify_credentials,

--- a/app/models/mixins/cinder_manager_mixin.rb
+++ b/app/models/mixins/cinder_manager_mixin.rb
@@ -14,15 +14,11 @@ module CinderManagerMixin
              :cloud_volume_backups,
              :to        => :cinder_manager,
              :allow_nil => true
+  end
 
-    private
+  private
 
-    def ensure_cinder_managers
-      ensure_cinder_manager
-      cinder_manager.name            = "#{name} Cinder Manager"
-      cinder_manager.zone_id         = zone_id
-      cinder_manager.provider_region = provider_region
-      true
-    end
+  def ensure_cinder_manager
+    cinder_manager || build_cinder_manager
   end
 end

--- a/app/models/mixins/has_infra_manager_mixin.rb
+++ b/app/models/mixins/has_infra_manager_mixin.rb
@@ -18,10 +18,10 @@ module HasInfraManagerMixin
 
   def ensure_infra_manager
     if infra_manager.nil?
-      build_infra_manager(:parent_manager  => self,
-                          :name            => "#{name} Virtualization Manager",
-                          :zone_id         => zone_id,
-                          :provider_region => provider_region)
+      build_infra_manager
+
+      # TODO: move this out of here and into ensure managers
+      propagate_child_manager_attributes(infra_manager, "#{name} Virtualization Manager")
     end
 
     infra_manager

--- a/app/models/mixins/has_monitoring_manager_mixin.rb
+++ b/app/models/mixins/has_monitoring_manager_mixin.rb
@@ -19,10 +19,9 @@ module HasMonitoringManagerMixin
 
   def ensure_monitoring_manager
     if monitoring_manager.nil?
-      build_monitoring_manager(:parent_manager  => self,
-                               :name            => "#{name} Monitoring Manager",
-                               :zone_id         => zone_id,
-                               :provider_region => provider_region)
+      build_monitoring_manager
+      # TODO: move this out of here and into ensure managers
+      propagate_child_manager_attributes(monitoring_manager, "#{name} Monitoring Manager")
     end
 
     monitoring_manager

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -25,16 +25,22 @@ module HasNetworkManagerMixin
 
     private
 
+    def ensure_network_manager
+      # TODO: remove name from here once all child classes
+      network_manager || build_network_manager(:name => "#{name} Network Manager")
+    end
+
+    # TODO: remove and have each manager implement this
     def ensure_managers
       ensure_network_manager
       network_manager.name = "#{name} Network Manager" if network_manager
       ensure_managers_zone_and_provider_region
     end
 
+    # TODO: remove and have each manager implement this
     def ensure_managers_zone_and_provider_region
       if network_manager
-        network_manager.zone_id         = zone_id
-        network_manager.provider_region = provider_region
+        propagate_child_manager_attributes(network_manager, "#{name} Network Manager")
       end
     end
   end

--- a/app/models/mixins/swift_manager_mixin.rb
+++ b/app/models/mixins/swift_manager_mixin.rb
@@ -11,15 +11,11 @@ module SwiftManagerMixin
              :cloud_object_store_objects,
              :to        => :swift_manager,
              :allow_nil => true
+  end
 
-    private
+  private
 
-    def ensure_swift_managers
-      ensure_swift_manager
-      swift_manager.name            = "#{name} Swift Manager"
-      swift_manager.zone_id         = zone_id
-      swift_manager.provider_region = provider_region
-      true
-    end
+  def ensure_swift_manager
+    swift_manager || build_swift_manager
   end
 end


### PR DESCRIPTION
Most providers have child managers as well.
These various providers seem to propagate different attributes to the child managers.

The thought is to us a common propagation method to add consistency.

In a higher view, I'd like to remove some of these delegations and pretty much redo the build, create, copy, and save callbacks for these. So I'm trying to make changes here that will not change much, but will allow us to make the changes we need in the provider specific repos.


/cc @agrare I want to make some changes in the open stack case and want to put these into there as well.