### PR TITLE
[rails6][service_template_ansible_playbook_spec.rb] Fix ems/provider lets

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -390,7 +390,9 @@ FactoryBot.define do
   factory :embedded_automation_manager_ansible,
           :aliases => ["manageiq/providers/embedded_ansible/automation_manager"],
           :class   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",
-          :parent  => :automation_manager
+          :parent  => :automation_manager do
+    provider :factory => :provider_embedded_ansible
+  end
 
   # Leaf classes for provisioning_manager
 

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ServiceTemplateAnsiblePlaybook do
   let(:script_source) { FactoryBot.create(:configuration_script_source, :manager => ems) }
 
   let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
-  let(:provider) { FactoryBot.create(:provider_embedded_ansible, :default_inventory => 1) }
-  let(:ems)      { FactoryBot.create(:automation_manager_ansible_tower, :provider => provider) }
+  let(:provider) { ems.provider }
+  let(:ems)      { FactoryBot.create(:embedded_automation_manager_ansible) }
 
   let(:playbook) do
     FactoryBot.create(:embedded_playbook,


### PR DESCRIPTION
This fix takes a page from a PR from @skateman:

https://github.com/ManageIQ/manageiq/pull/20031

Which was that instead of trying to assign the provider prior to making the EMS in the factories, default a provider object type as part of the `ext_management_system` child definition, and reference it in the `let(:provider)`.

This is not a problem in Rails 5.2, but does lead to the following error in Rails 6.0

```
5) ServiceTemplateAnsiblePlaybook.create_catalog_item creates and returns a catalog item

   Failure/Error: factory_exists?(factory) ? super : class_from_symbol(factory).create!(*args)

   ActiveRecord::HasManyThroughCantAssociateThroughHasOneOrManyReflection:

     Cannot modify association 'ManageIQ::Providers::EmbeddedAnsible::Provider#endpoints' because the source reflection class 'Endpoint' is associated to 'ExtManagementSystem' via :has_many.

   # ./spec/support/missing_factory_helper.rb:10:in `create'
   # ./spec/models/service_template_ansible_playbook_spec.rb:11:in `block (2 levels) in <top (required)>'
   # ./spec/models/service_template_ansible_playbook_spec.rb:7:in `block (2 levels) in <top (required)>'
   # ./spec/models/service_template_ansible_playbook_spec.rb:15:in `block (2 levels) in <top (required)>'
   # ./spec/models/service_template_ansible_playbook_spec.rb:40:in `block (2 levels) in <top (required)>'
   # ./spec/models/service_template_ansible_playbook_spec.rb:47:in `block (2 levels) in <top (required)>'
   # ./spec/models/service_template_ansible_playbook_spec.rb:82:in `block (3 levels) in <top (required)>'
```

Most likely do to a fix that I was unable to track down, but the following `git log command` is most likely to contain some of the commits with the fix:

```console
$ git log --oneline -E --grep "has.*many.*through" 5-2-stable..6-0-stable
```


Links
-----

* Part of the Rails 6 Upgrade:  https://github.com/ManageIQ/manageiq/issues/19977