### PR TITLE
Add validations for MiqWidgetSet

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -307,6 +307,18 @@ class MiqGroup < ApplicationRecord
     n_('Group', 'Groups', number)
   end
 
+  def delete_from_dashboard_order(widget_set_id)
+    return if settings.blank?
+
+    settings[:dashboard_order]&.delete(widget_set_id)
+  end
+
+  def add_to_dashboard_order(widget_set_id)
+    self.settings ||= {:dashboard_order => []}
+    self.settings[:dashboard_order] ||= []
+    self.settings[:dashboard_order] |= [widget_set_id]
+  end
+
   private
 
   # if this tenant is changing, make sure this is not a default group

--- a/app/models/miq_widget_set/set_data.rb
+++ b/app/models/miq_widget_set/set_data.rb
@@ -1,0 +1,41 @@
+module MiqWidgetSet::SetData
+  extend ActiveSupport::Concern
+
+  SET_DATA_COLS = %i[col1 col2 col3].freeze
+
+  included do
+    validate :set_data do
+      errors.add(:set_data, "One widget must be selected(set_data)") if widget_ids.empty?
+
+      filtered_widget_ids = set_data_widgets.pluck(:id)
+      if (widget_ids - filtered_widget_ids).present?
+        errors.add(:set_data, "Unable to find widget ids: #{(widget_ids - filtered_widget_ids).join(', ')}")
+      end
+    end
+
+    before_validation :init_set_data
+
+    def set_data_widgets
+      MiqWidget.where(:id => widget_ids)
+    end
+
+    private
+
+    def init_set_data
+      self.set_data ||= {}
+      new_set_data ||= {}
+      self.set_data.symbolize_keys!
+      SET_DATA_COLS.each do |col_key|
+        new_set_data[col_key] = self.set_data[col_key] || []
+      end
+
+      new_set_data[:reset_upon_login] = !!set_data[:reset_upon_login]
+      new_set_data[:locked] = !!set_data[:locked]
+      self.set_data = new_set_data
+    end
+
+    def widget_ids
+      SET_DATA_COLS.map { |x| set_data[x] }.flatten.compact
+    end
+  end
+end

--- a/spec/factories/miq_widget_set.rb
+++ b/spec/factories/miq_widget_set.rb
@@ -2,5 +2,17 @@ FactoryBot.define do
   factory :miq_widget_set do
     sequence(:name)         { |n| "widget_set_#{seq_padded_for_sorting(n)}" }
     sequence(:description)  { |n| "widget_set_#{seq_padded_for_sorting(n)}" }
+
+    trait :set_data_with_one_widget do
+      set_data do
+        {:col1             => [FactoryBot.create(:miq_widget).id],
+         :reset_upon_login => false,
+         :locked           => false}
+      end
+    end
+
+    before(:create) do |x|
+      x.group_id = x.owner_id if x.owner_id
+    end
   end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -317,25 +317,25 @@ RSpec.describe MiqGroup do
   context "#ordered_widget_sets" do
     let(:group) { FactoryBot.create(:miq_group) }
     it "uses dashboard_order if present" do
-      ws1 = FactoryBot.create(:miq_widget_set, :name => 'A1', :owner => group)
-      FactoryBot.create(:miq_widget_set, :name => 'C3', :owner => group)
-      ws3 = FactoryBot.create(:miq_widget_set, :name => 'B2', :owner => group)
+      ws1 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'A1', :owner => group)
+      FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'C3', :owner => group)
+      ws3 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'B2', :owner => group)
       group.update(:settings => {:dashboard_order => [ws3.id.to_s, ws1.id.to_s]})
 
       expect(group.ordered_widget_sets).to eq([ws3, ws1])
     end
 
     it "uses all owned widgets" do
-      ws1 = FactoryBot.create(:miq_widget_set, :name => 'A1', :owner => group)
-      ws2 = FactoryBot.create(:miq_widget_set, :name => 'C3', :owner => group)
-      ws3 = FactoryBot.create(:miq_widget_set, :name => 'B2', :owner => group)
+      ws1 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'A1', :owner => group)
+      ws2 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'C3', :owner => group)
+      ws3 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'B2', :owner => group)
       expect(group.ordered_widget_sets).to eq([ws1, ws3, ws2])
     end
 
     it "works when settings use strings" do
-      ws1 = FactoryBot.create(:miq_widget_set, :name => 'A1', :owner => group)
-      _ws2 = FactoryBot.create(:miq_widget_set, :name => 'C3', :owner => group)
-      ws3 = FactoryBot.create(:miq_widget_set, :name => 'B2', :owner => group)
+      ws1 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'A1', :owner => group)
+      _ws2 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'C3', :owner => group)
+      ws3 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => 'B2', :owner => group)
       group.update(:settings => {"dashboard_order" => [ws3.id.to_s, ws1.id.to_s]})
 
       expect(group.ordered_widget_sets).to eq([ws3, ws1])

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -130,15 +130,12 @@ RSpec.describe MiqWidget do
       end
 
       it "ignores the legacy format admin|db_name" do
-        ws = FactoryBot.create(:miq_widget_set, :name => "#{@user1.userid}|Home")
-        @widget_report_vendor_and_guest_os.make_memberof(ws)
-        expect(@widget_report_vendor_and_guest_os.grouped_subscribers).to be_kind_of(Hash)
-        expect(@widget_report_vendor_and_guest_os.grouped_subscribers).to be_empty
+        expect { FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :set_data_with_one_widget, :name => "#{@user1.userid}|Home", :owner => @user1.current_group) }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
       context 'with subscribers' do
         before do
-          ws = FactoryBot.create(:miq_widget_set, :name => "Home", :userid => @user1.userid, :group_id => @group1.id)
+          ws = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => "Home", :userid => @user1.userid, :group_id => @group1.id)
           @widget_report_vendor_and_guest_os.make_memberof(ws)
         end
 
@@ -199,7 +196,7 @@ RSpec.describe MiqWidget do
       end
 
       def add_dashboard_for_user(db_name, userid, group)
-        FactoryBot.create(:miq_widget_set, :name => db_name, :userid => userid, :group_id => group)
+        FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => db_name, :userid => userid, :group_id => group)
       end
     end
 
@@ -306,8 +303,8 @@ RSpec.describe MiqWidget do
         read_only: true
       ')
 
-      ws1 = FactoryBot.create(:miq_widget_set, :name => "default", :userid => user1.userid, :group_id => group1.id)
-      ws2 = FactoryBot.create(:miq_widget_set, :name => "default", :userid => @user2.userid, :group_id => @group2.id)
+      ws1 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => "default", :userid => user1.userid, :group_id => group1.id)
+      ws2 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => "default", :userid => @user2.userid, :group_id => @group2.id)
       @widget = MiqWidget.sync_from_hash(attrs)
       ws1.add_member(@widget)
       ws2.add_member(@widget)
@@ -484,7 +481,7 @@ RSpec.describe MiqWidget do
     it "with multiple timezones in one group" do
       user_est =  FactoryBot.create(:user, :userid => 'user_est', :miq_groups => [@group2], :settings => {:display => {:timezone => "Eastern Time (US & Canada)"}})
       expect(user_est.get_timezone).to eq("Eastern Time (US & Canada)")
-      ws = FactoryBot.create(:miq_widget_set, :name => "default", :userid => "user_est", :group_id => @group2.id)
+      ws = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => "default", :userid => "user_est", :group_id => @group2.id)
       ws.add_member(@widget)
 
       expect_any_instance_of(MiqWidget).to receive(:generate_content).with("MiqGroup", @group2.name, nil, ["Eastern Time (US & Canada)", "UTC"])
@@ -497,7 +494,7 @@ RSpec.describe MiqWidget do
     it "with report_sync" do
       user_est =  FactoryBot.create(:user, :userid => 'user_est', :miq_groups => [@group2], :settings => {:display => {:timezone => "Eastern Time (US & Canada)"}})
       expect(user_est.get_timezone).to eq("Eastern Time (US & Canada)")
-      ws = FactoryBot.create(:miq_widget_set, :name => "default", :userid => "user_est", :group_id => @group2.id)
+      ws = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => "default", :userid => "user_est", :group_id => @group2.id)
       ws.add_member(@widget)
 
       expect_any_instance_of(MiqWidget).to receive(:generate_content).with("MiqGroup", @group2.name, nil,
@@ -519,16 +516,17 @@ RSpec.describe MiqWidget do
         @widget.visibility[:roles] = "_ALL_"
         new_group1 = FactoryBot.create(:miq_group, :role => "operator")
         new_ws1 = FactoryBot.create(:miq_widget_set,
-                                     :name     => "default",
-                                     :userid   => @user2.userid,
-                                     :group_id => new_group1.id)
+                                    :set_data_with_one_widget,
+                                    :name     => "default",
+                                    :userid   => @user2.userid,
+                                    :group_id => new_group1.id)
         new_ws1.add_member(@widget)
 
         new_group2 = FactoryBot.create(:miq_group, :role => "approver")
-        new_ws2 = FactoryBot.create(:miq_widget_set,
-                                     :name     => "default",
-                                     :userid   => @user2.userid,
-                                     :group_id => new_group2.id)
+        new_ws2 = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget,
+                                    :name     => "default",
+                                    :userid   => @user2.userid,
+                                    :group_id => new_group2.id)
         new_ws2.add_member(@widget)
 
         call_count = 0
@@ -541,7 +539,7 @@ RSpec.describe MiqWidget do
         @widget.visibility[:roles] = "_ALL_"
         MiqWidgetSet.destroy_all
         user = FactoryBot.create(:user, :userid => 'alone', :miq_groups => [@group2])
-        ws = FactoryBot.create(:miq_widget_set, :name => "default", :userid => user.userid)
+        ws = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :name => "default", :userid => user.userid, :read_only => true)
         ws.add_member(@widget)
 
         expect(@widget).to receive(:generate_content_options).never
@@ -667,15 +665,15 @@ RSpec.describe MiqWidget do
                                    :miq_groups => [@group])
 
       @ws1 = FactoryBot.create(:miq_widget_set,
-                                :name     => "HOME",
-                                :userid   => @user1.userid,
-                                :group_id => @group.id
-                               )
+                               :set_data_with_one_widget,
+                               :name     => "HOME",
+                               :userid   => @user1.userid,
+                               :group_id => @group.id)
       @ws2 = FactoryBot.create(:miq_widget_set,
-                                :name     => "HOME",
-                                :userid   => @user2.userid,
-                                :group_id => @group.id
-                               )
+                               :set_data_with_one_widget,
+                               :name     => "HOME",
+                               :userid   => @user2.userid,
+                               :group_id => @group.id)
     end
 
     context "for non-self service user" do
@@ -758,7 +756,7 @@ RSpec.describe MiqWidget do
       before do
         @role.update(:settings => {:restrictions => {:vms => :user_or_group}})
         @group2 = FactoryBot.create(:miq_group, :miq_user_role => @role)
-        @ws3    = FactoryBot.create(:miq_widget_set,
+        @ws3    = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget,
                                      :name     => "HOME",
                                      :userid   => @user1.userid,
                                      :group_id => @group2.id

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -482,15 +482,15 @@ RSpec.describe RelationshipMixin do
 
   context ".alias_with_relationship_type" do
     before do
-      @ws = FactoryBot.create(:miq_widget_set)
-      @w1 = FactoryBot.create(:miq_widget)
-      @w2 = FactoryBot.create(:miq_widget)
-      @ws.add_member(@w1)
-      @ws.add_member(@w2)
+      group = FactoryBot.create(:miq_group)
+      @ws = FactoryBot.create(:miq_widget_set, :set_data_with_one_widget, :owner => group)
+      @widget = FactoryBot.create(:miq_widget)
+
+      @ws.add_member(@widget)
     end
 
     it "of a method with arguments" do
-      @ws.remove_member(@w1)
+      @ws.remove_member(@widget)
       expect(@ws.members.length).to eq(1)
     end
 


### PR DESCRIPTION
In order to add [MiqWidgetSet API Endpoint](https://github.com/ManageIQ/manageiq-api/pull/968)  following validations and update on related objects have been extracted from [UI dashboard controller:](url)

- Name cannot contain "|"
-  ~~Name cannot be changed during UPDATE~~ (only API)
- Unique description inside group
- At least one widget in `set_data`
- Widgets in set_data have to exist
- group_id has to be present for non-read_only
- Cannot delete readonly widget set


PR also adds initializaation of set_data and
`methods `update_members` and `delete_from_dashboard_order`, `add_to_dashboard_order `

  
@miq-bot add_label refactoring


#### Links
- [MiqWidgetSet API Endpoint](https://github.com/ManageIQ/manageiq-api/pull/968) 
