### PR TITLE
Tenant changes changes miq product features on all servers

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -107,6 +107,18 @@ class MiqProductFeature < ApplicationRecord
     @detail = nil
   end
 
+  # invalidate feature cache on this server and others
+  #
+  # called when data in the features change (typically tenant data).
+  # This then uses the queue to tell other servers they need to update as well.
+  def self.invalidate_caches_queue
+    invalidate_caches
+    MiqQueue.broadcast(
+      :class_name  => name,
+      :method_name => "invalidate_caches"
+    )
+  end
+
   def self.features
     @feature_cache ||= begin
       # create hash with parent identifier and details

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -62,6 +62,7 @@ class Tenant < ApplicationRecord
   virtual_column :display_type, :type => :string
 
   before_save :nil_blanks
+  after_save -> { MiqProductFeature.invalidate_caches }
   after_create :create_tenant_group, :create_miq_product_features_for_tenant_nodes
 
   def self.scope_by_tenant?

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -63,7 +63,7 @@ class Tenant < ApplicationRecord
 
   before_save :nil_blanks
   after_save -> { MiqProductFeature.invalidate_caches }
-  after_create :create_tenant_group, :create_miq_product_features_for_tenant_nodes
+  after_create :create_tenant_group, :create_miq_product_features_for_tenant_nodes, :update_miq_product_features_for_tenant_nodes
 
   def self.scope_by_tenant?
     true
@@ -317,6 +317,10 @@ class Tenant < ApplicationRecord
 
   def create_miq_product_features_for_tenant_nodes
     MiqProductFeature.seed_single_tenant_miq_product_features(self)
+  end
+
+  def update_miq_product_features_for_tenant_nodes
+    MiqProductFeature.invalidate_caches_queue
   end
 
   def destroy_with_subtree

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe Host do
       it "policy passes" do
         expect_any_instance_of(described_class).to receive(:ipmi_power_on)
 
+        MiqQueue.delete_all
         @host.start
         status, message, result = MiqQueue.first.deliver
         MiqQueue.first.delivered(status, message, result)


### PR DESCRIPTION
alternative for: https://github.com/ManageIQ/manageiq/pull/20708 (first commit is from that PR)

miq product features contain tenant data. So we want to update the product features data
on all servers when a tenant is added or changes.

This allows us to remove special logic from the front end: https://github.com/ManageIQ/manageiq-ui-classic/pull/7430

Closes ManageIQ/manageiq-api#928
Closes ManageIQ/manageiq#20708