### PR TITLE
Add a supports feature for Vm pause

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -136,6 +136,7 @@ module SupportsFeatureMixin
     :start                               => 'Start',
     :streaming_refresh                   => 'Streaming refresh',
     :suspend                             => 'Suspending',
+    :pause                               => 'Pause a VM',
     :terminate                           => 'Terminate a VM',
     :timeline                            => 'Query for events',
     :update_aggregate                    => 'Host Aggregate Update',


### PR DESCRIPTION
There is a supports_feature_mixin feature for suspend but not for pause

https://github.com/ManageIQ/manageiq/issues/20752