### PR TITLE
[JANSA] Cockpit is a monitor thread and is not a pod worker. #20823 jansa backport

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -78,7 +78,9 @@ module MiqServer::WorkerManagement::Monitor
         # Hack for schema-less backport(no new system_uid column):
         # reuse existing guid column to store/retrieve the system_uid, pod name in pods.
         # https://github.com/ManageIQ/manageiq/pull/20792
-        orphaned_rows = miq_workers.where.not(:guid => current_pods.keys)
+        #
+        # Cockpit is a threaded worker in the orchestrator that spins off a process it monitors and isn't a pod worker.
+        orphaned_rows = miq_workers.where.not(:type => %w[MiqCockpitWsWorker]).where.not(:guid => current_pods.keys)
         unless orphaned_rows.empty?
           _log.warn("Removing orphaned worker rows without corresponding pods: #{orphaned_rows.collect(&:guid).inspect}")
           orphaned_rows.destroy_all

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe MiqServer::WorkerManagement::Monitor do
           server.cleanup_orphaned_worker_rows
           expect(MiqWorker.count).to eq(2)
         end
+
+        it "skips MiqCockpitWsWorker rows" do
+          worker.update(:guid => "an_actual_guid", :type => "MiqCockpitWsWorker")
+          server.cleanup_orphaned_worker_rows
+          expect(MiqCockpitWsWorker.count).to eq(1)
+        end
       end
     end
 


### PR DESCRIPTION
Follow up to #20792

[Modified for jansa to use guid column instead of system_uid]
jansa backport of https://github.com/ManageIQ/manageiq/pull/20823

It runs in the orchestrator in pods in a thread and launches a process to communicate with cockpit.
The threaded worker monitors this process, has a miq_workers row, but does not run in a separate pod
and therefore doesn't currently update the row with it's pod name.  Therefore, we need to exclude cockpit
rows from the code that monitors for orphaned pod miq_workers.

In the future, we could populate the cockpit miq_workers row with the pod name of the orchestrator pod it's
running on but that would be a larger change and perhaps we should discuss that with a larger discussion about
cockpit and if it works as we want in pods.

EDIT:
This PR corrects the problem for this issue.  It doesn't fix cockpit in pods but it resolves the constant restarts.