### PR TITLE
Honor zone setting when queuing launch_ansible_job.

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -4,6 +4,10 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   delegate :playbook, :repository, :to => :service_template, :allow_nil => true
 
+  def my_zone
+    miq_request&.my_zone
+  end
+
   # A chance for taking options from automate script to override options from a service dialog
   def preprocess(action, add_options = {})
     if add_options.present?
@@ -33,7 +37,8 @@ class ServiceAnsiblePlaybook < ServiceGeneric
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "launch_ansible_job",
-      :role        => "embedded_ansible"
+      :role        => "embedded_ansible",
+      :zone        => my_zone
     }
 
     task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -248,6 +248,26 @@ RSpec.describe(ServiceAnsiblePlaybook) do
     end
   end
 
+  describe '#launch_ansible_job_queue' do
+    it "delivers to the queue" do
+      task = double("miq_task", :status_ok? => true)
+      request = double("miq_request", :my_zone => 'test')
+      allow(loaded_service).to receive(:miq_request).and_return(request)
+      q_options = {
+        :args        => [action],
+        :class_name  => described_class.name,
+        :instance_id => loaded_service.id,
+        :method_name => "launch_ansible_job",
+        :role        => "embedded_ansible",
+        :zone        => request.my_zone
+      }
+
+      expect(MiqQueue).to receive(:put).with(hash_including(q_options))
+      expect(MiqTask).to receive(:wait_for_taskid).and_return(task)
+      loaded_service.launch_ansible_job_queue(action)
+    end
+  end
+
   describe '#check_completed' do
     shared_examples 'checking progress for job execution' do |raw_status, expected_return|
       before do


### PR DESCRIPTION
Specify the zone when putting embedded ansible job into the queue.

@miq-bot add_label bug, lifecycle/services

https://bugzilla.redhat.com/show_bug.cgi?id=1905056

cc @tinaafitz 