### PR TITLE
replace cattr_accessor with class attribute

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -19,7 +19,7 @@ class MiqWorker < ApplicationRecord
   scope :with_miq_server_id, ->(server_id) { where(:miq_server_id => server_id) }
   scope :with_status,        ->(status)    { where(:status => status) }
 
-  cattr_accessor :my_guid, :instance_accessor => false
+  class_attribute :my_guid
 
   STATUS_CREATING = 'creating'.freeze
   STATUS_STARTING = 'starting'.freeze


### PR DESCRIPTION
i'd rather this were a class attribute

same change as was made in https://github.com/ManageIQ/manageiq/pull/20795, with probably the same level of concern — see https://github.com/ManageIQ/manageiq/pull/20795#issuecomment-726356151. this change is unlikely to matter but in principle if we don't need to use this I still think we shouldn't.

[in case anyone's curious about [the pr that started this purge](https://github.com/ManageIQ/manageiq/pull/20664#discussion_r511484783), i did threaten to remove all the remaining ones and got no pushback there, just as an observation]