### PR TITLE
[rails6][git_repository_spec.rb] Use .local_miq_server

### DIFF
--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe GitRepository do
       end
 
       before do
-        allow(MiqServer).to receive(:my_zone).and_return("default")
+        EvmSpecHelper.local_miq_server
         allow(gwt).to receive(:branches).with(anything).and_return(branch_list)
         allow(gwt).to receive(:tags).with(no_args).and_return(tag_list)
         allow(gwt).to receive(:branch_info) do |name|


### PR DESCRIPTION
In Rails 6, it seems like a validation callback for nested relations is causing a `GitRepository.save!` to fail.  In this case, a MiqQueue call validation that checks that the `Zone` that is being provided via the `options` to queue the work on actually exists.

This seems to have not been respected properly in the past, so this fix just simply switches to using actually `MiqServer`/`Zone` records instead of trying to stub them out.

Works in both Rails 5.2 and Rails 6.0


Links
-----

* Rails 6 Epic:  https://github.com/ManageIQ/manageiq/issues/19977