### PR TITLE
Adopt new memory/cpu request/limit(threshold) values

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1077,13 +1077,13 @@
   :worker_base:
     :defaults:
       :count: 1
-      :cpu_request_percent: 25
-      :cpu_threshold_percent: 50
+      :cpu_request_percent: 15
+      :cpu_threshold_percent: 100
       :gc_interval: 15.minutes
       :heartbeat_freq: 10.seconds
       :heartbeat_timeout: 2.minutes
-      :memory_request: 250.megabytes
-      :memory_threshold: 400.megabytes
+      :memory_request: 500.megabytes
+      :memory_threshold: 600.megabytes
       :nice_delta: 10
       :parent_time_threshold: 3.minutes
       :poll: 3.seconds
@@ -1119,13 +1119,11 @@
     :queue_worker_base:
       :defaults:
         :dequeue_method: :drb
-        :memory_threshold: 600.megabytes
         :poll_method: :normal
         :queue_timeout: 10.minutes
       :ems_metrics_collector_worker:
         :defaults:
           :count: 2
-          :memory_threshold: 600.megabytes
           :nice_delta: 3
           :poll_method: :escalate
         :ems_metrics_collector_worker_google: {}
@@ -1155,7 +1153,6 @@
       :generic_worker:
         :count: 2
       :priority_worker:
-        :memory_threshold: 600.megabytes
         :count: 2
         :nice_delta: 1
         :poll: 1.seconds


### PR DESCRIPTION
* cpu request. 25% to 15%. Run on nodes with less vCPUs/reserve less cpu.
* cpu threshold/limit. 50% to 100%. Decrease CPU throttling in pods.
* memory request. 250 to 500 MB.  More realistic for worker pods. 250 MB wasn't used previously anyway, see below.
* memory threshold/limit. 400 MB to 600 MB.  This is more realistic and is a more common baseline allowing overrides to be removed.

Note, prior to https://github.com/ManageIQ/manageiq/pull/20834, no request value was honored so kubenetes would use the limit as the request, causing us to reserve too much memory and cpu.

Note 2, appliances only enforce memory threshold/limit so this change has minimal impact outside of podified.