### PR TITLE
re-add the service display deprecation

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -63,6 +63,7 @@ class Service < ApplicationRecord
   include CustomActionsMixin
   include CustomAttributeMixin
   include ExternalUrlMixin
+  include DeprecationMixin
   include LifecycleMixin
   include Metric::CiMixin
   include NewWithTypeStiMixin
@@ -107,6 +108,7 @@ class Service < ApplicationRecord
 
   alias parent_service parent
   alias_attribute :service, :parent
+  deprecate_attribute :display, :visible
   virtual_belongs_to :service
 
   def power_states


### PR DESCRIPTION
In lieu of a process for determining which of these should be hidden and which should be deprecated, my decision to remove these lines was potentially too hasty.

"I'm not sure that we should have hidden this and removed the deprecation..." from https://github.com/ManageIQ/manageiq/pull/20456#issuecomment-744697746 sounds like we might change our minds. This is for if we do so.