### PR TITLE
remove unneeded base_class assignment

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -248,7 +248,7 @@ module Rbac
         else
           target_ids  = targets.collect(&:id)
           klass       = targets.first.class
-          klass       = base_class if !klass.respond_to?(:find) && (base_class = rbac_base_class(klass))
+          klass       = rbac_base_class(klass) unless klass.respond_to?(:find)
           klass       = safe_base_class(klass) if is_sti?(klass) # always scope to base class if model is STI
         end
         scope = apply_scope(klass, scope)


### PR DESCRIPTION
think this assignment can be condensed since `(base_class = rbac_base_class(klass))` isn't doing much

@miq-bot add_label cleanup

<sub><sup> 139/365 = 0.3808 </sub></sup>