### PR TITLE
[MiqPglogical] Add ConnectionHandling

### DIFF
--- a/lib/miq_pglogical/connection_handling.rb
+++ b/lib/miq_pglogical/connection_handling.rb
@@ -1,0 +1,27 @@
+class MiqPglogical
+  module ConnectionHandling
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def with_connection_error_handling
+        retry_attempted ||= false
+        yield
+      rescue PG::ConnectionBad
+        raise if retry_attempted
+
+        pglogical(true)
+        retry_attempted = true
+        retry
+      end
+
+      def pglogical(refresh = false)
+        @pglogical = nil if refresh
+        @pglogical ||= PG::LogicalReplication::Client.new(pg_connection)
+      end
+    end
+
+    def pglogical(refresh = false)
+      self.class.pglogical(refresh)
+    end
+  end
+end


### PR DESCRIPTION
Fixup PR for https://github.com/ManageIQ/manageiq/pull/20841


Description
-----------

So I made a boo-boo... though I blame @Fryguy for merging it in :trollface:

The main issue with the [previous PR](https://github.com/ManageIQ/manageiq/pull/20841) was that the `rescue` portion assumes certain methods exist in the `MiqPglogical` class itself... when in fact... it doesn't...

So, refactoring isn't always the best...

ANYway... what this PR is makes a shared module that is used instead of trying to share a single class method, since we also need to de-memoize the on the class that is the caller as well and that wasn't being doing in the previous implementation.


Links
-----

* Previous PR: https://github.com/ManageIQ/manageiq/pull/20841