### PR TITLE
Look in the correct places for migrations to determine the deployment_status

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -202,7 +202,7 @@ class EvmApplication
   end
 
   def self.deployment_status
-    context = ActiveRecord::MigrationContext.new('db/migrate')
+    context = ActiveRecord::MigrationContext.new(Rails.application.config.paths["db/migrate"])
     return "new_deployment" if context.current_version.zero?
     return "new_replica"    if MiqServer.my_server.nil?
     return "upgrade"        if context.needs_migration?


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-pods/issues/650

Our schema migrations don't live in db/migrate, they live in the manageiq-schema gem. So we were incorrectly reporting that we don't have any migrations that need to be run.

irb(main):001:0> ActiveRecord::MigrationContext.new('db/migrate').migrations.length
=> 0
irb(main):002:0> ActiveRecord::MigrationContext.new(Rails.application.config.paths["db/migrate"]).migrations.length
=> 844
