### PR TITLE
replace cattr_accessor in rel mixin with a class_attribute

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -26,7 +26,7 @@ module RelationshipMixin
   included do
     extend Memoist
 
-    cattr_accessor :default_relationship_type
+    class_attribute :default_relationship_type
     class_attribute :skip_relationships, :default => []
 
     has_many :all_relationships, :class_name => "Relationship", :dependent => :destroy, :as => :resource


### PR DESCRIPTION
since cattr_accessors are potentially problematic re: wandering class vars, I think this should also probably be a class attribute 