### PR TITLE
Ensure that options[:ems_id] is an Array when passed as an ENV var

### DIFF
--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -81,7 +81,7 @@ end
 # Skip heartbeating with single worker
 ENV["DISABLE_MIQ_WORKER_HEARTBEAT"] ||= options[:heartbeat] ? nil : '1'
 
-options[:ems_id] ||= ENV["EMS_ID"]
+options[:ems_id] ||= ENV["EMS_ID"].try(:split, ',')
 
 if options[:roles].present?
   MiqServer.my_server.server_role_names += options[:roles]


### PR DESCRIPTION
When passing the EMS_ID as an ENV var we need to ensure that it is an array to be consistent with how OptionParser is processing it

Longer term we should be able to drop EMS_ID as an array now that #20345 is passing the parent manager ems_id only for the queue_name.