### PR TITLE
fixed MiqPolicySet.seed when Condition record with the same description or name but different guid already exists

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -266,7 +266,8 @@ class Condition < ApplicationRecord
     condition.delete("modifier")
 
     status = {:class => name, :description => condition["description"]}
-    c = Condition.find_by(:guid => condition["guid"])
+    c = Condition.find_by(:guid => condition["guid"]) || Condition.find_by(:name => condition["name"]) ||
+        Condition.find_by(:description => condition["description"])
     msg_pfx = "Importing Condition: guid=[#{condition["guid"]}] description=[#{condition["description"]}]"
 
     if c.nil?

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -158,16 +158,18 @@ RSpec.describe Condition do
   end
 
   describe ".import_from_hash" do
-    let(:description) { "some description"}
+    let(:description) { "some description" }
     let(:name)        { "some name" }
     let(:guid)        { "some guid" }
     let(:expression)  { {">" => {"field" => "Vm-cpu_num", "value" => 2}} }
-    let(:condition)   { {"description" => description,
-                         "expression"  => MiqExpression.new(expression),
-                         "modifier"    => 'deny',
-                         "towhat"      => "Vm",
-                         "guid"        => guid,
-                         "name"        => name} }
+    let(:condition) do
+      {"description" => description,
+       "expression"  => MiqExpression.new(expression),
+       "modifier"    => 'deny',
+       "towhat"      => "Vm",
+       "guid"        => guid,
+       "name"        => name}
+    end
 
     before do
       @condition, _s = Condition.import_from_hash(condition)
@@ -181,14 +183,16 @@ RSpec.describe Condition do
     context "unique constrains" do
       let(:new_description) { "new description" }
       let(:new_name)        { "new name" }
-      let(:new_guid)        { "new guid"}
+      let(:new_guid)        { "new guid" }
       let(:new_expression)  { {">" => {"field" => "Vm-cpu_num", "value" => 55}} }
-      let(:new_condition)   { {"description" => new_description,
-                               "expression"  => MiqExpression.new(new_expression),
-                               "modifier"    => 'deny',
-                               "towhat"      => "Vm",
-                               "guid"        => new_guid,
-                               "name"        => new_name} }
+      let(:new_condition) do
+        {"description" => new_description,
+         "expression"  => MiqExpression.new(new_expression),
+         "modifier"    => 'deny',
+         "towhat"      => "Vm",
+         "guid"        => new_guid,
+         "name"        => new_name}
+      end
 
       it "adds new records if guid, name and description for record in Hash are unique" do
         _, status = Condition.import_from_hash(new_condition)
@@ -201,7 +205,6 @@ RSpec.describe Condition do
         expect(new_condition.description).to eq(new_description)
         expect(new_condition.guid).to eq(new_guid)
       end
-
 
       it "updates existing DB record if it has the same guid as record in Hash" do
         new_condition["guid"] = guid
@@ -241,7 +244,6 @@ RSpec.describe Condition do
         expect(new_condition.description).to eq(description)
         expect(new_condition.guid).to eq(new_guid)
       end
-
     end
   end
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -158,15 +158,90 @@ RSpec.describe Condition do
   end
 
   describe ".import_from_hash" do
-    it "removes condition modifier" do
-      cond_hash = {
-        "description" => "test condition",
-        "expression"  => MiqExpression.new(">" => {"field" => "Vm-cpu_num", "value" => 2}),
-        "modifier"    => 'deny',
-        "towhat"      => "Vm"
-      }
-      condition, _s = Condition.import_from_hash(cond_hash)
-      expect(condition.expression.exp).to eq("not" => {">" => {"field" => "Vm-cpu_num", "value" => 2}})
+    let(:description) { "some description"}
+    let(:name)        { "some name" }
+    let(:guid)        { "some guid" }
+    let(:expression)  { {">" => {"field" => "Vm-cpu_num", "value" => 2}} }
+    let(:condition)   { {"description" => description,
+                         "expression"  => MiqExpression.new(expression),
+                         "modifier"    => 'deny',
+                         "towhat"      => "Vm",
+                         "guid"        => guid,
+                         "name"        => name} }
+
+    before do
+      @condition, _s = Condition.import_from_hash(condition)
+    end
+
+    it "removes condition modifier and adds new record to Condition model" do
+      expect(@condition.expression.exp).to eq("not" => expression)
+      expect(Condition.count).to eq(1)
+    end
+
+    context "unique constrains" do
+      let(:new_description) { "new description" }
+      let(:new_name)        { "new name" }
+      let(:new_guid)        { "new guid"}
+      let(:new_expression)  { {">" => {"field" => "Vm-cpu_num", "value" => 55}} }
+      let(:new_condition)   { {"description" => new_description,
+                               "expression"  => MiqExpression.new(new_expression),
+                               "modifier"    => 'deny',
+                               "towhat"      => "Vm",
+                               "guid"        => new_guid,
+                               "name"        => new_name} }
+
+      it "adds new records if guid, name and description for record in Hash are unique" do
+        _, status = Condition.import_from_hash(new_condition)
+        expect(status[:status]).to eq(:add)
+
+        expect(Condition.count).to eq(2)
+        new_condition = Condition.last
+        expect(new_condition.expression.exp).to eq("not" => new_expression)
+        expect(new_condition.name).to eq(new_name)
+        expect(new_condition.description).to eq(new_description)
+        expect(new_condition.guid).to eq(new_guid)
+      end
+
+
+      it "updates existing DB record if it has the same guid as record in Hash" do
+        new_condition["guid"] = guid
+        _, status = Condition.import_from_hash(new_condition)
+        expect(status[:status]).to eq(:update)
+
+        expect(Condition.count).to eq(1)
+        new_condition = Condition.last
+        expect(new_condition.expression.exp).to eq("not" => new_expression)
+        expect(new_condition.name).to eq(new_name)
+        expect(new_condition.description).to eq(new_description)
+        expect(new_condition.guid).to eq(guid)
+      end
+
+      it "updates existing DB record if it has the same name as record in Hash but guids are different" do
+        new_condition["name"] = name
+        _, status = Condition.import_from_hash(new_condition)
+        expect(status[:status]).to eq(:update)
+
+        expect(Condition.count).to eq(1)
+        new_condition = Condition.last
+        expect(new_condition.expression.exp).to eq("not" => new_expression)
+        expect(new_condition.name).to eq(name)
+        expect(new_condition.description).to eq(new_description)
+        expect(new_condition.guid).to eq(new_guid)
+      end
+
+      it "updates existing DB record if it has the same description as record in Hash but guids are different" do
+        new_condition["description"] = description
+        _, status = Condition.import_from_hash(new_condition)
+        expect(status[:status]).to eq(:update)
+
+        expect(Condition.count).to eq(1)
+        new_condition = Condition.last
+        expect(new_condition.expression.exp).to eq("not" => new_expression)
+        expect(new_condition.name).to eq(new_name)
+        expect(new_condition.description).to eq(description)
+        expect(new_condition.guid).to eq(new_guid)
+      end
+
     end
   end
 


### PR DESCRIPTION
**ISSUE:**
There are three fields (in addition to id) in ```condition``` table which should be unique: ```name```, ```description```, and ```guid```. Uniqueness of ```name``` and ```description``` enforced inside model, uniqueness of ```guid``` assumed during seeding. 
When changes to ```guid```  done in separate commits than changes to ```name``` or ```description``` than```MiqPolicySet.seed```executed between commits will fail


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1904551

