### PR TITLE
[Gemfile] Lock the config gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        "~> 2.1.4",      :require => false
 gem "byebug",                                          :require => false
 gem "color",                          "~>1.8"
-gem "config",                         "~>2.2", ">=2.2.1", :require => false
+gem "config",                         "=2.2.1",        :require => false
 gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.3"
 gem "docker-api",                     "~>1.33.6",      :require => false


### PR DESCRIPTION
The `config` gem had a [recent change](https://github.com/railsconfig/config/issues/277) to it that was recently released which broke our build: 

- [master](https://travis-ci.com/github/ManageIQ/manageiq-api/jobs/456702122#L1985-L1994)
- [kasparov](https://travis-ci.com/github/ManageIQ/manageiq-api/builds/207478687#L1995-L2004)
- [jansa](https://travis-ci.com/github/ManageIQ/manageiq-api/builds/207524405#L2113-L2122)

So for now, lock the version to a known working version for us.

Links
-----

* Broken builds
  - https://travis-ci.com/github/ManageIQ/manageiq-api/jobs/456702122#L1985-L1994 (master)
  - https://travis-ci.com/github/ManageIQ/manageiq-api/builds/207478687#L1995-L2004 (kasparov)
  - https://travis-ci.com/github/ManageIQ/manageiq-api/builds/207524405#L2113-L2122 (jansa)
* Offending PR:  https://github.com/railsconfig/config/issues/277