### PR TITLE
remove unused vm var in vm hardware calculation test

### DIFF
--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -880,9 +880,9 @@ RSpec.describe VmOrTemplate do
     end
 
     it "uses calculated (inline) attribute with null hardware" do
-      vm = FactoryBot.create(:vm_vmware)
-      vm2 = VmOrTemplate.select(:id, :provisioned_storage).first
-      expect { expect(vm2.provisioned_storage).to eq(0) }.to_not make_database_queries
+      FactoryBot.create(:vm_vmware)
+      vm = VmOrTemplate.select(:id, :provisioned_storage).first
+      expect { expect(vm.provisioned_storage).to eq(0) }.to_not make_database_queries
     end
 
     it "calculates in ruby" do


### PR DESCRIPTION
we're not using this

@miq-bot add_label test, cleanup