### PR TITLE
vm or template children and parent can also be aliased

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -285,6 +285,8 @@ class VmOrTemplate < ApplicationRecord
 
   include RelationshipMixin
   self.default_relationship_type = "genealogy"
+  alias child_resources children
+  alias parent_resource parent
 
   include MiqPolicyMixin
   include AlertMixin
@@ -1772,14 +1774,6 @@ class VmOrTemplate < ApplicationRecord
     unless console_supported?('spice') || console_supported?('vnc')
       unsupported_reason_add(:console, N_("Console not supported"))
     end
-  end
-
-  def child_resources
-    children
-  end
-
-  def parent_resource
-    parent
   end
 
   def self.display_name(number = 1)

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe VmOrTemplate do
       reloaded_vm = Vm.find(vm.id)
       expect(reloaded_vm.parent).to eq(parent)
       expect(reloaded_vm.genealogy_parent).to eq(parent)
+      expect(reloaded_vm.parent_resource).to eq(parent)
+      expect(Vm.find(parent.id).child_resources).to eq([vm])
     end
 
     it "sets parent via =" do
@@ -124,7 +126,8 @@ RSpec.describe VmOrTemplate do
 
       reloaded_vm = Vm.find(vm.id)
       expect(reloaded_vm.parent).to eq(parent)
-      expect(reloaded_vm.genealogy_parent).to eq(parent)
+      expect(reloaded_vm.parent_resource).to eq(parent)
+      expect(Vm.find(parent.id).child_resources).to eq([vm])
     end
   end
 


### PR DESCRIPTION
`child_resources` and `parent_resource` also could be aliases

please see the first commit which is the test for the existing one line methods and the second which changes to aliases