### PR TITLE
Add collect_running_processes supports feature

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -77,6 +77,7 @@ module SupportsFeatureMixin
     :backup_restore                      => 'CloudVolume backup restore',
     :cinder_service                      => 'Cinder storage service',
     :cinder_volume_types                 => 'Cinder volume types',
+    :collect_running_processes           => 'Collect running processes',
     :conversion_host                     => 'Conversion host capable',
     :create_flavor                       => 'Flavor Creation',
     :create_floating_ip                  => 'Floating IP Creation',

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -39,6 +39,13 @@ module Vm::Operations
     rescue StandardError => err
       unsupported_reason_add(:launch_native_console, _('VM NATIVE Console error: %{error}') % {:error => err})
     end
+
+    supports :collect_running_processes do
+      check = validate_collect_running_processes
+      unless check[:message].nil?
+        unsupported_reason_add(:collect_running_processes, _(check[:message]))
+      end
+    end
   end
 
   def cockpit_url
@@ -60,28 +67,28 @@ module Vm::Operations
 
     # Report reasons why collection is not available for this VM
     unless ['windows'].include?(platform)
-      s[:message] = 'VM Process collection is only available for Windows VMs.'
+      s[:message] = N_('VM Process collection is only available for Windows VMs.')
       return s
     end
     unless self.runnable?
-      s[:message] = 'VM Process collection is only available for Runnable VMs.'
+      s[:message] = N_('VM Process collection is only available for Runnable VMs.')
       return s
     end
 
     # From here on out collection is possible, but may not be currently available.
     s[:available] = true
     unless state == "on"
-      s[:message] = 'VM Process collection is only available while the VM is powered on.'
+      s[:message] = N_('VM Process collection is only available while the VM is powered on.')
       return s
     end
 
     if my_zone.nil? || my_zone_obj.auth_user_pwd(:windows_domain).nil?
-      s[:message] = 'VM Process collection requires credentials set at the Zone level.'
+      s[:message] = N_('VM Process collection requires credentials set at the Zone level.')
       return s
     end
 
     if ipaddresses.blank?
-      s[:message] = 'VM Process collection requires an IP address for the VM.'
+      s[:message] = N_('VM Process collection requires an IP address for the VM.')
       return s
     end
 


### PR DESCRIPTION
By using `SupportsFeatureMixin` we can correctly mark the string indicating reason for not supported for translation.

Before:
![Screenshot from 2020-12-01 17-41-17](https://user-images.githubusercontent.com/6648365/100769654-a51f5000-33fc-11eb-881b-7716f2a88421.png)


After:
![Screenshot from 2020-12-01 17-37-23](https://user-images.githubusercontent.com/6648365/100769662-a8b2d700-33fc-11eb-8bba-7d25d2bc52db.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1752426