### PR TITLE
Modified Ruby Files in Order to Mark Strings for Translation

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -161,27 +161,36 @@ class MiqSchedule < ApplicationRecord
   def run_at_to_human(timezone)
     start_time = run_at[:start_time].in_time_zone(timezone)
     start_time = start_time.strftime("%a %b %d %H:%M:%S %Z %Y")
+
+    case run_at[:interval][:unit]
+    when "minutely"
+      unit = _("minutes")
+      interval = _("minutely")
+    when "hourly"
+      unit = _("hours")
+      interval = _("hourly")
+    when "daily"
+      unit = _("days")
+      interval = _("daily")
+    when "weekly"
+      unit = _("weeks")
+      interval = _("weekly")
+    when "monthly"
+      unit = _("months")
+      interval = _("monthly")
+    else
+      interval = run_at[:interval][:unit]
+    end
+
     if run_at[:interval][:unit].downcase == "once"
-      return _("Run %{interval} on %{start_time}") % {:interval => run_at[:interval][:unit], :start_time => start_time}
+      _("Run %{interval} on %{start_time}") % {:interval => interval, :start_time => start_time}
     else
       if run_at[:interval][:value].to_i == 1
-        return _("Run %{interval} starting on %{start_time}") % {:interval   => run_at[:interval][:unit],
+        _("Run %{interval} starting on %{start_time}") % {:interval   => interval,
                                                                  :start_time => start_time}
       else
-        case run_at[:interval][:unit]
-        when "minutely"
-          unit = _("minutes")
-        when "hourly"
-          unit = _("hours")
-        when "daily"
-          unit = _("days")
-        when "weekly"
-          unit = _("weeks")
-        when "monthly"
-          unit = _("months")
-        end
         return _("Run %{interval} every %{value} %{unit} starting on %{start_time}") %
-                 {:interval   => run_at[:interval][:unit],
+                 {:interval   => interval,
                   :value      => run_at[:interval][:value],
                   :unit       => unit,
                   :start_time => start_time}

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -2,26 +2,26 @@ class MiqTask < ApplicationRecord
   include_concern 'Purging'
 
   serialize :context_data
-  STATE_INITIALIZED = 'Initialized'.freeze
-  STATE_QUEUED      = 'Queued'.freeze
-  STATE_ACTIVE      = 'Active'.freeze
-  STATE_FINISHED    = 'Finished'.freeze
+  STATE_INITIALIZED = N_('Initialized').freeze
+  STATE_QUEUED      = N_('Queued').freeze
+  STATE_ACTIVE      = N_('Active').freeze
+  STATE_FINISHED    = N_('Finished').freeze
 
-  STATUS_OK         = 'Ok'.freeze
-  STATUS_WARNING    = 'Warn'.freeze
-  STATUS_ERROR      = 'Error'.freeze
-  STATUS_TIMEOUT    = 'Timeout'.freeze
-  STATUS_EXPIRED    = 'Expired'.freeze
-  STATUS_UNKNOWN    = 'Unknown'.freeze
+  STATUS_OK         = N_('Ok').freeze
+  STATUS_WARNING    = N_('Warn').freeze
+  STATUS_ERROR      = N_('Error').freeze
+  STATUS_TIMEOUT    = N_('Timeout').freeze
+  STATUS_EXPIRED    = N_('Expired').freeze
+  STATUS_UNKNOWN    = N_('Unknown').freeze
 
   HUMAN_STATUS      = {
     STATE_INITIALIZED => STATE_INITIALIZED,
     STATE_QUEUED      => STATE_QUEUED,
-    STATE_ACTIVE      => 'Running'.freeze,
-    STATUS_OK         => 'Complete'.freeze,
-    STATUS_WARNING    => 'Finished with Warnings'.freeze,
+    STATE_ACTIVE      => N_('Running').freeze,
+    STATUS_OK         => N_('Complete').freeze,
+    STATUS_WARNING    => N_('Finished with Warnings').freeze,
     STATUS_ERROR      => STATUS_ERROR,
-    STATUS_TIMEOUT    => 'Timed Out'.freeze
+    STATUS_TIMEOUT    => N_('Timed Out').freeze
   }.freeze
 
   DEFAULT_MESSAGE   = 'Initialized'.freeze

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -60,8 +60,9 @@ class MiqWidget < ApplicationRecord
 
   def status
     if miq_task.nil?
-      return "None" if last_run_on.nil?
-      return "Complete"
+      return N_("None") if last_run_on.nil?
+
+      return N_("Complete")
     end
     miq_task.human_status
   end


### PR DESCRIPTION
Found in: Overview -> Reports -> Dashboard Widgets

Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/7525

Modifies `miq_schedule.rb` in order to mark `%{interval}` string for translation. Also adds N_() tags to strings in `miq_widget.rb` so they can later be translated (see related PR).

Preview:
![image](https://user-images.githubusercontent.com/64800041/100465462-580a4980-309d-11eb-8376-59455cc6cd9d.png)