### PR TITLE
Auto-restart systemd workers results in duplicates

### DIFF
--- a/app/models/miq_server/at_startup.rb
+++ b/app/models/miq_server/at_startup.rb
@@ -3,6 +3,13 @@ module MiqServer::AtStartup
   include Vmdb::Logging
 
   module ClassMethods
+    def startup!
+      log_managed_entities
+      clean_all_workers
+      clean_dequeued_messages
+      purge_report_results
+    end
+
     def log_managed_entities
       region = MiqRegion.my_region
       prefix = "#{_log.prefix} Region: [#{region.region}], name: [#{region.name}]"

--- a/app/models/miq_server/at_startup.rb
+++ b/app/models/miq_server/at_startup.rb
@@ -5,6 +5,7 @@ module MiqServer::AtStartup
   module ClassMethods
     def startup!
       log_managed_entities
+      write_systemd_service_files if MiqEnvironment::Command.supports_systemd?
       clean_all_workers
       clean_dequeued_messages
       purge_report_results
@@ -15,6 +16,16 @@ module MiqServer::AtStartup
       prefix = "#{_log.prefix} Region: [#{region.region}], name: [#{region.name}]"
       log_under_management(prefix)
       log_not_under_management(prefix)
+    end
+
+    def write_systemd_service_files
+      MiqWorkerType.worker_class_names.each do |class_name|
+        worker_klass = class_name.safe_constantize
+        worker_klass.ensure_systemd_files if worker_klass&.systemd_worker?
+      rescue => err
+        _log.warn("Failed to write systemd service files: #{err}")
+        _log.log_backtrace(err)
+      end
     end
 
     # Delete and Kill all workers that were running previously

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -52,7 +52,6 @@ module MiqServer::WorkerManagement::Monitor
         c = class_name.constantize
         raise NameError, "Constant problem: expected: #{class_name}, constantized: #{c.name}" unless c.name == class_name
 
-        c.ensure_systemd_files if c.systemd_worker?
         result[c.name] = c.sync_workers
         result[c.name][:adds].each { |pid| worker_add(pid) unless pid.nil? }
       rescue => error

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -69,7 +69,7 @@ class MiqWorker
           WorkingDirectory=#{working_directory}
           Environment=BUNDLER_GROUPS=#{bundler_groups.join(",")}
           ExecStart=/bin/bash -lc '#{exec_start}'
-          Restart=always
+          Restart=no
           Slice=#{slice_name}
         UNIT_FILE
       end

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -12,8 +12,8 @@ class MiqWorker
       end
 
       def ensure_systemd_files
-        target_file_path.write(target_file) unless target_file_path.exist?
-        service_file_path.write(unit_file) unless service_file_path.exist?
+        target_file_path.write(target_file)
+        service_file_path.write(unit_file)
       end
 
       def service_base_name

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -118,10 +118,7 @@ class EvmServer
     configure_server_roles
     clear_queue
 
-    MiqServer.log_managed_entities
-    MiqServer.clean_all_workers
-    MiqServer.clean_dequeued_messages
-    MiqServer.purge_report_results
+    MiqServer.startup!
 
     @current_server.delete_active_log_collections_queue
 


### PR DESCRIPTION
Because the worker GUID is part of the systemd service when a systemd worker is restarted by systemd it will get a new PID but reuse the old GUID.

If MiqServer deletes the worker row because it doesn't see the PID then you end up with a service restarting and failing to find its row constantly.

Fixes https://github.com/ManageIQ/manageiq/issues/20822