### PR TITLE
use underscores for naming arguments we're not using in evm database ops

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -220,7 +220,7 @@ class EvmDatabaseOps
     PostgresAdmin.gc(options)
   end
 
-  def self.database_connections(database = nil, type = :all)
+  def self.database_connections(database = nil, _type = :all)
     database ||= ActiveRecord::Base.configurations[Rails.env]["database"]
     conn = ActiveRecord::Base.connection
     conn.client_connections.count { |c| c["database"] == database }


### PR DESCRIPTION
what the title says


@miq-bot add_label cleanup
