### PR TITLE
[EmbeddedAnsible::CrudCommon] Fix manager validation

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_ansible/crud_common.rb
@@ -50,6 +50,7 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
     end
 
     def create_in_provider_queue(manager_id, params, auth_user = nil)
+      parent.find(manager_id) # validation that the manager ID is from EmbeddedAnsible
       action = "Creating #{self::FRIENDLY_NAME}"
       action << " (name=#{params[:name]})" if params[:name]
       queue(nil, "create_in_provider", [manager_id, encrypt_queue_params(params)], action, auth_user)


### PR DESCRIPTION
Putting this back as this was used in the specs to validate the correct manager was being used in the credential_spec.rb for `EmbeddedAnsible`:

```ruby
  it ".create_in_provider_queue will fail with incompatible manager" do
    wrong_manager = FactoryBot.create(:configuration_manager_foreman)
    expect { credential_class.create_in_provider_queue(wrong_manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
  end
```

While there may be a better way of doing this, deleting the spec seems like the wrong way to fix this issue, and this was originally removed because it was assumed it wasn't needed.

For now, I at least added a comment in line, and fixed the unused variable issue so it is more apparent this is being used as a validation, and not the result being used later.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/20879
  - https://github.com/ManageIQ/manageiq/pull/20879/commits/3715bb7fed412b011095b4bee9758212953958d3
* https://gitter.im/ManageIQ/manageiq?at=5fcffda592aa1c4ef5cb31cb