### PR TITLE
prefer class attribute over cattr_accessor in miq_policy

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -51,7 +51,7 @@ class MiqPolicy < ApplicationRecord
 
   attr_accessor :reserved
 
-  cattr_accessor :associations_to_get_policies
+  class_attribute :associations_to_get_policies
 
   @@built_in_policies = nil
 


### PR DESCRIPTION
since cattr_accessors are potentially problematic re: wandering class vars, I think this should also probably be a class attribute

I'm not overly concerned with this one exhibiting the problematic behavior, however, because of the work done on https://github.com/ManageIQ/manageiq/pull/20274 this caught my eye because of Jason's https://github.com/ManageIQ/manageiq/pull/20664#discussion_r513793189. as a general rule we probably shouldn't be using cattr_accessor.

see https://github.com/ManageIQ/manageiq/pull/20785, in which the same change was made, for the same reason, with the same level of concern
 