### PR TITLE
Strip label value in tag mapping

### DIFF
--- a/app/models/provider_tag_mapping/mapper.rb
+++ b/app/models/provider_tag_mapping/mapper.rb
@@ -104,7 +104,7 @@ class ProviderTagMapping
 
     def map_label(type, label)
       label_name = case_sensitive_labels? ? label[:name] : label[:name]&.downcase
-      label_value = label[:value]
+      label_value = label[:value].strip
       # Apply both specific-type and any-type, independently.
       (map_name_type_value(label_name, type, label_value) +
        map_name_type_value(label_name, nil, label_value) +

--- a/app/models/provider_tag_mapping/mapper.rb
+++ b/app/models/provider_tag_mapping/mapper.rb
@@ -104,10 +104,11 @@ class ProviderTagMapping
 
     def map_label(type, label)
       label_name = case_sensitive_labels? ? label[:name] : label[:name]&.downcase
+      label_value = label[:value]
       # Apply both specific-type and any-type, independently.
-      (map_name_type_value(label_name, type, label[:value]) +
-       map_name_type_value(label_name, nil, label[:value]) +
-       map_name_type_value(label_name, "_all_entities_", label[:value]))
+      (map_name_type_value(label_name, type, label_value) +
+       map_name_type_value(label_name, nil, label_value) +
+       map_name_type_value(label_name, "_all_entities_", label_value))
     end
 
     def map_name_type_value(name, type, value)

--- a/spec/models/provider_tag_mapping_spec.rb
+++ b/spec/models/provider_tag_mapping_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe ProviderTagMapping do
         end
 
         let(:externals_labels) do # provider label
-          [{:name => label_name, :value => 'Accounting'}]
+          [{:name => label_name, :value => ' Accounting'}]
         end
 
         it "replaces an existing tag on the resource with the value of the external label" do
@@ -301,7 +301,7 @@ RSpec.describe ProviderTagMapping do
 
           let(:externals_labels) do # provider label
             [{:name => label_name, :value => 'Accounting'},
-             {:name => 'Locality', :value => 'Brno'}]
+             {:name => 'Locality', :value => '   Brno   '}]
           end
 
           before do
@@ -349,7 +349,7 @@ RSpec.describe ProviderTagMapping do
         let!(:multi_value_category_2) { FactoryBot.create(:classification_cost_center_with_tags) }
 
         let(:externals_labels) do # provider label
-          [{:name => label_name, :value => 'Accounting'}]
+          [{:name => label_name, :value => ' Accounting'}]
         end
 
         before do
@@ -427,7 +427,7 @@ RSpec.describe ProviderTagMapping do
           context "when mappings are targeted to same categories" do
             let(:externals_labels) do # provider labels
               [{:name => label_name, :value => 'Accounting'},
-               {:name => 'Finance Center', :value => '007'}]
+               {:name => 'Finance Center', :value => ' 007'}]
             end
 
             before do


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/20831.
**Tag mapping process** replaces space in tag value(tag name in MiQ side) with underscores (`_`) which is not appropriate.

This PR strips off space from tag values **tag mapping process**  and thanks to that 
mapping behaves like there are no leading and trailing spaces.

Idea of fix is supported by fact that we are not allowed to add tags with tag name (=value on provider side ) which contains spaces so mapping process has to handle spaces.

### Links
https://github.com/ManageIQ/manageiq/issues/20831

@miq-bot add_label bug

cc @chadh1313 

@miq-bot assign @gtanzillo 

### Next
I believe that it would be also beneficial for category names:
- strip spaces for resource label(label name) when mapping is created.
- strip spaces for label name in mapping process (similar to this change)

