### PR TITLE
Delete orphaned miq workers rows with no pods

### DIFF
--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -7,7 +7,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def cleanup_failed_deployments
-    ensure_pod_monitor_started
     delete_failed_deployments
   end
 

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -2,6 +2,7 @@ autoload(:Kubeclient, 'kubeclient')
 autoload(:KubeException, 'kubeclient')
 
 class ContainerOrchestrator
+  include Vmdb::Logging
   include_concern 'ObjectDefinition'
 
   TOKEN_FILE   = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
@@ -40,6 +41,7 @@ class ContainerOrchestrator
   end
 
   def delete_deployment(name)
+    _log.info("Deleting [#{name}] in namespace: #{my_namespace}")
     scale(name, 0)
     kube_apps_connection.delete_deployment(name, my_namespace)
   rescue KubeException => e

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -151,6 +151,7 @@ class EvmApplication
           "Queue"     => compact_queue_uri(w.queue_name, w.uri),
           "Started"   => compact_date(w.started_on),
           "Heartbeat" => compact_date(w.last_heartbeat),
+          "System UID" => w.system_uid,
           "MB Usage"  => mb_usage ? "#{mb_usage / 1.megabyte}/#{mb_threshold / 1.megabyte}" : ""
         }
       end

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -33,7 +33,7 @@ opt_parser = OptionParser.new do |opts|
     options[:ems_id] = val
   end
 
-  opts.on("-s=system_uid", "--system-uid=system_uid", "Set the system uid coorelating a MiqWorker row to an external system's resource.") do |val|
+  opts.on("-s=system_uid", "--system-uid=system_uid", "Set the system uid correlating a MiqWorker row to an external system's resource.") do |val|
     options[:system_uid] = val
   end
 

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe EvmApplication do
     let(:local_zone)  { FactoryBot.create(:zone, :name => 'A Zone') }
     let(:local)    { EvmSpecHelper.local_miq_server(:started_on => 1.hour.ago, :last_heartbeat => 2.days.ago, :zone => local_zone) }
     let(:remote)   { EvmSpecHelper.remote_miq_server(:is_master => true, :last_heartbeat => nil) }
-    let!(:ui)      { FactoryBot.create(:miq_ui_worker, :miq_server => local, :pid => 80_000) }
-    let!(:generic) { FactoryBot.create(:miq_generic_worker, :miq_server => remote, :pid => 7_000) }
+    let!(:ui)      { FactoryBot.create(:miq_ui_worker, :miq_server => local, :pid => 80_000, :system_uid => "1-ui-7f658c8654-5ln9g") }
+    let!(:generic) { FactoryBot.create(:miq_generic_worker, :miq_server => remote, :pid => 7_000, :system_uid => "1-generic-5cf45d7656-h6jzs") }
     let!(:refresh) { FactoryBot.create(:miq_ems_refresh_worker, :miq_server => remote) }
 
     it "displays worker status for local and remote server" do
@@ -83,6 +83,7 @@ RSpec.describe EvmApplication do
             "Queue"     => "",
             "Started"   => "",
             "Heartbeat" => "",
+            "System UID" => "1-ui-7f658c8654-5ln9g",
             "MB Usage"  => "",
           },
           {
@@ -96,6 +97,7 @@ RSpec.describe EvmApplication do
             "Queue"     => "",
             "Started"   => "",
             "Heartbeat" => "",
+            "System UID" => nil,
             "MB Usage"  => "",
           },
           {
@@ -109,6 +111,7 @@ RSpec.describe EvmApplication do
             "Queue"     => "",
             "Started"   => "",
             "Heartbeat" => "",
+            "System UID" => "1-generic-5cf45d7656-h6jzs",
             "MB Usage"  => "",
           },
         ]
@@ -158,9 +161,9 @@ RSpec.describe EvmApplication do
 
           * marks a master appliance
 
-           #{header(:Region)  } | #{header(:Zone, :ljust)} | Type | Status | #{header(:PID)         } | SPID | Server                   | Queue | Started | Heartbeat | MB Usage
-          -#{line_for(:Region)}-|-#{line_for(:Zone)      }-|------|--------|-#{line_for(:PID)       }-|------|--------------------------|-------|---------|-----------|----------
-           #{pad(rgn, :Region)} | #{local.zone.name      } | Ui   | ready  | #{pad(ui.pid, :PID)    } |      | #{      local.name     } |       |         |           |
+           #{header(:Region)  } | #{header(:Zone, :ljust)} | Type | Status | #{header(:PID)         } | SPID | Server                   | Queue | Started | Heartbeat | System UID | MB Usage
+          -#{line_for(:Region)}-|-#{line_for(:Zone)      }-|------|--------|-#{line_for(:PID)       }-|------|--------------------------|-------|---------|-----------|------------|----------
+           #{pad(rgn, :Region)} | #{local.zone.name      } | Ui   | ready  | #{pad(ui.pid, :PID)    } |      | #{      local.name     } |       |         |           |            |
         SERVER_INFO
 
       expect { EvmApplication.status }.to output(expected_output).to_stdout

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -34,6 +34,53 @@ RSpec.describe MiqServer::WorkerManagement::Monitor do
       expect(server.miq_workers.first.id).to eq(worker.id)
     end
 
+    context "#sync_from_system" do
+      context "#ensure_pod_monitor_started" do
+        it "podified, ensures pod monitor started and orphaned rows are removed" do
+          allow(server).to receive(:podified?).and_return(true)
+          expect(server).to receive(:ensure_pod_monitor_started)
+          expect(server).to receive(:cleanup_orphaned_worker_rows)
+          server.sync_from_system
+        end
+
+        it "non-podified, orphaned rows are removed" do
+          allow(server).to receive(:podified?).and_return(false)
+          expect(server).to receive(:ensure_pod_monitor_started).never
+          expect(server).to receive(:cleanup_orphaned_worker_rows)
+          server.sync_from_system
+        end
+      end
+    end
+
+    context "#cleanup_orphaned_worker_rows" do
+      context "podified" do
+        let(:server2) { EvmSpecHelper.remote_miq_server }
+
+        before do
+          allow(server).to receive(:podified?).and_return(true)
+          server.current_pods = {"1-generic-active" => {}}
+        end
+
+        after do
+          server.current_pods.clear
+        end
+
+        it "removes this server's orphaned rows" do
+          worker.update(:system_uid => "1-generic-orphan")
+          FactoryBot.create(:miq_worker, :type => "MiqGenericWorker", :miq_server => server, :system_uid => "1-generic-active")
+          server.cleanup_orphaned_worker_rows
+          expect(MiqWorker.count).to eq(1)
+        end
+
+        it "skips orphaned rows for other servers" do
+          worker.update(:miq_server => server2, :system_uid => "1-generic-orphan")
+          FactoryBot.create(:miq_worker, :type => "MiqGenericWorker", :miq_server => server2, :system_uid => "1-generic-active")
+          server.cleanup_orphaned_worker_rows
+          expect(MiqWorker.count).to eq(2)
+        end
+      end
+    end
+
     context "#sync_workers" do
       let(:server) { EvmSpecHelper.local_miq_server }
 


### PR DESCRIPTION
DEPENDS on: 

- [x] [New system_uid column](https://github.com/ManageIQ/manageiq-schema/pull/533)
- [x] [Set system_uid in worker pods based on hostname](https://github.com/ManageIQ/manageiq-pods/pull/651)

* synchronize miq_workers rows with the current pods in kubenetes, removing extra rows

Please review with whitespace changes removed.  I had to shuffle indents in some of the tests as I changed the location where we start the pod monitor thread.