### PR TITLE
Pluggable provider mapping prefixes and targets

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -50,6 +50,18 @@ class ExtManagementSystem < ApplicationRecord
     catalog_types.present?
   end
 
+  def self.label_mapping_classes
+    supported_subclasses.select(&:supports_label_mapping?)
+  end
+
+  def self.label_mapping_prefixes
+    label_mapping_classes.map(&:label_mapping_prefix).uniq
+  end
+
+  def self.entities_for_label_mapping
+    label_mapping_classes.reduce({}) { |all_mappings, klass| all_mappings.merge(klass.entities_for_label_mapping) }
+  end
+
   def self.provider_create_params
     supported_types_for_create.each_with_object({}) do |ems_type, create_params|
       create_params[ems_type.name] = ems_type.params_for_create if ems_type.respond_to?(:params_for_create)

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -101,6 +101,7 @@ module SupportsFeatureMixin
     :launch_html5_console                => 'Launch HTML5 Console',
     :launch_vmrc_console                 => 'Launch VMRC Console',
     :launch_native_console               => 'Launch Native Console',
+    :label_mapping                       => 'Label Mapping',
     :admin_ui                            => 'Open Admin UI for a Provider',
     :live_migrate                        => 'Live Migration',
     :warm_migrate                        => 'Warm Migration',

--- a/app/models/provider_tag_mapping.rb
+++ b/app/models/provider_tag_mapping.rb
@@ -22,7 +22,7 @@ class ProviderTagMapping < ApplicationRecord
 
   require_nested :Mapper
 
-  TAG_PREFIXES = %w(amazon azure kubernetes ibm openstack vmware).map { |name| "/managed/#{name}:" }.freeze
+  TAG_PREFIXES = ExtManagementSystem.label_mapping_prefixes.map { |name| "/managed/#{name}:" }.freeze
   validate :validate_tag_prefix
 
   # Return ProviderTagMapping::Mapper instance that holds all current mappings,

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe ExtManagementSystem do
+  it "supports label mapping for provider subclasses" do
+    expect(ExtManagementSystem.entities_for_label_mapping.keys).to include("VmOpenstack", "VmIBM")
+  end
+
   subject { FactoryBot.create(:ext_management_system) }
 
   include_examples "AggregationMixin"


### PR DESCRIPTION
Fixes and adds supporting method to solve 2 points from https://github.com/ManageIQ/manageiq/issues/19440:

1. Tag Mapper tag prefixes https://github.com/ManageIQ/manageiq/blob/master/app/models/provider_tag_mapping.rb#L25
2. Tag mapper categories (https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/settings/label_tag_mapping.rb#L21-L28)

**1. is fixed in this PR and 2. will be fixed in UI PR** 

Supported in providers:
- [x] Amazon https://github.com/ManageIQ/manageiq-providers-amazon/pull/669
- [x] Azure https://github.com/ManageIQ/manageiq-providers-azure/pull/424
- [x] IBM https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/116
- [x] Kubernetes https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/409
- [x] Openstack https://github.com/ManageIQ/manageiq-providers-openstack/pull/665
- [x] Vmware https://github.com/ManageIQ/manageiq-providers-vmware/pull/669



Links
-----

* https://github.com/ManageIQ/manageiq/issues/19440


