### PR TITLE
Run server logging in the server process

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -1,23 +1,24 @@
 class MiqScheduleWorker::Jobs
   def vmdb_appliance_log_config
-    queue_work(:class_name  => "Vmdb::Appliance", :method_name => "log_config", :server_guid => MiqServer.my_guid)
+    queue_work(:class_name  => "Vmdb::Appliance", :method_name => "log_config", :queue_name => 'miq_server', :server_guid => MiqServer.my_guid)
   end
 
   def miq_server_status_update
+    # Needs to be run on the server process
     queue_work(:class_name  => "MiqServer", :method_name => "status_update", :queue_name => 'miq_server', :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def miq_server_worker_log_status
-    queue_work(:class_name  => "MiqServer", :method_name => "log_status",     :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
-    queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqServer", :method_name => "log_status",     :queue_name => 'miq_server', :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :queue_name => 'miq_server', :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def miq_server_audit_managed_resources
-    queue_work(:class_name  => "MiqServer", :method_name => "audit_managed_resources", :task_id => "audit_managed_resources", :server_guid => MiqServer.my_guid)
+    queue_work(:class_name  => "MiqServer", :method_name => "audit_managed_resources", :queue_name => 'miq_server', :task_id => "audit_managed_resources", :server_guid => MiqServer.my_guid)
   end
 
   def vmdb_database_connection_log_statistics
-    queue_work(:class_name  => "VmdbDatabaseConnection", :method_name => "log_statistics", :server_guid => MiqServer.my_guid)
+    queue_work(:class_name  => "VmdbDatabaseConnection", :method_name => "log_statistics", :queue_name => 'miq_server', :server_guid => MiqServer.my_guid)
   end
 
   def miq_server_queue_update_registration_status

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -67,9 +67,30 @@ RSpec.describe MiqScheduleWorker::Jobs do
     let(:zone) { guid_server_zone.last }
 
     context "queues for miq_server process" do
+      it "#vmdb_database_connection_log_statistics" do
+        described_class.new.vmdb_database_connection_log_statistics
+        expect(MiqQueue.where(:method_name => "log_statistics").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+      end
+
+      it "#miq_server_audit_managed_resources" do
+        described_class.new.miq_server_audit_managed_resources
+        expect(MiqQueue.where(:method_name => "audit_managed_resources").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+      end
+
       it "#miq_server_status_update" do
         described_class.new.miq_server_status_update
         expect(MiqQueue.where(:method_name => "status_update").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+      end
+
+      it "#miq_server_worker_log_status" do
+        described_class.new.miq_server_worker_log_status
+        expect(MiqQueue.where(:method_name => "log_status").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+        expect(MiqQueue.where(:method_name => "log_status_all").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+      end
+
+      it "#vmdb_appliance_log_config" do
+        described_class.new.vmdb_appliance_log_config
+        expect(MiqQueue.where(:method_name => "log_config").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
       end
     end
   end


### PR DESCRIPTION
This change benefits pods by having this logging all in the same log file,
like appliances, by making the same server process log these messages.
This doesn't affect  appliances much but will make finding these log
message much easier in pods.

Followup to #20904