### PR TITLE
Run MiqServer.status_update in server process

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -4,7 +4,7 @@ class MiqScheduleWorker::Jobs
   end
 
   def miq_server_status_update
-    queue_work(:class_name  => "MiqServer", :method_name => "status_update", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqServer", :method_name => "status_update", :queue_name => 'miq_server', :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def miq_server_worker_log_status

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -60,4 +60,17 @@ RSpec.describe MiqScheduleWorker::Jobs do
       )
     end
   end
+
+  context "with guid, server, zone" do
+    let!(:guid_server_zone) { EvmSpecHelper.create_guid_miq_server_zone }
+    let(:guid) { guid_server_zone.first }
+    let(:zone) { guid_server_zone.last }
+
+    context "queues for miq_server process" do
+      it "#miq_server_status_update" do
+        described_class.new.miq_server_status_update
+        expect(MiqQueue.where(:method_name => "status_update").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #20835
[Errno::ESRCH]: No such process ... when run from a worker.

In appliance/systemd, you can run status_update in the server's workers.
In podified, each process is isolated so we must run this, specifically
process_status, in the server process.

It didn't make sense to run this is in the worker processes anyway so
change all installations to run this in the server process.

Note, I'm looking at the surrounding lines in this file and seeing that we're logging stuff in random generic/priority workers and much of it doesn't make sense in pods or even appliances... I'll add `:queue_name => 'miq_server'` to them in a followup as they're not BROKEN but just weird.  I'll keep this separate since it's broken and more backportable.