### PR TITLE
Use systemd-notify for worker heartbeating

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,6 +161,7 @@ end
 
 group :systemd, :optional => true do
   gem "dbus-systemd",    "~>1.1.0", :require => false
+  gem "sd_notify",       "~>0.1.0", :require => false
   gem "systemd-journal", "~>1.4.2", :require => false
 end
 

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -144,7 +144,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   def heartbeat_message_timeout(message)
     if message.msg_timeout
       timeout = worker_settings[:poll] + message.msg_timeout
-      heartbeat_to_file(timeout)
+      systemd_worker? ? worker.sd_notify_watchdog_usec(timeout) : heartbeat_to_file(timeout)
     end
   end
 end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -142,6 +142,7 @@ class MiqWorker::Runner
 
   def started_worker_record
     reload_worker_record
+    @worker.sd_notify_started if @worker.systemd_worker?
     @worker.status         = "started"
     @worker.last_heartbeat = Time.now.utc
     @worker.update_spid
@@ -191,6 +192,7 @@ class MiqWorker::Runner
     @worker.stopped_on = Time.now.utc
     @worker.save
 
+    @worker.sd_notify_stopping if @worker.systemd_worker?
     @worker.status_update
     @worker.log_status
   end
@@ -289,6 +291,7 @@ class MiqWorker::Runner
     return if @last_hb.kind_of?(Time) && (@last_hb + worker_settings[:heartbeat_freq]) >= now
 
     heartbeat_to_file
+    @worker.sd_notify_watchdog if @worker.systemd_worker?
 
     if config_out_of_date?
       _log.info("#{log_prefix} Synchronizing configuration...")

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -115,6 +115,21 @@ class MiqWorker
       systemd.StopUnit(unit_name, mode)
     end
 
+    def sd_notify_started
+      require "sd_notify"
+      SdNotify.ready
+    end
+
+    def sd_notify_stopping
+      require "sd_notify"
+      SdNotify.stopping
+    end
+
+    def sd_notify_watchdog
+      require "sd_notify"
+      SdNotify.watchdog
+    end
+
     private
 
     def systemd
@@ -166,6 +181,7 @@ class MiqWorker
         MemoryHigh=#{worker_settings[:memory_threshold].bytes}
         TimeoutStartSec=#{worker_settings[:starting_timeout]}
         TimeoutStopSec=#{worker_settings[:stopping_timeout]}
+        WatchdogSec=#{worker_settings[:heartbeat_timeout]}
         #{unit_environment_variables.map { |env_var| "Environment=#{env_var}" }.join("\n")}
       UNIT_CONFIG_FILE
     end

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -70,6 +70,7 @@ class MiqWorker
           Environment=BUNDLER_GROUPS=#{bundler_groups.join(",")}
           ExecStart=/bin/bash -lc '#{exec_start}'
           Restart=no
+          Type=notify
           Slice=#{slice_name}
         UNIT_FILE
       end

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -116,18 +116,15 @@ class MiqWorker
     end
 
     def sd_notify_started
-      require "sd_notify"
-      SdNotify.ready
+      sd_notify.ready
     end
 
     def sd_notify_stopping
-      require "sd_notify"
-      SdNotify.stopping
+      sd_notify.stopping
     end
 
     def sd_notify_watchdog
-      require "sd_notify"
-      SdNotify.watchdog
+      sd_notify.watchdog
     end
 
     private
@@ -136,6 +133,13 @@ class MiqWorker
       @systemd ||= begin
         require "dbus/systemd"
         DBus::Systemd::Manager.new
+      end
+    end
+
+    def sd_notify
+      @sd_notify ||= begin
+        require "sd_notify"
+        SdNotify
       end
     end
 

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -127,6 +127,11 @@ class MiqWorker
       sd_notify.watchdog
     end
 
+    def sd_notify_watchdog_usec(timeout_in_seconds)
+      usec = timeout_in_seconds * 1_000_000
+      sd_notify.notify("WATCHDOG_USEC=#{usec}", false)
+    end
+
     private
 
     def systemd


### PR DESCRIPTION
Notify the systemd service manager when a worker is finished starting up, when it is shutting down, and poke the watchdog for heartbeating

Systemd has a watchdog system which will track the status of services
via "liveness check-ins" done via the systemd-notify API.

A watchdog timeout can be specified in the service file: https://www.freedesktop.org/software/systemd/man/systemd.service.html#WatchdogSec=
> WatchdogSec=
>
>Configures the watchdog timeout for a service. The watchdog is activated when the start-up is completed. The service must call sd_notify(3) regularly with "WATCHDOG=1" (i.e. the "keep-alive ping"). If the time between two such calls is larger than the configured time, then the service is placed in a failed state and it will be terminated with SIGABRT (or the signal specified by WatchdogSignal=). 

When a worker is killed due to heartbeat timeout a SIGABRT is delivered:
```
Nov 24 13:57:27 desktop systemd[2415]: Started generic@7befe859-b923-4c76-9c92-6c4e51792301.service.
Nov 24 13:59:27 desktop systemd[2415]: generic@7befe859-b923-4c76-9c92-6c4e51792301.service: Watchdog timeout (limit 2min)!
Nov 24 13:59:27 desktop systemd[2415]: generic@7befe859-b923-4c76-9c92-6c4e51792301.service: Killing process 89351 (ruby) with signal SIGABRT.
Nov 24 13:59:27 desktop systemd[2415]: generic@7befe859-b923-4c76-9c92-6c4e51792301.service: Main process exited, code=killed, status=6/ABRT
Nov 24 13:59:27 desktop systemd[2415]: generic@7befe859-b923-4c76-9c92-6c4e51792301.service: Failed with result 'watchdog'
```

TODO
- [x] Adjust WATCHDOG_USEC= based on dynamic queue_timeout
- [x] Disable MiqServer heartbeat checking for systemd/podified