### PR TITLE
fix typos involving missing flying commas 

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -74,12 +74,12 @@ module MiqReport::ImportExport
             rep.attributes = report
             result = {:message => "Replaced Report: [#{report["name"]}]", :level => :info, :status => :update}
           else
-            # if report exists dont overwrite
+            # if report exists, do not overwrite
             msg = "Skipping Report (already in DB under a different group): [#{report["name"]}]"
             result = {:message => msg, :level => :error, :status => :skip}
           end
         else
-          # if report exists dont overwrite
+          # if report exists, do not overwrite
           msg = "Skipping Report (already in DB): [#{report["name"]}]"
           result = {:message => msg, :level => :info, :status => :keep}
         end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -254,7 +254,7 @@ module SupportsFeatureMixin
 
     def unsupported
       # This is a class variable and it might be modified during runtime
-      # because we dont eager load all classes at boot time, so it needs to be thread safe
+      # because we do not eager load all classes at boot time, so it needs to be thread safe
       @unsupported ||= Concurrent::Hash.new
     end
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -123,7 +123,7 @@ class PglogicalSubscription < ActsAsArModel
   def self.subscription_to_columns(sub)
     cols = sub.symbolize_keys
 
-    # delete the things we dont care about
+    # delete the things we do not care about
     cols.delete(:database_name)
     cols.delete(:owner)
     cols.delete(:slot_name)

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -446,7 +446,7 @@ class GitWorktree
 
   def create_commit(message, tree, parents)
     author = {:email => @email, :name => @username || @email, :time => Time.now}
-    # Create the actual commit but dont update the reference
+    # Create the actual commit but do not update the reference
     Rugged::Commit.create(@repo, :author  => author,  :committer  => author,
                                  :message => message, :parents    => parents,
                                  :tree    => tree)

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -72,7 +72,7 @@ class EvmApplication
     duplicate_columns.delete("Status") # always show status
     puts data.tableize(:columns => (data.first.keys - duplicate_columns.keys))
 
-    # dont give headsup for empty values
+    # do not give heads-up for empty values
     heads_up = duplicate_columns.select { |n, v| n == "Region" || (v != 0 && v.present?) }
     if heads_up.present?
       puts "", "All rows have the values: #{heads_up.map { |n, v| "#{n}=#{v}" }.join(", ")}"

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1408,7 +1408,7 @@ RSpec.describe ChargebackVm do
         expect(subject.total_cost).to               eq(fixed_cost + cpu_cost + mem_cost + disk_cost)
       end
 
-      context 'metrics are included (but dont have any)' do
+      context 'metrics are included (but do not have any)' do
         it 'is not generating report with options[:include_metrics]=true' do
           options[:include_metrics] = true
           expect(subject).to be_nil

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe MiqGroup do
 
       FactoryBot.create(:miq_group, :description => "want 1", :sequence => 999)
       FactoryBot.create(:miq_group, :description => "want 2", :sequence => 1000)
-      FactoryBot.create(:miq_group, :description => "dont want", :sequence => 1009)
+      FactoryBot.create(:miq_group, :description => "do not want", :sequence => 1009)
 
       expect(MiqGroup.where("description like 'want%'").next_sequence).to eq(1001)
     end

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe SupportsFeatureMixin do
     it "can be supported by the class" do
       stub_const("NukeablePost", Class.new(SpecialPost) do
         supports :nuke do
-          unsupported_reason_add(:nuke, "dont nuke the bribe") if bribe
+          unsupported_reason_add(:nuke, "do not nuke the bribe") if bribe
         end
       end)
       expect(NukeablePost.new(:bribe => true).supports_nuke?).to be false

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Service Filter" do
       end
     end
 
-    context "dont allow" do
+    context "do not allow" do
       let(:options) { {'include_service' => false} }
       it "check false value" do
         allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(workspace)

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe FixAuth::AuthConfigModel do
       )
     end
 
-    it "upgrades request (find with prefix, dont stringify keys)" do
+    it "upgrades request (find with prefix, do not stringify keys)" do
       subject.fix_passwords(request)
       expect(request).to be_changed
       new_options = YAML.load(request.options)
@@ -64,7 +64,7 @@ RSpec.describe FixAuth::AuthConfigModel do
       )
     end
 
-    it "upgrades request (find with prefix, dont stringify keys)" do
+    it "upgrades request (find with prefix, do not stringify keys)" do
       subject.fix_passwords(request)
       expect(request).to be_changed
       new_options = YAML.load(request.options)


### PR DESCRIPTION
s/dont[sic]/do not

avoiding apostrophe abuse entirely