### PR TITLE
Marked the Different Button Types for Translation

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -19,8 +19,8 @@ class CustomButton < ApplicationRecord
   include UuidMixin
   acts_as_miq_set_member
 
-  TYPES = { "default"          => "Default",
-            "ansible_playbook" => "Ansible Playbook"}.freeze
+  TYPES = {"default"          => N_("Default"),
+           "ansible_playbook" => N_("Ansible Playbook")}.freeze
 
   PLAYBOOK_METHOD = "Order_Ansible_Playbook".freeze
 


### PR DESCRIPTION
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/7454
Fixes: [#10515](https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10515)