### PR TITLE
[EmbeddedAnsible] Ensure newline for :ssh_key_data

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
@@ -54,6 +54,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < M
   alias ssh_key_data   auth_key
   alias ssh_key_unlock auth_key_password
 
+  before_validation :ensure_newline_for_ssh_key
+
   def self.display_name(number = 1)
     n_('Credential (SCM)', 'Credentials (SCM)', number)
   end
@@ -65,5 +67,11 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < M
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)  if attrs.key?(:ssh_key_unlock)
 
     attrs
+  end
+
+  private
+
+  def ensure_newline_for_ssh_key
+    self.auth_key = "#{auth_key}\n" if auth_key.present? && auth_key[-1] != "\n"
   end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -299,61 +299,86 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credenti
   end
 
   context "ScmCredential" do
-    it_behaves_like 'an embedded_ansible credential' do
-      let(:credential_class) { embedded_ansible::ScmCredential }
+    let(:credential_class) { embedded_ansible::ScmCredential }
+    let(:expected_ssh_key) { "secret2\n" }
 
-      let(:params) do
-        {
-          :name           => "Scm Credential",
-          :userid         => "userid",
-          :password       => "secret1",
-          :ssh_key_data   => "secret2",
-          :ssh_key_unlock => "secret3"
-        }
-      end
-      let(:queue_create_params) do
-        {
-          :name           => "Scm Credential",
-          :userid         => "userid",
-          :password       => ManageIQ::Password.encrypt("secret1"),
-          :ssh_key_data   => ManageIQ::Password.encrypt("secret2"),
-          :ssh_key_unlock => ManageIQ::Password.encrypt("secret3")
-        }
-      end
-      let(:params_to_attributes) do
-        {
-          :name              => "Scm Credential",
-          :userid            => "userid",
-          :password          => "secret1",
-          :auth_key          => "secret2",
-          :auth_key_password => "secret3",
-        }
-      end
-      let(:expected_values) do
-        {
-          :name                        => "Scm Credential",
-          :userid                      => "userid",
-          :password                    => "secret1",
-          :ssh_key_data                => "secret2",
-          :ssh_key_unlock              => "secret3",
-          :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
-          :auth_key_encrypted          => ManageIQ::Password.try_encrypt("secret2"),
-          :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret3")
-        }
-      end
-      let(:params_to_attrs) { [:auth_key, :auth_key_password] }
-      let(:update_params) do
-        {
-          :name     => "Updated Credential",
-          :password => "supersecret"
-        }
-      end
-      let(:update_queue_params) do
-        {
-          :name     => "Updated Credential",
-          :password => ManageIQ::Password.encrypt("supersecret")
-        }
-      end
+    let(:params) do
+      {
+        :name           => "Scm Credential",
+        :userid         => "userid",
+        :password       => "secret1",
+        :ssh_key_data   => passed_in_ssh_key,
+        :ssh_key_unlock => "secret3"
+      }
+    end
+    let(:queue_create_params) do
+      {
+        :name           => "Scm Credential",
+        :userid         => "userid",
+        :password       => ManageIQ::Password.encrypt("secret1"),
+        :ssh_key_data   => ManageIQ::Password.encrypt(passed_in_ssh_key),
+        :ssh_key_unlock => ManageIQ::Password.encrypt("secret3")
+      }
+    end
+    let(:params_to_attributes) do
+      {
+        :name              => "Scm Credential",
+        :userid            => "userid",
+        :password          => "secret1",
+        :auth_key          => passed_in_ssh_key,
+        :auth_key_password => "secret3",
+      }
+    end
+    let(:expected_values) do
+      {
+        :name                        => "Scm Credential",
+        :userid                      => "userid",
+        :password                    => "secret1",
+        :ssh_key_data                => expected_ssh_key,
+        :ssh_key_unlock              => "secret3",
+        :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
+        :auth_key_encrypted          => expected_ssh_key.present? ? ManageIQ::Password.try_encrypt(expected_ssh_key) : expected_ssh_key,
+        :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret3")
+      }
+    end
+    let(:params_to_attrs) { [:auth_key, :auth_key_password] }
+    let(:update_params) do
+      {
+        :name     => "Updated Credential",
+        :password => "supersecret"
+      }
+    end
+    let(:update_queue_params) do
+      {
+        :name     => "Updated Credential",
+        :password => ManageIQ::Password.encrypt("supersecret")
+      }
+    end
+
+    context "with an SSH key that ends with a newline" do
+      let(:passed_in_ssh_key) { "secret2\n" }
+
+      it_behaves_like 'an embedded_ansible credential'
+    end
+
+    context "with an SSH key that does not end with a newline" do
+      let(:passed_in_ssh_key) { "secret2" }
+
+      it_behaves_like 'an embedded_ansible credential'
+    end
+
+    context "with an nil SSH key" do
+      let(:passed_in_ssh_key) { nil }
+      let(:expected_ssh_key)  { nil }
+
+      it_behaves_like 'an embedded_ansible credential'
+    end
+
+    context "with a empty string SSH key" do
+      let(:passed_in_ssh_key) { "" }
+      let(:expected_ssh_key)  { "" }
+
+      it_behaves_like 'an embedded_ansible credential'
     end
   end
 


### PR DESCRIPTION
SSH formats like `OPENSSH` require that a newline exist on the last line, otherwise it is considered an invalid format.

This adds a `before_save` callback to the model to ensure that it adds a newline to the key in case it was stripped off by the UI or via other means.



Links
-----

* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1893014
* Related discussions:
  - https://gitter.im/ManageIQ/manageiq/ui?at=5fa02fff7cac87158f807568
  - https://gitter.im/ManageIQ/manageiq/automate?at=5f9afef1c10273610ad33f61
  - https://gitter.im/ManageIQ/manageiq-providers-embedded_ansible?at=5f9c20e3d5a5a635f28e7d13