### PR TITLE
Decrypt all text fields as passwords may have different key names

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -649,10 +649,9 @@ class MiqQueue < ApplicationRecord
     opts = messaging_options_from_env || messaging_options_from_file
     return if opts.nil?
 
-    opts.transform_values! { |v| String === v ? ManageIQ::Password.try_decrypt(v) : v }
+    opts.transform_values! { |v| v.kind_of?(String) ? ManageIQ::Password.try_decrypt(v) : v }
     opts.merge(:encoding => "json", :protocol => messaging_protocol)
   end
-
   private_class_method :messaging_client_options
 
   def self.messaging_protocol

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -646,11 +646,13 @@ class MiqQueue < ApplicationRecord
   private_class_method :optional_values
 
   def self.messaging_client_options
-    (messaging_options_from_env || messaging_options_from_file)&.merge(
-      :encoding => "json",
-      :protocol => messaging_protocol,
-    )&.tap { |h| h[:password] = ManageIQ::Password.try_decrypt(h.delete(:password)) }
+    opts = messaging_options_from_env || messaging_options_from_file
+    return if opts.nil?
+
+    opts.transform_values! { |v| String === v ? ManageIQ::Password.try_decrypt(v) : v }
+    opts.merge(:encoding => "json", :protocol => messaging_protocol)
   end
+
   private_class_method :messaging_client_options
 
   def self.messaging_protocol

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1058,15 +1058,16 @@ RSpec.describe MiqQueue do
 
       it "with encrypted password" do
         allow(YAML).to receive(:load_file).and_call_original
-        expect(YAML).to receive(:load_file).with(MiqQueue::MESSAGING_CONFIG_FILE).and_return("test" => {"hostname" => "kafka.example.com", "port" => 9092, "username" => "user", "password" => ManageIQ::Password.encrypt("password")})
+        expect(YAML).to receive(:load_file).with(MiqQueue::MESSAGING_CONFIG_FILE).and_return("test" => {"hostname" => "kafka.example.com", "port" => 9092, "username" => "user", "password" => ManageIQ::Password.encrypt("password"), "sasl.password" => ManageIQ::Password.encrypt("password")})
 
         expect(MiqQueue.send(:messaging_client_options)).to eq(
-          :encoding => "json",
-          :host     => "kafka.example.com",
-          :password => "password",
-          :port     => 9092,
-          :protocol => nil,
-          :username => "user"
+          :encoding        => "json",
+          :host            => "kafka.example.com",
+          :password        => "password",
+          :port            => 9092,
+          :protocol        => nil,
+          :"sasl.password" => "password",
+          :username        => "user"
         )
       end
     end


### PR DESCRIPTION
This is part of the solution for:
https://github.com/ManageIQ/manageiq-appliance-build/issues/456


Different security protocols will have different options, with passwords stored with different keys.

This PR will attempt to decrypt all options of type String, which will result in a no-op for strings not
encrypted.

Steps for Testing/QA 
-------------------------------

Configure an appliance with Kafka and monitor the kakfa topic `manageiq.ems-events` 

For example:

```bash
/opt/kafka/bin/kafka-console-consumer.sh --topic manageiq.ems-events --bootstrap-server my-kafka-server.example.com:9093 --consumer.config /opt/kafka/config/client.properties
```

