### PR TITLE
handle child_objs being nil in remove_child

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -679,10 +679,10 @@ module RelationshipMixin
   end
 
   def remove_children(*child_objs)
-    return child_objs.each { |child| child.with_relationship_type(relationship_type) { child.update!(:parent => nil) } } if use_ancestry?
-
     child_objs = child_objs.flatten.compact
     return child_objs if child_objs.empty?
+
+    return child_objs.each { |child| child.with_relationship_type(relationship_type) { child.update!(:parent => nil) } } if use_ancestry?
 
     child_rels = self.child_rels
 


### PR DESCRIPTION
`remove_child` in the rel mixin has a guard clause for handling nil children which should be first so we don't call `with_rel_type` on `nil` 

broken in https://github.com/ManageIQ/manageiq/pull/20274

the test that's failing: https://github.com/ManageIQ/manageiq/blob/master/spec/models/mixins/relationship_mixin_spec.rb#L14

@miq-bot assign @kbrock 
@miq-bot add_label bug
