### PR TITLE
Remove unused assignments

### DIFF
--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -31,7 +31,7 @@ class ChargebackRateDetailMeasure < ApplicationRecord
         rec = ChargebackRateDetailMeasure.find_by(:name => cbr[:name])
         if rec.nil?
           _log.info("Creating [#{cbr[:name]}] with units=[#{cbr[:units]}]")
-          rec = ChargebackRateDetailMeasure.create(cbr)
+          ChargebackRateDetailMeasure.create(cbr)
         else
           fixture_mtime = File.mtime(fixture_file_measure).utc
           if fixture_mtime > rec.created_at

--- a/app/models/manageiq/providers/embedded_ansible/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_ansible/crud_common.rb
@@ -50,7 +50,6 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
     end
 
     def create_in_provider_queue(manager_id, params, auth_user = nil)
-      manager = parent.find(manager_id)
       action = "Creating #{self::FRIENDLY_NAME}"
       action << " (name=#{params[:name]})" if params[:name]
       queue(nil, "create_in_provider", [manager_id, encrypt_queue_params(params)], action, auth_user)

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -95,7 +95,7 @@ module ManageIQ::Providers
       count += physical_chassis.where(:health_state => state).count
       count += physical_servers.where(:health_state => state).count
       count += physical_switches.where(:health_state => state).count
-      count += physical_storages.where(:health_state => state).count
+      count + physical_storages.where(:health_state => state).count
     end
 
     def assign_health_states
@@ -112,13 +112,13 @@ module ManageIQ::Providers
       count = 0
 
       if component
-        count = component.count
+        component.count
       else
         count += physical_racks.count
         count += physical_chassis.count
         count += physical_servers.count
         count += physical_switches.count
-        count += physical_storages.count
+        count + physical_storages.count
       end
     end
 

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -619,7 +619,6 @@ class MiqAction < ApplicationRecord
     log_prefix += " VM: [#{rec.name}] Id: [#{rec.id}]"
 
     age_threshold = (Time.now.utc - action.options[:age])
-    has_ch = false
     snaps_to_delete = rec.snapshots.each_with_object([]) do |s, arr|
       next if s.is_a_type?(:evm_snapshot)
 
@@ -646,7 +645,6 @@ class MiqAction < ApplicationRecord
     end
     log_prefix += " VM: [#{rec.name}] Id: [#{rec.id}]"
 
-    has_ch = false
     snap   = nil
     rec.snapshots.order("create_time DESC").each do |s|
       next if s.is_a_type?(:evm_snapshot)

--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -11,7 +11,6 @@ class MiqRetireTask < MiqRequestTask
              req_obj.source.name
            end
 
-    new_settings = []
     "#{request_class::TASK_DESCRIPTION} for: #{name}"
   end
 

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -17,7 +17,7 @@ class MiqShortcut < ApplicationRecord
       rec = db_data[s[:name]]
       if rec.nil?
         _log.info("Creating #{s.inspect}")
-        rec = create!(s)
+        create!(s)
       else
         rec.attributes = s
         if rec.changed?


### PR DESCRIPTION
Running the rubocop linter revealed the following unused assignments in app/models. This PR cleans them.