### PR TITLE
[EmbeddedAnsible] Ensure newline for auth_key in MachineCredential

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -59,4 +59,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
     self.manager_ref = self.id
     save!
   end
+
+  private
+
+  def ensure_newline_for_ssh_key
+    self.auth_key = "#{auth_key}\n" if auth_key.present? && auth_key[-1] != "\n"
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -94,6 +94,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
   alias ssh_key_data   auth_key
   alias ssh_key_unlock auth_key_password
 
+  before_validation :ensure_newline_for_ssh_key
+
   def self.display_name(number = 1)
     n_('Credential (Machine)', 'Credentials (Machine)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
@@ -68,10 +68,4 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < M
 
     attrs
   end
-
-  private
-
-  def ensure_newline_for_ssh_key
-    self.auth_key = "#{auth_key}\n" if auth_key.present? && auth_key[-1] != "\n"
-  end
 end

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Ansible::Runner::MachineCredential do
           "^Enter passphrase for [a-zA-Z0-9\-\/]+\/ssh_key_data:" => "keypass"
         )
 
-        expect(File.read(key_file)).to eq("key_data")
+        expect(File.read(key_file)).to eq("key_data\n")
       end
 
       it "doesn't create the password file if there are no passwords" do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -149,79 +149,104 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credenti
   end
 
   context "MachineCredential" do
-    it_behaves_like 'an embedded_ansible credential' do
-      let(:credential_class) { embedded_ansible::MachineCredential }
+    let(:credential_class) { embedded_ansible::MachineCredential }
+    let(:expected_ssh_key) { "secret2\n" }
 
-      let(:params) do
-        {
-          :name            => "Machine Credential",
-          :userid          => "userid",
-          :password        => "secret1",
-          :ssh_key_data    => "secret2",
-          :become_method   => "sudo",
-          :become_password => "secret3",
-          :become_username => "admin",
-          :ssh_key_unlock  => "secret4"
+    let(:params) do
+      {
+        :name            => "Machine Credential",
+        :userid          => "userid",
+        :password        => "secret1",
+        :ssh_key_data    => passed_in_ssh_key,
+        :become_method   => "sudo",
+        :become_password => "secret3",
+        :become_username => "admin",
+        :ssh_key_unlock  => "secret4"
+      }
+    end
+    let(:queue_create_params) do
+      {
+        :name            => "Machine Credential",
+        :userid          => "userid",
+        :password        => ManageIQ::Password.encrypt("secret1"),
+        :ssh_key_data    => ManageIQ::Password.encrypt(passed_in_ssh_key),
+        :become_method   => "sudo",
+        :become_password => ManageIQ::Password.encrypt("secret3"),
+        :become_username => "admin",
+        :ssh_key_unlock  => ManageIQ::Password.encrypt("secret4")
+      }
+    end
+    let(:params_to_attributes) do
+      {
+        :name              => "Machine Credential",
+        :userid            => "userid",
+        :password          => "secret1",
+        :auth_key          => passed_in_ssh_key,
+        :become_password   => "secret3",
+        :become_username   => "admin",
+        :auth_key_password => "secret4",
+        :options           => {
+          :become_method => "sudo"
         }
-      end
-      let(:queue_create_params) do
-        {
-          :name            => "Machine Credential",
-          :userid          => "userid",
-          :password        => ManageIQ::Password.encrypt("secret1"),
-          :ssh_key_data    => ManageIQ::Password.encrypt("secret2"),
-          :become_method   => "sudo",
-          :become_password => ManageIQ::Password.encrypt("secret3"),
-          :become_username => "admin",
-          :ssh_key_unlock  => ManageIQ::Password.encrypt("secret4")
+      }
+    end
+    let(:expected_values) do
+      {
+        :name                        => "Machine Credential",
+        :userid                      => "userid",
+        :password                    => "secret1",
+        :ssh_key_data                => expected_ssh_key,
+        :become_password             => "secret3",
+        :become_username             => "admin",
+        :become_method               => "sudo",
+        :auth_key_password           => "secret4",
+        :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
+        :auth_key_encrypted          => expected_ssh_key.present? ? ManageIQ::Password.try_encrypt(expected_ssh_key) : expected_ssh_key,
+        :become_password_encrypted   => ManageIQ::Password.try_encrypt("secret3"),
+        :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret4"),
+        :options                     => {
+          :become_method => "sudo"
         }
-      end
-      let(:params_to_attributes) do
-        {
-          :name              => "Machine Credential",
-          :userid            => "userid",
-          :password          => "secret1",
-          :auth_key          => "secret2",
-          :become_password   => "secret3",
-          :become_username   => "admin",
-          :auth_key_password => "secret4",
-          :options           => {
-            :become_method => "sudo"
-          }
-        }
-      end
-      let(:expected_values) do
-        {
-          :name                        => "Machine Credential",
-          :userid                      => "userid",
-          :password                    => "secret1",
-          :ssh_key_data                => "secret2",
-          :become_password             => "secret3",
-          :become_username             => "admin",
-          :become_method               => "sudo",
-          :auth_key_password           => "secret4",
-          :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
-          :auth_key_encrypted          => ManageIQ::Password.try_encrypt("secret2"),
-          :become_password_encrypted   => ManageIQ::Password.try_encrypt("secret3"),
-          :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret4"),
-          :options                     => {
-            :become_method => "sudo"
-          }
-        }
-      end
-      let(:params_to_attrs) { [:auth_key, :auth_key_password, :become_method] }
-      let(:update_params) do
-        {
-          :name     => "Updated Credential",
-          :password => "supersecret"
-        }
-      end
-      let(:update_queue_params) do
-        {
-          :name     => "Updated Credential",
-          :password => ManageIQ::Password.encrypt("supersecret")
-        }
-      end
+      }
+    end
+    let(:params_to_attrs) { [:auth_key, :auth_key_password, :become_method] }
+    let(:update_params) do
+      {
+        :name     => "Updated Credential",
+        :password => "supersecret"
+      }
+    end
+    let(:update_queue_params) do
+      {
+        :name     => "Updated Credential",
+        :password => ManageIQ::Password.encrypt("supersecret")
+      }
+    end
+
+    context "with an SSH key that ends with a newline" do
+      let(:passed_in_ssh_key) { "secret2\n" }
+
+      it_behaves_like 'an embedded_ansible credential'
+    end
+
+    context "with an SSH key that does not end with a newline" do
+      let(:passed_in_ssh_key) { "secret2" }
+
+      it_behaves_like 'an embedded_ansible credential'
+    end
+
+    context "with an nil SSH key" do
+      let(:passed_in_ssh_key) { nil }
+      let(:expected_ssh_key)  { nil }
+
+      it_behaves_like 'an embedded_ansible credential'
+    end
+
+    context "with a empty string SSH key" do
+      let(:passed_in_ssh_key) { "" }
+      let(:expected_ssh_key)  { "" }
+
+      it_behaves_like 'an embedded_ansible credential'
     end
   end
 


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/20771

Original Description
--------------------

SSH formats like `OPENSSH` require that a newline exist on the last line, otherwise it is considered an invalid format.

This adds a ~~`before_save`~~ `before_validation` callback to the model to ensure that it adds a newline to the key in case it was stripped off by the UI or via other means.


Links
-----

* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1893014
* Related discussions:
  - https://gitter.im/ManageIQ/manageiq/ui?at=5fa02fff7cac87158f807568
  - https://gitter.im/ManageIQ/manageiq/automate?at=5f9afef1c10273610ad33f61
  - https://gitter.im/ManageIQ/manageiq-providers-embedded_ansible?at=5f9c20e3d5a5a635f28e7d13