### PR TITLE
Drop the no longer used MiqSchedule.run_adhoc_db_gc method

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -267,19 +267,6 @@ class MiqSchedule < ApplicationRecord
     action_db_backup(DatabaseBackup, nil)
   end
 
-  def self.run_adhoc_db_gc(options)
-    # options can include:
-    # :userid       "admin"
-    # :aggressive   true  (if provided and true, a full GC will be done)
-
-    userid = options.delete(:userid)
-    raise _("No userid provided!") unless userid
-
-    sch = new(:userid => userid, :sched_action => {:options => options})
-    sch.action_db_gc(DatabaseBackup, nil)
-    # Don't save the schedule since we don't have CRUD for DB GC schedules yet
-  end
-
   def action_evaluate_alert(obj, _at)
     MiqAlert.evaluate_queue(obj)
     _log.info("Action [#{name}] has been run for target type: [#{obj.class}] with name: [#{obj.name}]")

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -685,41 +685,6 @@ RSpec.describe MiqSchedule do
       end
     end
 
-    context "valid db_gc unsaved schedule, run_adhoc_db_gc" do
-      before do
-        @task_id = MiqSchedule.run_adhoc_db_gc(:userid => "admin", :aggressive => true)
-        @gc_message = MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "gc", :role => "database_operations").first
-
-        @region = FactoryBot.create(:miq_region)
-        allow(MiqRegion).to receive(:my_region).and_return(@region)
-      end
-
-      it "should create 1 miq task" do
-        tasks = MiqTask.where(:name => "Database GC", :userid => "admin")
-        expect(tasks.length).to eq(1)
-        expect(tasks.first.id).to eq(@task_id)
-      end
-
-      it "should create one gc queue message for the database role" do
-        expect(MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "gc", :role => "database_operations").count).to eq(1)
-      end
-
-      context "deliver DatabaseBackup.gc message" do
-        before do
-          # stub out the actual backup behavior
-          allow(PostgresAdmin).to receive(:gc)
-
-          @status, message, result = @gc_message.deliver
-          @gc_message.delivered(@status, message, result)
-        end
-
-        it "should have queue message ok, and task is Ok and Finished" do
-          expect(@status).to eq("ok")
-          expect(MiqTask.where(:state => "Finished", :status => "Ok").count).to eq(1)
-        end
-      end
-    end
-
     context "valid action_automation_request" do
       let(:admin) { FactoryBot.create(:user_miq_request_approver) }
       let(:ems)   { FactoryBot.create(:ext_management_system) }


### PR DESCRIPTION
The only callsite of this method is being dropped [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/7535) so :scissors: 

@miq-bot add_label cleanup, kasparov/no
@miq-bot assign @jrafanie