### PR TITLE
Don't override model_class in Container collections

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -50,7 +50,6 @@ module ManageIQ::Providers
 
         def container_nodes
           add_properties(
-            :model_class    => ::ContainerNode,
             :secondary_refs => {:by_name => %i(name)},
             :delete_method  => :disconnect_inv
           )
@@ -105,7 +104,6 @@ module ManageIQ::Providers
 
         def container_groups
           add_properties(
-            :model_class            => ContainerGroup,
             :secondary_refs         => {:by_container_project_and_name => %i(container_project name)},
             :attributes_blacklist   => %i(namespace),
             :delete_method          => :disconnect_inv,
@@ -123,7 +121,6 @@ module ManageIQ::Providers
 
         def containers
           add_properties(
-            :model_class            => Container,
             # parser sets :ems_ref => "#{pod_id}_#{container.name}_#{container.image}"
             :delete_method          => :disconnect_inv,
             :custom_reconnect_block => custom_reconnect_block
@@ -186,7 +183,6 @@ module ManageIQ::Providers
 
         def container_templates
           add_properties(
-            :model_class          => ::ContainerTemplate,
             :attributes_blacklist => %i(namespace)
           )
           add_common_default_values


### PR DESCRIPTION
By setting the model_class in the base collections auto_model_class will never be invoked which forces the parser to always pass `:type` when building inventory objects.

This causes issues with providers which share parsers not allowing auto_model_class to properly pick up the child manager's subclass.
For example Kubernetes and Openshift share an inventory refresh parser, with :model_class set in the base the kubernetes parser has to explicitly set `:type => "ManageIQ::Providers::Kubernetes::ContainerManager::Container"` which means that openshift cannot inherit that parser without also getting `Kubernetes` type records.

This hasn't been a problem because STI hasn't allowed for Openshift to subclass K8s models anyway but https://github.com/ManageIQ/manageiq/pull/20756 is changing that.

Related PRs:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/411
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/198