### PR TITLE
Factory(:miq_report_with_results): Add number_of_results

### DIFF
--- a/spec/factories/miq_report.rb
+++ b/spec/factories/miq_report.rb
@@ -21,7 +21,11 @@ FactoryBot.define do
   end
 
   factory :miq_report_with_results, :parent => :miq_report do
-    miq_report_results { [FactoryBot.create(:miq_report_result, :miq_group => miq_group)] }
+    transient do
+      number_of_results { 1 }
+    end
+
+    miq_report_results { FactoryBot.create_list(:miq_report_result, number_of_results, :miq_group => miq_group) }
   end
 
   factory :miq_report_chargeback, :parent => :miq_report do


### PR DESCRIPTION
Allow the number of results for `FactoryBot.create(:miq_report_with_results)` to be configurable via a transient variable.


Links
-----

* Dependent API PR: https://github.com/ManageIQ/manageiq-api/pull/975
* Usages of this factory:  https://github.com/search?q=org%3AManageIQ+miq_report_with_results&type=code


Steps for Testing/QA
--------------------

A cross repo test will be created against `manageiq-ui-classic` and `manageiq-api` to confirm this doesn't break existing tests.