### PR TITLE
Add git remote connection check code

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -34,7 +34,7 @@ class GitRepository < ApplicationRecord
     require 'net/ping/external'
 
     # URI library cannot handle git urls, so just convert it to a standard url.
-    temp_url = url.dup
+    temp_url = url.dup.to_s
     temp_url = temp_url.sub(':', '/').sub('git@', 'https://') if temp_url.start_with?('git@')
 
     host = URI.parse(temp_url).hostname

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -34,8 +34,8 @@ class GitRepository < ApplicationRecord
     require 'net/ping/external'
 
     # URI library cannot handle git urls, so just convert it to a standard url.
-    url = url.sub(':', '/').sub('git@', 'https://') if url.start_with?('git@')
-    host = URI.parse(url).hostname
+    temp_url = url.sub(':', '/').sub('git@', 'https://') if url.start_with?('git@')
+    host = URI.parse(temp_url).hostname
 
     $log.debug("pinging '#{host}' to verify network connection")
     ext_ping = Net::Ping::External.new(host)

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -35,7 +35,7 @@ class GitRepository < ApplicationRecord
 
     # URI library cannot handle git urls, so just convert it to a standard url.
     temp_url = url.dup
-    temp_url = url.sub(':', '/').sub('git@', 'https://') if url.start_with?('git@')
+    temp_url = temp_url.sub(':', '/').sub('git@', 'https://') if temp_url.start_with?('git@')
 
     host = URI.parse(temp_url).hostname
 

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -25,6 +25,20 @@ class GitRepository < ApplicationRecord
     FileUtils.rm_rf(directory_name)
   end
 
+  # Check the connection for the remote.
+  #
+  # Does not clone a repo or use an existing one, and instead initializes a
+  # repo in a temp path to check the remote to see if it can accept
+  # connections.
+  def check_connection
+    Dir.mktmpdir do |tmp_repo_dir|
+      repo_opts    = worktree_params.merge(:new => true, :path => tmp_repo_dir)
+      tmp_worktree = GitWorktree.new(repo_opts)
+
+      tmp_worktree.check_connection(url)
+    end
+  end
+
   def refresh
     update_repo
     transaction do

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -34,7 +34,9 @@ class GitRepository < ApplicationRecord
     require 'net/ping/external'
 
     # URI library cannot handle git urls, so just convert it to a standard url.
+    temp_url = url.dup
     temp_url = url.sub(':', '/').sub('git@', 'https://') if url.start_with?('git@')
+
     host = URI.parse(temp_url).hostname
 
     $log.debug("pinging '#{host}' to verify network connection")

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -2,7 +2,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   include AnsibleExtraVarsMixin
   include AnsiblePlaybookMixin
 
-  delegate :playbook, :to => :service_template, :allow_nil => true
+  delegate :playbook, :repository, :to => :service_template, :allow_nil => true
 
   # A chance for taking options from automate script to override options from a service dialog
   def preprocess(action, add_options = {})
@@ -16,6 +16,10 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   def execute(action)
     launch_ansible_job_queue(action)
+  end
+
+  def check_connection(action)
+    repository(action).check_connection
   end
 
   def launch_ansible_job_queue(action)

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -19,7 +19,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   def check_connection(action)
-    repository(action).check_connection
+    repository(action).check_connection?
   end
 
   def launch_ansible_job_queue(action)

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -76,6 +76,10 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook.find(config_info[action.downcase.to_sym][:playbook_id])
   end
 
+  def repository(action)
+    GitRepository.find(config_info[action.downcase.to_sym][:repository_id])
+  end
+
   def update_catalog_item(options, auth_user = nil)
     config_info = validate_update_config_info(options)
     unless config_info

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -258,25 +258,6 @@ class GitWorktree
     end
   end
 
-  # Ping the git repository endpoint to verify that the network connection is still up.
-  # We use this approach for now over Rugged#check_connection because of a segfault:
-  #
-  #   https://github.com/libgit2/rugged/issues/859
-  #
-  def check_connection(url)
-    require 'net/ping/http'
-
-    # URI library cannot handle git urls, so just convert it to a standard url.
-    url = url.sub(':', '/').sub('git@', 'https://www.') if url.start_with?('git@')
-
-    # Secure endpoints only as port 80 may not be enabled for outgoing traffic.
-    url = url.sub('http', 'https') if url.start_with?('http://')
-
-    $log.debug("pinging url '#{url}' to verify network connection")
-
-    Net::Ping::HTTP.new(url).ping?
-  end
-
   def with_remote_options
     if @ssh_private_key
       @ssh_private_key_file = Tempfile.new

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -258,6 +258,22 @@ class GitWorktree
     end
   end
 
+  # Ping the git repository endpoint to verify that the network connection is still up.
+  #
+  def check_connection(url)
+    require 'net/ping/http'
+
+    # URI library cannot handle git urls, so just convert it to a standard url.
+    url = url.sub(':', '/').sub('git@', 'https://www.') if url.start_with?('git@')
+
+    # Secure endpoints only as port 80 may not be enabled for outgoing traffic.
+    url = url.sub('http', 'https') if url.start_with?('http://')
+
+    $log.debug("pinging url '#{url}' to verify network connection")
+
+    Net::Ping::HTTP.new(url).ping?
+  end
+
   def with_remote_options
     if @ssh_private_key
       @ssh_private_key_file = Tempfile.new

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -259,6 +259,9 @@ class GitWorktree
   end
 
   # Ping the git repository endpoint to verify that the network connection is still up.
+  # We use this approach for now over Rugged#check_connection because of a segfault:
+  #
+  #   https://github.com/libgit2/rugged/issues/859
   #
   def check_connection(url)
     require 'net/ping/http'

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -374,6 +374,20 @@ RSpec.describe GitRepository do
         expect($log).to receive(:debug).with(/pinging 'example.com' to verify network connection/)
         expect(repo.check_connection?).to eq(true)
       end
+
+      it "handles ssh urls without issue" do
+        allow(repo).to receive(:url).and_return("ssh://user@example.com:443/manageiq.git")
+        allow(ext_ping).to receive(:ping?).and_return(true)
+        expect($log).to receive(:debug).with(/pinging 'example.com' to verify network connection/)
+        expect(repo.check_connection?).to eq(true)
+      end
+
+      it "handles file urls without issue" do
+        allow(repo).to receive(:url).and_return("file://example.com/server/manageiq.git")
+        allow(ext_ping).to receive(:ping?).and_return(true)
+        expect($log).to receive(:debug).with(/pinging 'example.com' to verify network connection/)
+        expect(repo.check_connection?).to eq(true)
+      end
     end
   end
 end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -345,5 +345,35 @@ RSpec.describe GitRepository do
         end
       end
     end
+
+    context "check_connection?" do
+      require 'net/ping/external'
+      let(:ext_ping) { instance_double(Net::Ping::External) }
+
+      before do
+        allow(Net::Ping::External).to receive(:new).and_return(ext_ping)
+        allow(ext_ping).to receive(:exception)
+      end
+
+      it "returns true if it can ping the repo" do
+        allow(ext_ping).to receive(:ping?).and_return(true)
+        expect($log).to receive(:debug).with(/pinging '.*' to verify network connection/)
+        expect(repo.check_connection?).to eq(true)
+      end
+
+      it "returns false if it cannot ping the repo" do
+        allow(ext_ping).to receive(:ping?).and_return(false)
+        expect($log).to receive(:debug).with(/pinging '.*' to verify network connection/)
+        expect($log).to receive(:debug).with(/ping failed: .*/)
+        expect(repo.check_connection?).to eq(false)
+      end
+
+      it "handles git urls without issue" do
+        allow(repo).to receive(:url).and_return("git@example.com:ManageIQ/manageiq.git")
+        allow(ext_ping).to receive(:ping?).and_return(true)
+        expect($log).to receive(:debug).with(/pinging 'example.com' to verify network connection/)
+        expect(repo.check_connection?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Slight reworking of https://github.com/ManageIQ/manageiq/pull/20645

This is basically @NickLaMuro's PR, but with the `check_connection` method modified. Instead of making a Rugged connection on the API endpoint, we just perform an http ping on the repo.

I made these changes to Nick's PR for a couple reasons. First and foremost, the Rugged code was segfaulting with a difficult to diagnose error that indicates that, somewhere in the guts of either rugged or libgit2, it's trying to `free` something that it didn't allocate. Issue reported here: https://github.com/libgit2/rugged/issues/859. Unable to solve that, we had to find a different way.

Since the original issue was really a generic connectivity issue, and not specifically about the github API failing to return expected data, I felt the original rugged code was too heavy. It's the equivalent of a `git ls-remote`, which fetches data under the hood, and we don't need to fetch data, we just need to test for connectivity.

I chose net-ping as the solution because it was already a dependency in ManageIQ, because I'm the original author, and because it solves our needs. Although I have not been the maintainer for many years now, the code hasn't changed dramatically, so I have good familiarity with it.

@tinaafitz, @billfitzgerald0120, @d-m-u and I tested this on a vmware host where we temporarily disabled the network in the middle of provisioning a catalog item and it worked as expected, i.e. it would check the connection X number of times, and proceed if the connection was restored.

Original bug: https://bugzilla.redhat.com/show_bug.cgi?id=1835226