### PR TITLE
Fix escaping of < and > in ContainerLogger

### DIFF
--- a/lib/vmdb/loggers/container_logger.rb
+++ b/lib/vmdb/loggers/container_logger.rb
@@ -30,7 +30,7 @@ module Vmdb::Loggers
       def call(severity, time, progname, msg)
         # From https://github.com/ViaQ/elasticsearch-templates/releases -> Downloads -> *.asciidoc
         # NOTE: These values are in a specific order for easier human readbility via STDOUT
-        {
+        payload = {
           :@timestamp => format_datetime(time),
           :hostname   => hostname,
           :pid        => $PROCESS_ID,
@@ -39,7 +39,8 @@ module Vmdb::Loggers
           :level      => translate_error(severity),
           :message    => prefix_task_id(msg2str(msg)),
           # :tags => "tags string",
-        }.delete_nils.to_json << "\n"
+        }.delete_nils
+        JSON.generate(payload) << "\n"
       end
 
       private

--- a/spec/lib/vmdb/loggers/container_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/container_logger_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Vmdb::Loggers::ContainerLogger::Formatter do
-  it "stuff" do
+  it "logs a message" do
     time = Time.now
     result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")
     expected = {
@@ -12,5 +12,11 @@ RSpec.describe Vmdb::Loggers::ContainerLogger::Formatter do
       "tid"        => Thread.current.object_id.to_s(16),
     }.delete_nils
     expect(JSON.parse(result)).to eq(expected)
+  end
+
+  it "does not escape characters as in ActiveSupport::JSON extensions" do
+    time = Time.now
+    result = described_class.new.call("INFO", time, "some_program", "xxx < yyy > zzz")
+    expect(result).to include('"message":"xxx < yyy > zzz"')
   end
 end


### PR DESCRIPTION
This fixes the weird escaping in the container logger.  (Note that we apparently don't use ManageIQ::Loggers::Container logger, and this is still a copy, so I'll need to fix it there too).

Example:

Before

```json
[1] pry(main)> $container_log.info("xxx < yyy > zzz")
{"@timestamp":"2020-12-09T14:59:14.307800 ","pid":39458,"tid":"3fdc05c2ffd0","level":"info","message":"xxx \u003c yyy \u003e zzz"}
```

After

```json
[1] pry(main)> $container_log.info("xxx < yyy > zzz")
{"@timestamp":"2020-12-09T14:58:30.909153 ","pid":39417,"tid":"3fd6d382ffd4","level":"info","message":"xxx < yyy > zzz"}
```

@bdunne @NickLaMuro Please review.

cc @jrafanie @gtanzillo @agrare 
