### PR TITLE
don't require enumerator

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1,4 +1,3 @@
-require 'enumerator'
 require 'ostruct'
 
 class MiqRequestWorkflow


### PR DESCRIPTION
I think we don't need this. 

@miq-bot add_label cleanup
