### PR TITLE
revert the 118n fallbacks change

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,8 +59,8 @@ Vmdb::Application.configure do
   # config.threadsafe!
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = [I18n.default_locale]
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   # config.active_support.deprecation = :notify


### PR DESCRIPTION
This change can be reverted. I'd rather put it back to `true` for the sake of consistency. 

See https://github.com/ManageIQ/manageiq-schema/pull/535#issuecomment-726170179

