### PR TITLE
Add validation of worker memory/cpu request/limit

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -179,8 +179,12 @@ class MiqWorker < ApplicationRecord
   def self.fetch_worker_settings_from_server(miq_server, options = {})
     settings = {}
 
+    # figure out why/if this guard is needed.. it's weird to have miq_server required here but also accept options
     unless miq_server.nil?
       server_config = options[:config] || miq_server.settings
+
+      # extract a method to flatten the ancestry of worker settings into a single key value pair for this worker
+
       # Get the configuration values
       section = server_config[:workers]
       unless section.nil?

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -199,9 +199,13 @@ class MiqWorker < ApplicationRecord
         section = section[c]
         raise _("Missing config section %{section_name}") % {:section_name => c} if section.nil?
         defaults = section[:defaults]
-        settings.merge!(defaults) unless defaults.nil?
+        unless defaults.nil?
+          defaults.delete_if {|k, v| v == Vmdb::Settings::RESET_VALUE }
+          settings.merge!(defaults)
+        end
       end
 
+      section.delete_if {|k, v| v == Vmdb::Settings::RESET_VALUE }
       settings.merge!(section)
 
       # If not specified, provide the worker_settings cleaned up in fixnums, etc. instead of 1.seconds, 10.megabytes

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -188,10 +188,10 @@ module Vmdb
         errors = []
         worker_settings = worker_class.fetch_worker_settings_from_server(true, data)
 
-        cpu_request     = worker_settings.fetch(:cpu_request_percent, 0)
-        cpu_limit       = worker_settings.fetch(:cpu_threshold_percent, Float::INFINITY)
-        memory_request  = worker_settings.fetch(:memory_request, 0.bytes)
-        memory_limit    = worker_settings.fetch(:memory_threshold, Float::INFINITY.megabytes)
+        cpu_request     = worker_settings[:cpu_request_percent] || 0
+        cpu_limit       = worker_settings[:cpu_threshold_percent] || Float::INFINITY
+        memory_request  = worker_settings[:memory_request] || 0.bytes
+        memory_limit    = worker_settings[:memory_threshold] || Float::INFINITY.megabytes
 
         if cpu_request > cpu_limit
           valid = false

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -186,7 +186,8 @@ module Vmdb
       def validate_worker_request_limit(worker_class, data)
         valid = true
         errors = []
-        worker_settings = worker_class.worker_settings(data)
+        worker_settings = worker_class.fetch_worker_settings_from_server(true, data)
+
         cpu_request     = worker_settings.fetch(:cpu_request_percent, 0)
         cpu_limit       = worker_settings.fetch(:cpu_threshold_percent, Float::INFINITY)
         memory_request  = worker_settings.fetch(:memory_request, 0.bytes)

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -188,6 +188,7 @@ module Vmdb
         errors = []
         worker_settings = worker_class.fetch_worker_settings_from_server(true, data)
 
+        # add assertions that these keys exist - remove defaults
         cpu_request     = worker_settings[:cpu_request_percent] || 0
         cpu_limit       = worker_settings[:cpu_threshold_percent] || Float::INFINITY
         memory_request  = worker_settings[:memory_request] || 0.bytes

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -186,7 +186,7 @@ module Vmdb
       def validate_worker_request_limit(worker_class, data)
         valid = true
         errors = []
-        worker_settings = worker_class.fetch_worker_settings_from_server(true, data)
+        worker_settings = worker_class.worker_settings(data)
 
         # add assertions that these keys exist - remove defaults
         cpu_request     = worker_settings[:cpu_request_percent] || 0

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -195,12 +195,12 @@ module Vmdb
 
         if cpu_request > cpu_limit
           valid = false
-          errors << [:invalid_value, "#{worker_class.settings_name}: cpu_request_percent: #{cpu_request} cannot exceed cpu_threshold_percent: #{cpu_limit}"]
+          errors << [:cpu_request_percent, "#{worker_class.settings_name}: cpu_request_percent: #{cpu_request} cannot exceed cpu_threshold_percent: #{cpu_limit}"]
         end
 
         if memory_request > memory_limit
           valid = false
-          errors << [:invalid_value, "#{worker_class.settings_name}: memory_request: #{memory_request} cannot exceed memory_threshold: #{memory_limit}"]
+          errors << [:memory_request, "#{worker_class.settings_name}: memory_request: #{memory_request} cannot exceed memory_threshold: #{memory_limit}"]
         end
         return valid, errors
       end

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -186,13 +186,27 @@ module Vmdb
       def validate_worker_request_limit(worker_class, data)
         valid = true
         errors = []
-        worker_settings = worker_class.worker_settings(data)
+        worker_settings = worker_class.fetch_worker_settings_from_options_hash(data[:config])
 
-        # add assertions that these keys exist - remove defaults
-        cpu_request     = worker_settings[:cpu_request_percent] || 0
-        cpu_limit       = worker_settings[:cpu_threshold_percent] || Float::INFINITY
-        memory_request  = worker_settings[:memory_request] || 0.bytes
-        memory_limit    = worker_settings[:memory_threshold] || Float::INFINITY.megabytes
+        # Only validate request/limits if you specify any of them.  Specifying at least one of these four, requires
+        # all of them to be enumerated. This gets around tests that want to stub some of the worker_settings.
+        worker_settings_keys_with_dependencies = %i[cpu_request_percent cpu_threshold_percent memory_request memory_threshold]
+        return valid, errors if (worker_settings.keys & worker_settings_keys_with_dependencies).empty?
+
+        worker_settings_keys_with_dependencies.each do |key|
+          if !worker_settings.key?(key)
+            errors << [key, "#{worker_class.settings_name} #{key} is missing!"]
+            return false, errors
+          elsif !worker_settings[key].kind_of?(Numeric)
+            errors << [key, "#{worker_class.settings_name} #{key} has non-numeric value: #{worker_settings[key].inspect}"]
+            return false, errors
+          end
+        end
+
+        cpu_request     = worker_settings[:cpu_request_percent]
+        cpu_limit       = worker_settings[:cpu_threshold_percent]
+        memory_request  = worker_settings[:memory_request]
+        memory_limit    = worker_settings[:memory_threshold]
 
         if cpu_request > cpu_limit
           valid = false

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe Vmdb::Settings::Validator do
     end
 
     [:memory_request, 500.megabytes, :memory_threshold, 500.megabytes, :cpu_request, 50, :cpu_threshold_percent, 50].each_slice(2) do |key, value|
-      it "is valid when specifying only: #{key}" do
-        stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {key => value}}})
+      it "is valid with nil values replaced with default values, when specifying only: #{key}" do
+        stub_settings_merge(:workers => {:worker_base => {:defaults => {:cpu_request_percent => nil, :cpu_threshold_percent => nil}, :schedule_worker => {key => value}}})
         result, errors = subject.validate
         expect(result).to eql(true)
         expect(errors.empty?).to eql(true)

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -77,9 +77,10 @@ RSpec.describe Vmdb::Settings::Validator do
   end
 
   context "workers section" do
-    subject { described_class.new({:workers => {}}) }
+    subject { described_class.new(Settings) }
+
     it "is invalid with cpu_request_percent > cpu_threshold_percent" do
-      allow(MiqScheduleWorker).to receive(:worker_settings).and_return(:cpu_request_percent => 50, :cpu_threshold_percent => 40)
+      stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {:cpu_request_percent => 50, :cpu_threshold_percent => 40}}})
       result, errors = subject.validate
       expect(result).to eql(false)
       expect(errors.first.first).to eql("workers-invalid_value")
@@ -87,7 +88,7 @@ RSpec.describe Vmdb::Settings::Validator do
     end
 
     it "is invalid with memory_request > memory_threshold" do
-      allow(MiqScheduleWorker).to receive(:worker_settings).and_return(:memory_request => 600.megabytes, :memory_threshold => 500.megabytes)
+      stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {:memory_request => 600.megabytes, :memory_threshold => 500.megabytes}}})
       result, errors = subject.validate
       expect(result).to eql(false)
       expect(errors.first.first).to eql("workers-invalid_value")
@@ -96,7 +97,7 @@ RSpec.describe Vmdb::Settings::Validator do
 
     [:memory_request, 500.megabytes, :memory_threshold, 500.megabytes, :cpu_request, 50, :cpu_threshold_percent, 50].each_slice(2) do |key, value|
       it "is valid when specifying only: #{key}" do
-        allow(MiqScheduleWorker).to receive(:worker_settings).and_return(key => value)
+        stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {key => value}}})
         result, errors = subject.validate
         expect(result).to eql(true)
         expect(errors.empty?).to eql(true)

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -75,4 +75,32 @@ RSpec.describe Vmdb::Settings::Validator do
       expect(validator.valid?).to be expected
     end
   end
+
+  context "workers section" do
+    subject { described_class.new({:workers => {}}) }
+    it "is invalid with cpu_request_percent > cpu_threshold_percent" do
+      allow(MiqScheduleWorker).to receive(:worker_settings).and_return(:cpu_request_percent => 50, :cpu_threshold_percent => 40)
+      result, errors = subject.validate
+      expect(result).to eql(false)
+      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.last).to include("cannot exceed cpu_threshold_percent")
+    end
+
+    it "is invalid with memory_request > memory_threshold" do
+      allow(MiqScheduleWorker).to receive(:worker_settings).and_return(:memory_request => 600.megabytes, :memory_threshold => 500.megabytes)
+      result, errors = subject.validate
+      expect(result).to eql(false)
+      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.last).to include("cannot exceed memory_threshold")
+    end
+
+    [:memory_request, 500.megabytes, :memory_threshold, 500.megabytes, :cpu_request, 50, :cpu_threshold_percent, 50].each_slice(2) do |key, value|
+      it "is valid when specifying only: #{key}" do
+        allow(MiqScheduleWorker).to receive(:worker_settings).and_return(key => value)
+        result, errors = subject.validate
+        expect(result).to eql(true)
+        expect(errors.empty?).to eql(true)
+      end
+    end
+  end
 end

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe Vmdb::Settings::Validator do
       expect(errors.first.last).to include("cannot exceed memory_threshold")
     end
 
+    it "is invalid with inherited setting" do
+      stub_settings_merge(:workers => {:worker_base => {:defaults => {:cpu_request_percent => 15, :cpu_threshold_percent => 10}}})
+      result, errors = subject.validate
+      expect(result).to eql(false)
+      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.last).to include("cannot exceed cpu_threshold_percent")
+    end
+
+    it "is invalid with overridden worker setting" do
+      stub_settings_merge(:workers => {:worker_base => {:defaults => {:cpu_request_percent => 15, :cpu_threshold_percent => 20}, :schedule_worker => {:cpu_threshold_percent => 10}}})
+      result, errors = subject.validate
+      expect(result).to eql(false)
+      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.last).to include("cannot exceed cpu_threshold_percent")
+    end
+
     [:memory_request, 500.megabytes, :memory_threshold, 500.megabytes, :cpu_request, 50, :cpu_threshold_percent, 50].each_slice(2) do |key, value|
       it "is valid when specifying only: #{key}" do
         stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {key => value}}})

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Vmdb::Settings::Validator do
       stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {:cpu_request_percent => 50, :cpu_threshold_percent => 40}}})
       result, errors = subject.validate
       expect(result).to eql(false)
-      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.first).to eql("workers-cpu_request_percent")
       expect(errors.first.last).to include("cannot exceed cpu_threshold_percent")
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Vmdb::Settings::Validator do
       stub_settings_merge(:workers => {:worker_base => {:schedule_worker => {:memory_request => 600.megabytes, :memory_threshold => 500.megabytes}}})
       result, errors = subject.validate
       expect(result).to eql(false)
-      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.first).to eql("workers-memory_request")
       expect(errors.first.last).to include("cannot exceed memory_threshold")
     end
 
@@ -99,7 +99,7 @@ RSpec.describe Vmdb::Settings::Validator do
       stub_settings_merge(:workers => {:worker_base => {:defaults => {:cpu_request_percent => 15, :cpu_threshold_percent => 10}}})
       result, errors = subject.validate
       expect(result).to eql(false)
-      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.first).to eql("workers-cpu_request_percent")
       expect(errors.first.last).to include("cannot exceed cpu_threshold_percent")
     end
 
@@ -107,7 +107,7 @@ RSpec.describe Vmdb::Settings::Validator do
       stub_settings_merge(:workers => {:worker_base => {:defaults => {:cpu_request_percent => 15, :cpu_threshold_percent => 20}, :schedule_worker => {:cpu_threshold_percent => 10}}})
       result, errors = subject.validate
       expect(result).to eql(false)
-      expect(errors.first.first).to eql("workers-invalid_value")
+      expect(errors.first.first).to eql("workers-cpu_request_percent")
       expect(errors.first.last).to include("cannot exceed cpu_threshold_percent")
     end
 

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -275,11 +275,11 @@ RSpec.describe MiqWorker do
         {
           :workers => {
             :worker_base => {
-              :defaults          => {:memory_threshold => "100.megabytes"},
+              :defaults          => {:memory_threshold => "550.megabytes"},
               :queue_worker_base => {
-                :defaults           => {:memory_threshold => "300.megabytes"},
+                :defaults           => {:memory_threshold => "570.megabytes"},
                 :ems_refresh_worker => {
-                  :defaults                  => {:memory_threshold => "500.megabytes"},
+                  :defaults                  => {:memory_threshold => "600.megabytes"},
                   :ems_refresh_worker_amazon => {
                     :memory_threshold => "700.megabytes"
                   }
@@ -294,13 +294,13 @@ RSpec.describe MiqWorker do
         {
           :workers => {
             :worker_base => {
-              :defaults          => {:memory_threshold => "200.megabytes"},
+              :defaults          => {:memory_threshold => "555.megabytes"},
               :queue_worker_base => {
-                :defaults           => {:memory_threshold => "400.megabytes"},
+                :defaults           => {:memory_threshold => "575.megabytes"},
                 :ems_refresh_worker => {
-                  :defaults                  => {:memory_threshold => "600.megabytes"},
+                  :defaults                  => {:memory_threshold => "605.megabytes"},
                   :ems_refresh_worker_amazon => {
-                    :memory_threshold => "800.megabytes"
+                    :memory_threshold => "805.megabytes"
                   }
                 }
               }
@@ -316,11 +316,11 @@ RSpec.describe MiqWorker do
 
       it "uses the worker's miq_server" do
         expect(@worker.worker_settings[:memory_threshold]).to  eq(700.megabytes)
-        expect(@worker2.worker_settings[:memory_threshold]).to eq(800.megabytes)
+        expect(@worker2.worker_settings[:memory_threshold]).to eq(805.megabytes)
       end
 
       it "uses passed in config" do
-        expect(@worker.worker_settings(:config => config2)[:memory_threshold]).to  eq(800.megabytes)
+        expect(@worker.worker_settings(:config => config2)[:memory_threshold]).to  eq(805.megabytes)
         expect(@worker2.worker_settings(:config => config1)[:memory_threshold]).to eq(700.megabytes)
       end
 
@@ -328,8 +328,8 @@ RSpec.describe MiqWorker do
         @server.settings_changes.where(
           :key => "/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_amazon/memory_threshold"
         ).delete_all
-        expect(@worker.worker_settings[:memory_threshold]).to  eq(500.megabytes)
-        expect(@worker2.worker_settings[:memory_threshold]).to eq(800.megabytes)
+        expect(@worker.worker_settings[:memory_threshold]).to  eq(600.megabytes)
+        expect(@worker2.worker_settings[:memory_threshold]).to eq(805.megabytes)
       end
     end
   end


### PR DESCRIPTION
Kubernetes doesn't allow request > limit.

Follow up work seen in https://github.com/ManageIQ/manageiq/pull/20865

Here are some examples of what it looks like when you try to saving an invalid high request value:

1) In the workers tab:
![image](https://user-images.githubusercontent.com/19339/116471660-eea48780-a842-11eb-96e6-63b4f8bc89d6.png)



2) In the advanced tab:
![image](https://user-images.githubusercontent.com/19339/116471757-0f6cdd00-a843-11eb-9062-4646674a5747.png)




3) In CLI using configure_worker_settings.rb:

```
% ./tools/configure_server_settings.rb -t string -s 1 -p workers/worker_base/defaults/memory_request --value "1.2.gigabytes"
{:dry_run=>false, :serverid=>1, :path=>"workers/worker_base/defaults/memory_request", :value=>"1.2.gigabytes", :force=>false, :type=>"string", :all_servers=>false, :help=>false, :type_given=>true, :serverid_given=>true, :path_given=>true, :value_given=>true}
** ManageIQ master, codename: Morphy
Setting [workers/worker_base/defaults/memory_request], old value: [800.megabytes], new value: [1.2.gigabytes]
ERROR: Configuration is invalid:
	workers-memory_request: agent_coordinator_worker: memory_request: 1288490188 cannot exceed memory_threshold: 1073741824
```