### PR TITLE
Add a warning if the ems.update fails within ManageIQ::Providers::BaseManager::Refresher

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -52,18 +52,14 @@ module ManageIQ
             end
 
             # record the failed status and skip post-processing
-            unless ems.update(:last_refresh_error => e.to_s, :last_refresh_date => Time.now.utc)
-              _log.warn("Failed to update last_refresh_error and/or last_refresh_date: #{ems.errors.messages}")
-            end
+            ems.update!(:last_refresh_error => e.to_s, :last_refresh_date => Time.now.utc)
             partial_refresh_errors << e.to_s
             next
           ensure
             post_refresh_ems_cleanup(ems, targets)
           end
 
-          unless ems.update(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
-            _log.warn("Failed to update last_refresh_error and/or last_refresh_date: #{ems.errors.messages}")
-          end
+          ems.update!(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
           post_refresh(ems, ems_refresh_start_time)
         end
 

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -52,14 +52,18 @@ module ManageIQ
             end
 
             # record the failed status and skip post-processing
-            ems.update(:last_refresh_error => e.to_s, :last_refresh_date => Time.now.utc)
+            unless ems.update(:last_refresh_error => e.to_s, :last_refresh_date => Time.now.utc)
+              _log.warn("Failed to update last_refresh_error and/or last_refresh_date: #{ems.errors.messages}")
+            end
             partial_refresh_errors << e.to_s
             next
           ensure
             post_refresh_ems_cleanup(ems, targets)
           end
 
-          ems.update(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
+          unless ems.update(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
+            _log.warn("Failed to update last_refresh_error and/or last_refresh_date: #{ems.errors.messages}")
+          end
           post_refresh(ems, ems_refresh_start_time)
         end
 


### PR DESCRIPTION
Within the `ManageIQ::Providers::BaseManager::Refresher#refresh method` there are two possible places we update the `last_refresh_error` and `last_refresh_date`. However, we don't bother to check if the update was actually successful, as the `update` method only returns true or false, it doesn't raise an error.

Alternatively, we could change those to `update!` instead and let the errors bubble up naturally.

Originally inspired by https://bugzilla.redhat.com/show_bug.cgi?id=1856644