### PR TITLE
Cleanup a useless next unless in worker monitor

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -32,7 +32,7 @@ module MiqServer::WorkerManagement::Monitor
       # Push the heartbeat into the database
       persist_last_heartbeat(worker)
       # Check the worker record for heartbeat timeouts
-      next unless validate_worker(worker)
+      validate_worker(worker)
     end
 
     do_system_limit_exceeded if self.kill_workers_due_to_resources_exhausted?


### PR DESCRIPTION
There used to be a sync config action after the validate_worker method that was removed so the next unless is pointless now.

Removed by: https://github.com/ManageIQ/manageiq/pull/19666/files#diff-4a1cee6eab58de0540a89bab68b4d15c6e411dca2b538b28715641069a2679d0L35-L36