### PR TITLE
change query counts to ranges to fix sporadic failures

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ExtManagementSystem do
 
   it "does access database when unchanged model is saved" do
     r = FactoryBot.create(:ems_vmware)
-    expect { r.valid? }.to make_database_queries(:count => 3)
+    expect { r.valid? }.to make_database_queries(:count => 1..3)
   end
 
   it ".ems_infra_discovery_types" do

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ServiceTemplateCatalog do
 
   it "doesn’t access database when unchanged model is saved" do
     f1 = described_class.create!(:name => 'f1')
-    expect { f1.valid? }.to make_database_queries(:count => 2)
+    expect { f1.valid? }.to make_database_queries(:count => 0..2)
   end
 
   describe "#name" do


### PR DESCRIPTION
The `valid?` query count we added a little bit ago needs to be updated on a couple models because occasionally these will fail with lower count numbers. 