### PR TITLE
Expose supports_create_flavor as an API-queryable virtual_column

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -269,6 +269,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_volume_resizing, :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
   virtual_column :supports_cinder_volume_types, :type => :boolean
+  virtual_column :supports_create_flavor, :type => :boolean
   virtual_column :supports_volume_availability_zones, :type => :boolean
   virtual_column :supports_create_security_group, :type => :boolean
   virtual_column :supports_storage_services, :type => :boolean
@@ -781,6 +782,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_volume_resizing
     supports_volume_resizing?
+  end
+
+  def supports_create_flavor
+    supports_create_flavor?
   end
 
   def supports_cloud_object_store_container_create

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -75,6 +75,7 @@ module SupportsFeatureMixin
     :cinder_service                      => 'Cinder storage service',
     :cinder_volume_types                 => 'Cinder volume types',
     :conversion_host                     => 'Conversion host capable',
+    :create_flavor                       => 'Flavor Creation',
     :create_floating_ip                  => 'Floating IP Creation',
     :create_host_aggregate               => 'Host Aggregate Creation',
     :create_security_group               => 'Security Group Creation',


### PR DESCRIPTION
This will allow us to query the list of providers that support the creation of flavors via the API:
```
GET /api/providers?expand=resources&attributes=id,name,supports_create_flavor&filter[]=supports_create_flavor=true
```

This is required to make the Flavor form fully API driven.

@miq-bot assign @agrare 
@miq-bot add_label enhancement