### PR TITLE
Regex event detection

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -62,13 +62,13 @@ class EventStream < ApplicationRecord
 
     group = egroups.detect do |_, value|
       GROUP_LEVELS
-        .detect { |lvl| value[lvl]&.any? { |typ| typ.kind_of?(String) && typ == event_type } }
+        .detect { |lvl| value[lvl]&.any? { |typ| !typ.starts_with?("/") && typ == event_type } }
         .tap { |level_found| level = level_found || level }
     end&.first
 
     group ||= egroups.detect do |_, value|
       GROUP_LEVELS
-        .detect { |lvl| value[lvl]&.any? { |typ| typ.kind_of?(Regexp) && typ.match(event_type) } }
+        .detect { |lvl| value[lvl]&.any? { |typ| typ.starts_with?("/") && Regexp.new(typ[1..-2]).match?(event_type) } }
         .tap { |level_found| level = level_found || level }
     end&.first
 

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe EmsEvent do
       end
 
       let(:provider_event) { 'SomeSpecialProviderEvent' }
-      let(:provider_regex) { /Some.+Event/ }
+      let(:provider_regex) { "/Some.+Event/" }
 
       it 'returns the provider event if configured' do
         expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/17201

### Overview

The serialization of regular expressions in our yaml file is giving us issues when transitioning the data over json. 
this  breaks the react code that is transferring it

See issues in https://github.com/ManageIQ/manageiq-api/issues/979

### Solution

Store strings in yaml that are strings, but are detectable as being a regular expression.
This does transition the task of detecting it is a regular expression from yaml to ruby, but since that code already has special provisions for regular expression, it didn't seem to add too much additional knowledge.

### Implementation
This is a single line change. but I had to do a little too much to get there.

Please look at individual commits to see what is the refactor and what is the actual change.

### Tangent

I did not feel comfortable adding the regular expression logic in the loop. It is probably the same thing but this loop triggers events and needs to be as tight as possible.

It seems like we may be able to avoid this conversion every time. Especially since this is mostly relatively static. If we did that, we would see a big performance boost
