### PR TITLE
Apply rubocop fixes for Lint/UnusedMethodArgument.

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -102,7 +102,7 @@ class Chargeback < ActsAsArModel
     "#{consumption.resource_id}_#{ts_key}"
   end
 
-  def self.groupby_label_value(consumption, groupby_label)
+  def self.groupby_label_value(_consumption, _groupby_label)
     nil
   end
 

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -30,7 +30,7 @@ class Condition < ApplicationRecord
     pluck(:expression)
   end
 
-  def self.evaluate(cond, rec, inputs = {}, attr = :expression)
+  def self.evaluate(cond, rec, _inputs = {}, attr = :expression)
     expression = cond.send(attr)
     name = cond.try(:description) || cond.try(:name)
     if expression.kind_of?(MiqExpression)

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -66,19 +66,19 @@ class ContainerProject < ApplicationRecord
     end
   end
 
-  def perf_rollup_parents(interval_name = nil)
+  def perf_rollup_parents(_interval_name = nil)
     []
   end
 
-  def aggregate_memory(targets = nil)
+  def aggregate_memory(_targets = nil)
     Hardware.where(:computer_system => computer_systems).sum(:memory_mb)
   end
 
-  def aggregate_cpu_speed(targets = nil)
+  def aggregate_cpu_speed(_targets = nil)
     Hardware.where(:computer_system => computer_systems).sum(:cpu_speed)
   end
 
-  def aggregate_cpu_total_cores(targets = nil)
+  def aggregate_cpu_total_cores(_targets = nil)
     Hardware.where(:computer_system => computer_systems).sum(:cpu_total_cores)
   end
 

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -37,7 +37,7 @@ class ContainerReplicator < ApplicationRecord
     end
   end
 
-  def perf_rollup_parents(interval_name = nil)
+  def perf_rollup_parents(_interval_name = nil)
     []
   end
 end

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -32,7 +32,7 @@ class ContainerService < ApplicationRecord
 
   PERF_ROLLUP_CHILDREN = [:container_groups]
 
-  def perf_rollup_parents(interval_name = nil)
+  def perf_rollup_parents(_interval_name = nil)
     []
   end
 end

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -107,7 +107,7 @@ class DialogField < ApplicationRecord
     self.default_value = given_value
   end
 
-  def initialize_with_values(dialog_values)
+  def initialize_with_values(_dialog_values)
     # override in subclasses
     nil
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -575,7 +575,7 @@ class ExtManagementSystem < ApplicationRecord
     refresh_ems(ems_ids, true) unless ems_ids.empty?
   end
 
-  def self.refresh_ems(ems_ids, reload = false)
+  def self.refresh_ems(ems_ids, _reload = false)
     ems_ids = [ems_ids] unless ems_ids.kind_of?(Array)
     ems_ids = ems_ids.collect { |id| [ExtManagementSystem, id] }
     EmsRefresh.queue_refresh(ems_ids)

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -21,7 +21,7 @@ class HostAggregate < ApplicationRecord
 
   PERF_ROLLUP_CHILDREN = [:vms]
 
-  def perf_rollup_parents(interval_name = nil)
+  def perf_rollup_parents(_interval_name = nil)
     # don't rollup to ext_management_system since that's handled through availability zone
     nil
   end

--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -117,7 +117,7 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
     end
   end
 
-  def capture_ems_targets(options = {})
+  def capture_ems_targets(_options = {})
     raise(NotImplementedError, _("must be implemented in subclass"))
   end
 

--- a/app/models/manageiq/providers/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/cloud_manager/metrics_capture.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::CloudManager::MetricsCapture < ManageIQ::Providers::B
   # @return vms under all availability zones
   #         and vms under no availability zone
   # NOTE: some stacks (e.g. nova) default to no availability zone
-  def capture_ems_targets(options = {})
+  def capture_ems_targets(_options = {})
     MiqPreloader.preload([ems], :vms => [{:availability_zone => :tags}, :ext_management_system])
 
     ems.vms.select do |vm|

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -69,7 +69,7 @@ module Metric::Purging
     purge_by_date(older_than, "hourly", window, total_limit, &block)
   end
 
-  def self.purge_realtime(older_than, window = nil, total_limit = nil, &block)
+  def self.purge_realtime(older_than, _window = nil, _total_limit = nil)
     truncate_child_tables(older_than)
   end
 

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -475,7 +475,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     @ldap_ous
   end
 
-  def allowed_organizational_units(options = {})
+  def allowed_organizational_units(_options = {})
     {}
   end
 

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -407,7 +407,7 @@ module MiqReport::Generator
     res
   end
 
-  def build_table(data, db, options = {})
+  def build_table(data, _db, options = {})
     data = data.to_a
     objs = data[0] && data[0].kind_of?(Integer) ? db_klass.where(:id => data) : data.compact
 

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -80,7 +80,7 @@ class MiqRequestWorkflow
   end
 
   # Helper method when not using workflow
-  def make_request(request, values, requester = nil, auto_approve = false)
+  def make_request(request, values, _requester = nil, auto_approve = false)
     return false unless validate(values)
     password_helper(values, true)
     # Ensure that tags selected in the pre-dialog get applied to the request

--- a/app/models/miq_widget/import_export.rb
+++ b/app/models/miq_widget/import_export.rb
@@ -2,7 +2,7 @@ module MiqWidget::ImportExport
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def import_from_hash(widget, options = {})
+    def import_from_hash(widget, _options = {})
       raise _("No Widget to Import") if widget.nil?
 
       WidgetImportService.new.import_widget_from_hash(widget)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -457,7 +457,7 @@ class VmOrTemplate < ApplicationRecord
   end
   private_class_method :task_arguments
 
-  def powerops_callback(task_id, status, msg, result, queue_item)
+  def powerops_callback(task_id, status, msg, result, _queue_item)
     task = MiqTask.find_by(:id => task_id)
     task.queue_callback("Finished", status, msg, result) if task
   end

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -9,7 +9,7 @@ module VmOrTemplate::Operations
 
   alias_method :ruby_clone, :clone
 
-  def raw_clone(name, folder, pool = nil, host = nil, datastore = nil, powerOn = false, template_flag = false, transform = nil, config = nil, customization = nil, disk = nil)
+  def raw_clone(_name, _folder, _pool = nil, _host = nil, _datastore = nil, _powerOn = false, _template_flag = false, _transform = nil, _config = nil, _customization = nil, _disk = nil)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -29,7 +29,7 @@ module VmOrTemplate::Operations
     raw_mark_as_template
   end
 
-  def raw_mark_as_vm(pool, host = nil)
+  def raw_mark_as_vm(_pool, _host = nil)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -67,7 +67,7 @@ module VmOrTemplate::Operations
     check_policy_prevent(:request_vm_destroy, :destroy_queue)
   end
 
-  def raw_rename(new_name)
+  def raw_rename(_new_name)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -1,5 +1,5 @@
 module VmOrTemplate::Operations::Configuration
-  def raw_set_memory(mb)
+  def raw_set_memory(_mb)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -9,7 +9,7 @@ module VmOrTemplate::Operations::Configuration
     raw_set_memory(mb)
   end
 
-  def raw_set_number_of_cpus(num)
+  def raw_set_number_of_cpus(_num)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -79,7 +79,7 @@ module VmOrTemplate::Operations::Configuration
     raw_disconnect_floppies
   end
 
-  def raw_add_disk(disk_name, disk_size_mb, options = {})
+  def raw_add_disk(_disk_name, _disk_size_mb, _options = {})
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -89,7 +89,7 @@ module VmOrTemplate::Operations::Configuration
     raw_add_disk(disk_name, disk_size_mb, options)
   end
 
-  def raw_remove_disk(disk_name, options = {})
+  def raw_remove_disk(_disk_name, _options = {})
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -109,7 +109,7 @@ module VmOrTemplate::Operations::Configuration
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
-  def raw_attach_volume(volume_id, device = nil)
+  def raw_attach_volume(_volume_id, _device = nil)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -119,11 +119,11 @@ module VmOrTemplate::Operations::Configuration
     raw_attach_volume(volume_id, device)
   end
 
-  def raw_detach_volume(volume_id)
+  def raw_detach_volume(_volume_id)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
-  def detach_volume(volume_id, device = nil)
+  def detach_volume(volume_id, _device = nil)
     raise _("VM has no EMS, unable to detach volume") unless ext_management_system
 
     raw_detach_volume(volume_id)

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -38,7 +38,7 @@ module VmOrTemplate::Operations::Relocation
     raw_evacuate(options)
   end
 
-  def raw_migrate(host, pool = nil, priority = "defaultPriority", state = nil)
+  def raw_migrate(_host, _pool = nil, _priority = "defaultPriority", _state = nil)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -48,7 +48,7 @@ module VmOrTemplate::Operations::Relocation
     raw_migrate(host, pool, priority, state)
   end
 
-  def raw_relocate(host, pool = nil, datastore = nil, disk_move_type = nil, transform = nil, priority = "defaultPriority", disk = nil)
+  def raw_relocate(_host, _pool = nil, _datastore = nil, _disk_move_type = nil, _transform = nil, _priority = "defaultPriority", _disk = nil)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -58,7 +58,7 @@ module VmOrTemplate::Operations::Relocation
     raw_relocate(host, pool, datastore, disk_move_type, transform, priority, disk)
   end
 
-  def raw_move_into_folder(folder)
+  def raw_move_into_folder(_folder)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -44,7 +44,7 @@ module VmOrTemplate::Operations::Snapshot
     end
   end
 
-  def raw_create_snapshot(name, desc = nil, memory)
+  def raw_create_snapshot(_name, _desc = nil, _memory)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -56,7 +56,7 @@ module VmOrTemplate::Operations::Snapshot
     check_policy_prevent(:request_vm_create_snapshot, :create_snapshot_queue, name, desc, memory)
   end
 
-  def raw_remove_snapshot(snapshot_id)
+  def raw_remove_snapshot(_snapshot_id)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -111,7 +111,7 @@ module VmOrTemplate::Operations::Snapshot
     )
   end
 
-  def raw_remove_snapshot_by_description(description, refresh = false)
+  def raw_remove_snapshot_by_description(_description, _refresh = false)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
@@ -149,7 +149,7 @@ module VmOrTemplate::Operations::Snapshot
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
-  def raw_revert_to_snapshot(snapshot_id)
+  def raw_revert_to_snapshot(_snapshot_id)
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 


### PR DESCRIPTION
This is the result of applying the `Lint/UnusedMethodArgument` rubocop using version 1.1 of rubocop. This seems mostly straightforward as most of these appear to be for interface methods, but does raise some questions, so I've marked this as a draft for now.

Current questions:

* Was the `inputs` variable in `Condition.evaluate` supposed to actually be used since it's in the 3rd argument position?
* Why are the affected `ContainerProject` aggregate methods taking an argument at all?
* Why does `ExtManagementSystem#refresh_ems` take a `reload` argument?
* Why does the `MetricsCapture#capture_ems_targets` take an `options` argument?
* Why does `Purging.purge_realtime` take `window` and `total_limit` arguments, or a block?
* Why does `Generator#build_table` take a `db` argument?
* Why does `MiqRequestWorkflow#make_request` take a `requestor` argument?
* Why does `MiqWidget::ImportExport#import_from_hash` take an `options` argument?
* Why does `VmOrTemplate#powerops_callback` take a `queue_item` argument?