### PR TITLE
add a queue post service provision log message

### DIFF
--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -98,6 +98,8 @@ class ServiceTemplateProvisionTask < MiqRequestTask
   end
 
   def queue_post_provision
+    _log.info("Queuing post provision of #{self.class.name} id: #{id}, zone: #{my_zone}")
+
     MiqQueue.put(
       :class_name     => self.class.name,
       :instance_id    => id,


### PR DESCRIPTION
this might be useful for tracking the zone info that got added last year

@miq-bot add_label enhancement