### PR TITLE
Add tests for newlines in gettext catalogs

### DIFF
--- a/locale/es/manageiq.po
+++ b/locale/es/manageiq.po
@@ -55676,7 +55676,7 @@ msgstr "La acción Copiar no se aplica a la función seleccionada Automatizar es
 #: ../app/views/layouts/angular/_ansible_form_options_angular.html.haml:16
 #: ../app/views/layouts/angular/_ansible_form_options_angular.html.haml:17
 msgid "Copy from Provisioning"
-msgstr "Copiar desde Aprovisionamiento\\n"
+msgstr "Copiar desde Aprovisionamiento"
 
 #: ../app/views/catalog/_confirmation_modal.html.haml:35
 msgid "Copy from provisioning"

--- a/locale/es/manageiq.po
+++ b/locale/es/manageiq.po
@@ -10297,7 +10297,7 @@ msgstr "La creación de la copia de seguridad %{backup_name} del volumen %{subje
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3749
 msgid "Creating Backup %{backup_name} of Volume %{subject} failed: %{error_message}"
-msgstr "Error al crear la copia de seguridad %{backup_name} del volumen %{subject}:\n%{error_message}"
+msgstr "Error al crear la copia de seguridad %{backup_name} del volumen %{subject}: %{error_message}"
 
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3759
@@ -46818,7 +46818,7 @@ msgstr "Detectar"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:50
 msgid "Enables defining a URL path prefix for XCCDF file instead of accessing the default location.\n  example: http://my_file_server.org:3333/xccdf_files/\n  Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there."
-msgstr "Permite definir un prefijo de vía de acceso de URL para el archivo XCCDF, en lugar de acceder a la ubicación predeterminada.\n  Ejemplo: http://my_file_server.org:3333/xccdf_files/ Se espera encontrar el archivo com.redhat.rhsa-RHEL7.ds.xml.bz2 en esta ubicación."
+msgstr "Permite definir un prefijo de vía de acceso de URL para el archivo XCCDF, en lugar de acceder a la ubicación predeterminada.\n  Ejemplo: http://my_file_server.org:3333/xccdf_files/\n Se espera encontrar el archivo com.redhat.rhsa-RHEL7.ds.xml.bz2 en esta ubicación."
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:678
 msgid "Enables defining a URL path prefix for XCCDF file instead of accessing the default location.\nexample: http://my_file_server.org:3333/xccdf_files/\nExpecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there."
@@ -47739,7 +47739,7 @@ msgstr "Esta funcionalidad no se admite en la versión API del proveedor"
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb:51
 msgid "VMs must be scanned from an EVM server whose host is attached to the same\n  storage as the VM unless overridden via SmartProxy affinity.\n  Please verify that:\n  1) Direct LUNs are attached to ManageIQ appliance\n  2) Management Relationship is set for the ManageIQ appliance"
-msgstr "Se deben analizar las MV desde un servidor EVM cuyo host esté conectado al mismo almacenamiento que la MV, a menos que se anule mediante afinidad con SmartProxy.\n  Compruebe que:\n  1) Los LUN directos estén conectados a un dispositivo ManageIQ\n  2) La relación de gestión esté configurada para el dispositivo ManageIQ"
+msgstr "Se deben analizar las MV desde un servidor EVM cuyo host esté conectado al mismo\n almacenamiento que la MV, a menos que se anule mediante afinidad con SmartProxy.\n  Compruebe que:\n  1) Los LUN directos estén conectados a un dispositivo ManageIQ\n  2) La relación de gestión esté configurada para el dispositivo ManageIQ"
 
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation.rb:11

--- a/locale/it/manageiq.po
+++ b/locale/it/manageiq.po
@@ -47739,7 +47739,7 @@ msgstr "Questa funzione non è supportata dalla versione api del provider"
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb:51
 msgid "VMs must be scanned from an EVM server whose host is attached to the same\n  storage as the VM unless overridden via SmartProxy affinity.\n  Please verify that:\n  1) Direct LUNs are attached to ManageIQ appliance\n  2) Management Relationship is set for the ManageIQ appliance"
-msgstr "Le VM devono essere scansate da un server EVM il cui host è collegato alla stessa memoria della VM a meno che non sovrascrivi tramite affinità SmartProxy.\n  Si prega di verificare che: 1) I LUN diretti siano collegati al dispositivo ManageIQ 2) La Relazione di gestione sia impostata per il dispositivo ManageIQ"
+msgstr "Le VM devono essere scansate da un server EVM il cui host è collegato alla stessa\n  memoria della VM a meno che non sovrascrivi tramite affinità SmartProxy.\n  Si prega di verificare che:\n  1) I LUN diretti siano collegati al dispositivo ManageIQ\n  2) La Relazione di gestione sia impostata per il dispositivo ManageIQ"
 
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation.rb:11

--- a/locale/ja/manageiq.po
+++ b/locale/ja/manageiq.po
@@ -56867,7 +56867,7 @@ msgstr "必要なアクセス・モード"
 
 #: ../app/helpers/security_policy_rule_helper/textual_summary.rb:53
 msgid "Destination"
-msgstr "宛先\n"
+msgstr "宛先"
 
 #: ../app/helpers/network_router_helper/textual_summary.rb:55
 msgid "Destination CIDR"
@@ -66049,7 +66049,7 @@ msgstr "プロファイル・ポリシー:"
 #: ../app/presenters/menu/default_menu.rb:38
 #: ../app/controllers/configuration_profile_controller.rb:59
 msgid "Profiles"
-msgstr "プロファイル\n"
+msgstr "プロファイル"
 
 #: ../app/views/ops/_rbac_group_details.html.haml:96
 msgid "Project/Tenant"
@@ -68893,7 +68893,7 @@ msgstr "Ruby スクリプトは式でサポートされなくなりました。�
 #: ../app/helpers/security_policy_helper/textual_summary.rb:37
 #: ../config/yaml_strings.rb:1539
 msgid "Rules"
-msgstr "規則\n"
+msgstr "規則"
 
 #: ../app/views/ops/_schedule_form_timer.html.haml:7
 #: ../app/views/report/_schedule_form_timer.html.haml:8
@@ -77653,7 +77653,7 @@ msgstr "ターゲット・プロバイダー内で少なくとも 1 つの変換
 #:
 #: ../app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js:155
 msgid "You've selected a premigration or postmigration playbook service but no VMs on which to run the playbook service. Are you sure you want to continue?"
-msgstr "移行前または移行後の Playbook サービスを選択しましたが、Playbook サービスを実行する VM は選択していません。続行しますか?\n"
+msgstr "移行前または移行後の Playbook サービスを選択しましたが、Playbook サービスを実行する VM は選択していません。続行しますか?"
 
 #:
 #: ../app/javascript/react/screens/App/Overview/components/Migrations/MigrationInProgressListItem.js:182

--- a/locale/pt_BR/manageiq.po
+++ b/locale/pt_BR/manageiq.po
@@ -266,7 +266,7 @@ msgstr "O %{signal} não é permitido no estado %{state}"
 
 #: ../app/models/miq_provision_configured_system_request.rb:51
 msgid "%{table} install on [%{name}]"
-msgstr "Instalação do %{table} no\n[%{name}]"
+msgstr "Instalação do %{table} no [%{name}]"
 
 #: ../app/models/miq_request.rb:422 ../app/models/miq_request_task.rb:132
 msgid "%{task} request has already been processed"
@@ -353,7 +353,7 @@ msgstr "Um Servidor %{server} <%{name}> com o ID: <%{id}> não está associado a
 
 #: ../app/models/classification.rb:583
 msgid "A Tag Mapping exists for this category and must be removed before deleting"
-msgstr "Uma Tag Mapping existe para esta categoria e deve\nser removida antes da exclusão"
+msgstr "Uma Tag Mapping existe para esta categoria e deve ser removida antes da exclusão"
 
 #: ../app/models/manageiq/providers/cloud_manager/provision/cloning.rb:13
 msgid "A VM with name: [%{name}] already exists"
@@ -1652,7 +1652,7 @@ msgstr "Ativo - Tempo de atividade (segundos)"
 #: ../config/model_display_names.rb:3
 msgid "Asset Detail"
 msgid_plural "Asset Details"
-msgstr[0] "Detalhe do\nativo"
+msgstr[0] "Detalhe do ativo"
 msgstr[1] "Detalhes do ativo"
 
 #. TRANSLATORS: en.yml key: dictionary.column.resource_name
@@ -1757,7 +1757,7 @@ msgstr "Perfis Designados"
 #: ../config/model_display_names.rb:4
 msgid "Assigned Server Role"
 msgid_plural "Assigned Server Roles"
-msgstr[0] "Função de servidor\ndesignada"
+msgstr[0] "Função de servidor designada"
 msgstr[1] "Funções de servidor designadas"
 
 #: ../config/model_attributes.rb:52
@@ -1868,7 +1868,7 @@ msgstr "A anexação do volume %{subject} à Instância %{instance_name} falhou:
 #: ../config/model_display_names.rb:5
 msgid "Audit Event"
 msgid_plural "Audit Events"
-msgstr[0] "Evento de\nauditoria"
+msgstr[0] "Evento de auditoria"
 msgstr[1] "Eventos de auditoria"
 
 #: ../config/model_attributes.rb:58
@@ -1932,14 +1932,14 @@ msgstr "Autenticação"
 #: ../config/model_display_names.rb:7
 msgid "Authentication Configuration Script Base"
 msgid_plural "Authentication Configuration Script Bases"
-msgstr[0] "Base de script\nde configuração de\nautenticação"
-msgstr[1] "Bases de script de\nconfiguração de autenticação"
+msgstr[0] "Base de script de configuração de autenticação"
+msgstr[1] "Bases de script de configuração de autenticação"
 
 #: ../config/model_display_names.rb:8
 msgid "Authentication Orchestration Stack"
 msgid_plural "Authentication Orchestration Stacks"
-msgstr[0] "Pilha de\norquestração de\nautenticação"
-msgstr[1] "Pilhas de\norquestração de autenticação"
+msgstr[0] "Pilha de orquestração de autenticação"
+msgstr[1] "Pilhas de orquestração de autenticação"
 
 #: ../app/models/auth_token.rb:8
 msgid "Authentication Token"
@@ -2292,8 +2292,8 @@ msgstr "Simulação automatizada"
 #: ../config/model_display_names.rb:9
 msgid "Automate Workspace"
 msgid_plural "Automate Workspaces"
-msgstr[0] "Automatizar área de\ntrabalho"
-msgstr[1] "Automatizar áreas\nde trabalho"
+msgstr[0] "Automatizar área de trabalho"
+msgstr[1] "Automatizar áreas de trabalho"
 
 #: ../config/model_attributes.rb:135
 msgid "Automate workspace"
@@ -2822,13 +2822,13 @@ msgstr "Capturas instantâneas de base"
 #: ../config/model_display_names.rb:11
 msgid "Binary Blob"
 msgid_plural "Binary Blobs"
-msgstr[0] "Blob\nbinário"
+msgstr[0] "Blob binário"
 msgstr[1] "Blobs binários"
 
 #: ../config/model_display_names.rb:12
 msgid "Binary Blob Part"
 msgid_plural "Binary Blob Parts"
-msgstr[0] "Parte do blob\nbinário"
+msgstr[0] "Parte do blob binário"
 msgstr[1] "Partes do blob binário"
 
 #: ../config/model_attributes.rb:174
@@ -2898,8 +2898,8 @@ msgstr "Falha na ligação para o usuário %{user_name}"
 #: ../config/model_display_names.rb:13
 msgid "Blacklisted Event"
 msgid_plural "Blacklisted Events"
-msgstr[0] "Evento da lista de\nbloqueio"
-msgstr[1] "Eventos da lista de\nbloqueio"
+msgstr[0] "Evento da lista de bloqueio"
+msgstr[1] "Eventos da lista de bloqueio"
 
 #: ../config/model_attributes.rb:189
 msgid "Blacklisted event"
@@ -2999,7 +2999,7 @@ msgstr "Horário de inicialização"
 #: ../config/model_display_names.rb:14
 msgid "Bottleneck Event"
 msgid_plural "Bottleneck Events"
-msgstr[0] "Evento de\ngargalo"
+msgstr[0] "Evento de gargalo"
 msgstr[1] "Eventos de gargalo"
 
 #: ../config/model_attributes.rb:197
@@ -3850,7 +3850,7 @@ msgstr "Não é possível excluir o %{log_message} usado atualmente"
 
 #: ../app/models/service_template_transformation_plan.rb:129
 msgid "Cannot delete cutover date for non-warm migration"
-msgstr "Não é possível excluir a data de corte da\nmigração não warm"
+msgstr "Não é possível excluir a data de corte da migração não warm"
 
 #: ../app/models/miq_server.rb:345
 msgid "Cannot delete recently active %{log_message}"
@@ -3862,11 +3862,11 @@ msgstr "Não é possível analisar o ID do usuário %{user_id}"
 
 #: ../app/models/service_template_transformation_plan.rb:120
 msgid "Cannot set cutover date in the past"
-msgstr "Não é possível configurar a data de corte no\npassado"
+msgstr "Não é possível configurar a data de corte no passado"
 
 #: ../app/models/service_template_transformation_plan.rb:113
 msgid "Cannot update cutover date for non-warm migration"
-msgstr "Não é possível atualizar a data de corte da\nmigração não warm"
+msgstr "Não é possível atualizar a data de corte da migração não warm"
 
 #. TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
 #: ../config/dictionary_strings.rb:318
@@ -4178,7 +4178,7 @@ msgstr "Mudar senha de provedores de infraestrutura"
 #: ../config/model_display_names.rb:17
 msgid "Chargeable Field"
 msgid_plural "Chargeable Fields"
-msgstr[0] "Campo\ndebitável"
+msgstr[0] "Campo debitável"
 msgstr[1] "Campos debitáveis"
 
 #: ../config/model_attributes.rb:229
@@ -4244,26 +4244,26 @@ msgstr "Visualização de estorno da VM única"
 #: ../config/model_display_names.rb:18 ../config/dictionary_strings.rb:1286
 msgid "Chargeback Rate"
 msgid_plural "Chargeback Rates"
-msgstr[0] "Taxa\nde estorno"
+msgstr[0] "Taxa de estorno"
 msgstr[1] "Taxas de estorno"
 
 #: ../config/model_display_names.rb:19
 msgid "Chargeback Rate Detail"
 msgid_plural "Chargeback Rate Details"
-msgstr[0] "Detalhe da taxa de\nestorno"
-msgstr[1] "Detalhes da taxa de\nestorno"
+msgstr[0] "Detalhe da taxa de estorno"
+msgstr[1] "Detalhes da taxa de estorno"
 
 #: ../config/model_display_names.rb:20
 msgid "Chargeback Rate Detail Currency"
 msgid_plural "Chargeback Rate Detail Currencies"
-msgstr[0] "Moeda de detalhe da taxa de\nestorno"
-msgstr[1] "Moedas de detalhe da taxa de\nestorno"
+msgstr[0] "Moeda de detalhe da taxa de estorno"
+msgstr[1] "Moedas de detalhe da taxa de estorno"
 
 #: ../config/model_display_names.rb:21
 msgid "Chargeback Rate Detail Measure"
 msgid_plural "Chargeback Rate Detail Measures"
-msgstr[0] "Medida de detalhe da taxa\nde estorno"
-msgstr[1] "Medidas de detalhe da taxa de\nestorno"
+msgstr[0] "Medida de detalhe da taxa de estorno"
+msgstr[1] "Medidas de detalhe da taxa de estorno"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3396
@@ -4284,7 +4284,7 @@ msgstr "Taxas de estorno"
 #: ../config/model_display_names.rb:22
 msgid "Chargeback Tier"
 msgid_plural "Chargeback Tiers"
-msgstr[0] "Camada de\nestorno"
+msgstr[0] "Camada de estorno"
 msgstr[1] "Camadas de estorno"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ChargebackContainerImage
@@ -4566,7 +4566,7 @@ msgstr "Verificar conformidade da última configuração conhecida"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:739
 msgid "Check Compliance of Last Known Configuration for Hosts"
-msgstr "Verificar conformidade da última configuração\nconhecida dos hosts"
+msgstr "Verificar conformidade da última configuração conhecida dos hosts"
 
 #: ../app/models/storage.rb:357
 msgid "Check that an EMS has valid credentials for Datastore [%{name}] with id: [%{id}]"
@@ -4576,13 +4576,13 @@ msgstr "Verifique se um EMS tem credenciais válidas para o Armazenamento de dad
 #: ../app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb:90
 msgid "Cinder Block Storage Manager (OpenStack)"
 msgid_plural "Cinder Block Storage Managers (OpenStack)"
-msgstr[0] "Gerenciador de\narmazenamento de bloco do\nCinder (OpenStack)"
-msgstr[1] "Gerenciadores de\narmazenamento de bloco do Cinder (OpenStack)"
+msgstr[0] "Gerenciador de armazenamento de bloco do Cinder (OpenStack)"
+msgstr[1] "Gerenciadores de armazenamento de bloco do Cinder (OpenStack)"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::StorageManager::CinderManager (plural form)
 #: ../config/dictionary_strings.rb:1970
 msgid "Cinder Block Storage Managers (OpenStack)"
-msgstr "Gerenciadores de armazenamento de bloco do Cinder\n(OpenStack)"
+msgstr "Gerenciadores de armazenamento de bloco do Cinder (OpenStack)"
 
 #: ../app/models/classification.rb:223 ../app/models/classification.rb:292
 msgid "Class '%{name}' is not eligible for classification"
@@ -4710,14 +4710,14 @@ msgstr "Clonar máquinas virtuais"
 #: ../config/model_display_names.rb:23
 msgid "Cloud Database"
 msgid_plural "Cloud Databases"
-msgstr[0] "Banco de dados de\nnuvem"
+msgstr[0] "Banco de dados de nuvem"
 msgstr[1] "Bancos de dados de nuvem"
 
 #: ../config/model_display_names.rb:24
 msgid "Cloud Database Flavor"
 msgid_plural "Cloud Database Flavors"
-msgstr[0] "Tipo de banco de dados de\nnuvem"
-msgstr[1] "Tipos de bancos de dados de\nnuvem"
+msgstr[0] "Tipo de banco de dados de nuvem"
+msgstr[1] "Tipos de bancos de dados de nuvem"
 
 #. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_cloud_manager
 #. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_network_manager
@@ -4743,7 +4743,7 @@ msgstr "Rede na nuvem"
 #: ../app/models/manageiq/providers/amazon/network_manager/cloud_network.rb:3
 msgid "Cloud Network (Amazon)"
 msgid_plural "Cloud Networks (Amazon)"
-msgstr[0] "Rede em nuvem\n(Amazon)"
+msgstr[0] "Rede em nuvem (Amazon)"
 msgstr[1] "Redes em nuvem (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager/cloud_network.rb:3
@@ -4763,8 +4763,8 @@ msgstr[1] "Redes em nuvem (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/network_manager/cloud_network.rb:192
 msgid "Cloud Network (OpenStack)"
 msgid_plural "Cloud Networks (OpenStack)"
-msgstr[0] "Rede em nuvem\n(OpenStack)"
-msgstr[1] "Redes em nuvem\n(OpenStack)"
+msgstr[0] "Rede em nuvem (OpenStack)"
+msgstr[1] "Redes em nuvem (OpenStack)"
 
 #. TRANSLATORS: file: product/views/CloudNetwork.yaml
 #. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
@@ -4818,8 +4818,8 @@ msgstr "Contêineres de armazenamento de objeto de nuvem"
 #: ../config/model_display_names.rb:27 ../config/dictionary_strings.rb:2396
 msgid "Cloud Object Store Object"
 msgid_plural "Cloud Object Store Objects"
-msgstr[0] "Objeto de\narmazenamento de objeto de nuvem"
-msgstr[1] "Objetos de\narmazenamento de objeto de nuvem"
+msgstr[0] "Objeto de armazenamento de objeto de nuvem"
+msgstr[1] "Objetos de armazenamento de objeto de nuvem"
 
 #: ../app/controllers/cloud_object_store_object_controller.rb:14
 #: ../app/helpers/cloud_object_store_container_helper/textual_summary.rb:42
@@ -4843,8 +4843,8 @@ msgstr "Provedor de Nuvem"
 #: ../app/models/manageiq/providers/amazon/cloud_manager.rb:286
 msgid "Cloud Provider (Amazon)"
 msgid_plural "Cloud Providers (Amazon)"
-msgstr[0] "Provedor em nuvem\n(Amazon)"
-msgstr[1] "Provedores em nuvem\n(Amazon)"
+msgstr[0] "Provedor em nuvem (Amazon)"
+msgstr[1] "Provedores em nuvem (Amazon)"
 
 #: ../app/models/manageiq/providers/azure/cloud_manager.rb:191
 msgid "Cloud Provider (Microsoft Azure)"
@@ -4855,14 +4855,14 @@ msgstr[1] "Provedores em nuvem (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/cloud_manager.rb:719
 msgid "Cloud Provider (OpenStack)"
 msgid_plural "Cloud Providers (OpenStack)"
-msgstr[0] "Provedor em nuvem\n(OpenStack)"
-msgstr[1] "Provedores em nuvem\n(OpenStack)"
+msgstr[0] "Provedor em nuvem (OpenStack)"
+msgstr[1] "Provedores em nuvem (OpenStack)"
 
 #: ../app/models/manageiq/providers/vmware/cloud_manager.rb:307
 msgid "Cloud Provider (VMware vCloud)"
 msgid_plural "Cloud Providers (VMware vCloud)"
-msgstr[0] "Provedor em nuvem (VMware\nvCloud)"
-msgstr[1] "Provedores em nuvem (VMware\nvCloud)"
+msgstr[0] "Provedor em nuvem (VMware vCloud)"
+msgstr[1] "Provedores em nuvem (VMware Cloud)"
 
 #. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
 #: ../app/controllers/ems_cloud_controller.rb:32 ../config/yaml_strings.rb:1566
@@ -4893,13 +4893,13 @@ msgstr "Provedores de nuvem (VMware vCloud)"
 #: ../config/model_display_names.rb:28 ../config/dictionary_strings.rb:1302
 msgid "Cloud Resource Quota"
 msgid_plural "Cloud Resource Quotas"
-msgstr[0] "Cota do recurso em\nnuvem"
+msgstr[0] "Cota do recurso em nuvem"
 msgstr[1] "Cotas do recurso em nuvem"
 
 #: ../config/model_display_names.rb:29
 msgid "Cloud Service"
 msgid_plural "Cloud Services"
-msgstr[0] "Serviço de\nnuvem"
+msgstr[0] "Serviço de nuvem"
 msgstr[1] "Serviços de nuvem"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -4915,8 +4915,8 @@ msgstr "Sub-rede na nuvem"
 #: ../app/models/manageiq/providers/amazon/network_manager/cloud_subnet.rb:3
 msgid "Cloud Subnet (Amazon)"
 msgid_plural "Cloud Subnets (Amazon)"
-msgstr[0] "Sub-rede em nuvem\n(Amazon)"
-msgstr[1] "Sub-redes em nuvem\n(Amazon)"
+msgstr[0] "Sub-rede em nuvem (Amazon)"
+msgstr[1] "Sub-redes em nuvem (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager/cloud_subnet.rb:3
 msgid "Cloud Subnet (Google)"
@@ -4934,13 +4934,13 @@ msgstr[1] "Sub-redes em nuvem (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb:105
 msgid "Cloud Subnet (OpenStack)"
 msgid_plural "Cloud Subnets (OpenStack)"
-msgstr[0] "Sub-rede em nuvem\n(OpenStack)"
-msgstr[1] "Sub-redes em nuvem\n(OpenStack)"
+msgstr[0] "Sub-rede em nuvem (OpenStack)"
+msgstr[1] "Sub-redes em nuvem (OpenStack)"
 
 #: ../config/model_display_names.rb:31
 msgid "Cloud Subnet Network Port"
 msgid_plural "Cloud Subnet Network Ports"
-msgstr[0] "Porta de rede de sub-rede\nem nuvem"
+msgstr[0] "Porta de rede de sub-rede em nuvem"
 msgstr[1] "Portas de rede de sub-rede em nuvem"
 
 #: ../app/helpers/ems_network_helper/textual_summary.rb:100
@@ -4999,13 +4999,13 @@ msgstr "Locatário de nuvem"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb:52
 msgid "Cloud Tenant (OpenStack)"
 msgid_plural "Cloud Tenants (OpenStack)"
-msgstr[0] "Locatário em nuvem\n(OpenStack)"
-msgstr[1] "Locatários em nuvem\n(OpenStack)"
+msgstr[0] "Locatário em nuvem (OpenStack)"
+msgstr[1] "Locatários em nuvem (OpenStack)"
 
 #: ../config/model_display_names.rb:33
 msgid "Cloud Tenant Flavor"
 msgid_plural "Cloud Tenant Flavors"
-msgstr[0] "Tipo de locatário em\nnuvem"
+msgstr[0] "Tipo de locatário em nuvem"
 msgstr[1] "Tipos de locatário em nuvem"
 
 #: ../app/helpers/ems_network_helper/textual_summary.rb:113
@@ -5254,7 +5254,7 @@ msgstr "CloudDatabase|Armazenamento usado"
 #: ../app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb:66
 msgid "CloudFormation Template"
 msgid_plural "CloudFormation Templates"
-msgstr[0] "Modelo\nCloudFormation"
+msgstr[0] "Modelo CloudFormation"
 msgstr[1] "Modelos CloudFormation"
 
 #: ../app/presenters/tree_builder_orchestration_templates.rb:19
@@ -6031,8 +6031,8 @@ msgstr "Conformidade"
 #: ../config/model_display_names.rb:38
 msgid "Compliance Detail"
 msgid_plural "Compliance Details"
-msgstr[0] "Detalhe de\nconformidade"
-msgstr[1] "Detalhes de\nconformidade"
+msgstr[0] "Detalhe de conformidade"
+msgstr[1] "Detalhes de conformidade"
 
 #. TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
 #. TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
@@ -6135,8 +6135,8 @@ msgstr "Conformidade|Atualizado em"
 #: ../config/model_display_names.rb:39
 msgid "Computer System"
 msgid_plural "Computer Systems"
-msgstr[0] "Sistema de\ncomputador"
-msgstr[1] "Sistemas de\ncomputador"
+msgstr[0] "Sistema de computador"
+msgstr[1] "Sistemas de computador"
 
 #: ../config/model_attributes.rb:497
 msgid "Computer system"
@@ -6169,7 +6169,7 @@ msgstr "Condição"
 #: ../config/model_display_names.rb:41
 msgid "Condition Set"
 msgid_plural "Condition Sets"
-msgstr[0] "Conjunto de\ncondições"
+msgstr[0] "Conjunto de condições"
 msgstr[1] "Conjuntos de condições"
 
 #: ../config/model_attributes.rb:518
@@ -6498,26 +6498,26 @@ msgstr "Configuração"
 #: ../config/model_display_names.rb:42
 msgid "Configuration Architecture"
 msgid_plural "Configuration Architectures"
-msgstr[0] "Arquitetura de\nconfiguração"
+msgstr[0] "Arquitetura de configuração"
 msgstr[1] "Arquiteturas de configuração"
 
 #: ../config/model_display_names.rb:43
 msgid "Configuration Compute Profile"
 msgid_plural "Configuration Compute Profiles"
-msgstr[0] "Perfil de computação de\nconfiguração"
+msgstr[0] "Perfil de computação de configuração"
 msgstr[1] "Perfis de computação de configuração"
 
 #: ../config/model_display_names.rb:44
 msgid "Configuration Domain"
 msgid_plural "Configuration Domains"
-msgstr[0] "Domínio de\nconfiguração"
-msgstr[1] "Domínios de\nconfiguração"
+msgstr[0] "Domínio de configuração"
+msgstr[1] "Domínios de configuração"
 
 #: ../config/model_display_names.rb:45
 msgid "Configuration Environment"
 msgid_plural "Configuration Environments"
-msgstr[0] "Ambiente de\nconfiguração"
-msgstr[1] "Ambientes de\nconfiguração"
+msgstr[0] "Ambiente de configuração"
+msgstr[1] "Ambientes de configuração"
 
 #: ../app/helpers/application_helper/title.rb:35
 msgid "Configuration Jobs"
@@ -6589,31 +6589,31 @@ msgstr "Perfis de configuração (Foreman)"
 #: ../config/model_display_names.rb:49
 msgid "Configuration Realm"
 msgid_plural "Configuration Realms"
-msgstr[0] "Domínio de\nconfiguração"
+msgstr[0] "Domínio de configuração"
 msgstr[1] "Domínios de configuração"
 
 #: ../config/model_display_names.rb:50
 msgid "Configuration Script"
 msgid_plural "Configuration Scripts"
-msgstr[0] "Script de\nconfiguração"
-msgstr[1] "Scripts de\nconfiguração"
+msgstr[0] "Script de configuração"
+msgstr[1] "Scripts de configuração"
 
 #: ../config/model_display_names.rb:51
 msgid "Configuration Script Base"
 msgid_plural "Configuration Script Bases"
-msgstr[0] "Base de script de\nconfiguração"
-msgstr[1] "Bases de\nscript de configuração"
+msgstr[0] "Base de script de configuração"
+msgstr[1] "Bases de script de configuração"
 
 #: ../config/model_display_names.rb:52
 msgid "Configuration Script Payload"
 msgid_plural "Configuration Script Payloads"
-msgstr[0] "Carga útil de script de\nconfiguração"
-msgstr[1] "Cargas úteis de script de\nconfiguração"
+msgstr[0] "Carga útil de script de configuração"
+msgstr[1] "Cargas úteis de script de configuração"
 
 #: ../config/model_display_names.rb:53
 msgid "Configuration Tag"
 msgid_plural "Configuration Tags"
-msgstr[0] "Tag de\nconfiguração"
+msgstr[0] "Tag de configuração"
 msgstr[1] "Tags de configuração"
 
 #. TRANSLATORS: en.yml key: dictionary.column.config_xml
@@ -6893,7 +6893,7 @@ msgstr "ConfigurationTag|Número da região"
 #: ../config/model_display_names.rb:54 ../config/dictionary_strings.rb:2436
 msgid "Configured System"
 msgid_plural "Configured Systems"
-msgstr[0] "Sistema\nde configurados"
+msgstr[0] "Sistema de configurados"
 msgstr[1] "Sistemas configurados"
 
 #:
@@ -7085,14 +7085,14 @@ msgstr[1] "Contêiner"
 #: ../config/model_display_names.rb:56 ../config/dictionary_strings.rb:1336
 msgid "Container Build"
 msgid_plural "Container Builds"
-msgstr[0] "Compilação do\ncontêiner"
+msgstr[0] "Compilação do contêiner"
 msgstr[1] "Compilações do contêiner"
 
 #: ../config/model_display_names.rb:57
 msgid "Container Build Pod"
 msgid_plural "Container Build Pods"
-msgstr[0] "Pod de compilação do\ncontêiner"
-msgstr[1] "Pods de compilação do\ncontêiner"
+msgstr[0] "Pod de compilação do contêiner"
+msgstr[1] "Pods de compilação do contêiner"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2300
@@ -7109,7 +7109,7 @@ msgstr "Compilações de contêiner"
 #: ../config/model_display_names.rb:58
 msgid "Container Condition"
 msgid_plural "Container Conditions"
-msgstr[0] "Condição\ndo contêiner"
+msgstr[0] "Condição do contêiner"
 msgstr[1] "Condições do contêiner"
 
 #: ../app/models/container_env_var.rb:4
@@ -7121,15 +7121,15 @@ msgstr[1] "Variável de ambiente do contêiner"
 #: ../config/model_display_names.rb:59
 msgid "Container Groups Container Services"
 msgid_plural "Container Groups Container Services"
-msgstr[0] "Serviços de\ncontêiner dos grupos de contêineres"
-msgstr[1] "Serviços de\ncontêiner dos grupos de contêineres"
+msgstr[0] "Serviços de contêiner dos grupos de contêineres"
+msgstr[1] "Serviços de contêiner dos grupos de contêineres"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
 #: ../config/model_display_names.rb:60 ../config/dictionary_strings.rb:1378
 msgid "Container Image"
 msgid_plural "Container Images"
-msgstr[0] "Imagem de\ncontêiner"
-msgstr[1] "Imagens de\ncontêiner"
+msgstr[0] "Imagem de contêiner"
+msgstr[1] "Imagens de contêiner"
 
 #. TRANSLATORS: file: product/reports/170_Configuration Management - Containers/130_Images by Failed OpenSCAP Rule Results.yaml
 #: ../config/yaml_strings.rb:5182
@@ -7145,8 +7145,8 @@ msgstr "Registros da imagem do contêiner"
 #: ../config/model_display_names.rb:61 ../config/dictionary_strings.rb:1374
 msgid "Container Image Registry"
 msgid_plural "Container Image Registries"
-msgstr[0] "Registro de imagem de\ncontêiner"
-msgstr[1] "Registros de imagens de\ncontêiner"
+msgstr[0] "Registro de imagem de contêiner"
+msgstr[1] "Registros de imagens de contêiner"
 
 #. TRANSLATORS: file: product/views/ContainerImage.yaml
 #: ../app/presenters/menu/default_menu.rb:135 ../config/yaml_strings.rb:801
@@ -7156,14 +7156,14 @@ msgstr "Imagens do contêiner"
 #: ../config/model_display_names.rb:62
 msgid "Container Limit"
 msgid_plural "Container Limits"
-msgstr[0] "Limite de\ncontêiner"
+msgstr[0] "Limite de contêiner"
 msgstr[1] "Limites de contêiner"
 
 #: ../config/model_display_names.rb:63
 msgid "Container Limit Item"
 msgid_plural "Container Limit Items"
-msgstr[0] "Item de limite de\ncontêiner"
-msgstr[1] "Itens de limite de\ncontêiner"
+msgstr[0] "Item de limite de contêiner"
+msgstr[1] "Itens de limite de contêiner"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
 #. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
@@ -7172,8 +7172,8 @@ msgstr[1] "Itens de limite de\ncontêiner"
 #: ../config/yaml_strings.rb:6277
 msgid "Container Node"
 msgid_plural "Container Nodes"
-msgstr[0] "Nó do\ncontêiner"
-msgstr[1] "Nós do\ncontêiner"
+msgstr[0] "Nó do contêiner"
+msgstr[1] "Nós do contêiner"
 
 #: ../app/models/container_node_performance.rb:7
 #: ../config/model_display_names.rb:65
@@ -7205,8 +7205,8 @@ msgstr "Pods do contêiner"
 #: ../config/model_display_names.rb:66
 msgid "Container Port Config"
 msgid_plural "Container Port Configs"
-msgstr[0] "Configuração da porta do\ncontêiner"
-msgstr[1] "Configurações da porta do\ncontêiner"
+msgstr[0] "Configuração da porta do contêiner"
+msgstr[1] "Configurações da porta do contêiner"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
 #. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
@@ -7215,7 +7215,7 @@ msgstr[1] "Configurações da porta do\ncontêiner"
 #: ../config/yaml_strings.rb:6283
 msgid "Container Project"
 msgid_plural "Container Projects"
-msgstr[0] "Projeto do\ncontêiner"
+msgstr[0] "Projeto do contêiner"
 msgstr[1] "Projetos do contêiner"
 
 #. TRANSLATORS: file: product/views/ContainerProject.yaml
@@ -7226,14 +7226,14 @@ msgstr "Projetos do contêiner"
 #: ../app/models/manageiq/providers/kubernetes/container_manager.rb:59
 msgid "Container Provider (Kubernetes)"
 msgid_plural "Container Providers (Kubernetes)"
-msgstr[0] "Provedor de contêineres\n(Kubernetes)"
+msgstr[0] "Provedor de contêineres (Kubernetes)"
 msgstr[1] "Provedores de contêineres (Kubernetes)"
 
 #: ../app/models/manageiq/providers/openshift/container_manager.rb:58
 msgid "Container Provider (OpenShift)"
 msgid_plural "Container Providers (OpenShift)"
-msgstr[0] "Provedor de contêineres\n(OpenShift)"
-msgstr[1] "Provedores de contêineres\n(OpenShift)"
+msgstr[0] "Provedor de contêineres (OpenShift)"
+msgstr[1] "Provedores de contêineres (OpenShift)"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:1860
@@ -7254,20 +7254,20 @@ msgstr "Provedores de contêineres (OpenShift)"
 #: ../config/model_display_names.rb:68 ../config/dictionary_strings.rb:1340
 msgid "Container Quota"
 msgid_plural "Container Quotas"
-msgstr[0] "Cota\ndo contêiner"
+msgstr[0] "Cota do contêiner"
 msgstr[1] "Cotas do contêiner"
 
 #: ../config/model_display_names.rb:69
 msgid "Container Quota Item"
 msgid_plural "Container Quota Items"
-msgstr[0] "Item de cota de\ncontêiner"
+msgstr[0] "Item de cota de contêiner"
 msgstr[1] "Item de cota de contêiner"
 
 #: ../config/model_display_names.rb:70
 msgid "Container Quota Scope"
 msgid_plural "Container Quota Scopes"
-msgstr[0] "Scopo de cota de\ncontêiner"
-msgstr[1] "Scopos de cota de\ncontêiner"
+msgstr[0] "Scopo de cota de contêiner"
+msgstr[1] "Scopos de cota de contêiner"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
 #. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
@@ -7276,7 +7276,7 @@ msgstr[1] "Scopos de cota de\ncontêiner"
 #: ../config/yaml_strings.rb:6286
 msgid "Container Replicator"
 msgid_plural "Container Replicators"
-msgstr[0] "Replicador do\ncontêiner"
+msgstr[0] "Replicador do contêiner"
 msgstr[1] "Replicadores do contêiner"
 
 #. TRANSLATORS: file: product/views/ContainerProject.yaml
@@ -7298,14 +7298,14 @@ msgstr "Rotas do contêiner"
 #: ../config/model_display_names.rb:73 ../config/dictionary_strings.rb:1406
 msgid "Container Service"
 msgid_plural "Container Services"
-msgstr[0] "Serviço de\ncontêiner"
-msgstr[1] "Serviços de\ncontêiner"
+msgstr[0] "Serviço de contêiner"
+msgstr[1] "Serviços de contêiner"
 
 #: ../config/model_display_names.rb:74
 msgid "Container Service Port Config"
 msgid_plural "Container Service Port Configs"
-msgstr[0] "Configuração da\nporta do serviço de\ncontêiner"
-msgstr[1] "Configurações da porta do\nserviço de contêiner"
+msgstr[0] "Configuração da porta do serviço de contêiner"
+msgstr[1] "Configurações da porta do serviço de contêiner"
 
 #. TRANSLATORS: file: product/views/ContainerProject.yaml
 #. TRANSLATORS: file: product/views/ContainerService.yaml
@@ -7322,14 +7322,14 @@ msgstr "Modelo do contêiner"
 #: ../app/models/manageiq/providers/openshift/container_manager/container_template.rb:74
 msgid "Container Template (OpenShift)"
 msgid_plural "Container Templates (OpenShift)"
-msgstr[0] "Modelo de\ncontêiner (OpenShift)"
-msgstr[1] "Modelos de\ncontêiner\n(OpenShift)"
+msgstr[0] "Modelo de contêiner (OpenShift)"
+msgstr[1] "Modelos de contêiner (OpenShift)"
 
 #: ../config/model_display_names.rb:76
 msgid "Container Template Parameter"
 msgid_plural "Container Template Parameters"
-msgstr[0] "Parâmetro do modelo\nde contêiner"
-msgstr[1] "Parâmetros do modelo\nde contêiner"
+msgstr[0] "Parâmetro do modelo de contêiner"
+msgstr[1] "Parâmetros do modelo de contêiner"
 
 #. TRANSLATORS: file: product/views/ContainerTemplate.yaml
 #: ../app/presenters/menu/default_menu.rb:136 ../config/yaml_strings.rb:1745
@@ -7346,7 +7346,7 @@ msgstr "Modelos de contêiner (OpenShift)"
 #: ../config/model_display_names.rb:77
 msgid "Container Volume"
 msgid_plural "Container Volumes"
-msgstr[0] "Volume\ndo contêiner"
+msgstr[0] "Volume do contêiner"
 msgstr[1] "Volumes do contêiner"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerVolume (plural form)
@@ -10292,12 +10292,12 @@ msgstr "Criar capturas instantâneas"
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3747
 msgid "Creating Backup %{backup_name} of Volume %{subject} completed successfully."
-msgstr "A criação do\n%{backup_name}\nde backup do volume\n%{subject}\nfoi concluída com sucesso."
+msgstr "A criação do %{backup_name} de backup do volume %{subject} foi concluída com sucesso."
 
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3749
 msgid "Creating Backup %{backup_name} of Volume %{subject} failed: %{error_message}"
-msgstr "A criação do\n%{backup_name}\nde backup do volume\n%{subject}\nfalhou:\n%{error_message}"
+msgstr "A criação do %{backup_name} de backup do volume %{subject} falhou: %{error_message}"
 
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3759
@@ -10560,14 +10560,14 @@ msgstr "Custom"
 #: ../config/model_display_names.rb:80
 msgid "Custom Attribute"
 msgid_plural "Custom Attributes"
-msgstr[0] "Atributo\ncustomizado"
+msgstr[0] "Atributo customizado"
 msgstr[1] "Atributos customizados"
 
 #: ../config/model_display_names.rb:81
 msgid "Custom Button Event"
 msgid_plural "Custom Button Events"
-msgstr[0] "Evento de botão\ncustomizado"
-msgstr[1] "Eventos de botão\ncustomizado"
+msgstr[0] "Evento de botão customizado"
+msgstr[1] "Eventos de botão customizado"
 
 #. TRANSLATORS: file: product/views/CustomButtonEvent.yaml
 #: ../app/controllers/mixins/generic_show_mixin.rb:153
@@ -10584,7 +10584,7 @@ msgstr "Eventos de botão customizado"
 #: ../config/model_display_names.rb:82
 msgid "Custom Event"
 msgid_plural "Custom Events"
-msgstr[0] "Evento\ncustomizado"
+msgstr[0] "Evento customizado"
 msgstr[1] "Eventos customizados"
 
 #: ../config/model_attributes.rb:1253
@@ -10790,20 +10790,20 @@ msgstr "Explorador de customização"
 #: ../config/model_display_names.rb:83
 msgid "Customization Script"
 msgid_plural "Customization Scripts"
-msgstr[0] "Script de\ncustomização"
-msgstr[1] "Scripts de\ncustomização"
+msgstr[0] "Script de customização"
+msgstr[1] "Scripts de customização"
 
 #: ../config/model_display_names.rb:84
 msgid "Customization Script Medium"
 msgid_plural "Customization Script Media"
-msgstr[0] "Média de script de\ncustomização"
-msgstr[1] "Médias de script de\ncustomização"
+msgstr[0] "Média de script de customização"
+msgstr[1] "Médias de script de customização"
 
 #: ../config/model_display_names.rb:85
 msgid "Customization Script Ptable"
 msgid_plural "Customization Script Ptables"
-msgstr[0] "Ptable de script de\ncustomização"
-msgstr[1] "Ptables de script de\ncustomização"
+msgstr[0] "Ptable de script de customização"
+msgstr[1] "Ptables de script de customização"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3298
@@ -10813,8 +10813,8 @@ msgstr "Scripts de customização"
 #: ../config/model_display_names.rb:86
 msgid "Customization Spec"
 msgid_plural "Customization Specs"
-msgstr[0] "Especificação\nde customização"
-msgstr[1] "Especificações de\ncustomização"
+msgstr[0] "Especificação de customização"
+msgstr[1] "Especificações de customização"
 
 #: ../app/models/mixins/miq_provision_mixin.rb:202
 msgid "Customization Specification [%{name}] does not exist."
@@ -10827,20 +10827,20 @@ msgstr "Modelo de customização"
 #: ../config/model_display_names.rb:88
 msgid "Customization Template Cloud Init"
 msgid_plural "Customization Template Cloud Inits"
-msgstr[0] "Inicialização\nde nuvem de modelo de\ncustomização"
-msgstr[1] "Inicializações\nde nuvem de modelo de customização"
+msgstr[0] "Inicialização de nuvem de modelo de customização"
+msgstr[1] "Inicializações de nuvem de modelo de customização"
 
 #: ../config/model_display_names.rb:89
 msgid "Customization Template Kickstart"
 msgid_plural "Customization Template Kickstarts"
-msgstr[0] "Início rápido do\nmodelo de customização"
-msgstr[1] "Inícios rápidos do\nmodelo de customização"
+msgstr[0] "Início rápido do modelo de customização"
+msgstr[1] "Inícios rápidos do modelo de customização"
 
 #: ../config/model_display_names.rb:90
 msgid "Customization Template Sysprep"
 msgid_plural "Customization Template Syspreps"
-msgstr[0] "Sysprep do modelo de\ncustomização"
-msgstr[1] "Syspreps do modelo de\ncustomização"
+msgstr[0] "Sysprep do modelo de customização"
+msgstr[1] "Syspreps do modelo de customização"
 
 #. TRANSLATORS: file: product/views/CustomizationTemplate.yaml
 #: ../app/controllers/pxe_controller.rb:107 ../config/yaml_strings.rb:1407
@@ -11724,12 +11724,12 @@ msgstr "Excluir capturas instantâneas"
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3751
 msgid "Deleting Backup %{subject} of Volume %{volume_name} completed successfully."
-msgstr "A exclusão do\n%{subject}\nde backup do volume\n%{volume_name}\nfoi concluída com sucesso."
+msgstr "A exclusão do %{subject} de backup do volume %{volume_name} foi concluída com sucesso."
 
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3753
 msgid "Deleting Backup %{subject} of Volume %{volume_name} failed: %{error_message}"
-msgstr "A exclusão do\n%{subject}\nde backup do volume\n%{volume_name}\nfalhou:\n%{error_message}"
+msgstr "A exclusão do %{subject} de backup do volume %{volume_name} falhou: %{error_message}"
 
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3777
@@ -12017,73 +12017,73 @@ msgstr "O diálogo %{dialog_label} deve ter pelo menos uma Guia"
 #: ../config/model_display_names.rb:93
 msgid "Dialog Field"
 msgid_plural "Dialog Fields"
-msgstr[0] "Campo\nde diálogo"
+msgstr[0] "Campo de diálogo"
 msgstr[1] "Campos de diálogo"
 
 #: ../config/model_display_names.rb:94
 msgid "Dialog Field Check Box"
 msgid_plural "Dialog Field Check Boxes"
-msgstr[0] "Caixa de seleção do\ncampo de diálogo"
-msgstr[1] "Caixas de seleção do\ncampo de diálogo"
+msgstr[0] "Caixa de seleção do campo de diálogo"
+msgstr[1] "Caixas de seleção do campo de diálogo"
 
 #: ../config/model_display_names.rb:95
 msgid "Dialog Field Date Control"
 msgid_plural "Dialog Field Date Controls"
-msgstr[0] "Controle de data do\ncampo\nde diálogo"
-msgstr[1] "Controles de data do campo de\ndiálogo"
+msgstr[0] "Controle de data do campo de diálogo"
+msgstr[1] "Controles de data do campo de diálogo"
 
 #: ../config/model_display_names.rb:96
 msgid "Dialog Field Date Time Control"
 msgid_plural "Dialog Field Date Time Controls"
-msgstr[0] "Controle de data e hora do\ncampo\nde diálogo"
-msgstr[1] "Controles de data e hora do campo\nde\ndiálogo"
+msgstr[0] "Controle de data e hora do campo de diálogo"
+msgstr[1] "Controles de data e hora do campo de diálogo"
 
 #: ../config/model_display_names.rb:97
 msgid "Dialog Field Drop Down List"
 msgid_plural "Dialog Field Drop Down Lists"
-msgstr[0] "Lista suspensa do campo de\ndiálogo"
-msgstr[1] "Listas suspensas do campo de\ndiálogo"
+msgstr[0] "Lista suspensa do campo de diálogo"
+msgstr[1] "Listas suspensas do campo de diálogo"
 
 #: ../config/model_display_names.rb:98
 msgid "Dialog Field Radio Button"
 msgid_plural "Dialog Field Radio Buttons"
-msgstr[0] "Botão de opões do\ncampo\nde diálogo"
-msgstr[1] "Botões de opões do campo de\ndiálogo"
+msgstr[0] "Botão de opões do campo de diálogo"
+msgstr[1] "Botões de opões do campo de diálogo"
 
 #: ../config/model_display_names.rb:99
 msgid "Dialog Field Sorted Item"
 msgid_plural "Dialog Field Sorted Items"
-msgstr[0] "Item classificado do campo\nde diálogo"
-msgstr[1] "Botões de opões do campo de\ndiálogo"
+msgstr[0] "Item classificado do campo de diálogo"
+msgstr[1] "Botões de opões do campo de diálogo"
 
 #: ../config/model_display_names.rb:100
 msgid "Dialog Field Tag Control"
 msgid_plural "Dialog Field Tag Controls"
-msgstr[0] "Controle de tag do campo\nde diálogo"
-msgstr[1] "Controles de tag do campo de\ndiálogo"
+msgstr[0] "Controle de tag do campo de diálogo"
+msgstr[1] "Controles de tag do campo de diálogo"
 
 #: ../config/model_display_names.rb:101
 msgid "Dialog Field Text Area Box"
 msgid_plural "Dialog Field Text Area Boxes"
-msgstr[0] "Caixa de área de texto\ndo campo\nde diálogo"
-msgstr[1] "Caixas de área de texto do campo\nde\ndiálogo"
+msgstr[0] "Caixa de área de texto do campo de diálogo"
+msgstr[1] "Caixas de área de texto do campo de diálogo"
 
 #: ../config/model_display_names.rb:102
 msgid "Dialog Field Text Box"
 msgid_plural "Dialog Field Text Boxes"
-msgstr[0] "Caixa de texto do\ncampo de diálogo"
-msgstr[1] "Caixas de texto do\ncampo de diálogo"
+msgstr[0] "Caixa de texto do campo de diálogo"
+msgstr[1] "Caixas de texto do campo de diálogo"
 
 #: ../config/model_display_names.rb:103
 msgid "Dialog Group"
 msgid_plural "Dialog Groups"
-msgstr[0] "Grupo de\ndiálogo"
+msgstr[0] "Grupo de diálogo"
 msgstr[1] "Grupos de diálogo"
 
 #: ../config/model_display_names.rb:104
 msgid "Dialog Tab"
 msgid_plural "Dialog Tabs"
-msgstr[0] "Guia de\ndiálogo"
+msgstr[0] "Guia de diálogo"
 msgstr[1] "Guias de diálogo"
 
 #: ../app/models/dialog.rb:201
@@ -13014,7 +13014,7 @@ msgstr "Exibir tarefas de configuração individuais"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2418
 msgid "Display Individual Configuration Manager Provider"
-msgstr "Exibir o provedor do gerenciador de configuração\nindividual"
+msgstr "Exibir o provedor do gerenciador de configuração individual"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2450
@@ -13024,7 +13024,7 @@ msgstr "Exibir o perfil de configuração individual"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2468
 msgid "Display Individual Configured System"
-msgstr "Exibir o sistema configurado\nindividual"
+msgstr "Exibir o sistema configurado individual"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2294
@@ -13439,7 +13439,7 @@ msgstr "Exibir listas de tarefas de configuração"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2416
 msgid "Display Lists of Configuration Manager Providers"
-msgstr "Exibir listas de provedores de gerenciador de\nconfiguração"
+msgstr "Exibir listas de provedores de gerenciador de configuração"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2448
@@ -14157,7 +14157,7 @@ msgstr "Desvio"
 #: ../config/model_display_names.rb:106
 msgid "Drift State"
 msgid_plural "Drift States"
-msgstr[0] "Estado de\ndesvio"
+msgstr[0] "Estado de desvio"
 msgstr[1] "Estados de desvio"
 
 #: ../config/model_attributes.rb:1421
@@ -15301,13 +15301,13 @@ msgstr "Tempo decorrido (10 dias, 0 hora, 1 minuto, 44 segundos)"
 #: ../app/models/manageiq/providers/amazon/storage_manager/ebs.rb:44
 msgid "Elastic Block Storage Manager (Amazon)"
 msgid_plural "Elastic Block Storage Managers (Amazon)"
-msgstr[0] "Gerenciador de\narmazenamento de bloco do elástico\n(Amazon)"
-msgstr[1] "Gerenciadores de\narmazenamento de bloco do elástico (Amazon)"
+msgstr[0] "Gerenciador de armazenamento de bloco do elástico (Amazon)"
+msgstr[1] "Gerenciadores de armazenamento de bloco do elástico (Amazon)"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::StorageManager::Ebs (plural form)
 #: ../config/dictionary_strings.rb:1882
 msgid "Elastic Block Storage Managers (Amazon)"
-msgstr "Gerenciadores de armazenamento de bloco elástico\n(Amazon)"
+msgstr "Gerenciadores de armazenamento de bloco elástico (Amazon)"
 
 #. TRANSLATORS: file: product/views/MiqAlert.yaml
 #: ../config/yaml_strings.rb:1345
@@ -15327,13 +15327,13 @@ msgstr "Nome do cluster de EMS"
 #: ../config/model_display_names.rb:107
 msgid "Ems Extension"
 msgid_plural "Ems Extensions"
-msgstr[0] "Extensão do\nEms"
+msgstr[0] "Extensão do Ems"
 msgstr[1] "Extensões do Ems"
 
 #: ../config/model_display_names.rb:108
 msgid "Ems License"
 msgid_plural "Ems Licenses"
-msgstr[0] "Licença do\nEms"
+msgstr[0] "Licença do Ems"
 msgstr[1] "Licenças do Ems"
 
 #: ../config/model_attributes.rb:1428
@@ -15933,7 +15933,7 @@ msgstr "Erro '%{message}' ao gravar no FTP: [%{uri}], Nome do usuário: [%{id}]"
 
 #: ../app/models/service_template_transformation_plan.rb:118
 msgid "Error parsing datetime: %{error}"
-msgstr "Erro ao analisar a data/hora:\n%{error}"
+msgstr "Erro ao analisar a data/hora: %{error}"
 
 #: ../app/models/miq_request.rb:226
 msgid "Error returned from %{name} event processing in Automate: %{error_message}"
@@ -16025,7 +16025,7 @@ msgstr "Origem do evento"
 #: ../config/model_display_names.rb:112
 msgid "Event Stream"
 msgid_plural "Event Streams"
-msgstr[0] "Fluxo de\nevento"
+msgstr[0] "Fluxo de evento"
 msgstr[1] "Fluxos de evento"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -16435,7 +16435,7 @@ msgstr "Tudo em tarefas de configuração"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2412
 msgid "Everything under Configuration Manager Providers"
-msgstr "Tudo em provedores do gerenciador de\nconfiguração"
+msgstr "Tudo em provedores do gerenciador de configuração"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2444
@@ -17192,11 +17192,11 @@ msgstr "ExtManagementSystem|Suporta a criação de contêiner de armazenamento d
 
 #: ../config/model_attributes.rb:1677
 msgid "ExtManagementSystem|Supports create security group"
-msgstr "ExtManagementSystem | Suporta a criação de grupo de\nsegurança"
+msgstr "ExtManagementSystem | Suporta a criação de grupo de segurança"
 
 #: ../config/model_attributes.rb:1678
 msgid "ExtManagementSystem|Supports storage services"
-msgstr "ExtManagementSystem | Suporta serviços de\narmazenamento"
+msgstr "ExtManagementSystem | Suporta serviços de armazenamento"
 
 #: ../config/model_attributes.rb:1679
 msgid "ExtManagementSystem|Supports volume availability zones"
@@ -17294,8 +17294,8 @@ msgstr "ExtManagementSystem|Nome da zona"
 #: ../app/models/manageiq/providers/openstack/network_manager/cloud_network/public.rb:3
 msgid "External Cloud Network (OpenStack)"
 msgid_plural "External Cloud Networks (OpenStack)"
-msgstr[0] "Rede em nuvem externa\n(OpenStack)"
-msgstr[1] "Redes em nuvem externas\n(OpenStack)"
+msgstr[0] "Rede em nuvem externa (OpenStack)"
+msgstr[1] "Redes em nuvem externas (OpenStack)"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public (plural form)
 #: ../config/dictionary_strings.rb:1826
@@ -17309,7 +17309,7 @@ msgstr "Alertas externos do Prometheus"
 #: ../config/model_display_names.rb:113
 msgid "External Url"
 msgid_plural "External Urls"
-msgstr[0] "URL\nexterna"
+msgstr[0] "URL externa"
 msgstr[1] "URLs externas"
 
 #: ../config/model_attributes.rb:1702
@@ -17399,26 +17399,26 @@ msgstr "Arquivo"
 #: ../config/model_display_names.rb:114
 msgid "File Depot"
 msgid_plural "File Depots"
-msgstr[0] "Depósito de\narquivos"
+msgstr[0] "Depósito de arquivos"
 msgstr[1] "Depósitos de arquivos"
 
 #: ../config/model_display_names.rb:115
 msgid "File Depot Nfs"
 msgid_plural "File Depot Nfs"
-msgstr[0] "NTS de depósito de\narquivos"
-msgstr[1] "NTSs de depósitos de\narquivos"
+msgstr[0] "NTS de depósito de arquivos"
+msgstr[1] "NTSs de depósitos de arquivos"
 
 #: ../config/model_display_names.rb:116
 msgid "File Depot S3"
 msgid_plural "File Depot S3s"
-msgstr[0] "S3 de depósito de\narquivos"
-msgstr[1] "S3s de depósitos de\narquivos"
+msgstr[0] "S3 de depósito de arquivos"
+msgstr[1] "S3s de depósitos de arquivos"
 
 #: ../config/model_display_names.rb:117
 msgid "File Depot Swift"
 msgid_plural "File Depot Swifts"
-msgstr[0] "Swift de depósito de\narquivos"
-msgstr[1] "Swifts de depósitos de\narquivos"
+msgstr[0] "Swift de depósito de arquivos"
+msgstr[1] "Swifts de depósitos de arquivos"
 
 #. TRANSLATORS: file: product/views/Filesystem.yaml
 #. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
@@ -17621,7 +17621,7 @@ msgstr "O tipo de filtro deve ser um de %{filter}"
 #: ../config/model_display_names.rb:119
 msgid "Firewall Rule"
 msgid_plural "Firewall Rules"
-msgstr[0] "Regra de\nfirewall"
+msgstr[0] "Regra de firewall"
 msgstr[1] "Regras de firewall"
 
 #: ../config/model_attributes.rb:1745
@@ -17711,8 +17711,8 @@ msgstr "Binário de firmware"
 #: ../config/model_display_names.rb:122
 msgid "Firmware Binary Firmware Target"
 msgid_plural "Firmware Binary Firmware Targets"
-msgstr[0] "Destino de firmware\nbinário de firmware"
-msgstr[1] "Destinos de firmware\nbinário de firmware"
+msgstr[0] "Destino de firmware binário de firmware"
+msgstr[1] "Destinos de firmware binário de firmware"
 
 #: ../app/presenters/menu/default_menu.rb:116
 #: ../app/controllers/firmware_registry_controller.rb:25
@@ -17910,7 +17910,7 @@ msgstr "Tipo"
 #: ../app/models/manageiq/providers/amazon/cloud_manager/flavor.rb:14
 msgid "Flavor (Amazon)"
 msgid_plural "Flavors (Amazon)"
-msgstr[0] "Tipo\n(Amazon)"
+msgstr[0] "Tipo (Amazon)"
 msgstr[1] "Tipos (Amazon)"
 
 #: ../app/models/manageiq/providers/google/cloud_manager/flavor.rb:3
@@ -17928,7 +17928,7 @@ msgstr[1] "Tipos (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/flavor.rb:52
 msgid "Flavor (OpenStack)"
 msgid_plural "Flavors (OpenStack)"
-msgstr[0] "Tipo\n(OpenStack)"
+msgstr[0] "Tipo (OpenStack)"
 msgstr[1] "Tipos (OpenStack)"
 
 #. TRANSLATORS: file: product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
@@ -18067,21 +18067,21 @@ msgstr "IP flutuante"
 #: ../app/models/manageiq/providers/amazon/network_manager/floating_ip.rb:3
 msgid "Floating IP (Amazon)"
 msgid_plural "Floating IPs (Amazon)"
-msgstr[0] "IP flutuante\n(Amazon)"
+msgstr[0] "IP flutuante (Amazon)"
 msgstr[1] "IPs flutuantes (Amazon)"
 
 #: ../app/models/manageiq/providers/azure/network_manager/floating_ip.rb:7
 msgid "Floating IP (Microsoft Azure)"
 msgid_plural "Floating IPs (Microsoft Azure)"
-msgstr[0] "IP flutuante (Microsoft\nAzure)"
-msgstr[1] "IPs flutuantes (Microsoft\nAzure)"
+msgstr[0] "IP flutuante (Microsoft Azure)"
+msgstr[1] "IPs flutuantes (Microsoft Azure)"
 
 #:
 #: ../app/models/manageiq/providers/openstack/network_manager/floating_ip.rb:120
 msgid "Floating IP (OpenStack)"
 msgid_plural "Floating IPs (OpenStack)"
-msgstr[0] "IP flutuante\n(OpenStack)"
-msgstr[1] "IPs flutuantes\n(OpenStack)"
+msgstr[0] "IP flutuante (OpenStack)"
+msgstr[1] "IPs flutuantes (OpenStack)"
 
 #: ../app/presenters/menu/default_menu.rb:150
 #: ../app/controllers/floating_ip_controller.rb:219
@@ -18331,7 +18331,7 @@ msgstr "Genérico"
 #: ../config/model_display_names.rb:126 ../config/dictionary_strings.rb:1476
 msgid "Generic Object"
 msgid_plural "Generic Objects"
-msgstr[0] "Objeto\ngenérico"
+msgstr[0] "Objeto genérico"
 msgstr[1] "Objetos genéricos"
 
 #. TRANSLATORS: en.yml key: dictionary.model.GenericObjectDefinition
@@ -18339,7 +18339,7 @@ msgstr[1] "Objetos genéricos"
 #: ../config/dictionary_strings.rb:1480
 msgid "Generic Object Class"
 msgid_plural "Generic Object Classes"
-msgstr[0] "Classe de objeto\ngenérico"
+msgstr[0] "Classe de objeto genérico"
 msgstr[1] "Classes de objeto genérico"
 
 #. TRANSLATORS: en.yml key: dictionary.model.GenericObjectDefinition (plural form)
@@ -18423,13 +18423,13 @@ msgstr "GenericObject|UID"
 #: ../config/model_display_names.rb:127
 msgid "Git Branch"
 msgid_plural "Git Branches"
-msgstr[0] "Ramificação\ndo Git"
+msgstr[0] "Ramificação do Git"
 msgstr[1] "Ramificações do Git"
 
 #: ../config/model_display_names.rb:128
 msgid "Git Reference"
 msgid_plural "Git References"
-msgstr[0] "Referência do\nGit"
+msgstr[0] "Referência do Git"
 msgstr[1] "Referências do Git"
 
 #: ../app/helpers/persistent_volume_helper/textual_summary.rb:83
@@ -18440,7 +18440,7 @@ msgstr "Repositório de Git"
 #: ../config/model_display_names.rb:130
 msgid "Git Tag"
 msgid_plural "Git Tags"
-msgstr[0] "Tag do\nGit"
+msgstr[0] "Tag do Git"
 msgstr[1] "Tags do Git"
 
 #: ../config/model_attributes.rb:1846
@@ -19212,8 +19212,8 @@ msgstr "Código do estado de funcionamento"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/orchestration_template.rb:101
 msgid "Heat Template"
 msgid_plural "Heat Templates"
-msgstr[0] "Modelo de\naquecimento"
-msgstr[1] "Modelos de\naquecimento"
+msgstr[0] "Modelo de aquecimento"
+msgstr[1] "Modelos de aquecimento"
 
 #: ../app/presenters/tree_builder_orchestration_templates.rb:24
 #: ../app/presenters/tree_builder_orchestration_templates.rb:26
@@ -19302,7 +19302,7 @@ msgstr "Agregado do host"
 #: ../config/model_display_names.rb:136
 msgid "Host Aggregate Host"
 msgid_plural "Host Aggregate Hosts"
-msgstr[0] "Host\nagregado do host"
+msgstr[0] "Host agregado do host"
 msgstr[1] "Hosts agregados dos host"
 
 #: ../app/presenters/menu/default_menu.rb:83
@@ -19385,7 +19385,7 @@ msgstr "Tendências de utilização de memória do host (última semana)"
 #: ../config/model_display_names.rb:137
 msgid "Host Metric"
 msgid_plural "Host Metrics"
-msgstr[0] "Métrica do\nhost"
+msgstr[0] "Métrica do host"
 msgstr[1] "Métrica do host"
 
 #: ../app/assets/javascripts/services/alerts_center_service.js:77
@@ -19453,13 +19453,13 @@ msgstr "Propriedades do host"
 #: ../config/model_display_names.rb:138
 msgid "Host Service Group"
 msgid_plural "Host Service Groups"
-msgstr[0] "Grupo de serviços do\nhost"
+msgstr[0] "Grupo de serviços do host"
 msgstr[1] "Grupos de serviços do host"
 
 #: ../config/model_display_names.rb:139
 msgid "Host Storage"
 msgid_plural "Host Storages"
-msgstr[0] "Armazenamento do\nhost"
+msgstr[0] "Armazenamento do host"
 msgstr[1] "Armazenamentos do host"
 
 #. TRANSLATORS: file: product/reports/110_Configuration Management - Hosts/070_Storage Adapters.yaml
@@ -19480,7 +19480,7 @@ msgstr "Resumo de host com inf. de máquinas virtuais"
 #: ../config/model_display_names.rb:140
 msgid "Host Switch"
 msgid_plural "Host Switches"
-msgstr[0] "Comutador do\nhost"
+msgstr[0] "Comutador do host"
 msgstr[1] "Comutadores do host"
 
 #. TRANSLATORS: file: product/reports/110_Configuration Management - Hosts/060_VM Relationships.yaml
@@ -20478,7 +20478,7 @@ msgstr "Imagem"
 #: ../app/models/manageiq/providers/amazon/cloud_manager/template.rb:25
 msgid "Image (Amazon)"
 msgid_plural "Images (Amazon)"
-msgstr[0] "Imagem\n(Amazon)"
+msgstr[0] "Imagem (Amazon)"
 msgstr[1] "Imagens (Amazon)"
 
 #: ../app/models/manageiq/providers/google/cloud_manager/template.rb:16
@@ -20490,19 +20490,19 @@ msgstr[1] "Imagens (Google)"
 #: ../app/models/manageiq/providers/azure/cloud_manager/template.rb:18
 msgid "Image (Microsoft Azure)"
 msgid_plural "Images (Microsoft Azure)"
-msgstr[0] "Imagem (Microsoft\nAzure)"
+msgstr[0] "Imagem (Microsoft Azure)"
 msgstr[1] "Imagens (Microsoft Azure)"
 
 #: ../app/models/manageiq/providers/openstack/cloud_manager/template.rb:120
 msgid "Image (OpenStack)"
 msgid_plural "Images (OpenStack)"
-msgstr[0] "Imagem\n(OpenStack)"
+msgstr[0] "Imagem (OpenStack)"
 msgstr[1] "Imagens (OpenStack)"
 
 #: ../app/models/manageiq/providers/vmware/cloud_manager/template.rb:12
 msgid "Image (VMware vCloud)"
 msgid_plural "Images (VMware vCloud)"
-msgstr[0] "Imagem (VMware\nvCloud)"
+msgstr[0] "Imagem (VMware vCloud)"
 msgstr[1] "Imagens (VMware vCloud)"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -20625,7 +20625,7 @@ msgstr "Sanfona Importar/exportar"
 #: ../config/model_display_names.rb:141
 msgid "Import File Upload"
 msgid_plural "Import File Uploads"
-msgstr[0] "Upload de arquivo de\nimportação"
+msgstr[0] "Upload de arquivo de importação"
 msgstr[1] "Uploads de arquivo de importação"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -20691,7 +20691,7 @@ msgstr "Formato incorreto: Esperado %{expected_class} e recebido %{received_clas
 #: ../config/model_display_names.rb:142
 msgid "Infra Conversion Job"
 msgid_plural "Infra Conversion Jobs"
-msgstr[0] "Tarefa de conversão de\ninfraestrutura"
+msgstr[0] "Tarefa de conversão de infraestrutura"
 msgstr[1] "Tarefas de conversão de infraestrutura"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -20730,20 +20730,20 @@ msgstr[1] "Provedores de infraestrutura (Microsoft)"
 #: ../app/models/manageiq/providers/openstack/infra_manager.rb:434
 msgid "Infrastructure Provider (OpenStack)"
 msgid_plural "Infrastructure Providers (OpenStack)"
-msgstr[0] "Provedor de infraestrutura\n(OpenStack)"
-msgstr[1] "Provedores de infraestrutura\n(OpenStack)"
+msgstr[0] "Provedor de infraestrutura (OpenStack)"
+msgstr[1] "Provedores de infraestrutura (OpenStack)"
 
 #: ../app/models/manageiq/providers/redhat/infra_manager.rb:462
 msgid "Infrastructure Provider (Red Hat)"
 msgid_plural "Infrastructure Providers (Red Hat)"
-msgstr[0] "Provedor de infraestrutura\n(Red Hat)"
-msgstr[1] "Provedores de infraestrutura (Red\nHat)"
+msgstr[0] "Provedor de infraestrutura (Red Hat)"
+msgstr[1] "Provedores de infraestrutura (Red Hat)"
 
 #: ../app/models/manageiq/providers/vmware/infra_manager.rb:728
 msgid "Infrastructure Provider (VMware)"
 msgid_plural "Infrastructure Providers (VMware)"
-msgstr[0] "Provedor de infraestrutura\n(VMware)"
-msgstr[1] "Provedores de infraestrutura\n(VMware)"
+msgstr[0] "Provedor de infraestrutura (VMware)"
+msgstr[1] "Provedores de infraestrutura (VMware)"
 
 #. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
 #: ../app/controllers/ems_infra_controller.rb:31 ../config/yaml_strings.rb:1128
@@ -20804,7 +20804,7 @@ msgstr "Instância"
 #: ../app/models/manageiq/providers/amazon/cloud_manager/vm.rb:64
 msgid "Instance (Amazon)"
 msgid_plural "Instances (Amazon)"
-msgstr[0] "Instância\n(Amazon)"
+msgstr[0] "Instância (Amazon)"
 msgstr[1] "Instâncias (Amazon)"
 
 #: ../app/models/manageiq/providers/google/cloud_manager/vm.rb:58
@@ -20822,13 +20822,13 @@ msgstr[1] "Instâncias (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/vm.rb:167
 msgid "Instance (OpenStack)"
 msgid_plural "Instances (OpenStack)"
-msgstr[0] "Instância\n(OpenStack)"
+msgstr[0] "Instância (OpenStack)"
 msgstr[1] "Instâncias (OpenStack)"
 
 #: ../app/models/manageiq/providers/vmware/cloud_manager/vm.rb:36
 msgid "Instance (VMware vCloud)"
 msgid_plural "Instances (VMware vCloud)"
-msgstr[0] "Instância (VMware\nvCloud)"
+msgstr[0] "Instância (VMware vCloud)"
 msgstr[1] "Instâncias (VMware vCloud)"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -21447,7 +21447,7 @@ msgstr "Ativar criação de log externa"
 #: ../config/model_display_names.rb:145
 msgid "Lifecycle Event"
 msgid_plural "Lifecycle Events"
-msgstr[0] "Evento\nde ciclo de vida"
+msgstr[0] "Evento de ciclo de vida"
 msgstr[1] "Eventos de ciclo de vida"
 
 #: ../config/model_attributes.rb:2179
@@ -21544,7 +21544,7 @@ msgstr "Balanceador de carga"
 #: ../app/models/manageiq/providers/amazon/network_manager/load_balancer.rb:3
 msgid "Load Balancer (Amazon)"
 msgid_plural "Load Balancers (Amazon)"
-msgstr[0] "Balanceador de carga\n(Amazon)"
+msgstr[0] "Balanceador de carga (Amazon)"
 msgstr[1] "Balanceadores de carga (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager/load_balancer.rb:3
@@ -21556,44 +21556,44 @@ msgstr[1] "Balanceadores de carga (Google)"
 #: ../config/model_display_names.rb:147
 msgid "Load Balancer Health Check"
 msgid_plural "Load Balancer Health Checks"
-msgstr[0] "Verificação de\nfuncionamento do balanceador de\ncarga"
+msgstr[0] "Verificação de funcionamento do balanceador de carga"
 msgstr[1] "Verificações de funcionamento do balanceador de carga"
 
 #: ../config/model_display_names.rb:148
 msgid "Load Balancer Health Check Member"
 msgid_plural "Load Balancer Health Check Members"
-msgstr[0] "Membro de verificação de\nfuncionamento do balanceador de\ncarga"
-msgstr[1] "Membros de verificação de\nfuncionamento do\nbalanceador de carga"
+msgstr[0] "Membro de verificação de funcionamento do balanceador de carga"
+msgstr[1] "Membros de verificação de funcionamento do balanceador de carga"
 
 #: ../config/model_display_names.rb:149
 msgid "Load Balancer Listener"
 msgid_plural "Load Balancer Listeners"
-msgstr[0] "Listener do balanceador de\ncarga"
-msgstr[1] "Listeners do\nbalanceador de carga"
+msgstr[0] "Listener do balanceador de carga"
+msgstr[1] "Listeners do balanceador de carga"
 
 #: ../config/model_display_names.rb:150
 msgid "Load Balancer Listener Pool"
 msgid_plural "Load Balancer Listener Pools"
-msgstr[0] "Conjunto de listener do\nbalanceador de\ncarga"
-msgstr[1] "Conjunto de listener do balanceador de\ncarga"
+msgstr[0] "Conjunto de listener do balanceador de carga"
+msgstr[1] "Conjunto de listener do balanceador de carga"
 
 #: ../config/model_display_names.rb:151
 msgid "Load Balancer Pool"
 msgid_plural "Load Balancer Pools"
-msgstr[0] "Conjunto do\nbalanceador de carga"
+msgstr[0] "Conjunto do balanceador de carga"
 msgstr[1] "Conjuntos do balanceador de carga"
 
 #: ../config/model_display_names.rb:152
 msgid "Load Balancer Pool Member"
 msgid_plural "Load Balancer Pool Members"
-msgstr[0] "Membro do conjunto do\nbalanceador de\ncarga"
-msgstr[1] "Membros do conjunto do balanceador de\ncarga"
+msgstr[0] "Membro do conjunto do balanceador de carga"
+msgstr[1] "Membros do conjunto do balanceador de carga"
 
 #: ../config/model_display_names.rb:153
 msgid "Load Balancer Pool Member Pool"
 msgid_plural "Load Balancer Pool Member Pools"
-msgstr[0] "Conjunto de membro do\nconjunto do\nbalanceador de carga"
-msgstr[1] "Conjuntos de membro do\nconjunto do\nbalanceador de carga"
+msgstr[0] "Conjunto de membro do conjunto do balanceador de carga"
+msgstr[1] "Conjuntos de membro do conjunto do balanceador de carga"
 
 #. TRANSLATORS: en.yml key: dictionary.model.LoadBalancer (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.load_balancer (plural form)
@@ -21967,7 +21967,7 @@ msgstr "Configurações do repositório de logs não configuradas"
 #: ../config/model_display_names.rb:154
 msgid "Log File"
 msgid_plural "Log Files"
-msgstr[0] "Arquivo\nde log"
+msgstr[0] "Arquivo de log"
 msgstr[1] "Arquivos de log"
 
 #: ../app/models/miq_server/log_management.rb:56
@@ -23124,7 +23124,7 @@ msgstr[1] "Métricas"
 #: ../config/model_display_names.rb:156
 msgid "Metric Rollup"
 msgid_plural "Metric Rollups"
-msgstr[0] "Acumulação\nde métrica"
+msgstr[0] "Acumulação de métrica"
 msgstr[1] "Acumulações de métrica"
 
 #: ../config/model_attributes.rb:2360
@@ -24493,7 +24493,7 @@ msgstr "Definição de política do MIQ - Definir tipo"
 #: ../config/model_display_names.rb:157
 msgid "Miq Worker Type"
 msgid_plural "Miq Worker Types"
-msgstr[0] "Tipo de trabalhador\nMiq"
+msgstr[0] "Tipo de trabalhador Miq"
 msgstr[1] "Tipos de trabalhador Miq"
 
 #: ../config/model_attributes.rb:2587
@@ -27724,7 +27724,7 @@ msgstr "Modificar tarefa de configuração"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2428
 msgid "Modify Configuration Manager Providers"
-msgstr "Modificar os provedores do gerenciador de\nconfiguração"
+msgstr "Modificar os provedores do gerenciador de configuração"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2386
@@ -28320,7 +28320,7 @@ msgstr "Não disponível"
 
 #: ../app/models/vm.rb:36
 msgid "NATIVE remote console is not supported on %{vendor}."
-msgstr "O console remoto NATIVO não é suportado no\n%{vendor}."
+msgstr "O console remoto NATIVO não é suportado no %{vendor}."
 
 #. TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
 #: ../config/dictionary_strings.rb:1450
@@ -28391,7 +28391,7 @@ msgstr "Domínio de rede"
 #: ../config/model_display_names.rb:159
 msgid "Network Group"
 msgid_plural "Network Groups"
-msgstr[0] "Grupo\nde rede"
+msgstr[0] "Grupo de rede"
 msgstr[1] "Grupos de rede"
 
 #. TRANSLATORS: file: product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
@@ -28581,8 +28581,8 @@ msgstr "Porta de rede"
 #: ../app/models/manageiq/providers/amazon/network_manager/network_port.rb:3
 msgid "Network Port (Amazon)"
 msgid_plural "Network Ports (Amazon)"
-msgstr[0] "Porta de rede\n(Amazon)"
-msgstr[1] "Portas de rede\n(Amazon)"
+msgstr[0] "Porta de rede (Amazon)"
+msgstr[1] "Portas de rede (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager/network_port.rb:3
 msgid "Network Port (Google)"
@@ -28600,8 +28600,8 @@ msgstr[1] "Portas de rede (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/network_manager/network_port.rb:13
 msgid "Network Port (OpenStack)"
 msgid_plural "Network Ports (OpenStack)"
-msgstr[0] "Porta de rede\n(OpenStack)"
-msgstr[1] "Portas de rede\n(OpenStack)"
+msgstr[0] "Porta de rede (OpenStack)"
+msgstr[1] "Portas de rede (OpenStack)"
 
 #: ../config/model_display_names.rb:161
 msgid "Network Port Security Group"
@@ -28657,8 +28657,8 @@ msgstr "Provedor de rede"
 #: ../app/models/manageiq/providers/amazon/network_manager.rb:58
 msgid "Network Provider (Amazon)"
 msgid_plural "Network Providers (Amazon)"
-msgstr[0] "Provedor de rede\n(Amazon)"
-msgstr[1] "Provedores de rede\n(Amazon)"
+msgstr[0] "Provedor de rede (Amazon)"
+msgstr[1] "Provedores de rede (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager.rb:50
 msgid "Network Provider (Google)"
@@ -28669,8 +28669,8 @@ msgstr[1] "Provedores de rede (Google)"
 #: ../app/models/manageiq/providers/openstack/network_manager.rb:199
 msgid "Network Provider (OpenStack)"
 msgid_plural "Network Providers (OpenStack)"
-msgstr[0] "Provedor de rede\n(OpenStack)"
-msgstr[1] "Provedores de rede\n(OpenStack)"
+msgstr[0] "Provedor de rede (OpenStack)"
+msgstr[1] "Provedores de rede (OpenStack)"
 
 #. TRANSLATORS: file: product/views/ManageIQ_Providers_NetworkManager.yaml
 #: ../config/yaml_strings.rb:963
@@ -28704,8 +28704,8 @@ msgstr "Roteador de rede"
 #: ../app/models/manageiq/providers/amazon/network_manager/network_router.rb:3
 msgid "Network Router (Amazon)"
 msgid_plural "Network Routers (Amazon)"
-msgstr[0] "Roteador de rede\n(Amazon)"
-msgstr[1] "Roteadores de rede\n(Amazon)"
+msgstr[0] "Roteador de rede (Amazon)"
+msgstr[1] "Roteadores de rede (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager/network_router.rb:3
 msgid "Network Router (Google)"
@@ -28722,8 +28722,8 @@ msgstr "Roteador de rede (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/network_manager/network_router.rb:178
 msgid "Network Router (OpenStack)"
 msgid_plural "Network Routers (OpenStack)"
-msgstr[0] "Roteador de rede\n(OpenStack)"
-msgstr[1] "Roteadores de rede\n(OpenStack)"
+msgstr[0] "Roteador de rede (OpenStack)"
+msgstr[1] "Roteadores de rede (OpenStack)"
 
 #: ../app/controllers/network_router_controller.rb:396
 #: ../app/helpers/ems_network_helper/textual_summary.rb:84
@@ -28764,7 +28764,7 @@ msgstr "Serviço de Rede"
 #: ../config/model_display_names.rb:164 ../config/yaml_strings.rb:2138
 msgid "Network Service Entry"
 msgid_plural "Network Service Entries"
-msgstr[0] "Entrada de serviço de\nrede"
+msgstr[0] "Entrada de serviço de rede"
 msgstr[1] "Entradas de serviço de rede"
 
 #. TRANSLATORS: file: product/views/SecurityPolicyRule.yaml
@@ -29077,7 +29077,7 @@ msgstr "NetworkService | Número de região"
 
 #: ../config/model_attributes.rb:3439
 msgid "NetworkService|Security policy rules count"
-msgstr "NetworkService | Contagem de regras de política de\nsegurança"
+msgstr "NetworkService | Contagem de regras de política de segurança"
 
 #: ../app/presenters/menu/default_menu.rb:102
 #: ../app/controllers/infra_networking_controller.rb:542
@@ -29355,14 +29355,14 @@ msgstr[1] "Notificações"
 #: ../config/model_display_names.rb:166
 msgid "Notification Recipient"
 msgid_plural "Notification Recipients"
-msgstr[0] "Destinatário\nda notificação"
-msgstr[1] "Destinatários da\nnotificação"
+msgstr[0] "Destinatário da notificação"
+msgstr[1] "Destinatários da notificação"
 
 #: ../config/model_display_names.rb:167
 msgid "Notification Type"
 msgid_plural "Notification Types"
-msgstr[0] "Tipo da\nnotificação"
-msgstr[1] "Tipos da\nnotificação"
+msgstr[0] "Tipo da notificação"
+msgstr[1] "Tipos da notificação"
 
 #: ../config/model_attributes.rb:3457
 msgid "Notification recipient"
@@ -29733,13 +29733,13 @@ msgstr "Os domínios OpenStack definem limites administrativos. Ele é necessár
 #: ../config/model_display_names.rb:168
 msgid "Openscap Result"
 msgid_plural "Openscap Results"
-msgstr[0] "Resultado\nde Openscap"
+msgstr[0] "Resultado de Openscap"
 msgstr[1] "Resultados de Openscap"
 
 #: ../config/model_display_names.rb:169
 msgid "Openscap Rule Result"
 msgid_plural "Openscap Rule Results"
-msgstr[0] "Resultado de\nregra de Openscap"
+msgstr[0] "Resultado de regra de Openscap"
 msgstr[1] "Resultados de regra de Openscap"
 
 #: ../config/model_attributes.rb:3473
@@ -29839,7 +29839,7 @@ msgstr "Sistema operacional"
 #: ../config/model_display_names.rb:171
 msgid "Operating System Flavor"
 msgid_plural "Operating System Flavors"
-msgstr[0] "Tipo de sistema\noperacional"
+msgstr[0] "Tipo de sistema operacional"
 msgstr[1] "Tipos de sistema operacional"
 
 #: ../config/model_attributes.rb:3487
@@ -30003,7 +30003,7 @@ msgstr "Operações de máquinas virtuais ligadas/desligadas na última semana"
 
 #: ../app/models/manageiq/providers/base_manager/operations_worker.rb:14
 msgid "Operations Worker for Provider: %{name}"
-msgstr "Trabalhador de operações para provedor:\n%{name}"
+msgstr "Trabalhador de operações para provedor: %{name}"
 
 #: ../app/models/miq_alert.rb:446 ../app/models/miq_alert.rb:456
 #: ../app/models/miq_alert.rb:462 ../app/models/miq_alert.rb:471
@@ -30043,8 +30043,8 @@ msgstr "A Pilha de orquestração %{subject} foi aposentada."
 #: ../app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb:58
 msgid "Orchestration Stack (Amazon)"
 msgid_plural "Orchestration Stacks (Amazon)"
-msgstr[0] "Pilha de\norquestração\n(Amazon)"
-msgstr[1] "Pilhas de orquestração\n(Amazon)"
+msgstr[0] "Pilha de orquestração (Amazon)"
+msgstr[1] "Pilhas de orquestração (Amazon)"
 
 #:
 #: ../app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb:74
@@ -30058,26 +30058,26 @@ msgstr[1] "Pilhas de orquestração (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb:73
 msgid "Orchestration Stack (OpenStack)"
 msgid_plural "Orchestration Stacks (OpenStack)"
-msgstr[0] "Pilha de\norquestração\n(OpenStack)"
-msgstr[1] "Pilhas de\norquestração\n(OpenStack)"
+msgstr[0] "Pilha de orquestração (OpenStack)"
+msgstr[1] "Pilhas de orquestração (OpenStack)"
 
 #: ../config/model_display_names.rb:173
 msgid "Orchestration Stack Output"
 msgid_plural "Orchestration Stack Outputs"
-msgstr[0] "Saída da pilha de\norquestração"
-msgstr[1] "Saídas da pilha de\norquestração"
+msgstr[0] "Saída da pilha de orquestração"
+msgstr[1] "Saídas da pilha de orquestração"
 
 #: ../config/model_display_names.rb:174
 msgid "Orchestration Stack Parameter"
 msgid_plural "Orchestration Stack Parameters"
-msgstr[0] "Parâmetro da pilha de\norquestração"
-msgstr[1] "Parâmetros da pilha de\norquestração"
+msgstr[0] "Parâmetro da pilha de orquestração"
+msgstr[1] "Parâmetros da pilha de orquestração"
 
 #: ../config/model_display_names.rb:175
 msgid "Orchestration Stack Resource"
 msgid_plural "Orchestration Stack Resources"
-msgstr[0] "Recurso da\npilha de orquestração"
-msgstr[1] "Recursos da\npilha de orquestração"
+msgstr[0] "Recurso da pilha de orquestração"
+msgstr[1] "Recursos da pilha de orquestração"
 
 #: ../app/models/miq_request.rb:88
 msgid "Orchestration Stack Retire"
@@ -30138,7 +30138,7 @@ msgstr "Modelo de orquestração"
 
 #: ../app/models/service_orchestration.rb:197
 msgid "Orchestration template runner finished with error. Check evm.log for details."
-msgstr "O executor de modelo de orquestração foi\nconcluído com\nerro. Verifique o evm.log para obter detalhes."
+msgstr "O executor de modelo de orquestração foi concluído com erro. Verifique o evm.log para obter detalhes."
 
 #: ../config/model_attributes.rb:3552
 msgid "OrchestrationStackOutput|Description"
@@ -30440,7 +30440,7 @@ msgstr "Máquinas virtuais órfãs"
 #: ../config/model_display_names.rb:177
 msgid "Os Process"
 msgid_plural "Os Processes"
-msgstr[0] "Processo do\nSO"
+msgstr[0] "Processo do SO"
 msgstr[1] "Processos do SO"
 
 #: ../config/model_attributes.rb:3592
@@ -30994,7 +30994,7 @@ msgstr "Realizar operações em tarefas de configuração"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2420
 msgid "Perform Operations on Configuration Manager Providers and Configured Systems"
-msgstr "Executar operações em provedores do gerenciador de\nconfiguração e em sistemas\nconfigurados"
+msgstr "Executar operações em provedores do gerenciador de configuração e em sistemas configurados"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2452
@@ -31144,7 +31144,7 @@ msgstr "Executar operações em Roteadores de rede"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2148
 msgid "Perform Operations on Network Service Entries"
-msgstr "Executar operações em entradas de serviço de\nrede"
+msgstr "Executar operações em entradas de serviço de rede"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2126
@@ -31254,7 +31254,7 @@ msgstr "Executar operações em políticas de segurança"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:1992
 msgid "Perform Operations on Security Policy Rules"
-msgstr "Executar operações em regras de política de\nsegurança"
+msgstr "Executar operações em regras de política de segurança"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:280
@@ -31274,7 +31274,7 @@ msgstr "Executar operações em Gerenciadores de armazenamento"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3110
 msgid "Perform Operations on Storage Resources"
-msgstr "Executar operações em recursos de\narmazenamento"
+msgstr "Executar operações em recursos de armazenamento"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3012
@@ -31511,8 +31511,8 @@ msgstr "Volume persistente"
 #: ../config/model_display_names.rb:180
 msgid "Persistent Volume Claim"
 msgid_plural "Persistent Volume Claims"
-msgstr[0] "Solicitação de volume\npersistente "
-msgstr[1] "Solicitações de volume\npesistente"
+msgstr[0] "Solicitação de volume persistente "
+msgstr[1] "Solicitações de volume pesistente"
 
 #. TRANSLATORS: file: product/views/PersistentVolume.yaml
 #: ../config/yaml_strings.rb:984
@@ -31594,13 +31594,13 @@ msgstr "Chassi físico"
 #: ../app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb:6
 msgid "Physical Chassis (Lenovo)"
 msgid_plural "Physical Chassis (Lenovo)"
-msgstr[0] "Chassi físico\n(Lenovo)"
-msgstr[1] "Chassis físicos\n(Lenovo)"
+msgstr[0] "Chassi físico (Lenovo)"
+msgstr[1] "Chassis físicos (Lenovo)"
 
 #: ../config/model_display_names.rb:182
 msgid "Physical Disk"
 msgid_plural "Physical Disks"
-msgstr[0] "Disco\nfísico"
+msgstr[0] "Disco físico"
 msgstr[1] "Discos físicos"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -31644,7 +31644,7 @@ msgstr "Rack físico"
 #: ../app/models/manageiq/providers/lenovo/physical_infra_manager/physical_rack.rb:4
 msgid "Physical Rack (Lenovo)"
 msgid_plural "Physical Racks (Lenovo)"
-msgstr[0] "Rack físico\n(Lenovo)"
+msgstr[0] "Rack físico (Lenovo)"
 msgstr[1] "Racks físicos (Lenovo)"
 
 #. TRANSLATORS: file: product/views/PhysicalRack.yaml
@@ -31670,7 +31670,7 @@ msgstr "Servidor físico"
 #: ../app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb:7
 msgid "Physical Server (Lenovo)"
 msgid_plural "Physical Servers (Lenovo)"
-msgstr[0] "Servidor físico\n(Lenovo)"
+msgstr[0] "Servidor físico (Lenovo)"
 msgstr[1] "Servidores físicos (Lenovo)"
 
 #:
@@ -31733,14 +31733,14 @@ msgstr "Armazenamento físico"
 #: ../app/models/manageiq/providers/lenovo/physical_infra_manager/physical_storage.rb:4
 msgid "Physical Storage (Lenovo)"
 msgid_plural "Physical Storages (Lenovo)"
-msgstr[0] "Armazenamento físico\n(Lenovo)"
-msgstr[1] "Armazenamentos físicos\n(Lenovo)"
+msgstr[0] "Armazenamento físico (Lenovo)"
+msgstr[1] "Armazenamentos físicos (Lenovo)"
 
 #: ../config/model_display_names.rb:187
 msgid "Physical Storage Family"
 msgid_plural "Physical Storage Families"
-msgstr[0] "Família de\narmazenamento físico"
-msgstr[1] "Família de\narmazenamento físico"
+msgstr[0] "Família de armazenamento físico"
+msgstr[1] "Família de armazenamento físico"
 
 #. TRANSLATORS: file: product/views/PhysicalStorage.yaml
 #: ../app/controllers/physical_storage_controller.rb:27
@@ -31764,8 +31764,8 @@ msgstr "Comutador físico"
 #: ../app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch.rb:6
 msgid "Physical Switch (Lenovo)"
 msgid_plural "Physical Switches (Lenovo)"
-msgstr[0] "Comutador físico\n(Lenovo)"
-msgstr[1] "Comutadores físicos\n(Lenovo)"
+msgstr[0] "Comutador físico (Lenovo)"
+msgstr[1] "Comutadores físicos (Lenovo)"
 
 #. TRANSLATORS: file: product/views/PhysicalSwitch.yaml
 #: ../app/controllers/physical_switch_controller.rb:18
@@ -32501,8 +32501,8 @@ msgstr[1] "Eventos de política"
 #: ../config/model_display_names.rb:191
 msgid "Policy Event Content"
 msgid_plural "Policy Event Contents"
-msgstr[0] "Conteúdo de evento de\npolítica"
-msgstr[1] "Conteúdo de evento de\npolítica"
+msgstr[0] "Conteúdo de evento de política"
+msgstr[1] "Conteúdo de evento de política"
 
 #: ../app/controllers/application_controller/timelines/options.rb:2
 msgid "Policy Events"
@@ -32656,7 +32656,7 @@ msgstr "Portas"
 #:
 #: ../app/models/service_template_transformation_plan/validate_config_info.rb:42
 msgid "Postmigration service type MUST be \"ServiceTemplateAnsiblePlaybook\""
-msgstr "O tipo de serviço de pós-migração DEVE ser\n\"ServiceTemplateAnsiblePlaybook\""
+msgstr "O tipo de serviço de pós-migração DEVE ser \"ServiceTemplateAnsiblePlaybook\""
 
 #: ../app/controllers/mixins/actions/host_actions/power.rb:9
 #: ../app/helpers/application_helper/toolbar/vm_infras_center.rb:274
@@ -32735,7 +32735,7 @@ msgstr "Estado de energia"
 #:
 #: ../app/models/service_template_transformation_plan/validate_config_info.rb:35
 msgid "Premigration service type MUST be \"ServiceTemplateAnsiblePlaybook\""
-msgstr "O tipo de serviço de pré-migração DEVE ser\n\"ServiceTemplateAnsiblePlaybook\""
+msgstr "O tipo de serviço de pré-migração DEVE ser \"ServiceTemplateAnsiblePlaybook\""
 
 #. TRANSLATORS: file: product/compare/vms.yaml
 #: ../config/yaml_strings.rb:4253
@@ -33088,8 +33088,8 @@ msgstr "Nome do provedor"
 #: ../config/model_display_names.rb:193
 msgid "Provider Tag Mapping"
 msgid_plural "Provider Tag Mappings"
-msgstr[0] "Mapeamento de tag de\nprovedor"
-msgstr[1] "Mapeamentos de tag de\nprovedor"
+msgstr[0] "Mapeamento de tag de provedor"
+msgstr[1] "Mapeamentos de tag de provedor"
 
 #:
 #: ../app/javascript/react/screens/App/Settings/screens/ConversionHostsSettings/components/ConversionHostWizard/ConversionHostWizardLocationStep/ConversionHostWizardLocationStep.js:62
@@ -33115,7 +33115,7 @@ msgstr "O provedor falhou na última verificação de autenticação"
 
 #: ../config/model_attributes.rb:3784
 msgid "Provider tag mapping"
-msgstr "Mapeamento de tag de\nprovedor"
+msgstr "Mapeamento de tag de provedor"
 
 #: ../config/model_attributes.rb:3785
 msgid "ProviderTagMapping|Href slug"
@@ -33278,7 +33278,7 @@ msgstr "Provisionar máquinas virtuais"
 
 #: ../app/models/miq_request_workflow.rb:1477
 #: ../app/models/miq_provision_virt_workflow.rb:766
-msgid "Provision failed for the following reasons:\n%{errors}"
+msgid "Provision failed for the following reasons: %{errors}"
 msgstr "A provisão falhou pelos seguintes motivos: %{errors}"
 
 #: ../app/models/mixins/miq_provision_mixin.rb:77
@@ -33925,7 +33925,7 @@ msgstr "Atualizar relações e estados de energia para todos os itens relacionad
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:743
 msgid "Refresh relationships and power states for all items related to Hosts"
-msgstr "Atualizar relacionamentos e estados da energia\nde todos os itens relacionados a hosts"
+msgstr "Atualizar relacionamentos e estados da energia de todos os itens relacionados a hosts"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3180
@@ -33940,7 +33940,7 @@ msgstr "Atualizar relacionamentos e estados de energia de todos os itens relacio
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3266
 msgid "Refresh relationships and power states for all items related to Physical Servers"
-msgstr "Atualizar relacionamentos e estados da energia de\ntodos os itens relacionados a servidores físicos"
+msgstr "Atualizar relacionamentos e estados da energia de todos os itens relacionados a servidores físicos"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3224
@@ -33950,7 +33950,7 @@ msgstr "Atualizar relacionamentos e estados de energia de todos os itens relacio
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3206
 msgid "Refresh relationships and power states for all items related to Physical Switches"
-msgstr "Atualizar relacionamentos e estados da energia\nde\ntodos os itens relacionados a comutadores físicos"
+msgstr "Atualizar relacionamentos e estados da energia de todos os itens relacionados a comutadores físicos"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2574
@@ -33960,7 +33960,7 @@ msgstr "Atualizar relações para todos os itens relacionados a provedor"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2426
 msgid "Refresh relationships for all items related to Configuration Manager Provider"
-msgstr "Atualizar relacionamentos para todos os itens\nrelacionados ao provedor de gerenciador de configuração"
+msgstr "Atualizar relacionamentos para todos os itens relacionados ao provedor de gerenciador de configuração"
 
 #. TRANSLATORS: file: product/views/AutomationRequest.yaml
 #. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
@@ -34337,12 +34337,12 @@ msgstr "Remover tarefa de configuração"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2432
 msgid "Remove Configuration Manager Provider"
-msgstr "Remover o provedor do gerenciador de\nconfiguração"
+msgstr "Remover o provedor do gerenciador de configuração"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2430
 msgid "Remove Configuration Manager Providers"
-msgstr "Remover os provedores do gerenciador de\nconfiguração"
+msgstr "Remover os provedores do gerenciador de configuração"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:1902
@@ -34735,7 +34735,7 @@ msgstr "Data da solicitação"
 #: ../config/model_display_names.rb:196
 msgid "Request Event"
 msgid_plural "Request Events"
-msgstr[0] "Evento de\nsolicitação"
+msgstr[0] "Evento de solicitação"
 msgstr[1] "Eventos de solicitação"
 
 #: ../app/models/miq_request_task.rb:218
@@ -34873,13 +34873,13 @@ msgstr "O recurso %{resource_name} não é um recurso elegível para esta instâ
 #: ../config/model_display_names.rb:197
 msgid "Resource Action"
 msgid_plural "Resource Actions"
-msgstr[0] "Ação de\nrecurso"
+msgstr[0] "Ação de recurso"
 msgstr[1] "Ações de recurso"
 
 #: ../config/model_display_names.rb:198
 msgid "Resource Group"
 msgid_plural "Resource Groups"
-msgstr[0] "Grupo de\nrecursos"
+msgstr[0] "Grupo de recursos"
 msgstr[1] "Grupos de recursos"
 
 #: ../app/controllers/miq_policy_controller/miq_actions.rb:257
@@ -35240,12 +35240,12 @@ msgstr "Restaurar de um backup do volume"
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3755
 msgid "Restoring Backup %{subject} of Volume %{volume_name} completed successfully."
-msgstr "A restauração do\n%{subject}\nde backup do volume\n%{volume_name}\nfoi concluída com sucesso."
+msgstr "A restauração do %{subject} de backup do volume %{volume_name} foi concluída com sucesso."
 
 #. TRANSLATORS: file: db/fixtures/notification_types.yml
 #: ../config/yaml_strings.rb:3757
 msgid "Restoring Backup %{subject} of Volume %{volume_name} failed: %{error_message}"
-msgstr "A restauração do\n%{subject}\nde backup do volume\n%{volume_name}\nfalhou:\n%{error_message}"
+msgstr "A restauração do %{subject} de backup do volume %{volume_name} falhou: %{error_message}"
 
 #:
 #: ../app/javascript/react/screens/App/common/ListViewToolbar/ListViewToolbar.js:256
@@ -35539,7 +35539,7 @@ msgstr[1] "Histórico de varredura"
 #: ../config/model_display_names.rb:201 ../config/dictionary_strings.rb:2284
 msgid "Scan Item"
 msgid_plural "Scan Items"
-msgstr[0] "Item de\nvarredura"
+msgstr[0] "Item de varredura"
 msgstr[1] "Itens de varredura"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
@@ -35550,7 +35550,7 @@ msgstr "Escanear itens"
 #: ../config/model_display_names.rb:202
 msgid "Scan Result"
 msgid_plural "Scan Results"
-msgstr[0] "Resultado da\nvarredura"
+msgstr[0] "Resultado da varredura"
 msgstr[1] "Resultados da varredura"
 
 #: ../app/models/compliance.rb:44
@@ -35818,7 +35818,7 @@ msgstr "Segurança"
 #: ../config/model_display_names.rb:203
 msgid "Security Context"
 msgid_plural "Security Contexts"
-msgstr[0] "Contexto de\nsegurança"
+msgstr[0] "Contexto de segurança"
 msgstr[1] "Contextos de segurança"
 
 #:
@@ -35829,8 +35829,8 @@ msgstr "Grupo de segurança"
 #: ../app/models/manageiq/providers/amazon/network_manager/security_group.rb:3
 msgid "Security Group (Amazon)"
 msgid_plural "Security Groups (Amazon)"
-msgstr[0] "Grupo de segurança\n(Amazon)"
-msgstr[1] "Grupos de segurança\n(Amazon)"
+msgstr[0] "Grupo de segurança (Amazon)"
+msgstr[1] "Grupos de segurança (Amazon)"
 
 #: ../app/models/manageiq/providers/google/network_manager/security_group.rb:3
 msgid "Security Group (Google)"
@@ -35847,7 +35847,7 @@ msgstr "Grupo de segurança (Microsoft Azure)"
 #: ../app/models/manageiq/providers/openstack/network_manager/security_group.rb:159
 msgid "Security Group (OpenStack)"
 msgid_plural "Security Groups (OpenStack)"
-msgstr[0] "Grupo de segurança\n(OpenStack)"
+msgstr[0] "Grupo de segurança (OpenStack)"
 msgstr[1] "Grupos de segurança (OpenStack)"
 
 #: ../app/views/security_group/_common_new_edit.html.haml:6
@@ -35966,7 +35966,7 @@ msgstr "Regra de política de segurança"
 
 #: ../config/model_attributes.rb:3997
 msgid "Security policy rule destination security group"
-msgstr "Grupo de segurança de destino da regra de política de\nsegurança"
+msgstr "Grupo de segurança de destino da regra de política de segurança"
 
 #: ../config/model_attributes.rb:4001
 msgid "Security policy rule network service"
@@ -35974,7 +35974,7 @@ msgstr "Serviço de rede da regra de política de segurança"
 
 #: ../config/model_attributes.rb:4005
 msgid "Security policy rule source security group"
-msgstr "Grupo de segurança de origem da regra de política\nde segurança"
+msgstr "Grupo de segurança de origem da regra de política de segurança"
 
 #: ../config/model_attributes.rb:3955
 msgid "SecurityContext|Href slug"
@@ -36034,11 +36034,11 @@ msgstr "SecurityGroup|Número da região"
 
 #: ../config/model_attributes.rb:3970
 msgid "SecurityGroup|Total security policy rules as destination"
-msgstr "SecurityGroup|Total de regras de política de\nsegurança como destino"
+msgstr "SecurityGroup|Total de regras de política de segurança como destino"
 
 #: ../config/model_attributes.rb:3971
 msgid "SecurityGroup|Total security policy rules as source"
-msgstr "SecurityGroup|Total de regras de política de\nsegurança como origem"
+msgstr "SecurityGroup|Total de regras de política de segurança como origem"
 
 #: ../config/model_attributes.rb:3972
 msgid "SecurityGroup|Total vms"
@@ -36050,11 +36050,11 @@ msgstr "SecurityPolicyRuleDestinationSecurityGroup|Href slug"
 
 #: ../config/model_attributes.rb:3999
 msgid "SecurityPolicyRuleDestinationSecurityGroup|Region description"
-msgstr "SecurityPolicyRuleDestinationSecurityGroup|Descrição\nda região"
+msgstr "SecurityPolicyRuleDestinationSecurityGroup|Descrição da região"
 
 #: ../config/model_attributes.rb:4000
 msgid "SecurityPolicyRuleDestinationSecurityGroup|Region number"
-msgstr "SecurityPolicyRuleDestinationSecurityGroup|Número\nde região"
+msgstr "SecurityPolicyRuleDestinationSecurityGroup|Número de região"
 
 #: ../config/model_attributes.rb:4002
 msgid "SecurityPolicyRuleNetworkService|Href slug"
@@ -36062,11 +36062,11 @@ msgstr "SecurityPolicyRuleNetworkService|Href slug"
 
 #: ../config/model_attributes.rb:4003
 msgid "SecurityPolicyRuleNetworkService|Region description"
-msgstr "SecurityPolicyRuleNetworkService|Descrição da\nregião"
+msgstr "SecurityPolicyRuleNetworkService|Descrição da região"
 
 #: ../config/model_attributes.rb:4004
 msgid "SecurityPolicyRuleNetworkService|Region number"
-msgstr "SecurityPolicyRuleNetworkService|Número de\nregião"
+msgstr "SecurityPolicyRuleNetworkService|Número de região"
 
 #: ../config/model_attributes.rb:4006
 msgid "SecurityPolicyRuleSourceSecurityGroup|Href slug"
@@ -36074,11 +36074,11 @@ msgstr "SecurityPolicyRuleSourceSecurityGroup|Href slug"
 
 #: ../config/model_attributes.rb:4007
 msgid "SecurityPolicyRuleSourceSecurityGroup|Region description"
-msgstr "SecurityPolicyRuleSourceSecurityGroup|Descrição\nda região"
+msgstr "SecurityPolicyRuleSourceSecurityGroup|Descrição da região"
 
 #: ../config/model_attributes.rb:4008
 msgid "SecurityPolicyRuleSourceSecurityGroup|Region number"
-msgstr "SecurityPolicyRuleSourceSecurityGroup|Número\nde região"
+msgstr "SecurityPolicyRuleSourceSecurityGroup|Número de região"
 
 #: ../config/model_attributes.rb:3983
 msgid "SecurityPolicyRule|Action"
@@ -36090,7 +36090,7 @@ msgstr "SecurityPolicyRule|Descrição"
 
 #: ../config/model_attributes.rb:3985
 msgid "SecurityPolicyRule|Destination security groups count"
-msgstr "SecurityPolicyRule|Contagem de grupos de\nsegurança de destino"
+msgstr "SecurityPolicyRule|Contagem de grupos de segurança de destino"
 
 #: ../config/model_attributes.rb:3986
 msgid "SecurityPolicyRule|Direction"
@@ -36114,7 +36114,7 @@ msgstr "SecurityPolicyRule|Nome"
 
 #: ../config/model_attributes.rb:3991
 msgid "SecurityPolicyRule|Network services count"
-msgstr "SecurityPolicyRule|Contagem de serviços de\nrede"
+msgstr "SecurityPolicyRule|Contagem de serviços de rede"
 
 #: ../config/model_attributes.rb:3992
 msgid "SecurityPolicyRule|Region description"
@@ -36130,7 +36130,7 @@ msgstr "SecurityPolicyRule|Número de Sequência"
 
 #: ../config/model_attributes.rb:3995
 msgid "SecurityPolicyRule|Source security groups count"
-msgstr "SecurityPolicyRule|Contagem de grupos de\nsegurança de origem"
+msgstr "SecurityPolicyRule|Contagem de grupos de segurança de origem"
 
 #: ../config/model_attributes.rb:3996
 msgid "SecurityPolicyRule|Status"
@@ -36207,7 +36207,7 @@ msgstr "Servidor"
 #: ../config/model_display_names.rb:210
 msgid "Server Role"
 msgid_plural "Server Roles"
-msgstr[0] "Função do\nservidor"
+msgstr[0] "Função do servidor"
 msgstr[1] "Funções do servidor"
 
 #: ../app/models/miq_server.rb:289
@@ -36308,14 +36308,14 @@ msgstr "Adaptador do serviço"
 #: ../config/model_display_names.rb:212
 msgid "Service Ansible Playbook"
 msgid_plural "Service Ansible Playbooks"
-msgstr[0] "Playbook do Ansible do\nserviço"
-msgstr[1] "Playbooks do Ansible do\nserviço"
+msgstr[0] "Playbook do Ansible do serviço"
+msgstr[1] "Playbooks do Ansible do serviço"
 
 #: ../config/model_display_names.rb:213
 msgid "Service Ansible Tower"
 msgid_plural "Service Ansible Towers"
-msgstr[0] "Ansible Tower\ndo serviço"
-msgstr[1] "Ansible Towers do\nserviço"
+msgstr[0] "Ansible Tower do serviço"
+msgstr[1] "Ansible Towers do serviço"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3523
@@ -36346,8 +36346,8 @@ msgstr "Catálogos de serviços"
 #: ../config/model_display_names.rb:214
 msgid "Service Container Template"
 msgid_plural "Service Container Templates"
-msgstr[0] "Modelo de contêiner\nde serviço"
-msgstr[1] "Modelos de contêiner de\nserviço"
+msgstr[0] "Modelo de contêiner de serviço"
+msgstr[1] "Modelos de contêiner de serviço"
 
 #. TRANSLATORS: file: product/reports/110_Configuration Management - Hosts/015_Host - ESX Services.yaml
 #: ../config/yaml_strings.rb:6143
@@ -36357,13 +36357,13 @@ msgstr "Nome de exibição do serviço"
 #: ../config/model_display_names.rb:215
 msgid "Service Generic"
 msgid_plural "Service Generics"
-msgstr[0] "Genérico do\nserviço"
+msgstr[0] "Genérico do serviço"
 msgstr[1] "Genéricos do serviço"
 
 #: ../config/model_display_names.rb:216
 msgid "Service Instance"
 msgid_plural "Service Instances"
-msgstr[0] "Instância de\nserviço"
+msgstr[0] "Instância de serviço"
 msgstr[1] "Instâncias de serviço"
 
 #. TRANSLATORS: file: product/compare/hosts.yaml
@@ -36375,8 +36375,8 @@ msgstr "Nível de serviço"
 #: ../config/model_display_names.rb:217
 msgid "Service Linking Workflow"
 msgid_plural "Service Linking Workflows"
-msgstr[0] "Fluxo de trabalho de\nvinculação de serviço"
-msgstr[1] "Fluxos de trabalho de\nvinculação de serviço"
+msgstr[0] "Fluxo de trabalho de vinculação de serviço"
+msgstr[1] "Fluxos de trabalho de vinculação de serviço"
 
 #. TRANSLATORS: file: product/reports/110_Configuration Management - Hosts/015_Host - ESX Services.yaml
 #: ../config/yaml_strings.rb:6141
@@ -36386,7 +36386,7 @@ msgstr "Nome do serviço"
 #: ../config/model_display_names.rb:218
 msgid "Service Offering"
 msgid_plural "Service Offerings"
-msgstr[0] "Oferta de\nserviço"
+msgstr[0] "Oferta de serviço"
 msgstr[1] "Ofertas de serviço"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -36402,26 +36402,26 @@ msgstr "Operações de serviço"
 #: ../config/model_display_names.rb:219
 msgid "Service Orchestration"
 msgid_plural "Service Orchestrations"
-msgstr[0] "Orquestração de\nserviço"
-msgstr[1] "Orquestrações\nde serviço"
+msgstr[0] "Orquestração de serviço"
+msgstr[1] "Orquestrações de serviço"
 
 #: ../config/model_display_names.rb:220
 msgid "Service Order"
 msgid_plural "Service Orders"
-msgstr[0] "Ordem de\nserviço"
+msgstr[0] "Ordem de serviço"
 msgstr[1] "Ordens de serviço"
 
 #: ../config/model_display_names.rb:221
 msgid "Service Order Cart"
 msgid_plural "Service Order Carts"
-msgstr[0] "Carrinho de ordem de\nserviço"
+msgstr[0] "Carrinho de ordem de serviço"
 msgstr[1] "Carrinhos de ordem de serviço"
 
 #: ../config/model_display_names.rb:222
 msgid "Service Order V2V"
 msgid_plural "Service Order V2vs"
-msgstr[0] "V2V\nde ordem de serviço"
-msgstr[1] "V2Vs de ordem\nde serviço"
+msgstr[0] "V2V de ordem de serviço"
+msgstr[1] "V2Vs de ordem de serviço"
 
 #. TRANSLATORS: file: product/views/Patch.yaml
 #: ../app/helpers/textual_mixins/textual_os_info.rb:29
@@ -36432,8 +36432,8 @@ msgstr "Service pack"
 #: ../config/model_display_names.rb:223
 msgid "Service Parameters Set"
 msgid_plural "Service Parameters Sets"
-msgstr[0] "Conjunto de\nparâmetros de serviço"
-msgstr[1] "Conjuntos de\nparâmetros de serviço"
+msgstr[0] "Conjunto de parâmetros de serviço"
+msgstr[1] "Conjuntos de parâmetros de serviço"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3388
@@ -36451,7 +36451,7 @@ msgstr "Reconfiguração do serviço"
 #: ../config/model_display_names.rb:224
 msgid "Service Resource"
 msgid_plural "Service Resources"
-msgstr[0] "Recurso de\nserviço"
+msgstr[0] "Recurso de serviço"
 msgstr[1] "Recursos de serviço"
 
 #: ../app/models/miq_request.rb:97
@@ -36466,8 +36466,8 @@ msgstr "Serviço em execução"
 #: ../config/model_display_names.rb:225
 msgid "Service Template Tenant"
 msgid_plural "Service Template Tenants"
-msgstr[0] "Locatário de modelo\nde serviço"
-msgstr[1] "Locatários de modelo\nde serviço"
+msgstr[0] "Locatário de modelo de serviço"
+msgstr[1] "Locatários de modelo de serviço"
 
 #. TRANSLATORS: en.yml key: dictionary.column.service_time_sec
 #: ../config/dictionary_strings.rb:1248
@@ -37287,8 +37287,8 @@ msgstr "Sanfona de configurações"
 #: ../config/model_display_names.rb:227
 msgid "Settings Change"
 msgid_plural "Settings Changes"
-msgstr[0] "Mudança na\nconfiguração"
-msgstr[1] "Mudanças na\nconfiguração"
+msgstr[0] "Mudança na configuração"
+msgstr[1] "Mudanças na configuração"
 
 #: ../config/model_attributes.rb:4187
 msgid "Settings change"
@@ -37420,7 +37420,7 @@ msgstr "Mostrar dados de capacidade e utilização das zonas disponíveis"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:684
 msgid "Show Capacity & Utilization data of Clusters"
-msgstr "Mostrar os dados de capacidade e utilização dos\nclusters"
+msgstr "Mostrar os dados de capacidade e utilização dos clusters"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2388
@@ -37440,7 +37440,7 @@ msgstr "Mostrar dados de capacidade e utilização de agregados do host"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:727
 msgid "Show Capacity & Utilization data of Hosts"
-msgstr "Mostrar os dados de capacidade e utilização dos\nhosts"
+msgstr "Mostrar os dados de capacidade e utilização dos hosts"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2774
@@ -37724,7 +37724,7 @@ msgstr "Descrição da captura instantânea"
 #. TRANSLATORS: file: product/charts/miq_reports/vim_perf_topday.yaml
 #: ../config/yaml_strings.rb:6531
 msgid "Snapshot File Storage"
-msgstr "Armazenamento de arquivo de captura\ninstantânea"
+msgstr "Armazenamento de arquivo de captura instantânea"
 
 #. TRANSLATORS: file: product/charts/layouts/daily_tag_charts/Storage.yaml
 #: ../config/yaml_strings.rb:3970
@@ -38197,14 +38197,14 @@ msgstr "Perfil de armazenamento"
 #: ../config/model_display_names.rb:231
 msgid "Storage Profile Storage"
 msgid_plural "Storage Profile Storages"
-msgstr[0] "Armazenamento do\nperfil de armazenamento"
-msgstr[1] "Armazenamentos do\nperfil de armazenamento"
+msgstr[0] "Armazenamento do perfil de armazenamento"
+msgstr[1] "Armazenamentos do perfil de armazenamento"
 
 #: ../config/model_display_names.rb:232
 msgid "Storage Resource"
 msgid_plural "Storage Resources"
-msgstr[0] "Recurso\nde armazenamento"
-msgstr[1] "Recursos de\narmazenamento"
+msgstr[0] "Recurso de armazenamento"
+msgstr[1] "Recursos de armazenamento"
 
 #. TRANSLATORS: file: product/views/StorageResource.yaml
 #: ../app/presenters/menu/default_menu.rb:191 ../config/yaml_strings.rb:1434
@@ -38218,8 +38218,8 @@ msgstr "Serviço de Armazenamento"
 #: ../config/model_display_names.rb:234
 msgid "Storage Service Resource Attachment"
 msgid_plural "Storage Service Resource Attachments"
-msgstr[0] "Anexo do recurso de\nserviço de armazenamento"
-msgstr[1] "Anexos do recurso\nde\nserviço de armazenamento"
+msgstr[0] "Anexo do recurso de serviço de armazenamento"
+msgstr[1] "Anexos do recurso de serviço de armazenamento"
 
 #. TRANSLATORS: en.yml key: dictionary.column.storage_metric
 #: ../config/dictionary_strings.rb:1212
@@ -38386,7 +38386,7 @@ msgstr "StorageServiceResourceAttachment|slug Href"
 
 #: ../config/model_attributes.rb:4335
 msgid "StorageServiceResourceAttachment|Region description"
-msgstr "StorageServiceResourceAttachment|Descrição da\nregião"
+msgstr "StorageServiceResourceAttachment|Descrição da região"
 
 #: ../config/model_attributes.rb:4336
 msgid "StorageServiceResourceAttachment|Region number"
@@ -38958,7 +38958,7 @@ msgstr "Sincronizar usuários do provedor em nuvem"
 #: ../config/model_display_names.rb:237
 msgid "System Console"
 msgid_plural "System Consoles"
-msgstr[0] "Console do\nsistema"
+msgstr[0] "Console do sistema"
 msgstr[1] "Consoles do sistema"
 
 #. TRANSLATORS: en.yml key: dictionary.model.PxeImageType
@@ -38974,7 +38974,7 @@ msgstr "Tipos de imagem do sistema"
 #: ../config/model_display_names.rb:238
 msgid "System Service"
 msgid_plural "System Services"
-msgstr[0] "Serviço do\nsistema"
+msgstr[0] "Serviço do sistema"
 msgstr[1] "Serviços do sistema"
 
 #: ../app/models/system_service.rb:39
@@ -40118,14 +40118,14 @@ msgstr "Transformar MVs com tags"
 #: ../config/model_display_names.rb:244
 msgid "Transformation Mapping"
 msgid_plural "Transformation Mappings"
-msgstr[0] "Mapeamento de\ntransformação"
-msgstr[1] "Mapeamento de\ntransformação"
+msgstr[0] "Mapeamento de transformação"
+msgstr[1] "Mapeamento de transformação"
 
 #: ../config/model_display_names.rb:245
 msgid "Transformation Mapping Item"
 msgid_plural "Transformation Mapping Items"
-msgstr[0] "Item de\nmapeamento de transformação"
-msgstr[1] "Itens de\nmapeamento de transformação"
+msgstr[0] "Item de mapeamento de transformação"
+msgstr[1] "Itens de mapeamento de transformação"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:3324
@@ -41618,7 +41618,7 @@ msgstr "Migração da máquina virtual"
 
 #: ../app/models/vm/operations.rb:40
 msgid "VM NATIVE Console error: %{error}"
-msgstr "Erro do console NATIVO da VM:\n%{error}"
+msgstr "Erro do console NATIVO da VM: %{error}"
 
 #: ../app/models/vm/operations.rb:22
 msgid "VM NATIVE Console not supported"
@@ -41814,7 +41814,7 @@ msgstr "O tipo de VM não pertence ao cloud_tenant_flavors"
 #:
 #: ../app/models/service_template_transformation_plan/validate_config_info.rb:83
 msgid "VM flavor not available; can not proceed without it."
-msgstr "O tipo de MV não está disponível. Não é possível\ncontinuar\nsem ele."
+msgstr "O tipo de MV não está disponível. Não é possível continuar sem ele."
 
 #: ../app/models/vm_or_template/operations/configuration.rb:87
 msgid "VM has no EMS, unable to add disk"
@@ -41896,7 +41896,7 @@ msgstr "A máquina virtual não tem EMS, não é possível remover o disco"
 
 #: ../app/models/vm_or_template/operations/configuration.rb:103
 msgid "VM has no EMS, unable to resize disk"
-msgstr "A VM não tem EMS. Não é possível redimensionar o\ndisco"
+msgstr "A VM não tem EMS. Não é possível redimensionar o disco"
 
 #: ../app/models/vm_or_template/operations.rb:94
 msgid "VM has no EMS, unable to set custom attribute"
@@ -41961,12 +41961,12 @@ msgstr "Máquina virtual ou modelos"
 #:
 #: ../app/models/service_template_transformation_plan/validate_config_info.rb:92
 msgid "VM security group does not belong to the cloud_tenant_security_groups"
-msgstr "O grupo de segurança de VM não pertence ao\ncloud_tenant_security_groups"
+msgstr "O grupo de segurança de VM não pertence ao cloud_tenant_security_groups"
 
 #:
 #: ../app/models/service_template_transformation_plan/validate_config_info.rb:95
 msgid "VM security group not available; can not proceed without it."
-msgstr "O grupo de segurança VM não está disponível. Não\né possível continuar sem ele."
+msgstr "O grupo de segurança VM não está disponível. Não é possível continuar sem ele."
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2836
@@ -42354,7 +42354,7 @@ msgstr "Resumo de MV VMware"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/vnfd_template.rb:71
 msgid "VNF Template"
 msgid_plural "VNF Templates"
-msgstr[0] "Modelo de\nVNF"
+msgstr[0] "Modelo de VNF"
 msgstr[1] "Modelos de VNF"
 
 #: ../app/presenters/tree_builder_orchestration_templates.rb:39
@@ -42599,7 +42599,7 @@ msgstr "Visualizar tarefas de configuração"
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2414
 msgid "View Configuration Manager Providers"
-msgstr "Visualizar os provedores do gerenciador de\nconfiguração"
+msgstr "Visualizar os provedores do gerenciador de configuração"
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:2446
@@ -43138,31 +43138,31 @@ msgstr "Visualizar carrinho de compras"
 #: ../config/model_display_names.rb:247
 msgid "Vim Performance Daily"
 msgid_plural "Vim Performance Dailies"
-msgstr[0] "Desempenho diário de\nVim"
+msgstr[0] "Desempenho diário de Vim"
 msgstr[1] "Desempenho diário de Vim"
 
 #: ../config/model_display_names.rb:248
 msgid "Vim Performance Operating Range"
 msgid_plural "Vim Performance Operating Ranges"
-msgstr[0] "Intervalo de operação\nde desempenho de\nVim"
-msgstr[1] "Intervalos de operação\nde desempenho de\nVim"
+msgstr[0] "Intervalo de operação de desempenho de Vim"
+msgstr[1] "Intervalos de operação de desempenho de Vim"
 
 #: ../config/model_display_names.rb:249
 msgid "Vim Performance State"
 msgid_plural "Vim Performance States"
-msgstr[0] "Estado de desempenho\nde\nVim"
+msgstr[0] "Estado de desempenho de Vim"
 msgstr[1] "Estados de desempenho de Vim"
 
 #: ../config/model_display_names.rb:250
 msgid "Vim Performance Tag"
 msgid_plural "Vim Performance Tags"
-msgstr[0] "Tag de desempenho de\nVim"
+msgstr[0] "Tag de desempenho de Vim"
 msgstr[1] "Tags de desempenho de Vim"
 
 #: ../config/model_display_names.rb:251
 msgid "Vim Performance Tag Daily"
 msgid_plural "Vim Performance Tag Dailies"
-msgstr[0] "Tag de desempenho diário\nde\nVim"
+msgstr[0] "Tag de desempenho diário de Vim"
 msgstr[1] "Tags de desempenho diário de Vim"
 
 #: ../config/model_attributes.rb:4506
@@ -43275,13 +43275,13 @@ msgstr[1] "Máquinas virtuais (Microsoft)"
 #: ../app/models/manageiq/providers/redhat/infra_manager/vm.rb:109
 msgid "Virtual Machine (Red Hat)"
 msgid_plural "Virtual Machines (Red Hat)"
-msgstr[0] "Máquina virtual\n(Red Hat)"
-msgstr[1] "Máquinas virtuais (Red\nHat)"
+msgstr[0] "Máquina virtual (Red Hat)"
+msgstr[1] "Máquinas virtuais (Red Hat)"
 
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm.rb:45
 msgid "Virtual Machine (VMware)"
 msgid_plural "Virtual Machines (VMware)"
-msgstr[0] "Máquina virtual\n(VMware)"
+msgstr[0] "Máquina virtual (VMware)"
 msgstr[1] "Máquinas virtuais (VMware)"
 
 #. TRANSLATORS: file: product/charts/layouts/daily_tag_charts/EmsCluster.yaml
@@ -43357,7 +43357,7 @@ msgstr "Visual"
 #: ../config/model_display_names.rb:252
 msgid "Vm Metric"
 msgid_plural "Vm Metrics"
-msgstr[0] "Métrica de\nVM"
+msgstr[0] "Métrica de VM"
 msgstr[1] "Métricas de VM"
 
 #. TRANSLATORS: file: product/reports/420_Operations - Clusters/010_Cluster - DRS migrations.yaml
@@ -43373,7 +43373,7 @@ msgstr "Estado de energia da máquina virtual"
 #: ../config/model_display_names.rb:253
 msgid "Vm Scan"
 msgid_plural "Vm Scans"
-msgstr[0] "Varredura de\nVM"
+msgstr[0] "Varredura de VM"
 msgstr[1] "Varreduras de VM"
 
 #: ../config/model_attributes.rb:4521
@@ -44515,8 +44515,8 @@ msgstr "Captura instantânea do volume"
 #: ../app/models/manageiq/providers/openstack/cloud_manager/volume_snapshot_template.rb:14
 msgid "Volume Snapshot Template (Openstack)"
 msgid_plural "Volume Snapshot Templates (Openstack)"
-msgstr[0] "Modelo de captura\ninstantânea do volume (Openstack)"
-msgstr[1] "Modelos de captura\ninstantânea do volume (Openstack)"
+msgstr[0] "Modelo de captura instantânea do volume (Openstack)"
+msgstr[1] "Modelos de captura instantânea do volume (Openstack)"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate (plural form)
 #: ../config/dictionary_strings.rb:2058
@@ -44528,7 +44528,7 @@ msgstr "Modelos de captura instantânea de volume (Openstack)"
 msgid "Volume Template (Openstack)"
 msgid_plural "Volume Templates (Openstack)"
 msgstr[0] "Modelo de volume (Openstack)"
-msgstr[1] "Modelos\nde volume (Openstack)"
+msgstr[1] "Modelos de volume (Openstack)"
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate (plural form)
 #: ../config/dictionary_strings.rb:2062
@@ -44845,7 +44845,7 @@ msgstr "Sim"
 
 #: ../app/models/authenticator/database.rb:16
 msgid "Your account has been locked due to too many failed login attempts, please contact the administrator."
-msgstr "Sua conta foi bloqueada devido a muitas tentativas\nde login com falha, entre em contato com o administrador."
+msgstr "Sua conta foi bloqueada devido a muitas tentativas de login com falha, entre em contato com o administrador."
 
 #. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
 #. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
@@ -45066,7 +45066,7 @@ msgstr "não pode ser mudado porque o provedor está pausado"
 
 #: ../app/models/miq_server.rb:515
 msgid "cannot be changed when running in containers"
-msgstr "não pode ser alterado durante a execução em\ncontêineres"
+msgstr "não pode ser alterado durante a execução em contêineres"
 
 #: ../app/models/miq_server.rb:59
 msgid "cannot be maintenance zone"
@@ -45122,7 +45122,7 @@ msgstr "O diretório deve ser um de %{directory}"
 
 #: ../app/models/orchestration_template.rb:130
 msgid "eligible_manager_types must be implemented in subclass"
-msgstr "eligible_manager_types deve ser implementado na\nsubclasse"
+msgstr "eligible_manager_types deve ser implementado na subclasse"
 
 #:
 #: ../app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb:35
@@ -45185,7 +45185,7 @@ msgstr "find deve ser implementado em uma subclasse"
 
 #: ../app/models/authenticator/base.rb:181
 msgid "find_external_identity must be implemented in a subclass"
-msgstr "find_external_identity deve ser implementado em uma\nsubclasse"
+msgstr "find_external_identity deve ser implementado em uma subclasse"
 
 #: ../app/models/manageiq/providers/cloud_manager/vm.rb:112
 msgid "flavor cannot be found"
@@ -45197,7 +45197,7 @@ msgstr "o formato é inválido."
 
 #: ../app/models/miq_request_workflow.rb:777
 msgid "get_source_and_targets must be implemented in a subclass"
-msgstr "get_source_and_targets deve ser implementado em uma\nsubclasse"
+msgstr "get_source_and_targets deve ser implementado em uma subclasse"
 
 #: ../app/models/ext_management_system.rb:176
 msgid "has to be unique per provider type"
@@ -45507,11 +45507,11 @@ msgstr "prov_type não pode ser mudado"
 
 #: ../app/models/ems_cluster.rb:68
 msgid "provider_object must be implemented by a subclass"
-msgstr "provider_object deve ser implementado por uma\nsubclasse"
+msgstr "provider_object deve ser implementado por uma subclasse"
 
 #: ../app/models/ems_cluster.rb:72
 msgid "provider_object_release must be implemented by a subclass"
-msgstr "provider_object_release deve ser implementado por\numa subclasse"
+msgstr "provider_object_release deve ser implementado por uma subclasse"
 
 #: ../app/models/vm_or_template.rb:1180
 msgid "raise_created_event must be implemented in a subclass"
@@ -45531,7 +45531,7 @@ msgstr "raw_create_cloud_tenant deve ser implementado em uma subclasse"
 
 #: ../app/models/physical_storage.rb:84
 msgid "raw_create_physical_storage must be implemented in a subclass"
-msgstr "raw_create_physical_storage deve ser implementado\nem uma subclasse"
+msgstr "raw_create_physical_storage deve ser implementado em uma subclasse"
 
 #: ../app/models/orchestration_stack.rb:119
 msgid "raw_create_stack must be implemented in a subclass"
@@ -45547,7 +45547,7 @@ msgstr "raw_delete deve ser implementado em uma subclasse"
 
 #: ../app/models/cloud_network.rb:105
 msgid "raw_delete_cloud_network must be implemented in a subclass"
-msgstr "raw_delete_cloud_network deve ser implementada em\numa subclasse"
+msgstr "raw_delete_cloud_network deve ser implementada em uma subclasse"
 
 #: ../app/models/cloud_subnet.rb:63
 msgid "raw_delete_cloud_subnet must be implemented in a subclass"
@@ -45575,15 +45575,15 @@ msgstr "raw_delete_load_balancer deve ser implementado em uma subclasse"
 
 #: ../app/models/security_group.rb:88
 msgid "raw_delete_security_group must be implemented in a subclass"
-msgstr "raw_delete_security_group deve ser implementado em\numa subclasse"
+msgstr "raw_delete_security_group deve ser implementado em uma subclasse"
 
 #: ../app/models/security_policy.rb:70
 msgid "raw_delete_security_policy must be implemented in a subclass"
-msgstr "raw_delete_security_policy deve ser implementado em\numa subclasse"
+msgstr "raw_delete_security_policy deve ser implementado em uma subclasse"
 
 #: ../app/models/security_policy_rule.rb:81
 msgid "raw_delete_security_policy_rule must be implemented in a subclass"
-msgstr "raw_delete_security_policy_rule deve ser\nimplementado em uma subclasse"
+msgstr "raw_delete_security_policy_rule deve ser implementado em uma subclasse"
 
 #: ../app/models/cloud_volume_snapshot.rb:69
 msgid "raw_delete_snapshot must be implemented in a subclass"
@@ -45627,7 +45627,7 @@ msgstr "raw_status deve ser implementado em uma subclasse"
 
 #: ../app/models/cloud_network.rb:80
 msgid "raw_update_cloud_network must be implemented in a subclass"
-msgstr "raw_update_cloud_network deve ser implementado em\numa subclasse"
+msgstr "raw_update_cloud_network deve ser implementado em uma subclasse"
 
 #: ../app/models/cloud_tenant.rb:86
 msgid "raw_update_cloud_tenant must be implemented in a subclass"
@@ -45643,15 +45643,15 @@ msgstr "raw_update_load_balancer deve ser implementado em uma subclasse"
 
 #: ../app/models/security_group.rb:63
 msgid "raw_update_security_group must be implemented in a subclass"
-msgstr "raw_update_security_group deve ser implementado em\numa subclasse"
+msgstr "raw_update_security_group deve ser implementado em uma subclasse"
 
 #: ../app/models/security_policy.rb:45
 msgid "raw_update_security_policy must be implemented in a subclass"
-msgstr "raw_update_security_policy deve ser implementado em\numa subclasse"
+msgstr "raw_update_security_policy deve ser implementado em uma subclasse"
 
 #: ../app/models/security_policy_rule.rb:56
 msgid "raw_update_security_policy_rule must be implemented in a subclass"
-msgstr "raw_update_security_policy_rule deve ser\nimplementado em uma subclasse"
+msgstr "raw_update_security_policy_rule deve ser implementado em uma subclasse"
 
 #: ../app/models/orchestration_stack.rb:123
 msgid "raw_update_stack must be implemented in a subclass"
@@ -45667,7 +45667,7 @@ msgstr "refresh deve ser implementado em uma subclasse"
 
 #: ../app/models/ems_folder.rb:119 ../app/models/ems_cluster.rb:76
 msgid "register_host must be implemented by a subclass"
-msgstr "register_host deve ser implementado por uma\nsubclasse"
+msgstr "register_host deve ser implementado por uma subclasse"
 
 #: ../app/models/service_template.rb:507
 msgid "service_type cannot be changed"
@@ -45732,7 +45732,7 @@ msgstr "Zona desconhecida %{zone_name}"
 #: ../app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb:330
 msgid "vApp Template"
 msgid_plural "vApp Templates"
-msgstr[0] "Modelo de\nvApp"
+msgstr[0] "Modelo de vApp"
 msgstr[1] "Modelos de vApp"
 
 #: ../app/presenters/tree_builder_orchestration_templates.rb:44
@@ -45821,7 +45821,7 @@ msgstr "que deve ser um Número inteiro ou um de %{priority}"
 
 #: ../app/models/zone.rb:242
 msgid "zone name '%{name}' is used by a provider"
-msgstr "o nome da zona\n'%{name}'\né usado por um provedor"
+msgstr "o nome da zona '%{name}' é usado por um provedor"
 
 #: ../app/models/zone.rb:241
 msgid "zone name '%{name}' is used by a server"
@@ -45829,7 +45829,7 @@ msgstr "O nome da zona '%{name}' é usado por um servidor"
 
 #: ../app/controllers/api/providers_controller.rb:284
 msgid "Invalid attributes specified in the request: %{keys}"
-msgstr "Atributos inválidos especificados na solicitação:\n%{keys}"
+msgstr "Atributos inválidos especificados na solicitação: %{keys}"
 
 #: ../lib/api/utils.rb:15
 msgid "Invalid href_slug %{href_slug} specified"
@@ -45846,7 +45846,7 @@ msgstr "O usuário deve ser definido"
 #:
 #: ../lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb:74
 msgid "Ansible variables must start with a letter or underscore character, and contain only letters, numbers and underscores: [%{var}]"
-msgstr "As variáveis do Ansible devem iniciar com uma letra ou\num caractere sublinhado e conter apenas letras, números e\nsublinhados:\n[%{var}]"
+msgstr "As variáveis do Ansible devem iniciar com uma letra ou um caractere sublinhado e conter apenas letras, números e sublinhados: [%{var}]"
 
 #: ../lib/manageiq/automation_engine/engine.rb:16
 msgid "Automation Engine"
@@ -45866,7 +45866,7 @@ msgstr "A credencial '%{credential_name}' não existe no dispositivo, inclua ess
 
 #: ../app/models/miq_ae_yaml_import.rb:86
 msgid "Domain name change for a system domain import is not supported."
-msgstr "A mudança de nome de domínio para uma importação de\ndomínio do sistema não é suportada."
+msgstr "A mudança de nome de domínio para uma importação de domínio do sistema não é suportada."
 
 #: ../app/models/miq_ae_yaml_import.rb:263
 msgid "Error: Playbook method '%{method_name}' contains below listed error(s):"
@@ -45875,12 +45875,12 @@ msgstr "Erro: o método de Playbook '%{method_name}' contém os erros listados a
 #: ../app/models/miq_ae_yaml_import.rb:82
 #: ../app/models/miq_ae_yaml_import.rb:90
 msgid "Git based system domain import is not supported."
-msgstr "A importação de domínio do sistema baseado em Git\nnão é suportada."
+msgstr "A importação de domínio do sistema baseado em Git não é suportada."
 
 #:
 #: ../lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb:86
 msgid "Invalid attribute [%{attr}] for %{object}"
-msgstr "Atributo inválido\n[%{attr}]\npara\n%{object}"
+msgstr "Atributo inválido [%{attr}] para %{object}"
 
 #: ../app/models/miq_ae_git_import.rb:25
 msgid "Multiple Domain import is not supported."
@@ -45889,12 +45889,12 @@ msgstr "A importação de domínio múltiplo não é suportada."
 #:
 #: ../lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb:85
 msgid "Object not found: [%{obj_name}]"
-msgstr "Objeto não encontrado:\n[%{obj_name}]"
+msgstr "Objeto não encontrado: [%{obj_name}]"
 
 #:
 #: ../lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb:94
 msgid "Object update failed - service object not found for: [service_var__%{key} = %{value}]"
-msgstr "Falha na atualização do objeto - objeto de serviço\nnão encontrado para:\n[service_var__%{key}\n=\n%{value}]"
+msgstr "Falha na atualização do objeto - objeto de serviço não encontrado para: [service_var__%{key} = %{value}]"
 
 #: ../app/models/miq_ae_yaml_import.rb:302
 msgid "Playbook '%{playbook_name}' not found in repository '%{repository_name}', you  can refresh the repo or change the branch or tag and retry the import, if the playbook doesn't exist in the repo this import will never succeed, you can try importing by skiping this playbook using --skip_playbook pb1, pb2."
@@ -45915,7 +45915,7 @@ msgstr "A Credencial da área segura '%{vault_credential_name}' não existe no d
 #:
 #: ../lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb:367
 msgid "ae_state_max_retries is not set in automate field"
-msgstr "ae_state_max_retries não está configurado no campo\nautomatizado"
+msgstr "ae_state_max_retries não está configurado no campo automatizado"
 
 #: ../app/helpers/storage_helper/textual_summary.rb:27
 #: ../app/views/miq_ae_customization/_old_dialogs_form.html.haml:41
@@ -46093,11 +46093,11 @@ msgstr "ID da chave de acesso"
 
 #: ../app/models/authenticator/amazon.rb:42
 msgid "Access key %{number} belongs to IAM user, not to the AWS account holder."
-msgstr "A chave de acesso\n%{number}\npertence ao usuário do IAM, não ao titular da conta da AWS."
+msgstr "A chave de acesso %{number} pertence ao usuário do IAM, não ao titular da conta da AWS."
 
 #: ../app/models/authenticator/amazon.rb:96
 msgid "Access key %{number} does not match an IAM user for aws account holder."
-msgstr "A chave de acesso\n%{number}\nnão corresponde a um usuário do IAM para o titular da conta\nda AWS."
+msgstr "A chave de acesso %{number} não corresponde a um usuário do IAM para o titular da conta da AWS."
 
 #: ../lib/manageiq/providers/amazon/engine.rb:14
 msgid "Amazon Provider"
@@ -46151,7 +46151,7 @@ msgstr "É preciso ter acesso privilegiado, como root ou administrador."
 
 #: ../app/models/authenticator/amazon.rb:115
 msgid "SignatureMismatch - check your AWS Secret Access Key and signing method"
-msgstr "SignatureMismatch - verifique a chave de acesso\nde segredo da AWS e o método de assinatura"
+msgstr "SignatureMismatch - verifique a chave de acesso de segredo da AWS e o método de assinatura"
 
 #: ../app/helpers/textual_summary_helper.rb:218
 #: ../app/views/layouts/angular/_multi_auth_credentials.html.haml:29
@@ -46171,23 +46171,23 @@ msgstr "O Contêiner de Armazenamento já está vazio"
 #: ../app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb:4
 #: ../app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb:14
 msgid "The Storage Container is not connected to an active %{table}"
-msgstr "O contêiner de armazenamento não está conectado a\num\n%{table}\nativo"
+msgstr "O contêiner de armazenamento não está conectado a um %{table} ativo"
 
 #:
 #: ../app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb:4
 #: ../app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb:10
 msgid "The Storage Object is not connected to an active %{table}"
-msgstr "O Objeto de Armazenamento não está conectado a um\n%{table}\nativo"
+msgstr "O Objeto de Armazenamento não está conectado a um %{table} ativo"
 
 #:
 #: ../app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb:59
 msgid "Unable to process data for job with id %{job_id}"
-msgstr "Não é possível processar dados para uma tarefa com\no ID\n%{job_id}"
+msgstr "Não é possível processar dados para uma tarefa com o ID %{job_id}"
 
 #:
 #: ../app/models/manageiq/providers/amazon/agent_coordinator_worker/runner/response_thread.rb:66
 msgid "Unable to sync data for job with id %{job_id}"
-msgstr "Não é possível sincronizar dados para a tarefa\ncom a ID %{job_id}"
+msgstr "Não é possível sincronizar dados para a tarefa com a ID %{job_id}"
 
 #: ../app/views/layouts/angular/_multi_auth_credentials.html.haml:217
 msgid "Used for Docker Registry credentials required to perform SmartState Analysis on AWS."
@@ -46272,8 +46272,8 @@ msgstr "nenhuma credencial definida"
 #: ../app/decorators/manageiq/providers/autosde/storage_manager_decorator.rb:19
 msgid "%{number} Storage Pool"
 msgid_plural "%{number} Storage Pools"
-msgstr[0] "Conjunto de\narmazenamentos %{number}"
-msgstr[1] "Conjuntos de\narmazenamentos %{number}"
+msgstr[0] "Conjunto de armazenamentos %{number}"
+msgstr[1] "Conjuntos de armazenamentos %{number}"
 
 #: ../app/helpers/ems_network_helper/textual_summary.rb:60
 #: ../app/helpers/ems_physical_infra_helper/textual_summary.rb:55
@@ -46626,7 +46626,7 @@ msgstr "Se a MV é ou não 'preemptível'. Consulte https://cloud.google.com/com
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:119
 msgid "A server-side error occurred in the provisioning workflow"
-msgstr "Um erro do lado do servidor ocorreu no fluxo de\ntrabalho de fornecimento"
+msgstr "Um erro do lado do servidor ocorreu no fluxo de trabalho de fornecimento"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb:72
@@ -46636,7 +46636,7 @@ msgstr "Ocorreu um erro ao provisionar a instância."
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb:54
 msgid "Can't attach non-shareable volume that is in use."
-msgstr "Não é possível anexar o volume não compartilhável\nque\nestá em uso."
+msgstr "Não é possível anexar o volume não compartilhável que está em uso."
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb:35
@@ -46656,17 +46656,17 @@ msgstr "Processadores Autorizados"
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:93
 msgid "Entitled Processors field does not contain a well-formed positive number"
-msgstr "O campo Processadores autorizados não contém um\nnúmero positivo bem formado"
+msgstr "O campo Processadores autorizados não contém um número positivo bem formado"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:96
 msgid "For dedicated processors, the format is: \"positive integer\""
-msgstr "Para processadores dedicados, o formato é: \"número\ninteiro positivo\""
+msgstr "Para processadores dedicados, o formato é: \"número inteiro positivo\""
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:98
 msgid "For shared processors, the format is: \"positive whole multiple of 0.25\""
-msgstr "Para processadores compartilhados, o formato é:\n\"positivo inteiro múltiplo de 0,25\""
+msgstr "Para processadores compartilhados, o formato é: \"positivo inteiro múltiplo de 0,25\""
 
 #: ../app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb:51
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb:62
@@ -46685,13 +46685,13 @@ msgstr "Provedor IBM Cloud"
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:111
 msgid "IP-address field has to be either blank or a valid IPv4 address"
-msgstr "O campo IP-address tem que estar em branco ou ser um\nendereço IPv4 válido"
+msgstr "O campo IP-address tem que estar em branco ou ser um endereço IPv4 válido"
 
 #: ../app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb:22
 msgid "Instance (IBM)"
 msgid_plural "Instances (IBM)"
-msgstr[0] "Instância\n(IBM)"
-msgstr[1] "Instâncias\n(IBM)"
+msgstr[0] "Instância (IBM)"
+msgstr[1] "Instâncias (IBM)"
 
 #: ../app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb:84
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb:107
@@ -46717,7 +46717,7 @@ msgstr "Tipo do processador"
 #: ../app/models/manageiq/providers/ibm_cloud/vpc/network_manager/security_group.rb:3
 msgid "Security Group (IBM)"
 msgid_plural "Security Groups (IBM)"
-msgstr[0] "Grupo de segurança\n(IBM)"
+msgstr[0] "Grupo de segurança (IBM)"
 msgstr[1] "Grupos de segurança (IBM)"
 
 #:
@@ -46728,27 +46728,27 @@ msgstr "A Rede tem VMIs ativos relacionados a ela"
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb:93
 msgid "The number of entitled processors assigned to the VM"
-msgstr "O número de processadores autorizados atribuídos à\nVM"
+msgstr "O número de processadores autorizados atribuídos à VM"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb:66
 msgid "Unable to attach volume: %{error_message}"
-msgstr "Não é possível anexar o volume:\n%{error_message}"
+msgstr "Não é possível anexar o volume: %{error_message}"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb:79
 msgid "Unable to detach volume: %{error_message}"
-msgstr "Não é possível desanexar o volume:\n%{error_message}"
+msgstr "Não é possível desanexar o volume: %{error_message}"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb:22
 msgid "Unknown target API set: '%{service_type}'"
-msgstr "Conjunto de API de destino desconhecido:\n'%{service_type}'"
+msgstr "Conjunto de API de destino desconhecido: '%{service_type}'"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb:103
 msgid "dedicated: Dedicated, shared: Uncapped shared, capped: Capped shared"
-msgstr "dedicado: Dedicado, compartilhado: Compartilhado\nilimitado, limitado: Compartilhado limitado"
+msgstr "dedicado: Dedicado, compartilhado: Compartilhado ilimitado, limitado: Compartilhado limitado"
 
 #: ../app/controllers/mixins/actions/vm_actions/resize.rb:76
 msgid "unknown"
@@ -46760,20 +46760,20 @@ msgstr "URL do CloudPak for MCM"
 
 #: ../app/models/manageiq/providers/ibm_terraform/provider.rb:61
 msgid "CloudPak for MCM URL. e.g. https://cp-console.apps.mydomain.com"
-msgstr "URL do CloudPak for MCM. Por exemplo,\nhttps://cp-console.apps.mydomain.com"
+msgstr "URL do CloudPak for MCM. Por exemplo, https://cp-console.apps.mydomain.com"
 
 #: ../app/models/manageiq/providers/ibm_terraform/configuration_manager.rb:47
 msgid "Configuration Manager (IBM Terraform)"
 msgid_plural "Configuration Managers (IBM Terraform)"
-msgstr[0] "Gerenciador de configuração\n(IBM\nTerraform)"
-msgstr[1] "Gerenciadores de configuração (IBM\nTerraform)"
+msgstr[0] "Gerenciador de configuração (IBM Terraform)"
+msgstr[1] "Gerenciadores de configuração (IBM Terraform)"
 
 #:
 #: ../app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb:15
 msgid "Configured System (IBM Terraform)"
 msgid_plural "Configured Systems (IBM Terraform)"
-msgstr[0] "Sistema\nconfigurado (IBM\nTerraform)"
-msgstr[1] "Sistemas\nconfigurados (IBM Terraform)"
+msgstr[0] "Sistema configurado (IBM Terraform)"
+msgstr[1] "Sistemas configurados (IBM Terraform)"
 
 #: ../lib/manageiq/providers/ibm_terraform/engine.rb:14
 msgid "IBM Terraform Provider"
@@ -46800,7 +46800,7 @@ msgstr "Configurações avançadas"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:70
 msgid "Advanced Settings for provider configuration"
-msgstr "Configurações avançadas para configuração do\nprovedor"
+msgstr "Configurações avançadas para configuração do provedor"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:677
 msgid "CVE Location"
@@ -46818,11 +46818,11 @@ msgstr "Detectar"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:50
 msgid "Enables defining a URL path prefix for XCCDF file instead of accessing the default location.\n  example: http://my_file_server.org:3333/xccdf_files/\n  Expecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there."
-msgstr "Permite definir um prefixo de caminho de URL para o\narquivo XCCDF em vez de acessar o local padrão.\n  Por exemplo:\nhttp://my_file_server.org: 3333/xccdf_files/ Esperando\nencontrar o arquivo com.redhat.rhsa-RHEL7.ds.xml.bz2 lá."
+msgstr "Permite definir um prefixo de caminho de URL para o arquivo XCCDF em vez de acessar o local padrão.\n  Por exemplo: http://my_file_server.org:3333/xccdf_files/\n Esperando encontrar o arquivo com.redhat.rhsa-RHEL7.ds.xml.bz2 lá."
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:678
 msgid "Enables defining a URL path prefix for XCCDF file instead of accessing the default location.\nexample: http://my_file_server.org:3333/xccdf_files/\nExpecting to find com.redhat.rhsa-RHEL7.ds.xml.bz2 file there."
-msgstr "Permite definir um prefixo de caminho de URL para o\narquivo XCCDF em vez de acessar o local padrão.\nPor\nexemplo: http://my_file_server.org: 3333/xccdf_files/\nEsperando encontrar o arquivo\ncom.redhat.rhsa-RHEL7.ds.xml.bz2 lá."
+msgstr "Permite definir um prefixo de caminho de URL para o arquivo XCCDF em vez de acessar o local padrão.\nPor exemplo: http://my_file_server.org: 3333/xccdf_files/\nEsperando encontrar o arquivo com.redhat.rhsa-RHEL7.ds.xml.bz2 lá."
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:616
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:632
@@ -46833,19 +46833,19 @@ msgstr "Proxy HTTP"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:617
 msgid "HTTP Proxy to connect ManageIQ to the provider. example: http://user:password@my_http_proxy"
-msgstr "Proxy HTTP para conectar o ManageIQ ao provedor. Por\nexemplo:\nhttp://user:password@my_http_proxy"
+msgstr "Proxy HTTP para conectar o ManageIQ ao provedor. Por exemplo: http://user:password@my_http_proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:9
 msgid "HTTP Proxy to connect ManageIQ to the provider. example: http://user:password@my_https_proxy"
-msgstr "Proxy HTTP para conectar o ManageIQ ao provedor. Por\nexemplo:\nhttp://user:password@my_https_proxy"
+msgstr "Proxy HTTP para conectar o ManageIQ ao provedor. Por exemplo: http://user:password@my_https_proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:633
 msgid "HTTP Proxy to connect image inspector pods to the internet. example: http://user:password@my_http_proxy"
-msgstr "Proxy HTTP para conectar pods de inspetor de imagem\nà Internet. Por\nexemplo:\nhttp://user:password@my_http_proxy"
+msgstr "Proxy HTTP para conectar pods de inspetor de imagem à Internet. Por exemplo: http://user:password@my_http_proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:23
 msgid "HTTP Proxy to connect image inspector pods to the internet. example: http://user:password@my_https_proxy"
-msgstr "Proxy HTTP para conectar pods de inspetor de imagem\nà Internet. Por\nexemplo:\nhttp://user:password@my_https_proxy"
+msgstr "Proxy HTTP para conectar pods de inspetor de imagem à Internet. Por exemplo: http://user:password@my_https_proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:639
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:26
@@ -46855,7 +46855,7 @@ msgstr "Proxy HTTPS"
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:640
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:27
 msgid "HTTPS Proxy to connect image inspector pods to the internet. example: https://user:password@my_https_proxy"
-msgstr "Proxy HTTPS para conectar pods de inspetor de\nimagem à Internet. Por exemplo:\nhttps://user:password@my_https_proxy"
+msgstr "Proxy HTTPS para conectar pods de inspetor de imagem à Internet. Por exemplo: https://user:password@my_https_proxy"
 
 #: ../app/helpers/ems_container_helper/textual_summary.rb:101
 #: ../app/views/ems_container/_form.html.haml:80
@@ -46885,7 +46885,7 @@ msgstr "Repositório de inspetor de imagem"
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:654
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:35
 msgid "Image-Inspector Repository. example: openshift/image-inspector"
-msgstr "Repositório de inspetor de imagem. Por\nexemplo:\nopenshift/image-inspector"
+msgstr "Repositório de inspetor de imagem. Por exemplo: openshift/image-inspector"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:44
 msgid "Image-Inspector Tag"
@@ -46894,7 +46894,7 @@ msgstr "Tag de inspetor de imagem"
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:670
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:45
 msgid "Image-Inspector image tag. example: 2.1"
-msgstr "Tag de imagem do inspetor de imagem. Por\nexemplo:\n2.1"
+msgstr "Tag de imagem do inspetor de imagem. Por exemplo: 2.1"
 
 #: ../app/views/ems_container/_form.html.haml:92
 msgid "KubeVirt"
@@ -46910,7 +46910,7 @@ msgstr "Sem proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:31
 msgid "NO Proxy lists urls that should'nt be sent to any proxy. example: my_file_server.org"
-msgstr "Sem proxy lista as URLs que não devem ser\nenviadas\npara nenhum proxy. Por exemplo: my_file_server.org"
+msgstr "Sem proxy lista as URLs que não devem ser enviadas para nenhum proxy. Por exemplo: my_file_server.org"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:646
 msgid "No Proxy"
@@ -46918,7 +46918,7 @@ msgstr "Sem Proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:647
 msgid "No Proxy lists urls that should'nt be sent to any proxy. example: my_file_server.org"
-msgstr "Sem proxy lista as URLs que não devem ser enviadas\npara nenhum proxy. Por exemplo: my_file_server.org"
+msgstr "Sem proxy lista as URLs que não devem ser enviadas para nenhum proxy. Por exemplo: my_file_server.org"
 
 #: ../app/views/ems_container/_form.html.haml:69
 #: ../app/views/ems_container/_form.html.haml:80
@@ -46931,7 +46931,7 @@ msgstr "Proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:64
 msgid "Proxy Settings"
-msgstr "Definições\ndo Proxy"
+msgstr "Definições do Proxy"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:65
 msgid "Proxy Settings for connection to the provider"
@@ -46940,7 +46940,7 @@ msgstr "Configurações de proxy para conexão com o provedor"
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:662
 #: ../app/models/manageiq/providers/kubernetes/container_manager/options.rb:40
 msgid "Registry to provide the image inspector repository. example: docker.io"
-msgstr "Registro para fornecer o repositório de inspetor de\nimagem. Por exemplo: docker.io"
+msgstr "Registro para fornecer o repositório de inspetor de imagem. Por exemplo: docker.io"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:70
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:178
@@ -46956,7 +46956,7 @@ msgstr "Configurações para a ferramenta de Inspetor de Imagem"
 
 #: ../app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml:300
 msgid "Trusted CA Certificates"
-msgstr "Certificados de Autoridade de\nCertificação Confiáveis"
+msgstr "Certificados de Autoridade de Certificação Confiáveis"
 
 #: ../app/models/manageiq/providers/kubernetes/container_manager_mixin.rb:722
 msgid "Unsupported endpoint"
@@ -46997,7 +46997,7 @@ msgstr[1] "Máquinas virtuais (Kubevirt)"
 #:
 #: ../app/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender.rb:78
 msgid "%{method_name} is not a valid name to an Ansible operation!"
-msgstr "%{method_name}\nnão é um nome válido para uma operação do Ansible!"
+msgstr "%{method_name} não é um nome válido para uma operação do Ansible!"
 
 #: ../app/javascript/components/form/fields/physical_server_field.js:70
 msgid "Choose a Server"
@@ -47049,7 +47049,7 @@ msgstr "Máscara de sub-rede de CIDR"
 #:
 #: ../app/javascript/components/cloud-networks/nsxt-cloud-network-form.schema.js:79
 msgid "CIDR Subnet Mask for the subnet of the Cloud Network"
-msgstr "Máscara de sub-rede de CIDR para a sub-rede da rede\nem nuvem"
+msgstr "Máscara de sub-rede de CIDR para a sub-rede da rede em nuvem"
 
 #:
 #: ../app/javascript/components/cloud-networks/nsxt-cloud-network-form.schema.js:84
@@ -47059,19 +47059,19 @@ msgstr "A máscara de sub-rede de CIDR é necessária"
 #: ../app/models/manageiq/providers/nsxt/network_manager/cloud_network.rb:4
 msgid "Cloud Network (NSX-T)"
 msgid_plural "Cloud Networks (NSX-T)"
-msgstr[0] "Rede em nuvem\n(NSX-T)"
-msgstr[1] "Redes em nuvem\n(NSX-T)"
+msgstr[0] "Rede em nuvem (NSX-T)"
+msgstr[1] "Redes em nuvem (NSX-T)"
 
 #: ../app/models/manageiq/providers/nsxt/network_manager/cloud_subnet.rb:3
 msgid "Cloud Subnet (NSX-T)"
 msgid_plural "Cloud Subnets (NSX-T)"
-msgstr[0] "Sub-rede em nuvem\n(NSX-T)"
+msgstr[0] "Sub-rede em nuvem (NSX-T)"
 msgstr[1] "Sub-redes em nuvem (NSX-T)"
 
 #: ../app/models/manageiq/providers/nsxt/network_manager/cloud_tenant.rb:3
 msgid "Cloud Tenant (NSX-T)"
 msgid_plural "Cloud Tenants (NSX-T)"
-msgstr[0] "Locatário de nuvem\n(NSX-T)"
+msgstr[0] "Locatário de nuvem (NSX-T)"
 msgstr[1] "Locatários de nuvem (NSX-T)"
 
 #:
@@ -47121,7 +47121,7 @@ msgstr "Grupos de segurança de destino"
 #:
 #: ../app/javascript/components/security-policy-rules/nsxt-security-policy-rule-form.schema.js:39
 msgid "Destination Security Groups of the Security Policy Rule"
-msgstr "Grupos de segurança de destino da regra de política\nde segurança"
+msgstr "Grupos de segurança de destino da regra de política de segurança"
 
 #:
 #: ../app/helper/manageiq/providers/nsxt/toolbar_overrides/cloud_network_center.rb:18
@@ -47192,27 +47192,27 @@ msgstr "Nome da regra de política de segurança"
 #: ../app/models/manageiq/providers/nsxt/network_manager/network_port.rb:3
 msgid "Network Port (NSX-T)"
 msgid_plural "Networks Ports (NSX-T)"
-msgstr[0] "Porta de rede\n(NSX-T)"
+msgstr[0] "Porta de rede (NSX-T)"
 msgstr[1] "Portas de rede (NSX-T)"
 
 #: ../app/models/manageiq/providers/nsxt/network_manager/network_router.rb:3
 msgid "Network Router (NSX-T)"
 msgid_plural "Networks Router (NSX-T)"
-msgstr[0] "Roteador de rede\n(NSX-T)"
+msgstr[0] "Roteador de rede (NSX-T)"
 msgstr[1] "Roteadores de rede (NSX-T)"
 
 #: ../app/models/manageiq/providers/nsxt/network_manager/network_service.rb:3
 msgid "Network Service (NSX-T)"
 msgid_plural "Networks Service (NSX-T)"
-msgstr[0] "Serviço de rede\n(NSX-T)"
+msgstr[0] "Serviço de rede (NSX-T)"
 msgstr[1] "Serviços de rede (NSX-T)"
 
 #:
 #: ../app/models/manageiq/providers/nsxt/network_manager/network_service_entry.rb:3
 msgid "Network Service Entry (NSX-T)"
 msgid_plural "Networks Service Entry (NSX-T)"
-msgstr[0] "Entrada de serviço de rede\n(NSX-T)"
-msgstr[1] "Entradas de serviço de rede\n(NSX-T)"
+msgstr[0] "Entrada de serviço de rede (NSX-T)"
+msgstr[1] "Entradas de serviço de rede (NSX-T)"
 
 #:
 #: ../app/javascript/components/security-policy-rules/nsxt-security-policy-rule-form.schema.js:48
@@ -47240,21 +47240,21 @@ msgstr "Remover a regra de política de segurança"
 #: ../app/models/manageiq/providers/nsxt/network_manager/security_group.rb:4
 msgid "Security Group (NSX-T)"
 msgid_plural "Security Groups (NSX-T)"
-msgstr[0] "Grupo de segurança\n(NSX-T)"
+msgstr[0] "Grupo de segurança (NSX-T)"
 msgstr[1] "Grupos de segurança (NSX-T)"
 
 #: ../app/models/manageiq/providers/nsxt/network_manager/security_policy.rb:4
 msgid "Security Policy (NSX-T)"
 msgid_plural "Security Policies (NSX-T)"
-msgstr[0] "Política de segurança\n(NSX-T)"
-msgstr[1] "Políticas de segurança\n(NSX-T)"
+msgstr[0] "Política de segurança (NSX-T)"
+msgstr[1] "Políticas de segurança (NSX-T)"
 
 #:
 #: ../app/models/manageiq/providers/nsxt/network_manager/security_policy_rule.rb:4
 msgid "Security Policy Rule (NSX-T)"
 msgid_plural "Security Policy Rules (NSX-T)"
-msgstr[0] "Regra de política de\nsegurança\n(NSX-T)"
-msgstr[1] "Regra de políticas de segurança\n(NSX-T)"
+msgstr[0] "Regra de política de segurança (NSX-T)"
+msgstr[1] "Regra de políticas de segurança (NSX-T)"
 
 #:
 #: ../app/javascript/components/cloud-networks/nsxt-cloud-network-form.schema.js:93
@@ -47288,7 +47288,7 @@ msgstr "Grupos de segurança de origem"
 #:
 #: ../app/javascript/components/security-policy-rules/nsxt-security-policy-rule-form.schema.js:30
 msgid "Source Security Groups of the Security Policy Rule"
-msgstr "Grupos de segurança de origem da regra de política\nde segurança"
+msgstr "Grupos de segurança de origem da regra de política de segurança"
 
 #: ../app/models/manageiq/providers/openstack/cloud_manager.rb:129
 msgid "Tenant Mapping Enabled"
@@ -47321,22 +47321,22 @@ msgstr "Provedor VMware NSX-T"
 #:
 #: ../app/helper/manageiq/providers/nsxt/toolbar_overrides/cloud_networks_center.rb:35
 msgid "Warning: The selected Cloud Networks and ALL of their components will be permanently removed!"
-msgstr "Aviso: as Redes em Nuvem selecionadas e TODOS os\nseus componentes serão removidos permanentemente!"
+msgstr "Aviso: as Redes em Nuvem selecionadas e TODOS os seus componentes serão removidos permanentemente!"
 
 #:
 #: ../app/helper/manageiq/providers/nsxt/toolbar_overrides/security_groups_center.rb:34
 msgid "Warning: The selected Security Groups and their VM references will be permanently removed!"
-msgstr "Aviso: os Grupos de Segurança selecionados e suas\nreferências de VM serão removidos permanentemente!"
+msgstr "Aviso: os Grupos de Segurança selecionados e suas referências de VM serão removidos permanentemente!"
 
 #:
 #: ../app/helper/manageiq/providers/nsxt/toolbar_overrides/security_policies_center.rb:34
 msgid "Warning: The selected Security Policies and their Security Policy Rules will be permanently removed!"
-msgstr "Aviso: as Políticas de segurança selecionadas e\nsuas Regras de Política de Segurança serão removidas\npermanentemente!"
+msgstr "Aviso: as Políticas de segurança selecionadas e suas Regras de Política de Segurança serão removidas permanentemente!"
 
 #:
 #: ../app/helper/manageiq/providers/nsxt/toolbar_overrides/security_policy_rules_center.rb:34
 msgid "Warning: The selected Security Policy Rules and ALL of their components will be permanently removed!"
-msgstr "Aviso: as Regras de Política de Segurança\nselecionadas e TODOS os seus componentes serão removidos\npermanentemente!"
+msgstr "Aviso: as Regras de Política de Segurança selecionadas e TODOS os seus componentes serão removidos permanentemente!"
 
 #: ../app/helpers/textual_summary_helper.rb:214
 msgid "AMQP"
@@ -47426,7 +47426,7 @@ msgstr "Modelo do OpenShift"
 
 #: ../app/models/manageiq/providers/openstack/cloud_manager/flavor.rb:48
 msgid "%{cpus} CPUs, %{ram} RAM, %{disk_size} Root Disk"
-msgstr "%{cpus}\nCPUs,\n%{ram} RAM, %{disk_size} Disco raiz"
+msgstr "%{cpus} CPUs, %{ram} RAM, %{disk_size} Disco raiz"
 
 #: ../app/models/manageiq/providers/openstack/infra_manager/host.rb:332
 msgid "Cannot start. Already on."
@@ -47486,7 +47486,7 @@ msgstr "Região do provedor"
 #:
 #: ../app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb:76
 msgid "Provider stack is not ready to be updated, another operation is in progress."
-msgstr "A pilha do provedor não está pronta para ser\natualizada, outra operação está em andamento."
+msgstr "A pilha do provedor não está pronta para ser atualizada, outra operação está em andamento."
 
 #:
 #: ../app/models/manageiq/providers/openstack/network_manager/network_router.rb:47
@@ -47534,7 +47534,7 @@ msgstr "A Rede de nuvem não está conectada a um %{table} ativo"
 
 #: ../app/models/manageiq/providers/openstack/cloud_manager/flavor.rb:27
 msgid "The Flavor is not connected to an active %{table}"
-msgstr "O tipo não está conectado a um\n%{table}\nativo"
+msgstr "O tipo não está conectado a um %{table} ativo"
 
 #: ../app/models/manageiq/providers/openstack/network_manager/floating_ip.rb:10
 #: ../app/models/manageiq/providers/openstack/network_manager/floating_ip.rb:18
@@ -47543,7 +47543,7 @@ msgstr "O IP flutuante não está conectado a um %{table} ativo"
 
 #: ../app/models/manageiq/providers/openstack/cloud_manager/template.rb:78
 msgid "The Image is not connected to an active %{table}"
-msgstr "A Imagem não está conectada a um\n%{table}\nativo"
+msgstr "A Imagem não está conectada a um %{table} ativo"
 
 #: ../app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb:8
 msgid "The Instance cannot be resized, current state has to be active or shutoff."
@@ -47553,7 +47553,7 @@ msgstr "A instância não pode ser redimensionada, o estado atual deve ser ativo
 #: ../app/models/manageiq/providers/openstack/network_manager/network_router.rb:12
 #: ../app/models/manageiq/providers/openstack/network_manager/network_router.rb:25
 msgid "The Network Router is not connected to an active %{table}"
-msgstr "O Roteador de Rede não está conectado a um\n%{table}\nativo"
+msgstr "O Roteador de Rede não está conectado a um %{table} ativo"
 
 #:
 #: ../app/models/manageiq/providers/openstack/network_manager/security_group.rb:8
@@ -47594,17 +47594,17 @@ msgstr "Este %{instance} não tem nenhum %{security_groups} associado"
 #:
 #: ../app/models/manageiq/providers/openstack/network_manager/network_router.rb:17
 msgid "Unable to delete \"%{name}\" because it has associated ports."
-msgstr "Não é possível excluir\n\"%{name}\"\nporque ele tem portas associadas."
+msgstr "Não é possível excluir \"%{name}\" porque ele tem portas associadas."
 
 #:
 #: ../app/models/manageiq/providers/openstack/cloud_manager/orchestration_template.rb:187
 msgid "Unknown constraint %{constraint}"
-msgstr "Restrição desconhecida\n%{constraint}"
+msgstr "Restrição desconhecida %{constraint}"
 
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb:280
 msgid "%{description} VM Memory is larger than Memory Limit"
-msgstr "%{description}\nA memória da VM é maior que limite de memória"
+msgstr "%{description} A memória da VM é maior que limite de memória"
 
 #: ../app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb:1038
 #: ../app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb:1049
@@ -47622,7 +47622,7 @@ msgstr "Não é possível importar MVs arquivadas"
 
 #: ../app/models/manageiq/providers/redhat/infra_manager.rb:36
 msgid "Cannot import to a RHV provider of version < 4.1.5"
-msgstr "Não é possível importar para um provedor RHV da\nversão < 4.1.5"
+msgstr "Não é possível importar para um provedor RHV da versão < 4.1.5"
 
 #: ../app/models/manageiq/providers/redhat/infra_manager.rb:273
 msgid "Database name"
@@ -47635,7 +47635,7 @@ msgstr "O armazenamento de dados não existe ou não pode ser acessado. Não é 
 
 #: ../app/models/manageiq/providers/redhat/infra_manager.rb:396
 msgid "Datastore does not exist, unable to add disk"
-msgstr "O armazenamento de dados não existe. Não é\npossível\nincluir o disco"
+msgstr "O armazenamento de dados não existe. Não é possível incluir o disco"
 
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb:10
@@ -47646,7 +47646,7 @@ msgstr "O Conjunto de recursos padrão para o host <%{name}> não foi localizado
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb:64
 msgid "Delete is not allowed for a snapshot that is the active one"
-msgstr "A exclusão não é permitida para uma captura\ninstantânea que é a ativa"
+msgstr "A exclusão não é permitida para uma captura instantânea que é a ativa"
 
 #: ../app/models/manageiq/providers/redhat/infra_manager/vm_import.rb:65
 msgid "Error while configuring VM network."
@@ -47664,11 +47664,11 @@ msgstr "Host não especificado, não foi possível migrar a máquina virtual"
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb:275
 msgid "Memory Limit is supported for RHV 4.1 and above. Current provider version is %{version}."
-msgstr "O Limite de Memória é suportado para o RHV 4.1 e\nsuperior. A versão do provedor atual é\n%{version}."
+msgstr "O Limite de Memória é suportado para o RHV 4.1 e superior. A versão do provedor atual é %{version}."
 
 #: ../app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml:312
 msgid "Paste here the trusted CA certificates, in PEM format."
-msgstr "Cole aqui os Certificados de Autoridade de\nCertificação confiáveis no formato PEM."
+msgstr "Cole aqui os Certificados de Autoridade de Certificação confiáveis no formato PEM."
 
 #: ../app/helpers/application_helper/toolbar/x_vm_center.rb:19
 msgid "Perform SmartState Analysis on this VM"
@@ -47703,12 +47703,12 @@ msgstr "O provedor de origem deve ser do tipo VMware"
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb:14
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/operations/relocation.rb:46
 msgid "Specified Resource Pool <%{pool_name}> for Host <%{name}> is invalid, unable to migrate VM"
-msgstr "O Conjunto de recursos especificados<%{pool_name}> para o Host\n<%{name}> é inválido, não é possível migrar a VM"
+msgstr "O Conjunto de recursos especificados<%{pool_name}> para o Host <%{name}> é inválido, não é possível migrar a VM"
 
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/provision_workflow.rb:289
 msgid "Template sealing is supported only for non-Windows OS."
-msgstr "A selagem de modelo é suportada apenas para os\nSOs que não são Windows."
+msgstr "A selagem de modelo é suportada apenas para os SOs que não são Windows."
 
 #: ../app/models/manageiq/providers/redhat/infra_manager/host.rb:53
 msgid "The Host is not connected to an active provider"
@@ -47739,12 +47739,12 @@ msgstr "Este recurso não é suportado pela versão da API do provedor"
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/vm_or_template_shared/scanning.rb:51
 msgid "VMs must be scanned from an EVM server whose host is attached to the same\n  storage as the VM unless overridden via SmartProxy affinity.\n  Please verify that:\n  1) Direct LUNs are attached to ManageIQ appliance\n  2) Management Relationship is set for the ManageIQ appliance"
-msgstr "As VMs devem ser escaneadas a partir de um servidor EVM cujo host esteja conectado ao mesmo armazenamento que a VM, a menos que seja substituído por meio da afinidade do SmartProxy.\n  Verifique se:\n1) LUNs diretas estão conectadas ao dispositivo ManageIQ\n2) O relacionamento de gerenciamento está configurado para o dispositivo ManageIQ"
+msgstr "As VMs devem ser escaneadas a partir de um servidor EVM cujo host esteja conectado ao mesmo\n  armazenamento que a VM, a menos que seja substituído por meio da afinidade do SmartProxy.\n  Verifique se:\n1) LUNs diretas estão conectadas ao dispositivo ManageIQ\n2) O relacionamento de gerenciamento está configurado para o dispositivo ManageIQ"
 
 #:
 #: ../app/models/manageiq/providers/redhat/infra_manager/provision_workflow/dialog_field_validation.rb:11
 msgid "When the 'Linked Clone' option is set, disks and storage configuration cannot be changed"
-msgstr "Quando a opção 'Clone vinculado' é\nconfigurada, os discos e a configuração de armazenamento não podem ser\nalterados"
+msgstr "Quando a opção 'Clone vinculado' é configurada, os discos e a configuração de armazenamento não podem ser alterados"
 
 #: ../lib/manageiq/providers/ovirt/engine.rb:14
 msgid "oVirt Provider"
@@ -47887,7 +47887,7 @@ msgstr "O %{field_required} para o cluster ativado para não DRS"
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/ovf_service_template.rb:33
 msgid ":provision section is missing from :config_info in options hash."
-msgstr "A seção :provision está ausente em :config_info\nno hash de opções."
+msgstr "A seção :provision está ausente em :config_info no hash de opções."
 
 #: ../app/helpers/application_helper/toolbar/configured_system_center.rb:21
 #: ../app/helpers/application_helper/toolbar/configured_system_center.rb:22
@@ -47913,7 +47913,7 @@ msgstr "A operação de clonagem não é suportada"
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/inventory/parser.rb:310
 msgid "Default for %{parent_type} %{parent_name}"
-msgstr "Padrão para\n%{parent_type}\n%{parent_name}"
+msgstr "Padrão para %{parent_type} %{parent_name}"
 
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/provision_workflow/dialog_field_validation.rb:10
@@ -47935,7 +47935,7 @@ msgstr "O host não pode ser nil"
 
 #: ../app/models/manageiq/providers/vmware/infra_manager/host.rb:33
 msgid "Host must be connected to an EMS to refresh datastore files"
-msgstr "O host deve estar conectado a um EMS para atualizar\narquivos de armazenamento de dados"
+msgstr "O host deve estar conectado a um EMS para atualizar arquivos de armazenamento de dados"
 
 #: ../app/models/manageiq/providers/vmware/infra_manager/scanning/job.rb:171
 msgid "No Providers available to delete snapshot"
@@ -47949,13 +47949,13 @@ msgstr "Recusando-se a excluir uma captura instantânea de VCB"
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm/operations/snapshot.rb:23
 msgid "Refusing to delete snapshot when there is a Consolidate Helper snapshot"
-msgstr "Recusando-se a excluir captura instantânea quando\nhá uma captura instantânea do auxiliar consolidado"
+msgstr "Recusando-se a excluir captura instantânea quando há uma captura instantânea do auxiliar consolidado"
 
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/orchestration_template.rb:26
 #: ../app/models/manageiq/providers/vmware/infra_manager/ovf_service_template.rb:34
 msgid "Resource pool is required for content library item deployment."
-msgstr "O conjunto de recursos é necessário para\na implementação de item da biblioteca de conteúdo."
+msgstr "O conjunto de recursos é necessário para a implementação de item da biblioteca de conteúdo."
 
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb:9
@@ -47999,12 +47999,12 @@ msgstr "Provedor VMware"
 
 #: ../app/models/manageiq/providers/vmware/infra_manager/vm.rb:14
 msgid "Warm migratiobn can not migrate a VM with snapshots"
-msgstr "O migratiobn warm não pode migrar uma VM com\ncapturas instantâneas"
+msgstr "O migratiobn warm não pode migrar uma VM com capturas instantâneas"
 
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/orchestration_template.rb:27
 msgid "accept_all_eula is required for content library item deployment."
-msgstr "aceit_all_eula é necessário para a implementação do\nitem da biblioteca de conteúdo."
+msgstr "aceit_all_eula é necessário para a implementação do item da biblioteca de conteúdo."
 
 #: ../app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb:7
 msgid "no console credentials defined"
@@ -48017,7 +48017,7 @@ msgstr "Nenhuma credencial definida para %{type} %{name}"
 #:
 #: ../app/models/manageiq/providers/vmware/infra_manager/vim_connect_mixin.rb:61
 msgid "vCenter time is too far out of sync with the system time"
-msgstr "O horário do vCenter está muito fora de\nsincronização com\no horário do sistema"
+msgstr "O horário do vCenter está muito fora de sincronização com o horário do sistema"
 
 #: ../app/views/miq_ae_class/_class_fields.html.haml:5
 #: ../app/views/miq_ae_class/_class_fields.html.haml:49
@@ -48304,7 +48304,7 @@ msgstr "\"%{action}\" para o comutador \"%{name}\""
 
 #: ../app/controllers/mixins/generic_button_mixin.rb:108
 msgid "\"%{action}\" requires a single item to be selected."
-msgstr "\"%{action}\"\nrequer que um único item seja selecionado."
+msgstr "\"%{action}\" requer que um único item seja selecionado."
 
 #: ../app/controllers/application_controller/ci_processing.rb:823
 msgid "\"%{datastore_name}\": cannot be removed, has vms or hosts"
@@ -48316,7 +48316,7 @@ msgstr "O Domínio automatizado \"%{field}\" não pode ser excluído"
 
 #: ../app/controllers/mixins/generic_button_mixin.rb:117
 msgid "\"%{item_name}\" does not supports %{action}"
-msgstr "\"%{item_name}\"\nnão suporta\n%{action}"
+msgstr "\"%{item_name}\" não suporta %{action}"
 
 #: ../app/controllers/configuration_controller.rb:280
 msgid "\"%{name}\": Global Time Profiles cannot be deleted"
@@ -48411,7 +48411,7 @@ msgstr "%d Meses Atrás"
 #: ../app/javascript/components/notification-drawer/helpers.js:2
 msgid "%d New"
 msgid_plural "%d New"
-msgstr[0] "%d\nnovo"
+msgstr[0] "%d novo"
 msgstr[1] "%d novo"
 
 #: ../app/assets/javascripts/services/alerts_center_service.js:480
@@ -48429,13 +48429,13 @@ msgstr "%d Semanas Atrás"
 #: ../app/javascript/components/breadcrumbs/notifications-toggle.jsx:20
 msgid "%d unread notification"
 msgid_plural "%d unread notifications"
-msgstr[0] "%d notificação não\nlida"
+msgstr[0] "%d notificação não lida"
 msgstr[1] "%d notificações não lidas"
 
 #:
 #: ../app/assets/javascripts/controllers/ems_storage_dashboard/heatmap_controller.js:48
 msgid "%d%% in use"
-msgstr "%d%% em\nuso"
+msgstr "%d%% em uso"
 
 #:
 #: ../app/assets/javascripts/controllers/ems_container_dashboard/heatmap_controller.js:51
@@ -48471,7 +48471,7 @@ msgstr "O %s \"%s\" com as instâncias do %s não pode ser excluído"
 
 #: ../app/javascript/components/provider-form/index.jsx:132
 msgid "%s %s was saved"
-msgstr "%s\n%s foi\nsalvo"
+msgstr "%s %s foi salvo"
 
 #:
 #: ../app/assets/javascripts/components/vm_cloud/vm-cloud-add-security-group.js:59
@@ -48569,7 +48569,7 @@ msgstr "%{description}"
 
 #: ../app/helpers/application_helper.rb:825
 msgid "%{description} (Default)"
-msgstr "%{description}\n(Padrão)"
+msgstr "%{description} (Padrão)"
 
 #: ../app/controllers/ops_controller/settings/analysis_profiles.rb:699
 msgid "%{description} category Scan"
@@ -48602,7 +48602,7 @@ msgstr "O %{image} \"%{name}\" foi transferido por upload"
 
 #: ../app/controllers/ops_controller/settings/upload.rb:27
 msgid "%{image} must be a .%{type} file"
-msgstr "%{image}\ndeve ser\num .%{type} Lista de Arquivos"
+msgstr "%{image} deve ser um .%{type} Lista de Arquivos"
 
 #: ../app/helpers/generic_object_helper/textual_summary.rb:47
 #: ../app/helpers/generic_object_helper/textual_summary.rb:60
@@ -50206,7 +50206,7 @@ msgstr "Modos de Acesso"
 
 #: ../app/views/ops/_rbac_role_details.html.haml:33
 msgid "Access Restriction for Catalog Items, Orchestration Stacks, Key Pairs, Services, VMs, and Templates"
-msgstr "Restrição de acesso para itens do catálogo, pilhas\nde orquestração, pares de chaves, serviços, VMs e modelos"
+msgstr "Restrição de acesso para itens do catálogo, pilhas de orquestração, pares de chaves, serviços, VMs e modelos"
 
 #: ../app/helpers/pxe_helper/textual_summary.rb:16
 #: ../app/javascript/components/pxe-servers-form/pxe-server-form.schema.js:23
@@ -50290,7 +50290,7 @@ msgid "Actions for Policy Event \"%{events}\" were saved"
 msgstr "As ações para o Evento de Política do \"%{events}\" foram salvas"
 
 #: ../app/helpers/application_helper/button/role_suspend.rb:8
-msgid "Activate the %{server_role_description} Role on another Server to \\\nsuspend it on %{server_name} [%{server_id}]"
+msgid "Activate the %{server_role_description} Role on another Server to \\ suspend it on %{server_name} [%{server_id}]"
 msgstr "Ative a função %{server_role_description} em outro servidor para suspendê-la no %{server_name} [%{server_id}]"
 
 #: ../app/javascript/components/report-data-table.jsx:211
@@ -50517,7 +50517,7 @@ msgstr "Incluir um novo alerta"
 
 #: ../app/helpers/application_helper/toolbar/ems_block_storages_center.rb:24
 msgid "Add a New Block Storage Manager"
-msgstr "Incluir um novo gerenciador de armazenamento de\nbloco"
+msgstr "Incluir um novo gerenciador de armazenamento de bloco"
 
 #:
 #: ../app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb:12
@@ -50621,7 +50621,7 @@ msgstr "Incluir um novo provedor de gerenciador de automação"
 
 #: ../app/views/ems_block_storage/show_list.html.haml:5
 msgid "Add a new Block Storage Manager"
-msgstr "Incluir um novo gerenciador de armazenamento\nde bloco"
+msgstr "Incluir um novo gerenciador de armazenamento de bloco"
 
 #: ../app/helpers/application_helper/toolbar/custom_button_set_center.rb:18
 #: ../app/helpers/application_helper/toolbar/generic_object_definition_actions_node_center.rb:17
@@ -51004,7 +51004,7 @@ msgstr "A adição da nova política foi cancelada pelo usuário"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:58
 msgid "Add of new Provider Tag Mapping was cancelled by the user"
-msgstr "A inclusão do novo Mapeamento de tag do\nprovedor foi\ncancelada pelo usuário"
+msgstr "A inclusão do novo Mapeamento de tag do provedor foi cancelada pelo usuário"
 
 #: ../app/controllers/report_controller/reports/editor.rb:55
 msgid "Add of new Report was cancelled by the user"
@@ -51081,11 +51081,11 @@ msgstr "Incluindo uma nova política do %{model_name}"
 #: ../app/controllers/miq_ae_customization_controller.rb:364
 #: ../app/controllers/miq_ae_class_controller.rb:2620
 msgid "Adding a new %{model}"
-msgstr "Incluindo um Novo\n%{model}"
+msgstr "Incluindo um Novo %{model}"
 
 #: ../app/controllers/ops_controller.rb:697
 msgid "Adding a new %{tenant}"
-msgstr "Incluindo um Novo\n%{tenant}"
+msgstr "Incluindo um Novo %{tenant}"
 
 #: ../app/controllers/miq_policy_controller.rb:600
 msgid "Adding a new Action"
@@ -51236,7 +51236,7 @@ msgstr "Incluindo cópia de '%{description}'"
 
 #: ../app/javascript/components/physical-storage-form/index.jsx:19
 msgid "Adding of physical storage was cancelled by the user"
-msgstr "A inclusão do armazenamento físico foi cancelada\npelo usuário"
+msgstr "A inclusão do armazenamento físico foi cancelada pelo usuário"
 
 #:
 #: ../app/assets/javascripts/components/vm_cloud/vm-cloud-add-security-group.js:51
@@ -51683,7 +51683,7 @@ msgstr "Todos os comutadores"
 
 #: ../app/controllers/infra_networking_controller.rb:258
 msgid "All Switches (Names with \"%{search_text}\")"
-msgstr "Todos os comutadores (nomes com\n\"%{search_text}\")"
+msgstr "Todos os comutadores (nomes com \"%{search_text}\")"
 
 #: ../app/presenters/tree_builder_pxe_image_types.rb:10
 #: ../app/controllers/pxe_controller/pxe_image_types.rb:156
@@ -52254,7 +52254,7 @@ msgstr "Tem certeza de que deseja excluir registros órfãos para o usuário '%{
 #:
 #: ../app/helpers/application_helper/toolbar/automation_manager_provider_center.rb:35
 msgid "Are you sure you want to delete the following Ansible Tower Provider?"
-msgstr "Tem certeza de que deseja excluir o seguinte\nProvedor Ansible Tower?"
+msgstr "Tem certeza de que deseja excluir o seguinte Provedor Ansible Tower?"
 
 #:
 #: ../app/helpers/application_helper/toolbar/automation_manager_providers_center.rb:53
@@ -52329,7 +52329,7 @@ msgstr "Tem certeza de que deseja excluir este grupo?"
 
 #: ../app/helpers/application_helper/toolbar/miq_policy_profile_center.rb:28
 msgid "Are you sure you want to delete this Policy Profile?"
-msgstr "Tem certeza de que deseja excluir este perfil de\npolítica?"
+msgstr "Tem certeza de que deseja excluir este perfil de política?"
 
 #: ../app/helpers/application_helper/toolbar/miq_request_center.rb:23
 msgid "Are you sure you want to delete this Request?"
@@ -53650,7 +53650,7 @@ msgstr "Não é possível analisar o arquivo JSON: %{message}"
 
 #: ../app/controllers/restful_redirect_controller.rb:19
 msgid "Cannot redirect to \"%{record}\" provider."
-msgstr "Não é possível redirecionar para o provedor\n\"%{record}\"."
+msgstr "Não é possível redirecionar para o provedor \"%{record}\"."
 
 #: ../app/controllers/ops_controller/diagnostics.rb:483
 msgid "Cannot start log collection, a log collection is already in progress within this scope"
@@ -53720,7 +53720,7 @@ msgstr "Capturar métricas relacionadas a este provedor de contêineres?"
 
 #: ../app/controllers/catalog_controller.rb:647
 msgid "Catalog \"%{name}\" was saved"
-msgstr "O catálogo\n\"%{name}\"\nfoi salvo"
+msgstr "O catálogo \"%{name}\" foi salvo"
 
 #: ../app/controllers/catalog_controller.rb:397
 msgid "Catalog Bundle \"%{name}\" was added"
@@ -53817,7 +53817,7 @@ msgstr "Cuidado: mudanças manuais nos arquivos de configuração podem desativa
 
 #: ../app/views/ops/_settings_label_tag_mapping_tab.html.haml:7
 msgid "Caution: Mappings with Resource Entity 'All-Entities' could cause overwriting existing tags on resources with mapped provider labels."
-msgstr "Cuidado: os mapeamentos com a entidade de recurso\n'All-Entidades' podem causar a sobrescrição das tags\nexistentes em recursos com rótulos de provedor mapeados."
+msgstr "Cuidado: os mapeamentos com a entidade de recurso 'All-Entidades' podem causar a sobrescrição das tags existentes em recursos com rótulos de provedor mapeados."
 
 #: ../app/views/ops/_rbac_user_details.html.haml:1
 #: ../app/javascript/components/async-credentials/password-field.jsx:85
@@ -54471,15 +54471,15 @@ msgstr "Clique para remover esta política"
 #: ../app/views/miq_ae_class/_copy_objects_form.html.haml:71
 #: ../app/views/catalog/_form_basic_info.html.haml:174
 msgid "Click to select Provisioning Entry Point"
-msgstr "Clique para selecionar o ponto de entrada de\nfornecimento"
+msgstr "Clique para selecionar o ponto de entrada de fornecimento"
 
 #: ../app/views/catalog/_form_basic_info.html.haml:196
 msgid "Click to select Reconfigure Entry Point"
-msgstr "Clique para selecionar o ponto de entrada de\nreconfiguração"
+msgstr "Clique para selecionar o ponto de entrada de reconfiguração"
 
 #: ../app/views/catalog/_form_basic_info.html.haml:217
 msgid "Click to select Retirement Entry Point"
-msgstr "Clique para selecionar o ponto de entrada de\ndesativação"
+msgstr "Clique para selecionar o ponto de entrada de desativação"
 
 #: ../app/views/catalog/_sandt_tree_show.html.haml:250
 #: ../app/views/catalog/_stcat_tree_show.html.haml:26
@@ -54507,15 +54507,15 @@ msgstr "Clique para visualizar o %{group} "
 
 #: ../app/helpers/ops_helper/textual_summary.rb:127
 msgid "Click to view %{name} Group"
-msgstr "Clique para visualizar o grupo\n%{name}"
+msgstr "Clique para visualizar o grupo %{name}"
 
 #: ../app/helpers/ops_helper/textual_summary.rb:143
 msgid "Click to view %{name} Tenant"
-msgstr "Clique para visualizar\no\nlocatário %{name}"
+msgstr "Clique para visualizar o locatário %{name}"
 
 #: ../app/helpers/ops_helper/textual_summary.rb:156
 msgid "Click to view %{name} TenantProject"
-msgstr "Clique para visualizar\no TenantProject\n%{name}"
+msgstr "Clique para visualizar o TenantProject %{name}"
 
 #: ../app/views/report/_db_list.html.haml:12
 msgid "Click to view '%{title}'"
@@ -54756,7 +54756,7 @@ msgstr "O volume de nuvem \"%{name}\" não está conectado a nenhuma Instância"
 
 #: ../app/helpers/application_helper/button/volume_attach.rb:6
 msgid "Cloud Volume \"%{name}\" is not available to be attached to any Instances"
-msgstr "O volume de nuvem\n\"%{name}\"\nnão está disponível para ser anexado a nenhuma instância"
+msgstr "O volume de nuvem \"%{name}\" não está disponível para ser anexado a nenhuma instância"
 
 #: ../app/controllers/cloud_volume_controller.rb:329
 msgid "Cloud Volume \"%{name}\" updated"
@@ -54769,7 +54769,7 @@ msgstr "O volume de nuvem \"%{volume_name}\" não está anexado a nenhuma Instâ
 
 #: ../app/controllers/cloud_volume_controller.rb:27
 msgid "Cloud Volume \"%{volume_name}\" is not available to be attached to any Instances"
-msgstr "O volume de nuvem\n\"%{volume_name}\"\nnão está disponível para ser anexado a nenhuma instância"
+msgstr "O volume de nuvem \"%{volume_name}\" não está disponível para ser anexado a nenhuma instância"
 
 #: ../app/controllers/cloud_volume_controller.rb:229
 msgid "Cloud Volume creation failed: Task start failed"
@@ -54882,7 +54882,7 @@ msgstr "Nuvens"
 
 #: ../app/controllers/application_controller/ci_processing.rb:547
 msgid "Cluster \"%{name}\": Error during '%{task}': %{error_message}"
-msgstr "Cluster\n\"%{name}\":\nerro durante\n'%{task}': %{error_message}"
+msgstr "Cluster \"%{name}\": erro durante '%{task}': %{error_message}"
 
 #: ../app/controllers/ops_controller/settings/schedules.rb:631
 msgid "Cluster Analysis"
@@ -54905,16 +54905,16 @@ msgstr "Cluster: "
 
 #: ../app/presenters/tree_node/ems_cluster.rb:3
 msgid "Cluster: %{name}"
-msgstr "Cluster:\n%{name}"
+msgstr "Cluster: %{name}"
 
 #: ../app/controllers/application_controller/ci_processing.rb:552
 msgid "Cluster: %{task} successfully initiated"
-msgstr "Cluster:\n%{task}\niniciado com sucesso"
+msgstr "Cluster: %{task} iniciado com sucesso"
 
 #: ../app/views/ops/_rbac_group_details.html.haml:20
 #: ../app/views/ops/_rbac_group_details.html.haml:196
 msgid "Clusters, Datastores, Hosts, Managers & Providers"
-msgstr "Clusters, armazenamentos de dados, hosts,\ngerenciadores e provedores"
+msgstr "Clusters, armazenamentos de dados, hosts, gerenciadores e provedores"
 
 #:
 #: ../app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js:237
@@ -55296,11 +55296,11 @@ msgstr "Gerenciamento de configuração"
 #: ../app/views/layouts/listnav/_configuration_profile.html.haml:17
 #: ../app/views/layouts/listnav/_configured_system.html.haml:17
 msgid "Configuration Manager: %{name}"
-msgstr "Gerenciador de configuração:\n%{name}"
+msgstr "Gerenciador de configuração: %{name}"
 
 #: ../app/controllers/configuration_profile_controller.rb:43
 msgid "Configuration Profile console access failed: Task start failed"
-msgstr "Falha no acesso ao console do perfil de\nconfiguração: falha no início da tarefa"
+msgstr "Falha no acesso ao console do perfil de configuração: falha no início da tarefa"
 
 #: ../app/presenters/tree_node/configuration_profile.rb:4
 #: ../app/views/layouts/listnav/_configured_system.html.haml:22
@@ -55344,7 +55344,7 @@ msgstr "Configurar colunas do relatório"
 
 #: ../app/controllers/configured_system_controller.rb:36
 msgid "Configured System console access failed: Task start failed"
-msgstr "Falha no acesso ao console do sistema configurado:\nfalha no início da tarefa"
+msgstr "Falha no acesso ao console do sistema configurado: falha no início da tarefa"
 
 #: ../app/presenters/tree_node/configured_system.rb:4
 msgid "Configured System: %{hostname}"
@@ -55987,7 +55987,7 @@ msgstr "Criar uma nova condição designada a esta política"
 
 #: ../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:113
 msgid "Create a new snapshot for this Instance"
-msgstr "Criar uma nova captura instantânea para esta\ninstância"
+msgstr "Criar uma nova captura instantânea para esta instância"
 
 #: ../app/helpers/application_helper/toolbar/x_vm_center.rb:77
 #: ../app/helpers/application_helper/toolbar/x_vm_snapshot_center.rb:6
@@ -56393,7 +56393,7 @@ msgstr "Política de DNS"
 
 #: ../app/javascript/angular/dashboard/widget-wrapper.js:46
 msgid "Dashboard \"%s\" was refreshed"
-msgstr "O painel\n\"%s\"\nfoi atualizado"
+msgstr "O painel \"%s\" foi atualizado"
 
 #: ../app/controllers/report_controller/dashboards.rb:306
 msgid "Dashboard \"%{name}\""
@@ -56759,7 +56759,7 @@ msgstr "Excluir a condição %{condition_type}"
 
 #: ../app/helpers/application_helper/button/policy_delete.rb:6
 msgid "Delete %{policy_type} Policy"
-msgstr "Excluir a política\n%{policy_type}"
+msgstr "Excluir a política %{policy_type}"
 
 #: ../app/helpers/application_helper/toolbar/miq_action_center.rb:28
 msgid "Delete Action"
@@ -57630,7 +57630,7 @@ msgstr "O tamanho do disco precisa ser maior que 1 MB"
 
 #: ../app/views/vm_common/_reconfigure.html.haml:168
 msgid "Disk size has to be greater than {{1*disk.orgHdSize+1}} {{disk.orgHdUnit}}"
-msgstr "O tamanho do disco precisa ser maior que\n{{1*disk.orgHdSize+1}}\n{{disk.orgHdUnit}}"
+msgstr "O tamanho do disco precisa ser maior que {{1*disk.orgHdSize+1}} {{disk.orgHdUnit}}"
 
 #: ../app/javascript/components/flavor-form/flavor-form.schema.js:93
 msgid "Disk size in GB"
@@ -57989,7 +57989,7 @@ msgstr "Editar Tags do '%{customer_name}' para este grupo"
 
 #: ../app/helpers/application_helper/toolbar/tenant_center.rb:58
 msgid "Edit '%{customer_name}' Tags for this Tenant"
-msgstr "Editar Tags do '%{customer_name}' para\neste locatário"
+msgstr "Editar Tags do '%{customer_name}' para este locatário"
 
 #: ../app/helpers/application_helper/toolbar/user_center.rb:42
 msgid "Edit '%{customer_name}' Tags for this User"
@@ -58323,11 +58323,11 @@ msgstr "Editar tags para os grupos de segurança selecionados"
 
 #: ../app/helpers/application_helper/toolbar/security_policies_center.rb:50
 msgid "Edit Tags for the selected Security Policies"
-msgstr "Editar tags para as políticas de segurança\nselecionadas"
+msgstr "Editar tags para as políticas de segurança selecionadas"
 
 #: ../app/helpers/application_helper/toolbar/security_policy_rules_center.rb:50
 msgid "Edit Tags for the selected Security Policy Rules"
-msgstr "Editar tags para as regras de política de\nsegurança\nselecionadas"
+msgstr "Editar tags para as regras de política de segurança selecionadas"
 
 #: ../app/helpers/application_helper/toolbar/ems_storages_center.rb:54
 msgid "Edit Tags for the selected Storage Managers"
@@ -58414,7 +58414,7 @@ msgstr "Editar tags para esta sub-rede na nuvem"
 
 #: ../app/helpers/application_helper/toolbar/ems_configuration_center.rb:49
 msgid "Edit Tags for this Configuration Manager"
-msgstr "Editar tags para este gerenciador de\nconfiguração"
+msgstr "Editar tags para este gerenciador de configuração"
 
 #: ../app/helpers/application_helper/toolbar/ems_configurations_center.rb:68
 msgid "Edit Tags for this Configuration Manager Provider"
@@ -58602,7 +58602,7 @@ msgstr "Editar sequência do grupo de usuários"
 
 #: ../app/controllers/vm_common.rb:678
 msgid "Edit VM '%{name}'"
-msgstr "Editar a VM\n'%{name}'"
+msgstr "Editar a VM '%{name}'"
 
 #: ../app/views/cloud_volume/edit.html.haml:10
 msgid "Edit Volume"
@@ -58651,7 +58651,7 @@ msgstr "A edição da Condição do %{model} \"%{name}\" foi cancelada pelo usu�
 
 #: ../app/controllers/application_controller/miq_request_methods.rb:213
 msgid "Edit of %{model} Request \"%{name}\" was cancelled by the user"
-msgstr "A edição da Solicitação %{model}\n\"%{name}\" foi cancelada pelo usuário"
+msgstr "A edição da Solicitação %{model} \"%{name}\" foi cancelada pelo usuário"
 
 #: ../app/controllers/ops_controller/ops_rbac.rb:599
 msgid "Edit of %{name} was cancelled by the user"
@@ -58776,7 +58776,7 @@ msgstr "A edição do IP flutuante \"%{address}\" foi cancelada pelo usuário"
 
 #: ../app/controllers/host_controller.rb:167
 msgid "Edit of Host \"%{name}\" was cancelled by the user"
-msgstr "A edição do host\n\"%{name}\"\nfoi cancelada pelo usuário"
+msgstr "A edição do host \"%{name}\" foi cancelada pelo usuário"
 
 #: ../app/controllers/host_aggregate_controller.rb:112
 msgid "Edit of Host Aggregate \"%{name}\" failed: Task start failed"
@@ -58821,7 +58821,7 @@ msgstr "A edição da ordem de prioridade foi cancelada pelo usuário"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:60
 msgid "Edit of Provider Tag Mapping \"%{name}\" was cancelled by the user"
-msgstr "A edição do mapeamento de tag do provedor\n\"%{name}\"\nfoi cancelada pelo usuário"
+msgstr "A edição do mapeamento de tag do provedor \"%{name}\" foi cancelada pelo usuário"
 
 #: ../app/controllers/mixins/manager_controller_mixin.rb:65
 msgid "Edit of Provider was cancelled by the user"
@@ -58900,7 +58900,7 @@ msgstr "A edição da zona \"%{name}\" foi cancelada pelo usuário"
 
 #: ../app/controllers/host_controller.rb:164
 msgid "Edit of credentials for selected Hosts was cancelled by the user"
-msgstr "A edição de credenciais dos hosts selecionados foi\ncancelada pelo usuário"
+msgstr "A edição de credenciais dos hosts selecionados foi cancelada pelo usuário"
 
 #: ../app/controllers/miq_ae_class_controller.rb:1114
 msgid "Edit of schema for Automate Class \"%{name}\" was cancelled by the user"
@@ -59390,7 +59390,7 @@ msgstr "Editando o Esquema de classe \"%{name}\""
 
 #: ../app/controllers/pxe_controller.rb:195
 msgid "Editing Customization Template \"%{name}\""
-msgstr "Editando o modelo de customização\n\"%{name}\""
+msgstr "Editando o modelo de customização \"%{name}\""
 
 #: ../app/controllers/report_controller.rb:685
 msgid "Editing Dashboard \"%{name}\""
@@ -59714,7 +59714,7 @@ msgstr "Erro ao excluir o item do catálogo \"%s\": %s"
 #: ../app/javascript/components/remove-generic-item-modal.jsx:40
 #: ../app/javascript/components/remove-generic-item-modal.jsx:48
 msgid "Error deleting item \"%s\": %s"
-msgstr "Erro ao excluir o item\n\"%s\":\n%s"
+msgstr "Erro ao excluir o item \"%s\": %s"
 
 #: ../app/controllers/application_controller/filter.rb:97
 msgid "Error details: %{message}"
@@ -59891,11 +59891,11 @@ msgstr[1] "Erro ao excluir os relatórios salvos do banco de dados %{product}"
 
 #: ../app/controllers/application_controller/sysprep_answer_file.rb:16
 msgid "Error during Sysprep \"%{params}\" file upload: %{message}"
-msgstr "Erro durante o upload do arquivo\n\"%{params}\" Sysprep: %{message}"
+msgstr "Erro durante o upload do arquivo \"%{params}\" Sysprep: %{message}"
 
 #: ../app/controllers/application_controller/user_script_file.rb:17
 msgid "Error during User Script \"%{params}\" file upload: %{message}"
-msgstr "Erro durante o upload de arquivo\n\"%{params}\"\ndo script do usuário:\n%{message}"
+msgstr "Erro durante o upload de arquivo \"%{params}\" do script do usuário: %{message}"
 
 #: ../app/controllers/miq_policy_controller/alerts.rb:503
 msgid "Error during alarms: %{messages}"
@@ -60866,7 +60866,7 @@ msgstr "Definição de objeto genérico"
 
 #: ../app/controllers/generic_object_definition_controller.rb:196
 msgid "Generic Object Definition %{record_name}"
-msgstr "Definição de objeto genérico\n%{record_name}"
+msgstr "Definição de objeto genérico %{record_name}"
 
 #. TRANSLATORS: file: product/views/GenericObjectDefinition.yaml
 #: ../app/controllers/generic_object_definition_controller.rb:189
@@ -61115,7 +61115,7 @@ msgstr "O host \"%{hostname}\" foi removido do agregado do host \"%{name}\""
 
 #: ../app/controllers/host_controller.rb:178
 msgid "Host \"%{name}\" was saved"
-msgstr "O host\n\"%{name}\"\nfoi salvo"
+msgstr "O host \"%{name}\" foi salvo"
 
 #: ../app/controllers/mixins/actions/host_actions/misc.rb:12
 msgid "Host \"%{name}\": Error during '%{task}': %{message}"
@@ -61200,7 +61200,7 @@ msgstr "Plataforma do host"
 
 #: ../app/views/layouts/angular/_form_buttons_verify_angular.html.haml:3
 msgid "Host to validate against, Username and matching password fields are needed to perform verification of credentials"
-msgstr "O host para validação. Os campos de nome do\nusuário e de correspondência de senha são\nnecessários para realizar a\nverificação de credenciais"
+msgstr "O host para validação. Os campos de nome do usuário e de correspondência de senha são necessários para realizar a verificação de credenciais"
 
 #: ../app/presenters/tree_builder_storage_adapters.rb:23
 #: ../app/presenters/tree_builder_network.rb:23
@@ -61906,7 +61906,7 @@ msgstr "Tipo de item"
 
 #: ../app/controllers/mixins/actions/vm_actions/ownership.rb:117
 msgid "Items are required for Set Ownership screen"
-msgstr "Os itens são necessários para a tela\nDefinir propriedade"
+msgstr "Os itens são necessários para a tela Definir propriedade"
 
 #: ../app/presenters/tree_builder_policy_simulation.rb:54
 msgid "Items out of scope"
@@ -62908,11 +62908,11 @@ msgstr "Mapear tags"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:209
 msgid "Mapping for \"%{entity}\", Label \"%{label}\" and Tag Category \"%{cat_description}\" already exists"
-msgstr "O mapeamento para\n\"%{entity}\",\no rótulo\n\"%{label}\"\ne a categoria de tag\n\"%{cat_description}\"\njá existem"
+msgstr "O mapeamento para \"%{entity}\", o rótulo \"%{label}\" e a categoria de tag \"%{cat_description}\" já existem"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:211
 msgid "Mapping for \"%{entity}\", Label \"%{label}\": Tag Category \"%{cat_description}\" must exist"
-msgstr "O mapeamento para\n\"%{entity}\",\no rótulo\n\"%{label}\"\ne a categoria de tag\n\"%{cat_description}\"\nprecisam existir"
+msgstr "O mapeamento para \"%{entity}\", o rótulo \"%{label}\" e a categoria de tag \"%{cat_description}\" precisam existir"
 
 #: ../app/javascript/components/notification-drawer/notification-drawer.jsx:160
 msgid "Mark All Read"
@@ -63525,11 +63525,11 @@ msgstr "Nomenclatura"
 
 #: ../app/controllers/vm_remote.rb:128
 msgid "Native console access failed: %{message}"
-msgstr "O acesso ao console nativo falhou:\n%{message}"
+msgstr "O acesso ao console nativo falhou: %{message}"
 
 #: ../app/controllers/vm_remote.rb:115
 msgid "Native console access failed: Task start failed"
-msgstr "Falha no acesso ao console nativo: falha no início da\ntarefa"
+msgstr "Falha no acesso ao console nativo: falha no início da tarefa"
 
 #: ../app/views/vm_common/_config.html.haml:99
 msgid "Network Adapter"
@@ -63980,7 +63980,7 @@ msgstr "Nenhuma política de conformidade encontrada"
 
 #: ../app/controllers/application_controller/ci_processing.rb:396
 msgid "No Compliance Policies assigned to one or more of the selected items"
-msgstr "Nenhuma política de conformidade designada a um ou\nmais dos itens selecionados"
+msgstr "Nenhuma política de conformidade designada a um ou mais dos itens selecionados"
 
 #: ../app/helpers/application_helper/button/miq_check_compliance.rb:7
 msgid "No Compliance Policies assigned to this %{vm}"
@@ -64308,11 +64308,11 @@ msgstr "Nenhum provedor de nuvem é compatível com a criação de roteadores de
 
 #: ../app/helpers/application_helper/button/network_service_entry_new.rb:11
 msgid "No cloud providers support creating network service entries."
-msgstr "Nenhum provedor de nuvem suporta a criação de\nentradas de serviço de rede."
+msgstr "Nenhum provedor de nuvem suporta a criação de entradas de serviço de rede."
 
 #: ../app/helpers/application_helper/button/network_service_new.rb:11
 msgid "No cloud providers support creating network services."
-msgstr "Nenhum provedor de nuvem suporta a criação de\nserviços de rede."
+msgstr "Nenhum provedor de nuvem suporta a criação de serviços de rede."
 
 #: ../app/helpers/application_helper/button/security_group_new.rb:5
 msgid "No cloud providers support creating security groups."
@@ -64320,11 +64320,11 @@ msgstr "Nenhum provedor de nuvem é compatível com a criação de grupos de seg
 
 #: ../app/helpers/application_helper/button/security_policy_rule_new.rb:11
 msgid "No cloud providers support creating security policies."
-msgstr "Nenhum provedor de nuvem suporta a criação de\npolíticas de segurança."
+msgstr "Nenhum provedor de nuvem suporta a criação de políticas de segurança."
 
 #: ../app/helpers/application_helper/button/security_policy_new.rb:11
 msgid "No cloud providers support creating security policy rules."
-msgstr "Nenhum provedor de nuvem suporta a criação de\nregras de política de segurança."
+msgstr "Nenhum provedor de nuvem suporta a criação de regras de política de segurança."
 
 #: ../app/helpers/application_helper/button/auth_key_pair_cloud_create.rb:10
 msgid "No cloud providers support key pair import or creation."
@@ -64732,7 +64732,7 @@ msgstr "Nota: os recursos baseados no playbook do Ansible não podem ser incluí
 
 #: ../app/views/ops/_settings_cu_collection_tab.html.haml:22
 msgid "Note: Collect for All Clusters must be checked to be able to collect C & U data from Cloud Providers such as Red Hat OpenStack or Amazon EC2"
-msgstr "Observação: a opção Coletar para todos os clusters\ndeve ser marcada para que seja possível coletar dados\nde C e U dos\nProvedores em Nuvem, como o Red Hat OpenStack ou o Amazon\nEC2"
+msgstr "Observação: a opção Coletar para todos os clusters deve ser marcada para que seja possível coletar dados de C e U dos Provedores em Nuvem, como o Red Hat OpenStack ou o Amazon EC2"
 
 #: ../app/views/catalog/_form_request_info.html.haml:9
 #: ../app/views/miq_request/_prov_edit.html.haml:6
@@ -66583,15 +66583,15 @@ msgstr "Tipo de rede do provedor"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:273
 msgid "Provider Tag Mapping \"%{name}\" was added"
-msgstr "O mapeamento de tag do provedor\n\"%{name}\"\nfoi incluído"
+msgstr "O mapeamento de tag do provedor \"%{name}\" foi incluído"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:302
 msgid "Provider Tag Mapping \"%{name}\" was saved"
-msgstr "O mapeamento de tag do provedor\n\"%{name}\"\nfoi salvo"
+msgstr "O mapeamento de tag do provedor \"%{name}\" foi salvo"
 
 #: ../app/controllers/ops_controller/settings/label_tag_mapping.rb:327
 msgid "Provider Tag Mapping \"%{name}\": Delete successful"
-msgstr "Mapeamento de tag do provedor\n\"%{name}\":\nexclusão bem-sucedida"
+msgstr "Mapeamento de tag do provedor \"%{name}\": exclusão bem-sucedida"
 
 #: ../app/views/ops/_settings_authentication_tab.html.haml:91
 msgid "Provider Type:"
@@ -66961,7 +66961,7 @@ msgstr "Verificar novamente o status de autenticação para os provedores de inf
 
 #: ../app/helpers/application_helper/toolbar/ems_block_storages_center.rb:96
 msgid "Re-check Authentication Status for the selected block storage manager"
-msgstr "Status de autenticação de nova verificação do\ngerenciador de armazenamento de bloco selecionado"
+msgstr "Status de autenticação de nova verificação do gerenciador de armazenamento de bloco selecionado"
 
 #: ../app/helpers/application_helper/toolbar/ems_cloud_center.rb:98
 msgid "Re-check Authentication Status for this Cloud Provider"
@@ -68054,7 +68054,7 @@ msgstr "Remover tipos selecionados"
 #:
 #: ../app/helpers/application_helper/toolbar/generic_object_definitions_center.rb:26
 msgid "Remove selected Generic Object Definitions from Inventory"
-msgstr "Remover as definições de objeto genérico\nselecionadas do inventário"
+msgstr "Remover as definições de objeto genérico selecionadas do inventário"
 
 #: ../app/helpers/application_helper/toolbar/iso_datastores_center.rb:18
 msgid "Remove selected ISO Datastores from Inventory"
@@ -68264,7 +68264,7 @@ msgstr "Deseja remover este registro de firmware do inventário?"
 #:
 #: ../app/helpers/application_helper/toolbar/generic_object_definition_center.rb:29
 msgid "Remove this Generic Object Definitions from Inventory"
-msgstr "Remover estas definições de objeto genérico\ndo inventário"
+msgstr "Remover estas definições de objeto genérico do inventário"
 
 #: ../app/helpers/application_helper/toolbar/iso_datastore_center.rb:12
 msgid "Remove this ISO Datastore from Inventory"
@@ -68396,7 +68396,7 @@ msgstr "Remover este widget"
 
 #: ../app/controllers/mixins/actions/vm_actions/rename.rb:27
 msgid "Rename VM '%{name}'"
-msgstr "Renomear a VM\n'%{name}'"
+msgstr "Renomear a VM '%{name}'"
 
 #: ../app/controllers/mixins/actions/vm_actions/rename.rb:109
 msgid "Rename of VM \"%{name}\" was cancelled by the user"
@@ -68871,7 +68871,7 @@ msgstr "Conjunto de recursos \"%{name}\": erro durante '%{task}': %{error_messag
 
 #: ../app/controllers/catalog_controller.rb:887
 msgid "Resource Pool is required, please select one from the list"
-msgstr "O conjunto de recursos é necessário, selecione um\nda lista"
+msgstr "O conjunto de recursos é necessário, selecione um da lista"
 
 #: ../app/helpers/container_project_helper/textual_summary.rb:27
 msgid "Resource Quota"
@@ -69239,7 +69239,7 @@ msgstr "Recomendação de Tamanho certo para %{vm_or_template} \"%{name}\""
 
 #: ../app/controllers/vm_common.rb:531
 msgid "Right Size VM '%{name}'"
-msgstr "Tamanho certo da VM\n'%{name}'"
+msgstr "Tamanho certo da VM '%{name}'"
 
 #: ../app/helpers/application_helper/toolbar/vm_infras_center.rb:93
 #: ../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:47
@@ -69991,7 +69991,7 @@ msgstr "Selecione uma única função para editar"
 
 #: ../app/helpers/application_helper/toolbar/ems_block_storages_center.rb:31
 msgid "Select a single Storage Manager to edit"
-msgstr "Selecione um único gerenciador de armazenamento para\neditar"
+msgstr "Selecione um único gerenciador de armazenamento para editar"
 
 #: ../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:18
 msgid "Select a single System Image Type to edit"
@@ -70149,7 +70149,7 @@ msgstr "Selecionar valor da tag"
 #:
 #: ../app/javascript/components/orchestration-template/orchestration-template-form.schema.js:112
 msgid "Select the format type below to apply syntax highlighting for better readability"
-msgstr "Selecione o tipo de formato abaixo para aplicar o\ndestaque da sintaxe e melhorar a capacidade de\nleitura"
+msgstr "Selecione o tipo de formato abaixo para aplicar o destaque da sintaxe e melhorar a capacidade de leitura"
 
 #: ../app/helpers/application_helper/toolbar/host_aggregate_center.rb:12
 #: ../app/helpers/application_helper/toolbar/host_aggregate_center.rb:22
@@ -70338,7 +70338,7 @@ msgid "Server \"%{name}\": Error during 'destroy': "
 msgstr "Servidor \"%{name}\": erro durante 'destroy': "
 
 #: ../app/helpers/application_helper/button/delete_server.rb:6
-msgid "Server %{server_name} [%{server_id}] can only be deleted if it is stopped or \\\nhas not responded for a while"
+msgid "Server %{server_name} [%{server_id}] can only be deleted if it is stopped or \\ has not responded for a while"
 msgstr "O servidor %{server_name} [%{server_id}] poderá ser excluído apenas se ele for interrompido ou não tiver respondido por um tempo"
 
 #: ../app/views/ops/_settings_server_tab.html.haml:95
@@ -70871,7 +70871,7 @@ msgstr "Mostrar histórico de conformidade desta imagem do contêiner (últimas 
 
 #: ../app/helpers/host_helper/textual_summary.rb:370
 msgid "Show Compliance History of this Host (Last 10 Checks)"
-msgstr "Mostrar o histórico de conformidade deste host\n(últimas 10 verificações)"
+msgstr "Mostrar o histórico de conformidade deste host (últimas 10 verificações)"
 
 #: ../app/helpers/container_node_helper/textual_summary.rb:129
 msgid "Show Compliance History of this Node (Last 10 Checks)"
@@ -71335,7 +71335,7 @@ msgstr "Mostrar na linha do tempo"
 
 #: ../app/javascript/components/notification-drawer/notification-drawer.jsx:139
 msgid "Show only the first %s"
-msgstr "Mostrar apenas o primeiro\n%s"
+msgstr "Mostrar apenas o primeiro %s"
 
 #: ../app/views/vm_common/_policy_options.html.haml:13
 #: ../app/views/miq_policy/_rsop_results.html.haml:11
@@ -71344,15 +71344,15 @@ msgstr "Mostrar itens fora do escopo:"
 
 #: ../app/views/layouts/listnav/_configuration_profile.html.haml:17
 msgid "Show parent Configuration Manager for this Configuration Profile"
-msgstr "Mostrar o gerenciador de configuração deste\nperfil de configuração"
+msgstr "Mostrar o gerenciador de configuração deste perfil de configuração"
 
 #: ../app/views/layouts/listnav/_configured_system.html.haml:17
 msgid "Show parent Configuration Manager for this Configured System"
-msgstr "Mostrar o gerenciador de configuração pai deste\nsistema configurado"
+msgstr "Mostrar o gerenciador de configuração pai deste sistema configurado"
 
 #: ../app/views/layouts/listnav/_configured_system.html.haml:22
 msgid "Show parent Configuration Profile for this Configured System"
-msgstr "Mostrar o perfil de configuração pai deste\nsistema configurado"
+msgstr "Mostrar o perfil de configuração pai deste sistema configurado"
 
 #: ../app/helpers/vm_helper/textual_summary.rb:451
 msgid "Show parent and child VMs"
@@ -71378,8 +71378,8 @@ msgstr "Mostrar o %{label} instalado nesta VM"
 #: ../app/helpers/host_helper/textual_summary.rb:463
 msgid "Show the Advanced Setting installed on this Host"
 msgid_plural "Show the Advanced Settings installed on this Host"
-msgstr[0] "Mostrar a configuração\navançada instalada neste host"
-msgstr[1] "Mostrar as\nconfigurações avançadas instaladas neste host"
+msgstr[0] "Mostrar a configuração avançada instalada neste host"
+msgstr[1] "Mostrar as configurações avançadas instaladas neste host"
 
 #: ../app/helpers/textual_mixins/vm_common.rb:127
 msgid "Show the File System Driver installed on this VM"
@@ -71390,8 +71390,8 @@ msgstr[1] "Mostrar os File System Drivers instalados nesta VM"
 #: ../app/helpers/host_helper/textual_summary.rb:453
 msgid "Show the File installed on this Host"
 msgid_plural "Show the Files installed on this Host"
-msgstr[0] "Mostrar o arquivo\ninstalado neste host"
-msgstr[1] "Mostrar os arquivos\ninstalados neste host"
+msgstr[0] "Mostrar o arquivo instalado neste host"
+msgstr[1] "Mostrar os arquivos instalados neste host"
 
 #: ../app/helpers/textual_mixins/textual_filesystems.rb:6
 msgid "Show the File installed on this VM"
@@ -71402,14 +71402,14 @@ msgstr[1] "Mostrar os arquivos instalados nesta VM"
 #: ../app/helpers/host_helper/textual_summary.rb:403
 msgid "Show the Firewall Rule defined on this Host"
 msgid_plural "Show the Firewall Rules defined on this Host"
-msgstr[0] "Mostrar a regra de\nfirewall definida neste host"
-msgstr[1] "Mostrar as regras de\nfirewall definidas neste host"
+msgstr[0] "Mostrar a regra de firewall definida neste host"
+msgstr[1] "Mostrar as regras de firewall definidas neste host"
 
 #: ../app/helpers/host_helper/textual_summary.rb:391
 msgid "Show the Group defined on this Host"
 msgid_plural "Show the Groups defined on this Host"
-msgstr[0] "Mostrar o grupo definido\nneste host"
-msgstr[1] "Mostrar os grupos definidos\nneste host"
+msgstr[0] "Mostrar o grupo definido neste host"
+msgstr[1] "Mostrar os grupos definidos neste host"
 
 #: ../app/helpers/textual_mixins/vm_common.rb:89
 msgid "Show the Group defined on this VM"
@@ -71433,13 +71433,13 @@ msgstr[1] "Mostrar os Kernel Drivers instalados nesta VM"
 msgid "Show the Package installed on this Host"
 msgid_plural "Show the Packages installed on this Host"
 msgstr[0] "Mostrar o pacote instalado neste host"
-msgstr[1] "Mostrar os pacotes\ninstalados neste host"
+msgstr[1] "Mostrar os pacotes instalados neste host"
 
 #: ../app/helpers/host_helper/textual_summary.rb:421
 msgid "Show the Patch defined on this Host"
 msgid_plural "Show the Patches defined on this Host"
-msgstr[0] "Mostrar a correção\ndefinida\nneste host"
-msgstr[1] "Mostrar as correções definidas\nneste host"
+msgstr[0] "Mostrar a correção definida neste host"
+msgstr[1] "Mostrar as correções definidas neste host"
 
 #: ../app/helpers/textual_mixins/textual_patches.rb:8
 msgid "Show the Patch defined on this VM"
@@ -71506,15 +71506,15 @@ msgstr "Mostrar o locatário de nuvem pai deste objeto na nuvem"
 
 #: ../app/helpers/configuration_profile_helper/textual_summary.rb:57
 msgid "Show this Configuration Profile's Configuration Manager"
-msgstr "Mostrar este gerenciador de configuração do perfil\nde configuração"
+msgstr "Mostrar este gerenciador de configuração do perfil de configuração"
 
 #: ../app/helpers/configured_system_helper/textual_summary.rb:52
 msgid "Show this Configured System's Configuration Manager"
-msgstr "Mostrar este gerenciador de configuração do sistema\nconfigurado"
+msgstr "Mostrar este gerenciador de configuração do sistema configurado"
 
 #: ../app/helpers/configured_system_helper/textual_summary.rb:62
 msgid "Show this Configured System's Configuration Profile"
-msgstr "Mostrar este perfil de configuração do sistema\nconfigurado"
+msgstr "Mostrar este perfil de configuração do sistema configurado"
 
 #: ../app/helpers/host_helper/textual_summary.rb:338
 msgid "Show this Host's Availability Zone"
@@ -72799,7 +72799,7 @@ msgstr "A empresa"
 
 #: ../app/controllers/host_controller.rb:225
 msgid "The Host SSH key has changed, do you want to accept the new key?"
-msgstr "A chave SSH do host mudou. Deseja aceitar\na nova\nchave?"
+msgstr "A chave SSH do host mudou. Deseja aceitar a nova chave?"
 
 #: ../app/controllers/ems_infra_controller.rb:202
 msgid "The URL is blank or not a String"
@@ -72823,7 +72823,7 @@ msgstr "O valor da contagem de verificação deve ser um número inteiro para co
 
 #: ../app/javascript/components/copy-catalog-form/copy-catalog-form.jsx:17
 msgid "The copied item will not be displayed in the catalog by default"
-msgstr "O item copiado não será exibido no catálogo por\npadrão"
+msgstr "O item copiado não será exibido no catálogo por padrão"
 
 #: ../app/controllers/application_controller/advanced_search.rb:263
 msgid "The current search details have been reset"
@@ -72835,7 +72835,7 @@ msgstr "A entidade não está disponível ou o usuário não está autorizado a 
 
 #: ../app/javascript/components/remove-generic-item-modal.jsx:29
 msgid "The item \"%s\" has been successfully deleted"
-msgstr "O item\n\"%s\"\nfoi excluído com sucesso"
+msgstr "O item \"%s\" foi excluído com sucesso"
 
 #: ../app/controllers/application_controller.rb:1035
 msgid "The selected %{label} is not in the current region"
@@ -72943,7 +72943,7 @@ msgstr "O servidor está sendo iniciado. Uma nova tentativa de acesso será feit
 
 #: ../app/helpers/ops_helper.rb:67
 msgid "The server zone cannot be changed when running in containers"
-msgstr "A zona do servidor não pode ser alterada\ndurante a execução\nem contêineres"
+msgstr "A zona do servidor não pode ser alterada durante a execução em contêineres"
 
 #: ../app/controllers/ops_controller/settings/common.rb:348
 msgid "The test email is being delivered, check \"%{email}\" to verify it was successful"
@@ -74484,7 +74484,7 @@ msgstr "O usuário não existe mais"
 
 #: ../app/controllers/application_controller/user_script_file.rb:13
 msgid "User script \"%{params}\" upload was successful"
-msgstr "O upload do script do usuário\n\"%{params}\"\nfoi bem-sucedido"
+msgstr "O upload do script do usuário \"%{params}\" foi bem-sucedido"
 
 #: ../app/views/ops/_rbac_group_details.html.haml:143
 msgid "User to Look Up"
@@ -74620,11 +74620,11 @@ msgstr "Informações de monitoramento da MV"
 
 #: ../app/controllers/catalog_controller.rb:1852
 msgid "VM Name already exists, Please select a different VM Name"
-msgstr "O nome da MV já existe, selecione um nome de VM\ndiferente"
+msgstr "O nome da MV já existe, selecione um nome de VM diferente"
 
 #: ../app/helpers/application_helper/button/vm_native_console.rb:12
 msgid "VM Native Console error: %{error}"
-msgstr "Erro do console nativo da MV:\n%{error}"
+msgstr "Erro do console nativo da MV: %{error}"
 
 #: ../app/views/miq_request/_prov_field.html.haml:150
 #: ../app/views/miq_request/_prov_field.html.haml:157
@@ -74681,7 +74681,7 @@ msgstr "Condições da máquina virtual e da instância"
 
 #: ../app/views/ops/_settings_cu_collection_tab.html.haml:35
 msgid "VM data will be collected for VMs under selected Hosts only. Data is collected for a Cluster and all of its Hosts when at least one Host is selected."
-msgstr "Os dados da VM serão coletados somente para VMs em\nHosts selecionados. Os dados são coletados para um cluster\ne todos os seus hosts quando pelo menos um host é\nselecionado."
+msgstr "Os dados da VM serão coletados somente para VMs em Hosts selecionados. Os dados são coletados para um cluster e todos os seus hosts quando pelo menos um host é selecionado."
 
 #: ../app/controllers/vm_common.rb:225
 msgid "VM has too many parents."
@@ -74783,7 +74783,7 @@ msgstr "Validar configurações da Amazon"
 #: ../app/views/ops/_ldap_verify_button.html.haml:4
 #: ../app/views/ops/_ldap_verify_button.html.haml:4
 msgid "Validate the LDAP Settings by binding with the Host"
-msgstr "Validar as configurações de LDAP pela ligação com o\nHost"
+msgstr "Validar as configurações de LDAP pela ligação com o Host"
 
 #: ../app/views/layouts/_auth_credentials2.html.haml:10
 msgid "Validate the credentials"
@@ -74798,7 +74798,7 @@ msgstr "Validar as credenciais efetuando login no servidor"
 #: ../app/views/layouts/_form_buttons_verify.html.haml:12
 #: ../app/views/layouts/angular/_form_buttons_verify_angular.html.haml:2
 msgid "Validate the credentials by logging into the selected Host"
-msgstr "Validar as credenciais ao fazer login no host\nselecionado"
+msgstr "Validar as credenciais ao fazer login no host selecionado"
 
 #: ../app/javascript/react/screens/App/Plan/PlanConstants.js:54
 msgid "Validating"
@@ -75020,11 +75020,11 @@ msgstr "Visualizar o Guia %{title}"
 
 #: ../app/helpers/ops_helper/textual_summary.rb:99
 msgid "View the list of relevant Automate Domains"
-msgstr "Visualizar a lista de domínios automatizados\nrelevantes"
+msgstr "Visualizar a lista de domínios automatizados relevantes"
 
 #: ../app/helpers/ops_helper/textual_summary.rb:84
 msgid "View the list of relevant Catalog Items and Bundles"
-msgstr "Visualizar a lista de itens de catálogo e pacotes\nconfiguráveis\nrelevantes"
+msgstr "Visualizar a lista de itens de catálogo e pacotes configuráveis relevantes"
 
 #: ../app/helpers/ops_helper/textual_summary.rb:114
 msgid "View the list of relevant Providers"
@@ -75493,7 +75493,7 @@ msgstr "Aviso: este provedor de contêiner e TODOS os seus componentes serão re
 #:
 #: ../app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb:24
 msgid "Warning: This Custom Button Group will be permanently removed!"
-msgstr "Aviso: este grupo de botões personalizados será\nremovido permanentemente!"
+msgstr "Aviso: este grupo de botões personalizados será removido permanentemente!"
 
 #:
 #: ../app/helpers/application_helper/toolbar/customization_template_center.rb:27
@@ -75524,7 +75524,7 @@ msgstr "Aviso: este IP flutuante e TODOS os componentes dele serão removidos."
 #: ../app/helpers/application_helper/toolbar/generic_object_definition_center.rb:33
 #: ../app/helpers/application_helper/toolbar/generic_object_definitions_center.rb:32
 msgid "Warning: This Generic Object Definition will be permanently removed!"
-msgstr "Aviso: esta definição de definição de objeto será\nremovida permanentemente!"
+msgstr "Aviso: esta definição de definição de objeto será removida permanentemente!"
 
 #: ../app/helpers/application_helper/toolbar/iso_datastore_center.rb:15
 msgid "Warning: This ISO Datastore and ALL of its components will be permanently removed!"
@@ -75583,11 +75583,11 @@ msgstr "Aviso: este grupo de segurança e TODOS os componentes dele serão remov
 
 #: ../app/helpers/application_helper/toolbar/security_policy_rules_center.rb:28
 msgid "Warning: This Security Policy Rule and ALL of its components will be removed!"
-msgstr "Aviso: esta regra de política de segurança e TODOS\nos seus componentes serão removidos!"
+msgstr "Aviso: esta regra de política de segurança e TODOS os seus componentes serão removidos!"
 
 #: ../app/helpers/application_helper/toolbar/security_policies_center.rb:28
 msgid "Warning: This Security Policy and ALL of its components will be removed!"
-msgstr "Aviso: esta política de segurança e TODOS\nos seus componentes serão removidos!"
+msgstr "Aviso: esta política de segurança e TODOS os seus componentes serão removidos!"
 
 #: ../app/helpers/application_helper/toolbar/service_center.rb:21
 msgid "Warning: This Service and ALL of their components will be permanently removed!"
@@ -76383,7 +76383,7 @@ msgstr "Todas as redes de origem foram mapeadas."
 
 #: ../app/javascript/react/screens/App/Plan/PlanConstants.js:64
 msgid "Applying Right-Sizing Recommendation"
-msgstr "Aplicando a recomendação de\ndimensionamento correto"
+msgstr "Aplicando a recomendação de dimensionamento correto"
 
 #:
 #: ../app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js:139
@@ -77645,7 +77645,7 @@ msgstr "Selecionar um ou mais hosts..."
 #:
 #: ../app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js:351
 msgid "Select one or more source networks to map to a single target. Select Add Mapping. Multiple mappings can be added."
-msgstr "Selecione uma ou mais redes de origem para mapear\npara um único destino. Selecione Incluir mapeamento. Vários\nmapeamentos podem ser incluídos."
+msgstr "Selecione uma ou mais redes de origem para mapear para um único destino. Selecione Incluir mapeamento. Vários mapeamentos podem ser incluídos."
 
 #:
 #: ../app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardAdvancedOptionsStep/PlanWizardAdvancedOptionsStep.js:70
@@ -77666,12 +77666,12 @@ msgstr "Selecione a linha %s"
 #:
 #: ../app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js:171
 msgid "Select source cluster(s) and a target cluster and click Add Mapping to add the mapping. Multiple mappings can be added."
-msgstr "Selecione clusters de origem e um cluster de\ndestino e clique em Incluir mapeamento para incluir o\nmapeamento. Vários\nmapeamentos podem ser incluídos."
+msgstr "Selecione clusters de origem e um cluster de destino e clique em Incluir mapeamento para incluir o mapeamento. Vários mapeamentos podem ser incluídos."
 
 #:
 #: ../app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js:322
 msgid "Select source datastore(s) and a target datastore and click Add Mapping to add the mapping. Multiple mappings can be added."
-msgstr "Selecione armazenamentos de dados de origem e um\narmazenamento de dados de\ndestino e clique em Incluir mapeamento para incluir o\nmapeamento. Vários\nmapeamentos podem ser incluídos."
+msgstr "Selecione armazenamentos de dados de origem e um armazenamento de dados de destino e clique em Incluir mapeamento para incluir o mapeamento. Vários mapeamentos podem ser incluídos."
 
 #:
 #: ../app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardGeneralStep/PlanWizardGeneralStep.js:36
@@ -78116,7 +78116,7 @@ msgstr "Aguardando um host de conversão disponível. É possível continuar esp
 #:
 #: ../app/javascript/react/screens/App/Overview/components/Migrations/MigrationInProgressListItem.js:82
 msgid "Waiting for an available conversion host. You can continue waiting or go to the Migration Settings page to increase the number of migrations per host."
-msgstr "Aguardando um host de conversão disponível. É\npossível continuar esperando ou acessar a página\nConfigurações de migração para aumentar o número de\nmigrações por host."
+msgstr "Aguardando um host de conversão disponível. É possível continuar esperando ou acessar a página Configurações de migração para aumentar o número de migrações por host."
 
 #: ../app/javascript/react/screens/App/Plan/PlanConstants.js:61
 msgid "Waiting for inventory refresh"
@@ -78134,12 +78134,12 @@ msgstr "Você atingiu o comprimento máximo de %s caracteres."
 #:
 #: ../app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepConstants.js:7
 msgid "You must enable at least one conversion host in the target cluster. You can continue to create an infrastructure mapping that includes this cluster, but you must enable a conversion host before running the migration plan."
-msgstr "Deve-se ativar pelo menos um host de conversão\nno cluster de destino. É possível continuar criando um\nmapeamento de infraestrutura que inclua este cluster, mas deve-se ativar um host de conversão antes de\nexecutar o plano de migração."
+msgstr "Deve-se ativar pelo menos um host de conversão no cluster de destino. É possível continuar criando um mapeamento de infraestrutura que inclua este cluster, mas deve-se ativar um host de conversão antes de executar o plano de migração."
 
 #:
 #: ../app/javascript/react/screens/App/Mappings/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStepConstants.js:8
 msgid "You must enable at least one conversion host in the target provider. You can continue to create an infrastructure mapping that includes this project, but you must enable a conversion host before running the migration plan."
-msgstr "Deve-se ativar pelo menos um host de conversão no\nprovedor de destino. É possível continuar criando um\nmapeamento de infraestrutura que inclua este projeto, mas\ndeve-se ativar um host de conversão antes de executar o\nplano de migração."
+msgstr "Deve-se ativar pelo menos um host de conversão no provedor de destino. É possível continuar criando um mapeamento de infraestrutura que inclua este projeto, mas deve-se ativar um host de conversão antes de executar o plano de migração."
 
 #:
 #: ../app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js:155

--- a/spec/i18n/newlines_spec.rb
+++ b/spec/i18n/newlines_spec.rb
@@ -1,0 +1,3 @@
+describe :newlines do
+  include_examples :newlines, Rails.root.join('locale').to_s
+end

--- a/spec/shared/i18n/newlines.rb
+++ b/spec/shared/i18n/newlines.rb
@@ -1,0 +1,52 @@
+def add_string_chevrons(input)
+  "#{"\u00BB".encode("UTF-8")}#{input}#{"\u00AB".encode("UTF-8")}"
+end
+
+shared_examples :newlines do |dir|
+  it "translations honor newlines" do
+    boundary_errors = {}
+    overall_errors = {}
+
+    Pathname.glob(File.join(dir, "**", "*.po")).each do |po_file|
+      po = FastGettext::PoFile.new(po_file, :report_warning => false)
+      locale = po_file.dirname.basename.to_s
+      next if locale == 'en' # There's no need to test english .po
+
+      po.data.each do |original, translation|
+        next if original.empty? || translation.blank?
+
+        # Check newlines at string ends
+        if (translation[-1] == "\n" && original[-1] != "\n") || (translation[-1] != "\n" && original[-1] == "\n")
+          boundary_errors.store_path(po_file.to_s, add_string_chevrons(original), add_string_chevrons(translation))
+        end
+
+        # Check newlines at string starts
+        if (translation[0] == "\n" && original[0] != "\n") || (translation[0] != "\n" && original[0] == "\n")
+          boundary_errors.store_path(po_file.to_s, add_string_chevrons(original), add_string_chevrons(translation))
+        end
+
+        # Check that overall amount of newlines in original and translation matches
+        if original.scan("\n").length != translation.scan("\n").length
+          overall_errors.store_path(po_file.to_s, add_string_chevrons(original), add_string_chevrons(translation))
+        end
+      end
+    end
+
+    [['newlines at string boundaries', boundary_errors], ['overall number of newlines', overall_errors]].each do |rule, err|
+      next if err.empty?
+
+      puts "The following translation entries do not honor #{rule}:"
+      err.each do |file, file_errors|
+        puts ">> File: #{file}\n", "----------"
+        file_errors.each do |original, translation|
+          puts original, translation, "----------"
+        end
+        puts
+      end
+    end
+
+    expect(boundary_errors).to be_empty
+    # We intentionaly do not expect overall_errors to be empty, since in certain cases it may be desirable
+    # for newlines in translated string not to match its original. We'll still be logging the mismatches above.
+  end
+end


### PR DESCRIPTION
It seems that with lately added translation we have a new problem in our gettext catalogs: the translations do not honor newlines at string starts and string ends.

For example, from `locale/es/manageiq.po`:
```
msgid "Copy from Provisioning"
msgstr "Copiar desde Aprovisionamiento\\n"
```
Same thing shown in UI:
![Screenshot from 2020-11-13 18-25-01](https://user-images.githubusercontent.com/6648365/99101910-93a50e00-25dd-11eb-87c9-6ff832ffc9e9.png)


The rules that we need to enforce here:
1. if original string starts with a newline, translation needs to start with a newline too
2. if original string ends with a newline, translated string also needs to end with a newline
3. overal amount of newlines in original and translated string needs to match

In this PR, I am introducing a new test, which tests the above rules. The exception is the 3rd rule, since it seems that in some places the newline might have been added (or omitted) intentionaly. So we're just logging these.

This PR also fixes strings in catalogs that break the above rules.

@miq-bot add_label internationalization, test, wip