### PR TITLE
settings.yml support string settings values

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -19,7 +19,7 @@ class MiqWorker::Runner
 
   def poll_method
     return @poll_method unless @poll_method.nil?
-    self.poll_method = worker_settings[:poll_method]
+    self.poll_method = worker_settings[:poll_method]&.to_sym
   end
 
   def poll_method=(val)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -963,13 +963,13 @@
   :worker_monitor:
     :enforce_resource_constraints: false
     :kill_algorithm:
-      :name: :used_swap_percent_gt_value
+      :name: used_swap_percent_gt_value
       :value: 80
     :miq_server_time_threshold: 2.minutes
     :nice_delta: 1
     :poll: 2.seconds
     :start_algorithm:
-      :name: :used_swap_percent_lt_value
+      :name: used_swap_percent_lt_value
       :value: 60
     :sync_interval: 30.minutes
     :wait_for_started_timeout: 10.minutes
@@ -1064,7 +1064,7 @@
       :parent_time_threshold: 3.minutes
       :poll: 3.seconds
       :poll_escalate_max: 30.seconds
-      :poll_method: :normal
+      :poll_method: normal
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
       :systemd_enabled: true
@@ -1083,28 +1083,28 @@
         :poll: 10.seconds
     :queue_worker_base:
       :defaults:
-        :dequeue_method: :drb
-        :poll_method: :normal
+        :dequeue_method: drb
+        :poll_method: normal
         :queue_timeout: 10.minutes
       :ems_metrics_collector_worker:
         :defaults:
           :count: 2
           :nice_delta: 3
-          :poll_method: :escalate
+          :poll_method: escalate
       :ems_metrics_processor_worker:
         :count: 2
         :memory_threshold: 800.megabytes
         :nice_delta: 7
-        :poll_method: :escalate
+        :poll_method: escalate
       :ems_operations_worker: {}
       :ems_refresh_worker:
         :defaults:
           :memory_threshold: 2.gigabytes
           :nice_delta: 7
           :poll: 10.seconds
-          :poll_method: :normal
+          :poll_method: normal
           :queue_timeout: 120.minutes
-          :dequeue_method: :sql
+          :dequeue_method: sql
       :event_handler:
         :nice_delta: 7
       :generic_worker:

--- a/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe MiqServer do
       _, @server, = EvmSpecHelper.create_guid_miq_server_zone
       @monitor_settings = YAML.load(<<-EOS
         :kill_algorithm:
-          :name: :used_swap_percent_gt_value
+          :name: used_swap_percent_gt_value
           :value: 80
         :start_algorithm:
-          :name: :used_swap_percent_lt_value
+          :name: used_swap_percent_lt_value
           :value: 60
         EOS
                                    )


### PR DESCRIPTION
### Overview
The serialization of symbols in our yaml file is giving us issues when transferring the data over json.
this breaks the react code that is transferring it

See issues in ManageIQ/manageiq-api#979

### Change

Most of the symbol values we use are used in send or have a `to_sym` so the storage format does not matter.
This change fixes the one place in our code where we do not have a to_sym

### yaml changes

I'm more than happy removing the yaml change, I just wanted us to see the underlying change so we can better visualize this PR.