### PR TITLE
don't call queue merge with objects

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -130,6 +130,11 @@ module EmsRefresh
     MiqQueue.put_or_update(queue_options) do |msg, item|
       targets = msg.nil? ? targets : msg.data.concat(targets)
       targets = uniq_targets(targets)
+      obj = targets.select { |t| t.kind_of?(ApplicationRecord) }
+      if obj.present?
+        obj.each { |i| _log.warn("queue_merge called with class: #{i.class.name}, id: #{i.id}") }
+        raise ArgumentError, "cannot call queue_merge with an activerecord object"
+      end
 
       # If we are merging with an existing queue item we don't need a new
       # task, just use the original one

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -250,8 +250,12 @@ RSpec.describe EmsRefresh do
     let(:vm)  { FactoryBot.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems) }
 
     it 'sends the command to queue' do
-      EmsRefresh.queue_merge([vm], ems)
+      EmsRefresh.queue_merge([vm.class.to_s, vm.id], ems)
       expect(MiqQueue.count).to eq(1)
+    end
+
+    it 'raises arg error if passed an object' do
+      expect { EmsRefresh.queue_merge([vm], ems) }.to raise_error(ArgumentError)
     end
 
     context "task creation" do
@@ -261,12 +265,12 @@ RSpec.describe EmsRefresh do
       end
 
       it 'returns id of MiqTask linked to queued item' do
-        task_id = EmsRefresh.queue_merge([vm], ems, true)
+        task_id = EmsRefresh.queue_merge([vm.class.to_s, vm.id], ems, true)
         expect(task_id).to eq @miq_task.id
       end
 
       it 'links created task with queued item' do
-        task_id = EmsRefresh.queue_merge([vm], ems)
+        task_id = EmsRefresh.queue_merge([vm.class.to_s, vm.id], ems)
         queue_item = MiqQueue.find_by(:method_name => 'refresh', :role => "ems_inventory")
         expect(queue_item.miq_task_id).to eq task_id
       end


### PR DESCRIPTION
think this should be list of classes and ids, not objects. 

found when looking at https://github.com/ManageIQ/manageiq/pull/20788#issuecomment-723574975 

Even if this isn't the right approach, https://github.com/ManageIQ/manageiq/blob/88c2db48f79baf5902a9d50f506519e5c1b35adb/app/models/ems_refresh.rb#L152 feels problematic to me and we should have a conversation about it. 

