### PR TITLE
OpenStack CloudVolumes should live in the Storage Manager

### DIFF
--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -3,7 +3,9 @@ FactoryBot.define do
     sequence(:volume_type) { |n| "volume_type_#{seq_padded_for_sorting(n)}" }
   end
 
-  factory :cloud_volume_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume", :parent => :cloud_volume do
+  factory :cloud_volume_openstack,
+          :class  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume",
+          :parent => :cloud_volume do
     status { "available" }
   end
 end

--- a/spec/factories/cloud_volume_backup.rb
+++ b/spec/factories/cloud_volume_backup.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
     sequence(:ems_ref) { |n| "ems_ref_#{seq_padded_for_sorting(n)}" }
   end
 
-  factory :cloud_volume_backup_openstack, :parent => :cloud_volume_backup, :class => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
+  factory :cloud_volume_backup_openstack,
+          :parent => :cloud_volume_backup,
+          :class  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup"
 end

--- a/spec/factories/cloud_volume_snapshot.rb
+++ b/spec/factories/cloud_volume_snapshot.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
   end
 
   factory :cloud_volume_snapshot_openstack,
-          :class  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot",
+          :class  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot",
           :parent => :cloud_volume_snapshot do
     status { "available" }
   end


### PR DESCRIPTION
OpenStack CloudVolumes belong to the cinder_manager not the main cloud_manager and their class name should reflect that.

Required for: https://github.com/ManageIQ/manageiq-providers-openstack/pull/664