### PR TITLE
Disable :embedded_automation_manager_ansible factory

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -391,7 +391,9 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/embedded_ansible/automation_manager"],
           :class   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",
           :parent  => :automation_manager do
-    provider :factory => :provider_embedded_ansible
+    provider {
+      raise "DO NOT USE!  Use :provider_embedded_ansible and reference the automation_manager from that record"
+    }
   end
 
   # Leaf classes for provisioning_manager

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
 
     let(:ansible_script_source) { FactoryBot.create(:embedded_ansible_configuration_script_source, :manager => manager) }
     let(:playbook)              { FactoryBot.create(:embedded_playbook, :configuration_script_source => ansible_script_source, :manager => manager) }
-    let(:manager)               { FactoryBot.create(:embedded_automation_manager_ansible, :provider) }
+    let(:manager)               { provider.automation_manager }
+    let(:provider)              { FactoryBot.create(:provider_embedded_ansible) }
 
     let(:machine_credential)    { FactoryBot.create(:ansible_machine_credential, :manager_ref => "1", :resource => manager) }
     let(:cloud_credential)      { FactoryBot.create(:ansible_cloud_credential,   :manager_ref => "2", :resource => manager) }

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
-  let(:manager)               { FactoryBot.create(:embedded_automation_manager_ansible, :provider) }
+  let(:provider)              { FactoryBot.create(:provider_embedded_ansible) }
+  let(:manager)               { provider.automation_manager }
   let(:ansible_script_source) { FactoryBot.create(:embedded_ansible_configuration_script_source, :manager_id => manager.id) }
   let(:playbook)              { FactoryBot.create(:embedded_playbook, :configuration_script_source => ansible_script_source) }
 

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
   end
 
   describe '#catalog_types' do
-    let(:ems) { FactoryBot.create(:embedded_automation_manager_ansible) }
+    let(:provider) { FactoryBot.create(:provider_embedded_ansible) }
+    let(:ems)      { provider.automation_manager }
 
     it "includes generic_ansible_playbook" do
       expect(ems.catalog_types).to include("generic_ansible_playbook")

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ServiceTemplateAnsiblePlaybook do
   let(:script_source) { FactoryBot.create(:configuration_script_source, :manager => ems) }
 
   let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
-  let(:provider) { ems.provider }
-  let(:ems)      { FactoryBot.create(:embedded_automation_manager_ansible) }
+  let(:provider) { FactoryBot.create(:provider_embedded_ansible) }
+  let(:ems)      { provider.automation_manager }
 
   let(:playbook) do
     FactoryBot.create(:embedded_playbook,


### PR DESCRIPTION
**SHOULD MERGE AFTER https://github.com/ManageIQ/manageiq-ui-classic/pull/7508 and https://github.com/ManageIQ/manageiq-automation_engine/pull/466 have switched to not using this factory to avoid test failures**

This factory is the incorrect way for generating a manager for `EmbeddedAnsible`, since a lot of what is necessary for the Manager requires the `Provider`, and the provider has it's own mechanism for ensuring a AutomationManager exists for it.

See commit 31a2f329b8809b76c1ef8fce572edde9917973de

As a result, it is better to prevent the usage of this factory, which in this case, we do a lazy loaded `raise` that will get called when the factory attempts to assign the `provider` value.

Instead, users should create a Provider record using the `:provider_embedded_ansible` factory, and call to the `automation_manager` associated with that record.


Links
-----

* Follow up to: https://github.com/ManageIQ/manageiq/pull/20787
* Search in ManageIQ org other offending usages:  https://github.com/search?q=org%3AManageIQ+embedded_automation_manager_ansible&type=code
* Example failure from earlier:  https://travis-ci.com/github/ManageIQ/manageiq/jobs/439402657