### PR TITLE
[WIP] Add a utility to decrypt env vars for services that don't connect to VMDB (e.g. non-rails workers)

### DIFF
--- a/tools/decrypt_env_vars
+++ b/tools/decrypt_env_vars
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require "manageiq-password"
+
+ManageIQ::Password.key_root = File.expand_path("../certs", __dir__)
+decrypted_env_vars = ENV.to_hash.transform_values { |val| ManageIQ::Password.try_decrypt(val) }
+
+puts decrypted_env_vars.to_yaml

--- a/tools/miq_secrets
+++ b/tools/miq_secrets
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require "awesome_spawn"
+cmd = File.expand_path("decrypt_env_vars", __dir__)
+result = AwesomeSpawn.run!(cmd)
+
+require "yaml"
+env_vars = YAML.load(result.output)
+
+Process.detach(Kernel.spawn(env_vars, ARGV.join(" ")))


### PR DESCRIPTION
The common pattern for accessing encrypted credentials for MIQ workers is to pull them from the database (which stores them encrypted).  As we move away from workers that are run with Rails and can connect to the main database we have to solve the issue of how do we get "secrets" to these workers in a secure way.

This adds a utility which can be run by any service to decrypt and print out its environment variables (these are inherited from the parent program by default) so that they can be used.

Required for: https://github.com/ManageIQ/manageiq-providers-vmware/pull/522