### PR TITLE
Switch MiqRequestWorkflow dialogs accessor to writer only

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -8,7 +8,8 @@ class MiqRequestWorkflow
   # We rely on MiqRequestWorkflow's descendants to be comprehensive
   singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
 
-  attr_accessor :dialogs, :requester, :values, :last_vm_id
+  attr_accessor :requester, :values, :last_vm_id
+  attr_writer :dialogs
 
   def self.automate_dialog_request
     nil


### PR DESCRIPTION
Spotted by ruboop. There's already a reader method for `dialogs` on line 308:

https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request_workflow.rb#L308-L310