### PR TITLE
Rubocop fixes for Condition and Host models

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -196,7 +196,7 @@ class Condition < ApplicationRecord
 
     result = true
     list.each do |obj|
-      opts, ref, object = options2hash(raw_opts, obj)
+      opts, _ref, _object = options2hash(raw_opts, obj)
       value = MiqExpression.quote(obj.send(checkattr), opts[:type])
       value = value.gsub(/\\/, '\&\&') if value.kind_of?(String)
       e = check.gsub(/<value[^>]*>.+<\/value>/im, value.to_s)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1095,10 +1095,10 @@ class Host < ApplicationRecord
     services = ssu.shell_exec("systemctl -a --type service --no-legend")
     if services
       # If there is a systemd use only that, chconfig is calling systemd on the background, but has misleading results
-      services = MiqLinux::Utils.parse_systemctl_list(services)
+      MiqLinux::Utils.parse_systemctl_list(services)
     else
       services = ssu.shell_exec("chkconfig --list")
-      services = MiqLinux::Utils.parse_chkconfig_list(services)
+      MiqLinux::Utils.parse_chkconfig_list(services)
     end
   end
 


### PR DESCRIPTION
Just a couple minor linter fixes that eliminate or underscore unused variables.