### PR TITLE
Add a refresh_interval to provider generator

### DIFF
--- a/lib/generators/manageiq/provider/templates/config/settings.yml
+++ b/lib/generators/manageiq/provider/templates/config/settings.yml
@@ -9,6 +9,9 @@
             - <%= provider_name.upcase %>_instance_power_on
             - <%= provider_name.upcase %>_instance_power_off
 <% end -%>
+:ems_refresh:
+  :<%= provider_name %>:
+    :refresh_interval: 15.minutes
 :http_proxy:
   :<%= provider_name %>:
     :host:


### PR DESCRIPTION
Most initial providers do not have an event catcher that triggers refreshes automatically.  Typically providers without an event catcher have the schedule worker queue a refresh every 15 minutes. 

Noticed in: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/110