### PR TITLE
Avoid direct float comparisons with 0.0 in storage.rb

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -581,12 +581,12 @@ class Storage < ApplicationRecord
   alias_method :v_used_space, :used_space
 
   def used_space_percent_of_total
-    total_space.to_f == 0.0 ? 0.0 : (used_space.to_f / total_space.to_f * 1000.0).round / 10.0
+    total_space.to_f.zero? ? 0.0 : (used_space.to_f / total_space.to_f * 1000.0).round / 10.0
   end
   alias_method :v_used_space_percent_of_total, :used_space_percent_of_total
 
   def free_space_percent_of_total
-    total_space.to_f == 0.0 ? 0.0 : (free_space.to_f / total_space.to_f * 1000.0).round / 10.0
+    total_space.to_f.zero? ? 0.0 : (free_space.to_f / total_space.to_f * 1000.0).round / 10.0
   end
   alias_method :v_free_space_percent_of_total, :free_space_percent_of_total
 
@@ -618,23 +618,23 @@ class Storage < ApplicationRecord
   alias_method :v_total_disk_size,     :disk_size
 
   def v_debris_percent_of_used
-    used_space.to_f == 0.0 ? 0.0 : (debris_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (debris_size.to_f / used_space.to_f * 1000.0).round / 10.0
   end
 
   def v_snapshot_percent_of_used
-    used_space.to_f == 0.0 ? 0.0 : (snapshot_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (snapshot_size.to_f / used_space.to_f * 1000.0).round / 10.0
   end
 
   def v_memory_percent_of_used
-    used_space.to_f == 0.0 ? 0.0 : (vm_ram_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (vm_ram_size.to_f / used_space.to_f * 1000.0).round / 10.0
   end
 
   def v_vm_misc_percent_of_used
-    used_space.to_f == 0.0 ? 0.0 : (vm_misc_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (vm_misc_size.to_f / used_space.to_f * 1000.0).round / 10.0
   end
 
   def v_disk_percent_of_used
-    used_space.to_f == 0.0 ? 0.0 : (disk_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (disk_size.to_f / used_space.to_f * 1000.0).round / 10.0
   end
 
   def v_total_provisioned
@@ -642,7 +642,7 @@ class Storage < ApplicationRecord
   end
 
   def v_provisioned_percent_of_total
-    total_space.to_f == 0 ? 0.0 : (v_total_provisioned.to_f / total_space.to_f * 1000.0).round / 10.0
+    total_space.to_f.zero? ? 0.0 : (v_total_provisioned.to_f / total_space.to_f * 1000.0).round / 10.0
   end
 
   #

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -581,12 +581,12 @@ class Storage < ApplicationRecord
   alias_method :v_used_space, :used_space
 
   def used_space_percent_of_total
-    total_space.to_f.zero? ? 0.0 : (used_space.to_f / total_space.to_f * 1000.0).round / 10.0
+    total_space.to_f.zero? ? 0.0 : (used_space.to_f / total_space * 1000.0).round / 10.0
   end
   alias_method :v_used_space_percent_of_total, :used_space_percent_of_total
 
   def free_space_percent_of_total
-    total_space.to_f.zero? ? 0.0 : (free_space.to_f / total_space.to_f * 1000.0).round / 10.0
+    total_space.to_f.zero? ? 0.0 : (free_space.to_f / total_space * 1000.0).round / 10.0
   end
   alias_method :v_free_space_percent_of_total, :free_space_percent_of_total
 
@@ -618,23 +618,23 @@ class Storage < ApplicationRecord
   alias_method :v_total_disk_size,     :disk_size
 
   def v_debris_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (debris_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (debris_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_snapshot_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (snapshot_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (snapshot_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_memory_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (vm_ram_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (vm_ram_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_vm_misc_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (vm_misc_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (vm_misc_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_disk_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (disk_size.to_f / used_space.to_f * 1000.0).round / 10.0
+    used_space.to_f.zero? ? 0.0 : (disk_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_total_provisioned
@@ -642,7 +642,7 @@ class Storage < ApplicationRecord
   end
 
   def v_provisioned_percent_of_total
-    total_space.to_f.zero? ? 0.0 : (v_total_provisioned.to_f / total_space.to_f * 1000.0).round / 10.0
+    total_space.to_f.zero? ? 0.0 : (v_total_provisioned.to_f / total_space * 1000.0).round / 10.0
   end
 
   #

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -581,12 +581,12 @@ class Storage < ApplicationRecord
   alias_method :v_used_space, :used_space
 
   def used_space_percent_of_total
-    total_space.to_f.zero? ? 0.0 : (used_space.to_f / total_space * 1000.0).round / 10.0
+    total_space.zero? ? 0.0 : (used_space.to_f / total_space * 1000.0).round / 10.0
   end
   alias_method :v_used_space_percent_of_total, :used_space_percent_of_total
 
   def free_space_percent_of_total
-    total_space.to_f.zero? ? 0.0 : (free_space.to_f / total_space * 1000.0).round / 10.0
+    total_space.zero? ? 0.0 : (free_space.to_f / total_space * 1000.0).round / 10.0
   end
   alias_method :v_free_space_percent_of_total, :free_space_percent_of_total
 
@@ -618,23 +618,23 @@ class Storage < ApplicationRecord
   alias_method :v_total_disk_size,     :disk_size
 
   def v_debris_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (debris_size.to_f / used_space * 1000.0).round / 10.0
+    used_space.zero? ? 0.0 : (debris_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_snapshot_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (snapshot_size.to_f / used_space * 1000.0).round / 10.0
+    used_space.zero? ? 0.0 : (snapshot_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_memory_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (vm_ram_size.to_f / used_space * 1000.0).round / 10.0
+    used_space.zero? ? 0.0 : (vm_ram_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_vm_misc_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (vm_misc_size.to_f / used_space * 1000.0).round / 10.0
+    used_space.zero? ? 0.0 : (vm_misc_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_disk_percent_of_used
-    used_space.to_f.zero? ? 0.0 : (disk_size.to_f / used_space * 1000.0).round / 10.0
+    used_space.zero? ? 0.0 : (disk_size.to_f / used_space * 1000.0).round / 10.0
   end
 
   def v_total_provisioned
@@ -642,7 +642,7 @@ class Storage < ApplicationRecord
   end
 
   def v_provisioned_percent_of_total
-    total_space.to_f.zero? ? 0.0 : (v_total_provisioned.to_f / total_space * 1000.0).round / 10.0
+    total_space.zero? ? 0.0 : (v_total_provisioned.to_f / total_space * 1000.0).round / 10.0
   end
 
   #


### PR DESCRIPTION
Currently the rubocop linter gives us a handful of warnings for the Storage class like this:

`app/models/storage.rb:621:5: W: Lint/FloatComparison: Avoid (in)equality comparisons of floats as they are unreliable.
    used_space.to_f == 0.0 ? 0.0 : (debris_size.to_f / used_space.to_f * 1000.0).round / 10.0`

So, this PR just switches them to use the `zero?` method. Core Ruby appears to have its own code for checking floats vs. zero (which the zero? method uses):

https://github.com/ruby/ruby/blob/master/numeric.c#L1122-L1126

If we feel this isn't worthwhile, then I would vote to update our rubocop config to exclude these.

Update: originally I was only fixing the linter warnings, but I also went ahead and fixed the `Style/FloatDivision` warnings as well while I was here.