### PR TITLE
Patch deployment resource constraints

### DIFF
--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -159,8 +159,10 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
 
   def save_deployment(deployment)
     name = deployment.metadata.name
-    current_deployments[name] ||= Concurrent::Hash.new
-    current_deployments[name].merge!(deployment.to_h)
+    new_hash = Concurrent::Hash.new
+    new_hash[:spec] = deployment.spec.to_h
+    current_deployments[name] ||= new_hash
+    current_deployments[name].merge!(new_hash)
   end
 
   def delete_deployment(deployment)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -19,11 +19,15 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
     return unless podified?
     return unless Settings.server.worker_monitor.enforce_resource_constraints
 
+    checked_deployments = Set.new
     podified_miq_workers.each do |worker|
+      next if checked_deployments.include?(worker.worker_deployment_name)
+
       if worker.deployment_resource_constraints_changed?
         _log.info("Constraints changed, patching deployment: [#{worker.worker_deployment_name}]")
         worker.patch_deployment
       end
+      checked_deployments << worker.worker_deployment_name
     end
   end
 

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -48,14 +48,17 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def constraints_changed?(current, desired)
-    return true if current.blank? && desired.present?
-    return true if current.present? && desired.blank?
-    return false if current.blank? && desired.blank?
-
-    !cpu_value_eql?(current.fetch_path(:requests, :cpu), desired.fetch_path(:requests, :cpu)) ||
-      !cpu_value_eql?(current.fetch_path(:limits, :cpu), desired.fetch_path(:limits, :cpu)) ||
-      !mem_value_eql?(current.fetch_path(:requests, :memory), desired.fetch_path(:requests, :memory)) ||
-      !mem_value_eql?(current.fetch_path(:limits, :memory), desired.fetch_path(:limits, :memory))
+    if current.present? && desired.present?
+      !cpu_value_eql?(current.fetch_path(:requests, :cpu), desired.fetch_path(:requests, :cpu)) ||
+        !cpu_value_eql?(current.fetch_path(:limits, :cpu), desired.fetch_path(:limits, :cpu)) ||
+        !mem_value_eql?(current.fetch_path(:requests, :memory), desired.fetch_path(:requests, :memory)) ||
+        !mem_value_eql?(current.fetch_path(:limits, :memory), desired.fetch_path(:limits, :memory))
+    else
+      # current, no desired    => changed
+      # no current, desired    => changed
+      # no current, no desired => unchanged
+      current.blank? ^ desired.blank?
+    end
   end
 
   private

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -142,9 +142,13 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def save_deployment(deployment)
+    name = deployment.metadata.name
+    current_deployments[name] ||= Concurrent::Hash.new
+    current_deployments[name].merge!(deployment.to_h)
   end
 
   def delete_deployment(deployment)
+    current_deployments.delete(deployment.metadata.name)
   end
 
   def save_pod(pod)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -21,8 +21,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def sync_deployment_settings
-    return unless podified?
-
     checked_deployments = Set.new
     podified_miq_workers.each do |worker|
       next if checked_deployments.include?(worker.worker_deployment_name)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -65,8 +65,8 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
 
   def cpu_value_eql?(current, desired)
     # Convert to millicores if not already converted: "1" -> 1000; "1000m" -> 1000
-    current = current.to_s[-1] == "m" ? current.to_i : current.to_i * 1000
-    desired = desired.to_s[-1] == "m" ? desired.to_i : desired.to_i * 1000
+    current = current.to_s[-1] == "m" ? current.to_f : current.to_f * 1000
+    desired = desired.to_s[-1] == "m" ? desired.to_f : desired.to_f * 1000
     current == desired
   end
 

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -22,7 +22,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
 
   def sync_deployment_settings
     return unless podified?
-    return unless Settings.server.worker_monitor.enforce_resource_constraints
 
     checked_deployments = Set.new
     podified_miq_workers.each do |worker|
@@ -42,6 +41,8 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   end
 
   def deployment_resource_constraints_changed?(worker)
+    return false unless Settings.server.worker_monitor.enforce_resource_constraints
+
     container = current_deployments.fetch_path(worker.worker_deployment_name, :spec, :template, :spec, :containers).try(:first)
     current_constraints = container.try(:fetch, :resources, nil) || {}
     desired_constraints = worker.resource_constraints

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -4,6 +4,11 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
   included do
     class_attribute :current_pods
     self.current_pods = Concurrent::Hash.new
+
+    class_attribute :current_deployments
+    self.current_deployments = Concurrent::Hash.new
+
+    attr_accessor :deployments_monitor_thread, :pods_monitor_thread
   end
 
   def cleanup_failed_deployments
@@ -38,31 +43,41 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
 
   private
 
-  def start_pod_monitor
+  def start_kube_monitor(resource = :pods)
     require 'http'
     Thread.new do
-      _log.info("Started new monitor thread of #{Thread.list.length} total")
+      _log.info("Started new #{resource} monitor thread of #{Thread.list.length} total")
       begin
-        monitor_pods
+        send("monitor_#{resource}")
       rescue HTTP::ConnectionError => e
-        _log.error("Exiting monitor thread due to [#{e.class.name}]: #{e}")
+        _log.error("Exiting #{resource} monitor thread due to [#{e.class.name}]: #{e}")
       rescue => e
-        _log.error("Exiting monitor thread after uncaught error")
+        _log.error("Exiting #{resource} monitor thread after uncaught error")
         _log.log_backtrace(e)
       end
     end
   end
+  # Remove callers to start_pod_monitor
+  alias_method :start_pod_monitor, :start_kube_monitor
 
-  def ensure_pod_monitor_started
-    if @monitor_thread.nil? || !@monitor_thread.alive?
-      if !@monitor_thread.nil? && @monitor_thread.status.nil?
-        dead_thread, @monitor_thread = @monitor_thread, nil
-        _log.info("Waiting for the Monitor Thread to exit...")
-        dead_thread.join
+  def ensure_kube_monitors_started
+    [:deployments, :pods].each do |resource|
+      getter = "#{resource}_monitor_thread"
+      thread = send(getter)
+      if thread.nil? || !thread.alive?
+        if !thread.nil? && thread.status.nil?
+          dead_thread = thread
+          send("#{getter}=", nil)
+          _log.info("Waiting for the #{getter} Monitor Thread to exit...")
+          dead_thread.join
+        end
+
+        send("#{getter}=", start_kube_monitor(resource))
       end
-      @monitor_thread = start_pod_monitor
     end
   end
+  # Remove callers to ensure_pod_monitor_started
+  alias_method :ensure_pod_monitor_started, :ensure_kube_monitors_started
 
   def delete_failed_deployments
     failed_deployments.each do |failed|
@@ -74,43 +89,62 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
     @orchestrator ||= ContainerOrchestrator.new
   end
 
-  def monitor_pods
+  def monitor_deployments
     loop do
-      current_pods.clear
-      resource_version = collect_initial_pods
+      current_deployments.clear
+      resource_version = collect_initial(:deployments)
 
-      # watch_for_pod_events doesn't return unless an error caused us to break out of it, so we'll start over again
-      watch_for_pod_events(resource_version)
+      watch_for_events(:deployments, resource_version)
     end
   end
 
-  def collect_initial_pods
-    pods = orchestrator.get_pods
-    pods.each { |p| save_pod(p) }
-    pods.resourceVersion
+  def monitor_pods
+    loop do
+      current_pods.clear
+      resource_version = collect_initial(:pods)
+
+      # watch_for_events doesn't return unless an error caused us to break out of it, so we'll start over again
+      watch_for_events(:pods, resource_version)
+    end
   end
 
-  def watch_for_pod_events(resource_version)
-    orchestrator.watch_pods(resource_version).each do |event|
+  def collect_initial(resource = :pods)
+    objects = orchestrator.send("get_#{resource}")
+    objects.each { |p| send("save_#{resource.to_s.singularize}", p) }
+    objects.resourceVersion
+  end
+  # TODO: Remove callers to collect_initial_pods
+  alias_method :collect_initial_pods, :collect_initial
+
+  def watch_for_events(resource, resource_version)
+    orchestrator.send("watch_#{resource}", resource_version).each do |event|
       case event.type.downcase
       when "added", "modified"
-        save_pod(event.object)
+        send("save_#{resource.to_s.singularize}", event.object)
       when "deleted"
-        delete_pod(event.object)
+        send("delete_#{resource.to_s.singularize}", event.object)
       when "error"
         if (status = event.object)
           # ocp 3 appears to return 'ERROR' watch events with the object containing the 410 code and "Gone" reason like below:
           # #<Kubeclient::Resource type="ERROR", object={:kind=>"Status", :apiVersion=>"v1", :metadata=>{}, :status=>"Failure", :message=>"too old resource version: 199900 (27177196)", :reason=>"Gone", :code=>410}>
-          log_pod_error_event(status.code, status.message, status.reason)
+          log_resource_error_event(status.code, status.message, status.reason)
         end
 
         break
       end
     end
   end
+  # TODO: Remove callers of watch_for_events
+  alias_method :watch_for_pod_events, :watch_for_events
 
-  def log_pod_error_event(code, message, reason)
+  def log_resource_error_event(code, message, reason)
     _log.warn("Restarting watch_for_pod_events due to error: [#{code} #{reason}], [#{message}]")
+  end
+
+  def save_deployment(deployment)
+  end
+
+  def delete_deployment(deployment)
   end
 
   def save_pod(pod)

--- a/app/models/miq_server/worker_management/monitor/kubernetes.rb
+++ b/app/models/miq_server/worker_management/monitor/kubernetes.rb
@@ -87,8 +87,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
       end
     end
   end
-  # Remove callers to start_pod_monitor
-  alias_method :start_pod_monitor, :start_kube_monitor
 
   def ensure_kube_monitors_started
     [:deployments, :pods].each do |resource|
@@ -106,8 +104,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
       end
     end
   end
-  # Remove callers to ensure_pod_monitor_started
-  alias_method :ensure_pod_monitor_started, :ensure_kube_monitors_started
 
   def delete_failed_deployments
     failed_deployments.each do |failed|
@@ -143,8 +139,6 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
     objects.each { |p| send("save_#{resource.to_s.singularize}", p) }
     objects.resourceVersion
   end
-  # TODO: Remove callers to collect_initial_pods
-  alias_method :collect_initial_pods, :collect_initial
 
   def watch_for_events(resource, resource_version)
     orchestrator.send("watch_#{resource}", resource_version).each do |event|
@@ -164,11 +158,9 @@ module MiqServer::WorkerManagement::Monitor::Kubernetes
       end
     end
   end
-  # TODO: Remove callers of watch_for_events
-  alias_method :watch_for_pod_events, :watch_for_events
 
   def log_resource_error_event(code, message, reason)
-    _log.warn("Restarting watch_for_pod_events due to error: [#{code} #{reason}], [#{message}]")
+    _log.warn("Restarting watch_for_events due to error: [#{code} #{reason}], [#{message}]")
   end
 
   def save_deployment(deployment)

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -69,6 +69,10 @@ class MiqWorker
 
       mem_limit = self.class.worker_settings[:memory_threshold]
       cpu_limit = self.class.worker_settings[:cpu_threshold_percent]
+
+      # TODO: If request > limit, set request = limit or raise an error
+      # kubeclient will raise each time if we try:
+      # [Kubeclient::HttpError]: Deployment.apps "1-schedule" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "567Mi": must be less than or equal to memory limit
       mem_request   = self.class.worker_settings[:memory_request]
       cpu_request   = self.class.worker_settings[:cpu_request_percent]
 

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -70,11 +70,13 @@ class MiqWorker
       mem_limit = self.class.worker_settings[:memory_threshold]
       cpu_limit = self.class.worker_settings[:cpu_threshold_percent]
 
-      # TODO: If request > limit, set request = limit or raise an error
-      # kubeclient will raise each time if we try:
+      # If request > limit, kubeclient will raise each time we try
       # [Kubeclient::HttpError]: Deployment.apps "1-schedule" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "567Mi": must be less than or equal to memory limit
       mem_request   = self.class.worker_settings[:memory_request]
       cpu_request   = self.class.worker_settings[:cpu_request_percent]
+
+      raise ArgumentError, "cpu_request_percent cannot exceed cpu_threshold_percent" if (cpu_request || 0) > (cpu_limit || Float::INFINITY)
+      raise ArgumentError, "memory_request cannot exceed memory_threshold"           if (mem_request || 0) > (mem_limit || Float::INFINITY.megabytes)
 
       {}.tap do |h|
         h.store_path(:limits, :memory, format_memory_threshold(mem_limit)) if mem_limit

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -85,13 +85,6 @@ class MiqWorker
       end
     end
 
-    def deployment_resource_constraints_changed?
-      container = ContainerOrchestrator.cached_deployment.fetch_path(worker_deployment_name, :spec, :template, :spec, :containers).try(:first)
-      current_constraints = container.try(:fetch, :resources, nil) || {}
-      desired_constraints = resource_constraints
-      (current_constraints.blank? && !desired_constraints.blank?) || (current_constraints != desired_constraints)
-    end
-
     def container_image_namespace
       ENV["CONTAINER_IMAGE_NAMESPACE"]
     end

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -80,9 +80,11 @@ class ContainerOrchestrator
   end
 
   def get_deployments
+    kube_apps_connection.get_deployments(default_get_options)
   end
 
   def watch_deployments(resource_version = nil)
+    kube_apps_connection.watch_deployments(default_get_options.merge(:resource_version => resource_version))
   end
 
   def get_pods

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -8,20 +8,39 @@ class ContainerOrchestrator
   TOKEN_FILE   = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
   CA_CERT_FILE = "/run/secrets/kubernetes.io/serviceaccount/ca.crt".freeze
 
+  class_attribute :cached_deployment, :default => Hash.new({})
+
   def self.available?
     File.exist?(TOKEN_FILE) && File.exist?(CA_CERT_FILE)
   end
 
   def scale(deployment_name, replicas)
-    kube_apps_connection.patch_deployment(deployment_name, { :spec => { :replicas => replicas } }, my_namespace)
+    patch_deployment(deployment_name, {:spec => {:replicas => replicas}})
+  end
+
+  def patch_deployment(deployment_name, data)
+    _log.info("deployment_name: #{deployment_name}, data: #{data.inspect}")
+    kube_apps_connection.patch_deployment(deployment_name, data, my_namespace).tap do
+      cache_deployment(deployment_name, data, :merge)
+    end
   end
 
   def create_deployment(name)
     definition = deployment_definition(name)
     yield(definition) if block_given?
-    kube_apps_connection.create_deployment(definition)
+    kube_apps_connection.create_deployment(definition).tap { cache_deployment(name, definition) }
   rescue KubeException => e
     raise unless e.message =~ /already exists/
+  end
+
+  def cache_deployment(name, data, type = :full)
+    # Track the current definition as we create/update so we can detect changes
+    case type
+    when :merge
+      self.class.cached_deployment[name] = self.class.cached_deployment[name].deep_merge(data)
+    when :full
+      self.class.cached_deployment[name] = data
+    end
   end
 
   def create_service(name, selector, port)

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -79,16 +79,22 @@ class ContainerOrchestrator
     raise unless e.message =~ /not found/
   end
 
+  def get_deployments
+  end
+
+  def watch_deployments(resource_version = nil)
+  end
+
   def get_pods
-    kube_connection.get_pods(pod_options)
+    kube_connection.get_pods(default_get_options)
   end
 
   def watch_pods(resource_version = nil)
-    kube_connection.watch_pods(pod_options.merge(:resource_version => resource_version))
+    kube_connection.watch_pods(default_get_options.merge(:resource_version => resource_version))
   end
 
   private
-  def pod_options
+  def default_get_options
     {:namespace => my_namespace, :label_selector => [app_name_selector, orchestrated_by_selector].join(",")}
   end
 

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -130,24 +130,24 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
 
     it "saves replicas" do
       server.send(:save_deployment, fake_deployment_data)
-      expect(server.current_deployments[pod_name].fetch_path(:spec, :replicas)).to eql(2)
+      expect(server.current_deployments[pod_name].fetch_path(:spec, :replicas)).to eq(2)
     end
 
     it "saves containers" do
       server.send(:save_deployment, fake_deployment_data)
-      expect(server.current_deployments[pod_name].fetch_path(:spec, :template, :spec, :containers).first[:name]).to eql(pod_name)
+      expect(server.current_deployments[pod_name].fetch_path(:spec, :template, :spec, :containers).first[:name]).to eq(pod_name)
     end
 
     it "discards other keys" do
       server.send(:save_deployment, fake_deployment_data)
-      expect(server.current_deployments[pod_name].keys).to eql([:spec])
+      expect(server.current_deployments[pod_name].keys).to eq([:spec])
     end
 
     it "updates existing saved deployment" do
       server.send(:save_deployment, fake_deployment_data)
       fake_deployment_data.spec.replicas = 5
       server.send(:save_deployment, fake_deployment_data)
-      expect(server.current_deployments[pod_name].fetch_path(:spec, :replicas)).to eql(5)
+      expect(server.current_deployments[pod_name].fetch_path(:spec, :replicas)).to eq(5)
     end
   end
 
@@ -180,9 +180,9 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
     it "calls save_pod for running pod" do
       server.send(:collect_initial)
 
-      expect(server.current_pods[deployment_name][:label_name]).to eql(pod_label)
-      expect(server.current_pods[deployment_name][:last_state_terminated]).to eql(false)
-      expect(server.current_pods[deployment_name][:container_restarts]).to eql(0)
+      expect(server.current_pods[deployment_name][:label_name]).to eq(pod_label)
+      expect(server.current_pods[deployment_name][:last_state_terminated]).to eq(false)
+      expect(server.current_pods[deployment_name][:container_restarts]).to eq(0)
     end
 
     it "calls save_pod to update a known running pod" do
@@ -191,10 +191,10 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
       pod_hash[:last_state_terminated] = true
 
       server.current_pods[deployment_name] = pod_hash
-      expect(server.current_pods[deployment_name][:last_state_terminated]).to eql(true)
+      expect(server.current_pods[deployment_name][:last_state_terminated]).to eq(true)
 
       server.send(:collect_initial)
-      expect(server.current_pods[deployment_name][:last_state_terminated]).to eql(false)
+      expect(server.current_pods[deployment_name][:last_state_terminated]).to eq(false)
     end
 
     it "calls save_pod for terminated pod" do
@@ -203,13 +203,13 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
       allow(pods.first.status.containerStatuses.first).to receive(:restartCount).and_return(10)
       server.send(:collect_initial)
 
-      expect(server.current_pods[deployment_name][:label_name]).to eql(pod_label)
-      expect(server.current_pods[deployment_name][:last_state_terminated]).to eql(true)
-      expect(server.current_pods[deployment_name][:container_restarts]).to eql(10)
+      expect(server.current_pods[deployment_name][:label_name]).to eq(pod_label)
+      expect(server.current_pods[deployment_name][:last_state_terminated]).to eq(true)
+      expect(server.current_pods[deployment_name][:container_restarts]).to eq(10)
     end
 
     it "returns resource_version" do
-      expect(server.send(:collect_initial)).to eql(resource_version)
+      expect(server.send(:collect_initial)).to eq(resource_version)
     end
   end
 
@@ -261,9 +261,9 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
         allow(event_object).to receive(:reason).and_return(expected_reason)
 
         allow(server).to receive(:log_pod_error_event) do |code, message, reason|
-          expect(code).to eql(expected_code)
-          expect(message).to eql(expected_message)
-          expect(reason).to eql(expected_reason)
+          expect(code).to eq(expected_code)
+          expect(message).to eq(expected_message)
+          expect(reason).to eq(expected_reason)
         end
 
         server.send(:watch_for_events, :pods, nil)
@@ -339,7 +339,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
     it "detects no changes if not enforced" do
       stub_settings(:server => {:worker_monitor => {:enforce_resource_constraints => false}})
       expect(server).to receive(:constraints_changed?).never
-      expect(server.deployment_resource_constraints_changed?(worker)).to eql(false)
+      expect(server.deployment_resource_constraints_changed?(worker)).to eq(false)
     end
   end
 
@@ -349,54 +349,54 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
     let(:constraint_two) { {:limits => {:cpu => "888m", :memory => "1Gi"}, :requests => {:cpu => "150m", :memory => "500Mi"}} }
 
     it "No current, no desired constraints" do
-      expect(server.constraints_changed?(empty, empty)).to eql(false)
+      expect(server.constraints_changed?(empty, empty)).to eq(false)
     end
 
     it "No current, new desired constraints" do
-      expect(server.constraints_changed?(empty, constraint_one)).to eql(true)
+      expect(server.constraints_changed?(empty, constraint_one)).to eq(true)
     end
 
     it "Current equals desired" do
-      expect(server.constraints_changed?(constraint_one, constraint_one)).to eql(false)
+      expect(server.constraints_changed?(constraint_one, constraint_one)).to eq(false)
     end
 
     it "Current does not equal desired" do
-      expect(server.constraints_changed?(constraint_one, constraint_two)).to eql(true)
+      expect(server.constraints_changed?(constraint_one, constraint_two)).to eq(true)
     end
 
     it "Detects 1024Mi memory == 1Gi" do
       new_value = {:limits => {:memory => "1024Mi"}}
-      expect(server.constraints_changed?(constraint_one, constraint_one.deep_merge(new_value))).to eql(false)
+      expect(server.constraints_changed?(constraint_one, constraint_one.deep_merge(new_value))).to eq(false)
     end
 
     it "Current missing cpu limit" do
       current = {:limits => {:memory => "1Gi"},                 :requests => {:cpu => "150m", :memory => "500Mi"}}
       desired = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m", :memory => "500Mi"}}
-      expect(server.constraints_changed?(current, desired)).to eql(true)
+      expect(server.constraints_changed?(current, desired)).to eq(true)
     end
 
     it "Desired missing cpu limit" do
       current = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m", :memory => "500Mi"}}
       desired = {:limits => {:memory => "1Gi"},                 :requests => {:cpu => "150m", :memory => "500Mi"}}
-      expect(server.constraints_changed?(current, desired)).to eql(true)
+      expect(server.constraints_changed?(current, desired)).to eq(true)
     end
 
     it "Current missing memory request" do
       current = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m"}}
       desired = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m", :memory => "500Mi"}}
-      expect(server.constraints_changed?(current, desired)).to eql(true)
+      expect(server.constraints_changed?(current, desired)).to eq(true)
     end
 
     it "Desired missing memory request" do
       current = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m", :memory => "500Mi"}}
       desired = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m"}}
-      expect(server.constraints_changed?(current, desired)).to eql(true)
+      expect(server.constraints_changed?(current, desired)).to eq(true)
     end
 
     it "checks millicores" do
       current = constraint_one.deep_merge(:limits => {:cpu => "1"})
       desired = constraint_one.deep_merge(:limits => {:cpu => "1000m"})
-      expect(server.constraints_changed?(current, desired)).to eql(false)
+      expect(server.constraints_changed?(current, desired)).to eq(false)
     end
   end
 end

--- a/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kubernetes_spec.rb
@@ -369,6 +369,13 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Kubernetes do
       expect(server.constraints_changed?(constraint_one, constraint_one.deep_merge(new_value))).to eq(false)
     end
 
+    it "Detects 0.15 == 150m" do
+      # From: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+      # A request with a decimal point, like 0.1, is converted to 100m by the API, and precision finer than 1m is not allowed. For this reason, the form 100m might be preferred.
+      new_value = {:requests => {:cpu => "0.15"}}
+      expect(server.constraints_changed?(constraint_one, constraint_one.deep_merge(new_value))).to eq(false)
+    end
+
     it "Current missing cpu limit" do
       current = {:limits => {:memory => "1Gi"},                 :requests => {:cpu => "150m", :memory => "500Mi"}}
       desired = {:limits => {:cpu => "999m", :memory => "1Gi"}, :requests => {:cpu => "150m", :memory => "500Mi"}}

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -154,6 +154,11 @@ RSpec.describe MiqWorker::ContainerCommon do
         expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
       end
 
+      it "raises ArgumentError when request > limit" do
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_request => 750.megabytes, :memory_threshold => 500.megabytes)
+        expect { MiqGenericWorker.new.resource_constraints }.to raise_error(ArgumentError)
+      end
+
       it "returns only memory when memory is set" do
         allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes)
         constraints = {


### PR DESCRIPTION
### Summary
* Patch deployments so you can change resource `limit/requests` in our settings and have them applied automatically.  Previously, any `limit/requests` settings would require each deployment to be deleted/recreated either manually or by manually restarting the orchestrator.
* Pods will still be restarted when the deployment is patched but there is no need to manually delete the deployment.

### Details
* Monitors pod deployment specs from kubernetes (a second monitoring thread - first did pods, this second one does deployments, each with different API endpoints)
* Detect when the desired resource constraints (requests/limits) doesn't match the current specs
* Patch any deployments not matching desired values
  * Honors changes made in our UI/configure_server_settings.rb/our settings.yml.
  * Rollback any request/limits changes made outside of manageiq, such as through kubernetes/`oc edit deploy`
* Alter the existing `scale` patch mechanism to use the same logic so we track both replica and resources 
* Handle comparison problems
  * Millicores: "1" == "1000m" (valid and equal - shouldn't trigger patch_deployment)
   * Gibibytes/Mebibytes comparisons: "1024Mi" == "1Gi" (shouldn't trigger patch_deployment)
  * Decimal CPU: "0.5" == "500m" (valid and equal - shouldn't trigger patch_deployment)
### Example logging

* When scaling the deployment:
```
[----] I, [2020-12-08T16:50:05.218922 #8:2b1de6d25968]  INFO -- : MIQ(MiqGenericWorker.sync_workers) Workers are being synchronized: Current #: [1], Desired #: [2]
[----] I, [2020-12-08T16:50:05.241662 #8:2b1de6d25968]  INFO -- : MIQ(ContainerOrchestrator#patch_deployment) deployment_name: 1-generic, data: {:spec=>{:replicas=>2}}
```

* When a change in `requests` / `limits` is detected:
```
[----] I, [2020-12-08T16:52:53.806163 #8:2b1de6d25968]  INFO -- : MIQ(MiqServer#sync_deployment_settings) Constraints changed, patching deployment: [1-generic]
[----] I, [2020-12-08T16:52:53.810591 #8:2b1de6d25968]  INFO -- : MIQ(ContainerOrchestrator#patch_deployment) deployment_name: 1-generic, data: {:spec=>{:template=>{:spec=>{:containers=>[{:name=>"1-generic", :image=>"jrafanie/manageiq-base-worker:patch-deploy5", :resources=>{:limits=>{:memory=>"600Mi", :cpu=>"1000m"}, :requests=>{:memory=>"500Mi", :cpu=>"150m"}}}]}}}}
```


Fixes: #20727

TODO:

- [x] Finish writing specs
- [x] Rewrite commits specifying https://github.com/ManageIQ/manageiq/issues/20727 