### PR TITLE
remove unused generic_group_set variable in generic object def test

### DIFF
--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe GenericObjectDefinition do
     it "returns the custom actions in a hash grouped by buttons and button groups" do
       FactoryBot.create(:custom_button, :name => "generic_no_group", :applies_to_class => "GenericObject")
       generic_group = FactoryBot.create(:custom_button, :name => "generic_group", :applies_to_class => "GenericObject")
-      generic_group_set = FactoryBot.create(:custom_button_set, :name => "generic_group_set", :set_data => {:button_order => [generic_group.id]})
+      FactoryBot.create(:custom_button_set, :name => "generic_group_set", :set_data => {:button_order => [generic_group.id]})
 
       FactoryBot.create(
         :custom_button,


### PR DESCRIPTION
we're not using this variable in this test and once again i have to have a commit for the day

@miq-bot add_label cleanup
