### PR TITLE
replace cattr_accessor with class var

### DIFF
--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -2,7 +2,7 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   extend ActiveSupport::Concern
 
   included do
-    cattr_accessor :current_pods
+    class_attribute :current_pods
     self.current_pods = Concurrent::Hash.new
   end
 


### PR DESCRIPTION
since cattr_accessors are potentially problematic re: wandering class vars, I think this should also probably be a class attribute

because of the work done on https://github.com/ManageIQ/manageiq/pull/20274 this caught my eye because of Jason's https://github.com/ManageIQ/manageiq/pull/20664#discussion_r513793189. as a general rule we probably shouldn't be using cattr_accessor.

see https://github.com/ManageIQ/manageiq/pull/20785, in which the same change was made, for the same reason

@miq-bot assign @kbrock 
