### PR TITLE
Support synchronized dialog fields when adding a new OVF service template

### DIFF
--- a/app/models/miq_provision_orch_workflow.rb
+++ b/app/models/miq_provision_orch_workflow.rb
@@ -52,7 +52,22 @@ class MiqProvisionOrchWorkflow < MiqProvisionVirtWorkflow
     result[:vm] = ci_to_hash_struct(svm)
     result[:ems] = ci_to_hash_struct(svm.ext_management_system)
 
-    result
+    return result if result.blank?
+
+    add_target(:host_id, :host, Host, result)
+    add_target(:storage_id, :storage, Storage, result)
+    add_target(:resource_pool_id, :respool, ResourcePool, result)
+    add_target(:ems_folder_id, :folder, EmsFolder, result)
+
+    if result[:folder_id].nil?
+      add_target(:datacenter_id, :datacenter, EmsFolder, result)
+    else
+      result[:datacenter] = find_datacenter_for_ci(result[:folder], get_ems_metadata_tree(result))
+      result[:datacenter_id] = result[:datacenter].id unless result[:datacenter].nil?
+    end
+
+    rails_logger('get_source_and_targets', 1)
+    @target_resource = result
   end
 
   # Run the relationship methods and perform set intersections on the returned values.
@@ -62,5 +77,23 @@ class MiqProvisionOrchWorkflow < MiqProvisionVirtWorkflow
     return {} if (sources = resources_for_ui).blank?
     get_ems_metadata_tree(sources)
     super(ci, relats, sources, filtered_ids)
+  end
+
+  def self.automate_dialog_request
+    nil
+  end
+
+  def self.default_dialog_file
+    "miq_provision_vmware_dialogs_ovf"
+  end
+
+  def update_field_visibility(options = {})
+  end
+
+  def set_on_vm_id_changed
+  end
+
+  def allowed_storage_profiles(_options = {})
+    []
   end
 end


### PR DESCRIPTION
Add a few methods to support synchronized dialog fields when adding a new OVF service template.

Related to https://github.com/ManageIQ/manageiq-providers-vmware/pull/680.

@miq-bot add_label enhancement, lifecycle/services
 
https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/16023

