### PR TITLE
remove last factory girl reference and alias

### DIFF
--- a/spec/support/factory_bot_helper.rb
+++ b/spec/support/factory_bot_helper.rb
@@ -18,7 +18,6 @@ def seq_padded_for_sorting(n)
 end
 
 require 'factory_bot'
-FactoryGirl = FactoryBot # Alias until all associated repositories are updated
 
 # In case we are running as an engine, the factories are located in the dummy app
 FactoryBot.definition_file_paths << 'spec/manageiq/spec/factories'
@@ -48,7 +47,7 @@ FactoryBot.define do
 
       sequence_id = "id_for_other_region_#{instance.class}_#{evaluator.other_region}".to_sym
       @sequence ||= {}
-      @sequence[sequence_id] ||= FactoryGirl::Syntax::Default::DSL.new.sequence(sequence_id) { |n| instance.class.id_in_region(n, evaluator.other_region.region) }
+      @sequence[sequence_id] ||= FactoryBot::Syntax::Default::DSL.new.sequence(sequence_id) { |n| instance.class.id_in_region(n, evaluator.other_region.region) }
       instance.id = generate(sequence_id)
     end
   end


### PR DESCRIPTION
Jason just merged the last two non-core factory girl replacement prs so we should be able to remove the alias now. 

see https://github.com/ManageIQ/manageiq/pull/20740#issuecomment-717335589

@miq-bot add_label technical debt