### PR TITLE
don't call postprocess without job in playbook on_error

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -89,8 +89,12 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   def on_error(action)
     _log.info("on_error called for service action: #{action}")
     update(:retirement_state => 'error') if action == "Retirement"
-    job(action).try(:refresh_ems)
-    postprocess(action)
+    if job(action)
+      job(action).try(:refresh_ems)
+      postprocess(action)
+    else
+      _log.info("postprocess not called because job was nil")
+    end
   end
 
   def retain_resources_on_retirement?


### PR DESCRIPTION
playbook postprocessing shouldn't happen if the job is nil in `on_error`

since having a nil job is a potential outcome of the valid scenarios we're trying to handle with the retry of ansible playbook connection stuff (see the related pr), we also need to handle this logic branch 

related to the work done on https://github.com/ManageIQ/manageiq/pull/20738

