### PR TITLE
add back the alias for all vms and templates

### DIFF
--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -8,5 +8,8 @@ module AggregationMixin
     virtual_sum :aggregate_physical_cpus,   :host_hardwares, :cpu_sockets
     virtual_sum :aggregate_vm_cpus,         :vm_hardwares,   :cpu_sockets
     virtual_sum :aggregate_vm_memory,       :vm_hardwares,   :memory_mb
+
+    alias_method :all_vms_and_templates,  :vms_and_templates
+    alias_method :all_vm_or_template_ids, :vm_or_template_ids
   end
 end


### PR DESCRIPTION
the change in the ui to use `vms_and_templates` instead of `all_vms_and_templates` broke the list of vms loaded under folders. for now i'd like to revert the change that took this alias out. 

(broken in https://github.com/ManageIQ/manageiq-ui-classic/pull/7136 and https://github.com/ManageIQ/manageiq/pull/20149 originally)

related to https://github.com/ManageIQ/manageiq-ui-classic/pull/7542

see https://gitter.im/ManageIQ/manageiq?at=5fda3ad21082b94fe1d53659

@miq-bot add_label bug

