### PR TITLE
Add basic script to print pod throttling information

### DIFF
--- a/tools/pod_throttling.rb
+++ b/tools/pod_throttling.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+# This is only useful for pods in determining cpu throttling
+
+# Some useful links:
+# /sys/fs/cgroup/* information: https://engineering.squarespace.com/blog/2017/understanding-linux-container-scheduling
+# Looking at cpu.stat throttling to find a kernel bug:
+#   part 1) https://medium.com/indeed-engineering/unthrottled-fixing-cpu-limits-in-the-cloud-a0995ede8e89
+#   part 2) https://medium.com/indeed-engineering/unthrottled-how-a-valid-fix-becomes-a-regression-f61eabb2fbd9
+# Example bash script checking throttling of all pods on your host: https://gist.github.com/simonsj/ca7f532df95eec401a53f13ad31cbaff
+CPU_STAT_FILE = '/sys/fs/cgroup/cpu,cpuacct/cpu.stat'
+if File.exist?(CPU_STAT_FILE)
+  nr_periods   = 0
+  nr_throttled = 0
+
+  File.read(CPU_STAT_FILE).each_line do |line|
+    key, value = line.split(" ")
+
+    case key
+    when "nr_throttled"
+      # break if there's no throttling
+      if value == "0"
+        STDOUT.puts "No throttling"
+        break
+      end
+
+      nr_throttled = value.to_i
+    when "nr_periods"
+      # break if request/limits not set (nr_periods 0)
+      if value == "0"
+        STDOUT.puts "No periods monitored: no limit set?"
+        break
+      end
+
+      nr_periods = value.to_f
+    end
+  end
+
+  if nr_periods > 0 && nr_throttled > 0
+    STDOUT.puts "#{nr_throttled/nr_periods}, nr_throttled/nr_periods, #{nr_throttled}/#{nr_periods}"
+  end
+end


### PR DESCRIPTION
We could possibly throw this into a bash script that all images have
and therefore we could run within the httpd/postgresql pods too.

Either this, this is just a first cut, first try to make sure it works.
We can change this to a ruby method/shell function that outputs % throttled
or whatever we want.  We can then choose to log this or raise events based on it.

This is what it looks like when I run this using images containing this script:

```
% for I in `oc get pods -o wide | grep -v NAME | awk '{ print $1 }'`; do echo $I; oc exec -t $I  ruby /var/www/miq/vmdb/tools/pod_throttling.rb; done

1-event-handler-86bc8c48-j6527
0.0022497187851518562, nr_throttled/nr_periods, 4/1778.0

1-generic-76c4cc89df-j8zk8
0.015989036089538604, nr_throttled/nr_periods, 35/2189.0

1-priority-6db6fb54bc-s6fvk
0.011067475901463763, nr_throttled/nr_periods, 31/2801.0

...
1-ui-64bb7d5fb8-f28nw
0.006785411365564037, nr_throttled/nr_periods, 8/1179.0
1-web-service-bff886b46-4cwbr
0.001834862385321101, nr_throttled/nr_periods, 3/1635.0
...
orchestrator-dd875c564-6lvvq
No periods monitored: no limit set?
...

```