### PR TITLE
allow ibm_cloud and ibm_terraform global loggers

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -14,6 +14,8 @@ Style/GlobalVars:
   - $datawarehouse_log
   - $fog_log
   - $gce_log
+  - $ibm_cloud_log
+  - $ibm_terraform_log
   - $kube_log
   - $lenovo_log
   - $log


### PR DESCRIPTION
Allow ibm_cloud and ibm_terraform global loggers to suppress the rubocop warnings.