### PR TITLE
Expose EventDefinitionSets in API.

### DIFF
--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -27,4 +27,6 @@ class MiqEventDefinitionSet < ApplicationRecord
   def self.display_name(number = 1)
     n_('Event Definition Set', 'Event Definition Sets', number)
   end
+
+  alias_method :events, :miq_event_definitions
 end

--- a/spec/factories/miq_event_definition_set.rb
+++ b/spec/factories/miq_event_definition_set.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :miq_event_definition_set do
+    transient { events { nil } }
+    sequence(:name)         { |n| "event_set_#{seq_padded_for_sorting(n)}" }
+    sequence(:description)  { |n| "event_set_#{seq_padded_for_sorting(n)}" }
+
+    after(:create) do |event_set, builder|
+      if builder.events
+        builder.events.each do |event|
+          event_set.add_member(event)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Expose EventDefinitionSets in API.

Blocks https://github.com/ManageIQ/manageiq-api/pull/954

https://github.com/ManageIQ/manageiq-api/issues/936

@miq-bot add_label enhancement