### PR TITLE
Call ResetFailedUnit when cleaning up failed services

### DIFF
--- a/app/models/miq_server/worker_management/monitor/systemd.rb
+++ b/app/models/miq_server/worker_management/monitor/systemd.rb
@@ -29,6 +29,7 @@ module MiqServer::WorkerManagement::Monitor::Systemd
   def systemd_stop_services(service_names)
     service_names.each do |service_name|
       systemd_manager.StopUnit(service_name, "replace")
+      systemd_manager.ResetFailedUnit(service_name)
 
       service_settings_dir = systemd_unit_dir.join("#{service_name}.d")
       FileUtils.rm_r(service_settings_dir) if service_settings_dir.exist?

--- a/spec/models/miq_server/worker_management/monitor/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/systemd_spec.rb
@@ -20,11 +20,14 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Systemd do
     end
 
     context "with failed services" do
-      let(:units) { [{:name => "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "failed", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
+      let(:service_name) { "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
+      let(:units) { [{:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "failed", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
 
       it "calls DisableUnitFiles with the service name" do
-        expect(systemd_manager).to receive(:StopUnit).with("generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", "replace")
-        expect(systemd_manager).to receive(:DisableUnitFiles).with(["generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service"], false)
+        expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
+        expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name], false)
+
         server.cleanup_failed_systemd_services
       end
     end


### PR DESCRIPTION
If a systemd service has failed it stays around until you call `systemd reset-failed unit-name` otherwise it stays around as:
```
# systemctl status
● vmware_infra_manager_event_catcher@8f2f33a3-d1b1-4603-a8aa-44a7156347d9.service   loaded failed failed    vmware_infra_manager_event_catcher@8f2f33a3-d1b1-4603-a8aa-44a7156347d9.service

# systemctl status vmware_infra_manager_event_catcher@8f2f33a3-d1b1-4603-a8aa-44a7156347d9.service
Warning: The unit file, source configuration file or drop-ins of vmware_infra_manager_event_catcher@8f2f33a3-d1b1-4603-a8aa-44a7156347d9.service changed on disk. Run 'systemctl daemon-reload' to reload units.
● vmware_infra_manager_event_catcher@8f2f33a3-d1b1-4603-a8aa-44a7156347d9.service
   Loaded: loaded (/etc/systemd/system/vmware_infra_manager_event_catcher@.service; disabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/vmware_infra_manager_event_catcher@8f2f33a3-d1b1-4603-a8aa-44a7156347d9.service.d
           └─override.conf
   Active: inactive (dead) since Thu 2020-11-12 11:26:12 EST; 1h 25min ago
  Process: 178314 ExecStart=/bin/bash -lc exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::EventCatcher --heartbeat --guid=8f2f33a3-d1b1-4603-a8aa-44a7156347d9 (code=exi>
 Main PID: 178314 (code=exited, status=1/FAILURE)
 ```