### PR TITLE
[WIP] handle user being nil in resource action automate_queue_hash

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -39,10 +39,10 @@ class ResourceAction < ApplicationRecord
       :open_url_task_id => open_url_task_id,
       :attrs            => attrs,
     }.merge(override_values).tap do |args|
-      args[:user_id] ||= user.id
-      args[:miq_group_id] ||= user.current_group.id
-      args[:tenant_id] ||= user.current_tenant.id
-      args[:username] ||= user.userid
+      args[:user_id] ||= user.try(:id)
+      args[:miq_group_id] ||= user.try(:current_group).try(:id)
+      args[:tenant_id] ||= user.try(:current_tenant).try(:id)
+      args[:username] ||= user.try(:userid)
     end
   end
 

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -111,15 +111,30 @@ RSpec.describe ResourceAction do
   context "#automate_queue_hash" do
     let(:button) { FactoryBot.create(:custom_button, :applies_to_class => "Vm") }
     let(:ra)     { FactoryBot.create(:resource_action, :resource => button) }
-    let(:user)   { FactoryBot.create(:user_with_group) }
     let(:target) { FactoryBot.create(:vm_vmware) }
 
-    it "passes result_format" do
-      expect(ra.automate_queue_hash(target, {"result_format"=>"ignore"}, user)).to include(:attrs => {"result_format"=>"ignore"})
+    context "with user" do
+      let(:user) { FactoryBot.create(:user_with_group) }
+
+      it "passes result_format" do
+        expect(ra.automate_queue_hash(target, {"result_format"=>"ignore"}, user)).to include(:attrs => {"result_format"=>"ignore"})
+      end
+
+      it "does not pass result_format by default" do
+        expect(ra.automate_queue_hash(target, {}, user)).not_to include(:attrs => {"result_format"=>"ignore"})
+      end
     end
 
-    it "does not pass result_format by default" do
-      expect(ra.automate_queue_hash(target, {}, user)).not_to include(:attrs => {"result_format"=>"ignore"})
+    context "without user" do
+      let(:user) { nil }
+
+      it "passes result_format" do
+        expect(ra.automate_queue_hash(target, {"result_format"=>"ignore"}, user)).to include(:attrs => {"result_format"=>"ignore"})
+      end
+
+      it "does not pass result_format by default" do
+        expect(ra.automate_queue_hash(target, {}, user)).not_to include(:attrs => {"result_format"=>"ignore"})
+      end
     end
   end
 end


### PR DESCRIPTION
at one point we let this user arg be nil if current_user for any reason wasn't set:`args[:user_id] ||= User.current_user.try(:id)` (see https://github.com/ManageIQ/manageiq/commit/65464f4cdd65bb9d39510ac499a20edf5874e781). unless we are absolutely certain we changed every case in which `user.current_user` might not be set, we still need this leniency.