### PR TITLE
Use requests, not defaultRequest, in deploy definition

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -53,8 +53,8 @@ class MiqWorker
         h.store_path(:limits, :memory, format_memory_threshold(mem_limit)) if mem_limit
         h.store_path(:limits, :cpu, format_cpu_threshold(cpu_limit)) if cpu_limit
 
-        h.store_path(:defaultRequest, :memory, format_memory_threshold(mem_request)) if mem_request
-        h.store_path(:defaultRequest, :cpu, format_cpu_threshold(cpu_request)) if cpu_request
+        h.store_path(:requests, :memory, format_memory_threshold(mem_request)) if mem_request
+        h.store_path(:requests, :cpu, format_cpu_threshold(cpu_request)) if cpu_request
       end
     end
 

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       it "returns default cpu when it is set" do
         allow(MiqGenericWorker).to receive(:worker_settings).and_return(:cpu_request_percent => 10)
         constraints = {
-          :defaultRequest => {
+          :requests => {
             :cpu => "100m"
           }
         }
@@ -187,7 +187,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       it "returns default memory when it is set" do
         allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_request => 250.megabytes)
         constraints = {
-          :defaultRequest => {
+          :requests => {
             :memory => "250Mi",
           }
         }
@@ -197,7 +197,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       it "returns memory pair when set" do
         allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_request => 250.megabytes, :memory_threshold => 600.megabytes)
         constraints = {
-          :defaultRequest => {
+          :requests => {
             :memory => "250Mi",
           },
           :limits         => {


### PR DESCRIPTION
Followup to #20661

Previously, it looks like kubernetes was silently ignoring the defaultRequest,
while still honoring the rest of the definition.

We were seeing definitions with the resource limits but no requests:

```
$ oc get deploy 1-generic -o yaml | grep -A 6 "resources:"
        resources:
          limits:
            cpu: "1"
            memory: 1Gi
```

We found that existing deployment definitions in other projects used the key
'requests', so after making this change, we now have both limits and requests
in the deployment definition:

```
$ oc get deploy 1-generic -o yaml | grep -A 6 "resources:"
        resources:
          limits:
            cpu: "1"
            memory: 1Gi
          requests:
            cpu: 150m
           memory: 500Mi
```