### PR TITLE
Fix group by tag for consumption without rollups

### DIFF
--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -17,7 +17,7 @@ class Chargeback
     end
 
     def tag_names
-      resource.tags.collect(&:name)
+      resource ? resource.tags.collect(&:name).map { |x| x.gsub("/managed/", "") } : []
     end
 
     def hash_features_affecting_rate
@@ -25,7 +25,7 @@ class Chargeback
     end
 
     def tag_list_with_prefix
-      tag_names.map { |t| "vm/tag#{t}" }
+      tag_names.map { |t| "vm/tag/managed/#{t}" }
     end
 
     def parents_determining_rate


### PR DESCRIPTION
Chargeback report without using metric rollup did not display all tag groups on report result with option group by tag.
Tag groups were melt down into one tag group called "None".

Chargeback for VM report settings:
<img width="400" alt="Screenshot 2020-12-01 at 13 36 44" src="https://user-images.githubusercontent.com/14937244/100741368-43e68500-33da-11eb-9b5f-15f2b59f5dc8.png">

### Report results

Before
<img width="1675" alt="Screenshot 2020-12-01 at 13 34 57" src="https://user-images.githubusercontent.com/14937244/100741231-36c99600-33da-11eb-9615-969855779209.png">

After
<img width="1669" alt="Screenshot 2020-12-01 at 13 35 19" src="https://user-images.githubusercontent.com/14937244/100741225-34673c00-33da-11eb-9e9f-71e19ce821f1.png">



To fix this we need to fix key [generation](https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback.rb#L86), this key represent tag group. 
`classification` was `nil` and it was not recognised because when we are looking for we are not expecting prefix "/managed" [here.](https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback/report_options.rb#L140)

Fix is to remove prefix "/managed/" from `ConsumptionWithoutRollups#tag_names`.
And when remove it from  `ConsumptionWithoutRollups#tag_names` we have to add prefix to `ConsumptionWithoutRollups #tag_list_with_prefix` to don't break selection of rates.


`ConsumptionWithoutRollups#tag_names` and `ConsumptionWithoutRollups#tag_names`  mirrors `ConsumptionWithRollups#tag_names` and `ConsumptionWithRollups#tag_names`  now.


@miq_bot add_label bug
@miq-bot assign @gtanzillo 