### PR TITLE
Mark x axis labels as translations in Overview -> Utilization chart

### DIFF
--- a/config/locale_task_config.yaml
+++ b/config/locale_task_config.yaml
@@ -36,3 +36,4 @@ yaml_strings_to_extract:
   - title
   - name
   - headers
+  - generate_rows

--- a/lib/manageiq/reporting/formatter/c3.rb
+++ b/lib/manageiq/reporting/formatter/c3.rb
@@ -50,7 +50,7 @@ module ManageIQ
           if chart_is_2d?
             category_labels = categories.collect { |c| c.kind_of?(Array) ? c.first : c }
             limit = pie_type? ? LEGEND_LENGTH : LABEL_LENGTH
-            mri.chart[:axis][:x][:categories] = category_labels.collect { |c| slice_legend(c, limit) }
+            mri.chart[:axis][:x][:categories] = category_labels.collect { |c| slice_legend(_(c), limit) }
             mri.chart[:miq][:category_table] = category_labels
           end
         end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -72,6 +72,15 @@ namespace :locale do
       end
     end
 
+    def key_from_yaml(yaml_key_value)
+      case yaml_key_value
+      when Array
+        yaml_key_value.first
+      else
+        yaml_key_value
+      end
+    end
+
     root_path = args[:root] || Rails.root
 
     config_file = root_path.join('config/locale_task_config.yaml')
@@ -97,7 +106,7 @@ namespace :locale do
         output[key].sort.uniq.each do |file|
           f.puts "# TRANSLATORS: file: #{file}"
         end
-        f.puts '_("%{key}")' % {:key => key}
+        f.puts '_("%{key}")' % {:key => key_from_yaml(key)}
       end
     end
   end


### PR DESCRIPTION
 - [x] https://github.com/ManageIQ/manageiq/pull/20929 (to avoid conflicts)  

Fixes https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/8675,
this translations from `Overview -> Utilization -> Enterprise` label x axis:

before

<img width="1402" alt="Screenshot 2021-01-05 at 20 36 48" src="https://user-images.githubusercontent.com/14937244/103690991-c80dc880-4f95-11eb-9cf8-27e9e6e430d7.png">


after

<img width="1424" alt="Screenshot 2021-01-05 at 20 26 51" src="https://user-images.githubusercontent.com/14937244/103690064-70bb2880-4f94-11eb-90dd-7cde344152f8.png">

- report uses this [yaml](https://github.com/ManageIQ/manageiq/blob/master/product/charts/miq_reports/vim_perf_util_4_ts.yaml#L39)
- but rake task  `locale:extract_yaml_strings` was failings when I added required  `generate_rows` to  [locale_task_config.yaml ](https://github.com/ManageIQ/manageiq/blob/master/config/locale_task_config.yam)
- it was failing because rake task did not count with array in the key `generate_rows` - **this PR fixes this**
- this PR also marks x axis labels as translations in chart

### Summary
- this PR fixes so rake task  `locale:extract_yaml_strings`  can work with array in the keys of yaml
- this PR also marks x axis labels as translations in chart (red square on the picture)

@miq-bot assign @mzazrivec 


# Links
- [ ] https://github.com/ManageIQ/manageiq/pull/20929 (to avoid conflicts) 
- [ ] https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10136?

@miq-bot add_label translations

