### PR TITLE
This change will enable the appliance_console to set the messaging_ty…

### DIFF
--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -7,6 +7,7 @@ module EvmSettings
     "/authentication/oidc_enabled",
     "/authentication/provider_type",
     "/authentication/local_login_disabled"
+    "/prototype/messaging_type"
   ].freeze
 
   INFO  ||= "info".freeze

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -6,7 +6,7 @@ module EvmSettings
     "/authentication/saml_enabled",
     "/authentication/oidc_enabled",
     "/authentication/provider_type",
-    "/authentication/local_login_disabled"
+    "/authentication/local_login_disabled",
     "/prototype/messaging_type"
   ].freeze
 

--- a/spec/lib/tasks/evm_settings_spec.rb
+++ b/spec/lib/tasks/evm_settings_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/provider_type=none")
         expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
+        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=")
         EvmSettings.get_keys
       end
 
@@ -51,6 +52,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=true")
         expect(STDOUT).to receive(:puts).with("/authentication/provider_type=oidc")
         expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
+        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=")
         EvmSettings.get_keys
       end
 
@@ -75,8 +77,19 @@ RSpec.describe "EvmSettings", :type => :rake_task do
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/provider_type=saml")
         expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
+        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=")
         EvmSettings.get_keys
       end
+    end
+  end
+
+  describe "ALLOWED_KEYS" do
+    it "has the correct keys" do
+      @settings_keys = ["/authentication/httpd_role", "/authentication/local_login_disabled", "/authentication/mode",
+                       "/authentication/oidc_enabled", "/authentication/provider_type", "/authentication/saml_enabled",
+                       "/authentication/sso_enabled", "/prototype/messaging_type"].sort
+
+      expect(EvmSettings::ALLOWED_KEYS.sort).to eq(@settings_keys)
     end
   end
 end

--- a/spec/lib/tasks/evm_settings_spec.rb
+++ b/spec/lib/tasks/evm_settings_spec.rb
@@ -85,9 +85,8 @@ RSpec.describe "EvmSettings", :type => :rake_task do
 
   describe "ALLOWED_KEYS" do
     it "has the correct keys" do
-      @settings_keys = ["/authentication/httpd_role", "/authentication/local_login_disabled", "/authentication/mode",
-                       "/authentication/oidc_enabled", "/authentication/provider_type", "/authentication/saml_enabled",
-                       "/authentication/sso_enabled", "/prototype/messaging_type"].sort
+      @settings_keys = ["/authentication/httpd_role", "/authentication/local_login_disabled", "/authentication/mode", "/authentication/oidc_enabled",
+                        "/authentication/provider_type", "/authentication/saml_enabled", "/authentication/sso_enabled", "/prototype/messaging_type"].sort
 
       expect(EvmSettings::ALLOWED_KEYS.sort).to eq(@settings_keys)
     end

--- a/spec/lib/tasks/evm_settings_spec.rb
+++ b/spec/lib/tasks/evm_settings_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
                                :local_login_disabled => false,
                                :provider_type        => "none",
                                :sso_enabled          => false},
+           :prototype      => {:messaging_type       => "krabby patties"},
            :binary_blob    => {:purge_window_size    => 100}}
 
         allow(Settings).to receive(:to_hash).and_return(@settings_hash)
@@ -27,7 +28,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/provider_type=none")
         expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
-        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=")
+        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=krabby patties")
         EvmSettings.get_keys
       end
 
@@ -42,6 +43,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
                                :local_login_disabled => false,
                                :provider_type        => "oidc",
                                :sso_enabled          => false},
+           :prototype      => {:messaging_type       => "krabby patties"},
            :binary_blob    => {:purge_window_size    => 100}}
 
         allow(Settings).to receive(:to_hash).and_return(@settings_hash)
@@ -52,7 +54,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=true")
         expect(STDOUT).to receive(:puts).with("/authentication/provider_type=oidc")
         expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
-        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=")
+        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=krabby patties")
         EvmSettings.get_keys
       end
 
@@ -67,6 +69,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
                                :local_login_disabled => false,
                                :provider_type        => "saml",
                                :sso_enabled          => false},
+           :prototype      => {:messaging_type       => "krabby patties"},
            :binary_blob    => {:purge_window_size    => 100}}
 
         allow(Settings).to receive(:to_hash).and_return(@settings_hash)
@@ -77,7 +80,7 @@ RSpec.describe "EvmSettings", :type => :rake_task do
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/provider_type=saml")
         expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
-        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=")
+        expect(STDOUT).to receive(:puts).with("/prototype/messaging_type=krabby patties")
         EvmSettings.get_keys
       end
     end


### PR DESCRIPTION
This PR is required so the appliance_console can toggle **Settings.prototype.messaging_type**
which is introduced in: https://github.com/ManageIQ/manageiq-appliance_console/pull/137