### PR TITLE
Fix simulate_queue_worker not marking queue records as state dequeue

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -33,6 +33,7 @@ module Vmdb
         end
         if q
           puts "\e[33;1m\n** Delivering #{MiqQueue.format_full_log_msg(q)}\n\e[0;m"
+          q.update!(:state => MiqQueue::STATE_DEQUEUE, :handler => MiqServer.my_server)
           status, message, result = q.deliver
           q.delivered(status, message, result) unless status == MiqQueue::STATUS_RETRY
         else


### PR DESCRIPTION
When a queue_worker performs a `MiqQueue.get()` the messages are marked with `msg.update!(:state => STATE_DEQUEUE` before being returned to the worker to be operated on.

This is critical if the queue item being executed does a `MiqQueue.put_or_update` which might update the current queue item.  A good example of this is (maybe the only one?) `EmsRefresh.refresh` which queues refreshes for its child managers.

If the current queue item being run isn't marked as `"dequeue"` then instead of creating a new queue item for the child managers, the child targets are merged into the current queue item which is then deleted after it is completed.  This results in the child managers never getting refreshed.