### PR TITLE
Add ability to declare an intermediate class as acting like a leaf class

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -9,8 +9,12 @@ class ExtManagementSystem < ApplicationRecord
     where(:tenant_id => tenant.ancestor_ids + [tenant_id])
   end
 
+  def self.concrete_subclasses
+    leaf_subclasses | descendants.select { |d| d.try(:acts_as_sti_leaf_class?) }
+  end
+
   def self.types
-    leaf_subclasses.collect(&:ems_type)
+    concrete_subclasses.collect(&:ems_type)
   end
 
   def self.supported_types
@@ -18,7 +22,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.supported_subclasses
-    leaf_subclasses.select(&:permitted?)
+    concrete_subclasses.select(&:permitted?)
   end
 
   def self.permitted?
@@ -402,7 +406,7 @@ class ExtManagementSystem < ApplicationRecord
 
   def self.model_from_emstype(emstype)
     emstype = emstype.downcase
-    ExtManagementSystem.leaf_subclasses.detect { |k| k.ems_type == emstype }
+    ExtManagementSystem.concrete_subclasses.detect { |k| k.ems_type == emstype }
   end
 
   def self.short_token

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -506,7 +506,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
   # @returns Hash<class, Integer> Hash of ems_class => refresh_interval
   def schedule_settings_for_ems_refresh
-    ExtManagementSystem.leaf_subclasses.each.with_object({}) do |klass, hash|
+    ExtManagementSystem.supported_subclasses.each.with_object({}) do |klass, hash|
       next unless klass.ems_type
       every = ::Settings.ems_refresh[klass.ems_type].try(:refresh_interval) || ::Settings.ems_refresh.refresh_interval
       every = every.respond_to?(:to_i_with_method) ? every.to_i_with_method : every.to_i

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -25,14 +25,12 @@ class Provider < ApplicationRecord
 
   supports :refresh_ems
 
-  def self.leaf_subclasses
-    descendants.select { |d| d.subclasses.empty? }
+  def self.concrete_subclasses
+    leaf_subclasses | descendants.select { |d| d.try(:acts_as_sti_leaf_class?) }
   end
 
   def self.supported_subclasses
-    subclasses.flat_map do |s|
-      s.subclasses.empty? ? s : s.supported_subclasses
-    end
+    concrete_subclasses
   end
 
   def self.short_token

--- a/lib/acts_as_sti_leaf_class.rb
+++ b/lib/acts_as_sti_leaf_class.rb
@@ -1,0 +1,14 @@
+module ActsAsStiLeafClass
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def acts_as_sti_leaf_class?
+      true
+    end
+
+    private def type_condition(table = arel_table)
+      sti_column = table[inheritance_column]
+      predicate_builder.build(sti_column, [sti_name])
+    end
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ExtManagementSystem do
   end
 
   it ".model_name_from_emstype" do
-    described_class.leaf_subclasses.each do |klass|
+    described_class.concrete_subclasses.each do |klass|
       expect(described_class.model_name_from_emstype(klass.ems_type)).to eq(klass.name)
     end
     expect(described_class.model_name_from_emstype('foo')).to be_nil


### PR DESCRIPTION
The purpose of this mixin is to allow declaring an intermediate class (or more accurately a leaf class' parent) as acting like a leaf class, so that when querying it, it will ignore STI subclasses in the type conditions.  Where this is specifically useful is in provider subclassing.  Right now if we want to create a provider that is a subclass of another provider, we can't do that because querying the records will bring back both the parent provider type as well as the child.

#### Code Layout

Presently, we resort to creating mixins in those providers which is unnatural.  So when we need to "subclass" a provider, all of the code must be moved into mixins, then the base parent provider type and child provider types are implemented as direct leaf classes that each have to mix in the shared code.

Current layout:

```text
ExtManagementSystem
- ManageIQ::Providers::ContainerManager
  - ManageIQ::Providers::Kubernetes::ContainerManager (empty) + ManageIQ::Providers::Kubernetes::ContainerManagerMixin
  - ManageIQ::Providers::OpenShift::ContainerManager (empty) + ManageIQ::Providers::Kubernetes::ContainerManagerMixin
```

New layout that's possible:

```text
ExtManagementSystem
- ManageIQ::Providers::ContainerManager
  - ManageIQ::Providers::Kubernetes::ContainerManager + ActsAsStiLeafClass
    - ManageIQ::Providers::OpenShift::ContainerManager
```

#### Querying

This works by changing the definition of the type condition for the class from `[self] + descendants` to just `[self]`.  This can be seen in the following query demonstration.

Without ActsAsStiLeafClass (see PR https://github.com/ManageIQ/manageiq-providers-amazon/pull/667 showing what an a hypothetical amazon subclass provider might be like when not using mixins)

```ruby
[1] pry(main)> ManageIQ::Providers::Kubernetes::ContainerManager.all.to_sql
=> "SELECT \"ext_management_systems\".* FROM \"ext_management_systems\" WHERE " 
   "\"ext_management_systems\".\"type\" IN ('ManageIQ::Providers::Kubernetes::ContainerManager', 'ManageIQ::Providers::Amazon::ContainerManager')"
[2] pry(main)> ManageIQ::Providers::Amazon::ContainerManager.all.to_sql
=> "SELECT \"ext_management_systems\".* FROM \"ext_management_systems\" WHERE "
   "\"ext_management_systems\".\"type\" IN ('ManageIQ::Providers::Amazon::ContainerManager')"
```

Now with ActsAsStiLeafClass (add in ~~https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/408~~ ManageIQ/manageiq-providers-kubernetes#410 - better PoC with actual inheritance)

```ruby
[1] pry(main)> ManageIQ::Providers::Kubernetes::ContainerManager.all.to_sql
=> "SELECT \"ext_management_systems\".* FROM \"ext_management_systems\" WHERE "
   "\"ext_management_systems\".\"type\" = 'ManageIQ::Providers::Kubernetes::ContainerManager'"
[2] pry(main)> ManageIQ::Providers::Amazon::ContainerManager.all.to_sql
=> "SELECT \"ext_management_systems\".* FROM \"ext_management_systems\" WHERE "
   "\"ext_management_systems\".\"type\" = 'ManageIQ::Providers::Amazon::ContainerManager'"
```

---

@agrare Please review.

My only 2 concerns at the moment are:
- People making changes to the parent provider type to add some new object and forgetting to add in `include ActsAsStiLeafClass`.  I'm not sure if there's a way to detect that or write some general spec pattern that would detect that.
- Technically children inherit this method meaning all children will be considered as leaf classes as well.  From the point of view of our provider objects, this is probably fine, since any child provider type is also a leaf class anyway.  However, from a generic `ActsAsStiLeafClass` naming point of view that may be unexpected.  Not sure how to fix this...maybe we only apply the type check on the included class directly, but I'm not sure how?

Part of #20741 
