### PR TITLE
Use ancestry for Vm genealogy 

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1,3 +1,4 @@
+require 'ancestry'
 require 'ostruct'
 require 'cgi'
 require 'uri'
@@ -9,6 +10,7 @@ class VmOrTemplate < ApplicationRecord
   include SupportsFeatureMixin
 
   self.table_name = 'vms'
+  has_ancestry
 
   include_concern 'Operations'
   include_concern 'RetirementManagement'
@@ -285,6 +287,7 @@ class VmOrTemplate < ApplicationRecord
 
   include RelationshipMixin
   self.default_relationship_type = "genealogy"
+  self.skip_relationships += ["genealogy"]
 
   include MiqPolicyMixin
   include AlertMixin


### PR DESCRIPTION
vms need ancestry and we have to set the class attribute so that we can migrate the existing rels that are currently doing this stuff. 

depends on https://github.com/ManageIQ/manageiq-schema/pull/492

@miq-bot assign @kbrock 