### PR TITLE
Add Filters mixin to schedules

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -1,6 +1,8 @@
 class MiqSchedule < ApplicationRecord
   include DeprecationMixin
   include_concern 'ImportExport'
+  include_concern 'Filters'
+
   include YAMLImportExportMixin
   deprecate_attribute :towhat, :resource_type
 

--- a/app/models/miq_schedule/filters.rb
+++ b/app/models/miq_schedule/filters.rb
@@ -1,0 +1,90 @@
+module MiqSchedule::Filters
+  extend ActiveSupport::Concern
+
+  def build_hash_filter_expression(value, other_value = nil, filter_type = "Base")
+    check_compliance = sched_action&.dig(:method) == "check_compliance"
+    filter_resource_type = if check_compliance
+                             if resource_type == "ContainerImage"
+                               "ContainerImageCheckCompliance"
+                             else
+                               "CheckCompliance"
+                             end
+                           else
+                             resource_type
+                           end
+
+    case filter_resource_type
+    when "Storage"
+      case filter_type
+      when "ExtManagementSystem" then {"CONTAINS" => {"field" => "Storage.ext_management_systems-name", "value" => value}}
+      when "Host"                then {"CONTAINS" => {"field" => "Storage.hosts-name", "value" => value}}
+      when "Storage"             then {"=" => {"field" => "Storage-name", "value" => value}}
+      else {"IS NOT NULL" => {"field" => "Storage-name"}}
+      end
+    when "Host"
+      case filter_type
+      when "EmsCluster"
+        if value.present?
+          {"AND" => [
+            {"=" => {"field" => "Host-v_owning_cluster", "value" => value}},
+            {"=" => {"field" => "Host-v_owning_datacenter", "value" => other_value}}
+          ]}
+        end
+      when "ExtManagementSystem" then {"=" => {"field" => "Host.ext_management_system-name", "value" => value}}
+      when "Host"                then {"=" => {"field" => "Host-name", "value" => value}}
+      else {"IS NOT NULL" => {"field" => "Host-name"}}
+      end
+    when "ContainerImage", "ContainerImageCheckCompliance"
+      case filter_type
+      when "ExtManagementSystem" then {"=" => {"field" => "ContainerImage.ext_management_system-name", "value" => value}}
+      when "ContainerImage"      then {"=" => {"field" => "ContainerImage-name", "value" => value}}
+      else {"IS NOT NULL" => {"field" => "ContainerImage-name"}}
+      end
+    when "EmsCluster"
+      case filter_type
+      when "EmsCluster"
+        if value.present?
+          {"AND" => [
+            {"=" => {"field" => "EmsCluster-name", "value" => value}},
+            {"=" => {"field" => "EmsCluster-v_parent_datacenter", "value" => other_value}}
+          ]}
+        end
+      when "ExtManagementSystem" then {"=" => {"field" => "EmsCluster.ext_management_system-name", "value" => value}}
+      else {"IS NOT NULL" => {"field" => "EmsCluster-name"}}
+      end
+    when "CheckCompliance"
+      case filter_type
+      when "EmsCluster"
+        if value.present?
+          {"AND" => [
+            {"=" => {"field" => "#{resource_type}-v_owning_cluster", "value" => value}},
+            {"=" => {"field" => "#{resource_type}-v_owning_datacenter", "value" => other_value}}
+          ]}
+        end
+      when "ExtManagementSystem" then {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
+      when "Host" then {"=" => {"field" => "Host-name", "value" => value}}
+      when "Vm"   then {"=" => {"field" => "Vm-name", "value" => value}}
+      else             {"IS NOT NULL" => {"field" => "#{resource_type}-name"}}
+      end
+    else
+      case filter_type
+      when "EmsCluster"
+        if value.present?
+          {"AND" => [
+            {"=" => {"field" => "#{resource_type}-v_owning_cluster", "value" => value}},
+            {"=" => {"field" => "#{resource_type}-v_owning_datacenter", "value" => other_value}}
+          ]}
+        end
+      when "ExtManagementSystem" then {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
+      when "Host"         then {"=" => {"field" => "#{resource_type}.host-name", "value" => value}}
+      when "MiqTemplate", "Vm", "ContainerImage" then {"=" => {"field" => "#{resource_type}-name", "value" => value}}
+      else {"IS NOT NULL" => {"field" => "#{resource_type}-name"}}
+      end
+    end
+  end
+
+  def build_filter_expression_from(value, other_value = nil, filter_type = "Base")
+    expression = build_hash_filter_expression(value, other_value, filter_type)
+    schedule.filter = MiqExpression.new(expression)
+  end
+end

--- a/spec/models/miq_schedule/filters_spec.rb
+++ b/spec/models/miq_schedule/filters_spec.rb
@@ -1,0 +1,320 @@
+RSpec.describe MiqSchedule::Filters do
+  let(:method)      { "scan" }
+  let(:schedule)    { FactoryBot.create(:miq_schedule, :sched_action => {:method => method}) }
+  let(:value)       { nil }
+  let(:other_value) { nil }
+
+  let(:filter_type) { "Base" }
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  subject do
+    schedule.build_hash_filter_expression(value, other_value, filter_type)
+  end
+
+  context "with Storage resource_type" do
+    before do
+      schedule.update(:resource_type => "Storage")
+    end
+
+    let(:expected_expression) { {"IS NOT NULL" => {"field" => "Storage-name"}} }
+
+    it "builds expression" do
+      expect(subject).to eq(expected_expression)
+    end
+
+    context "filter typ is ExtManagementSystem" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "ExtManagementSystem" }
+
+      let(:expected_expression) do
+        {"CONTAINS" => {"field" => "Storage.ext_management_systems-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is Host" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "Host" }
+
+      let(:expected_expression) do
+        {"CONTAINS" => {"field" => "Storage.hosts-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is Storage" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "Storage" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "Storage-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+  end
+
+  context "with ContainerImage and ContainerImageCheckCompliance" do
+    %w[ContainerImage ContainerImageCheckCompliance].each do |resource_type|
+      before do
+        schedule.update(:resource_type => resource_type)
+      end
+
+      let(:expected_expression) do
+        {"IS NOT NULL" => {"field" => "ContainerImage-name"}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+
+      context "filter typ is ExtManagementSystem" do
+        let(:value)               { "XXX" }
+        let(:filter_type)         { "ExtManagementSystem" }
+
+        let(:expected_expression) do
+          {"=" => {"field" => "ContainerImage.ext_management_system-name", "value" => value}}
+        end
+
+        it "builds expression" do
+          expect(subject).to eq(expected_expression)
+        end
+      end
+
+      context "filter typ is ContainerImage" do
+        let(:value)               { "XXX" }
+        let(:filter_type)         { "ContainerImage" }
+
+        let(:expected_expression) do
+          {"=" => {"field" => "ContainerImage-name", "value" => value}}
+        end
+
+        it "builds expression" do
+          expect(subject).to eq(expected_expression)
+        end
+      end
+    end
+  end
+
+  context "with Host resource_type" do
+    before do
+      schedule.update(:resource_type => "Host")
+    end
+
+    let(:expected_expression) { {"IS NOT NULL" => {"field" => "Host-name"}} }
+
+    it "builds expression" do
+      expect(subject).to eq(expected_expression)
+    end
+
+    context "filter typ is Cluster" do
+      let(:value)               { "XXX" }
+      let(:other_value)         { "YYY" }
+      let(:filter_type)         { "EmsCluster" }
+
+      let(:expected_expression) do
+        {"AND" => [
+          {"=" => {"field" => "Host-v_owning_cluster", "value" => value}},
+          {"=" => {"field" => "Host-v_owning_datacenter", "value" => other_value}}
+        ]}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is ExtManagementSystem" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "ExtManagementSystem" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "Host.ext_management_system-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is Host" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "Host" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "Host-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+  end
+
+  %w[Vm MiqTemplate].each do |resource_type|
+    context "with #{resource_type} resource_type (SmartState Analysis)" do
+      before do
+        schedule.update(:resource_type => resource_type)
+      end
+
+      let(:expected_expression) { {"IS NOT NULL" => {"field" => "#{resource_type}-name"}} }
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+
+      context "filter typ is Cluster" do
+        let(:value)               { "XXX" }
+        let(:other_value)         { "YYY" }
+        let(:filter_type)         { "EmsCluster" }
+
+        let(:expected_expression) do
+          {"AND" => [
+            {"=" => {"field" => "#{resource_type}-v_owning_cluster", "value" => value}},
+            {"=" => {"field" => "#{resource_type}-v_owning_datacenter", "value" => other_value}}
+          ]}
+        end
+
+        it "builds expression" do
+          expect(subject).to eq(expected_expression)
+        end
+      end
+
+      context "filter typ is ExtManagementSystem" do
+        let(:value)               { "XXX" }
+        let(:other_value)         { "YYY" }
+        let(:filter_type)         { "ExtManagementSystem" }
+
+        let(:expected_expression) do
+          {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
+        end
+
+        it "builds expression" do
+          expect(subject).to eq(expected_expression)
+        end
+      end
+    end
+  end
+
+  context "with EmsCluster resource_type" do
+    before do
+      schedule.update(:resource_type => "EmsCluster")
+    end
+
+    let(:expected_expression) { {"IS NOT NULL" => {"field" => "EmsCluster-name"}} }
+
+    it "builds expression" do
+      expect(subject).to eq(expected_expression)
+    end
+
+    context "filter typ is Cluster" do
+      let(:value)               { "XXX" }
+      let(:other_value)         { "YYY" }
+      let(:filter_type)         { "EmsCluster" }
+
+      let(:expected_expression) do
+        {"AND" => [
+          {"=" => {"field" => "EmsCluster-name", "value" => value}},
+          {"=" => {"field" => "EmsCluster-v_parent_datacenter", "value" => other_value}}
+        ]}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is ExtManagementSystem" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "ExtManagementSystem" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "EmsCluster.ext_management_system-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+  end
+
+  context "with check_compliance resource_type" do
+    before do
+      schedule.update(:resource_type => "Vm")
+    end
+
+    let(:method)              { "check_compliance" }
+    let(:expected_expression) { {"IS NOT NULL" => {"field" => "#{schedule.resource_type}-name"}} }
+
+    it "builds expression" do
+      expect(subject).to eq(expected_expression)
+    end
+
+    context "filter typ is Cluster" do
+      let(:value)               { "XXX" }
+      let(:other_value)         { "YYY" }
+      let(:filter_type)         { "EmsCluster" }
+
+      let(:expected_expression) do
+        {"AND" => [
+          {"=" => {"field" => "#{schedule.resource_type}-v_owning_cluster", "value" => value}},
+          {"=" => {"field" => "#{schedule.resource_type}-v_owning_datacenter", "value" => other_value}}
+        ]}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is ExtManagementSystem" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "ExtManagementSystem" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "Vm.ext_management_system-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is Host" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "Host" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "Host-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+
+    context "filter typ is Vm" do
+      let(:value)               { "XXX" }
+      let(:filter_type)         { "Vm" }
+
+      let(:expected_expression) do
+        {"=" => {"field" => "Vm-name", "value" => value}}
+      end
+
+      it "builds expression" do
+        expect(subject).to eq(expected_expression)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This is second part of issue** https://github.com/ManageIQ/manageiq/issues/20768
------


This moves methods(`build_filter_expression_from`, ...) responsible for building search filter(expression) for schedules added here (https://github.com/ManageIQ/manageiq-ui-classic/pull/7470)

**WIP:**
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/7470

## Links
https://github.com/ManageIQ/manageiq-ui-classic/pull/7470
Next: https://github.com/ManageIQ/manageiq/pull/20764


@miq-bot add_label refactoring
