### PR TITLE
use underscores for unused args in miq_alert queue alert test

### DIFF
--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MiqAlert do
         messages = MiqQueue.order("id")
         expect(messages.length).to eq(@events_to_alerts.length)
 
-        messages.each_with_index do |msg, i|
+        messages.each_with_index do |msg, _i|
           alert = MiqAlert.find_by(:id => msg.instance_id)
           expect(alert).not_to be_nil
 


### PR DESCRIPTION
i don't think we're using this argument and i need a commit for the day 


@miq-bot add_label cleanup
