### PR TITLE
Modified MiqReport::GROUPINGS to Include Plural Strings

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -52,7 +52,7 @@ class MiqReport < ApplicationRecord
 
   attr_accessor_that_yamls :reserved, :skip_references # For legacy imports
 
-  GROUPINGS = [[:min, N_("Minimum")], [:avg, N_("Average")], [:max, N_("Maximum")], [:total, N_("Total")]].freeze
+  GROUPINGS = [[:min, N_("Minimum"), N_("Minima")], [:avg, N_("Average"), N_("Averages")], [:max, N_("Maximum"), N_("Maxima")], [:total, N_("Total"), N_("Totals")]].freeze
   PIVOTS    = [[:min, "Minimum"], [:avg, "Average"], [:max, "Maximum"], [:total, "Total"]]
   IMPORT_CLASS_NAMES = %w(MiqReport).freeze
 

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -156,7 +156,7 @@ module MiqReport::Generator::Html
         if extras[:grouping][group].key?(calc.first) # Only add a row if there are calcs of this type for this group value
           grp_output = ""
           grp_output << "<tr>"
-          grp_output << "<td#{in_a_widget ? "" : " class='group'"} style='text-align:right'>#{_(calc.last.pluralize)}:</td>"
+          grp_output << "<td#{in_a_widget ? "" : " class='group'"} style='text-align:right'>#{_(calc.last)}:</td>"
           col_order.each_with_index do |c, c_idx|        # Go through the columns
             next if c_idx == 0                                # Skip first column
             grp_output << "<td#{in_a_widget ? "" : " class='group'"} style='text-align:right'>"


### PR DESCRIPTION
Found in: Services -> Workloads -> All VMs and Instances -> Monitoring -> Chargeback Preview

Needs to be Merged with: https://github.com/ManageIQ/manageiq-ui-classic/pull/7530

Adds on to changes made in https://github.com/ManageIQ/manageiq/pull/20781 by adding plural strings to `MiqReport::GROUPINGS` so they can be properly marked for translation. Also marks the `Chargeback Rates` column of the table for translation.

Preview:
![image](https://user-images.githubusercontent.com/64800041/101199264-9f12b480-3632-11eb-9d49-4bc69eea487d.png)
