### PR TITLE
Introducing supports cloud_volume_create

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -269,6 +269,8 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_volume_resizing, :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
   virtual_column :supports_cinder_volume_types, :type => :boolean
+  virtual_column :supports_cloud_volume, :type => :boolean
+  virtual_column :supports_cloud_volume_create, :type => :boolean
   virtual_column :supports_create_flavor, :type => :boolean
   virtual_column :supports_volume_availability_zones, :type => :boolean
   virtual_column :supports_create_security_group, :type => :boolean
@@ -794,6 +796,14 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_cinder_volume_types
     supports_cinder_volume_types?
+  end
+
+  def supports_cloud_volume
+    supports_cloud_volume?
+  end
+
+  def supports_cloud_volume_create
+    supports_cloud_volume_create?
   end
 
   def supports_volume_availability_zones

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -66,6 +66,8 @@ module SupportsFeatureMixin
     # FIXME: this is just a internal helper and should be refactored
     :control                             => 'Basic control operations',
     :cloud_tenants                       => 'CloudTenant',
+    :cloud_volume                        => 'Cloud Volume',
+    :cloud_volume_create                 => 'Create Cloud Volume',
     :cloud_tenant_mapping                => 'CloudTenant mapping',
     :cloud_object_store_container_create => 'Create Object Store Container',
     :cloud_object_store_container_clear  => 'Clear Object Store Container',


### PR DESCRIPTION
Some providers that support the access to block storage (cloud volumes) don't allow the creation of cloud volumes. Therefore, we need a way to query the ones that do for the CloudVolume creation form.

@miq-bot add_label enhancement
@miq-bot assign @agrare 