### PR TITLE
Fix CPU cores for chargeback project

### DIFF
--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe ChargebackContainerProject do
 
   let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
+  def cpu_cores_used_metric_for(project, hours)
+    metric_used = used_average_for(:cpu_usage_rate_average, hours, project)
+    derived_vm_numvcpus = used_average_for(:derived_vm_numvcpus, project.metric_rollups.count, project)
+
+    (metric_used * derived_vm_numvcpus) / 100.00
+  end
+
   before do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
@@ -73,14 +80,14 @@ RSpec.describe ChargebackContainerProject do
       end
 
       it "cpu" do
-        metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day, @project)
+        metric_used = cpu_cores_used_metric_for(@project, hours_in_day)
         expect(subject.cpu_cores_used_metric).to eq(metric_used)
         expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
       end
     end
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day, @project)
+      metric_used = cpu_cores_used_metric_for(@project, hours_in_day)
       expect(subject.cpu_cores_used_metric).to eq(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
@@ -113,7 +120,7 @@ RSpec.describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month, @project)
+      metric_used = cpu_cores_used_metric_for(@project, hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
@@ -147,7 +154,7 @@ RSpec.describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month, @project)
+      metric_used = cpu_cores_used_metric_for(@project, hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
@@ -165,7 +172,7 @@ RSpec.describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month, @project)
+      metric_used = cpu_cores_used_metric_for(@project, hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
       expect(subject.tag_name).to eq('Production')


### PR DESCRIPTION
There is column **CPU Cores Used Metric** in chargeback project.
We lastly updated this column [here](https://github.com/ManageIQ/manageiq/pull/8547) where `v_derived_cpu_total_cores_used`  was replaced with `cpu_usage_rate_average` because `v_derived_cpu_total_cores_used`  is virtual column and 
we could not use `v_derived_cpu_total_cores_used`  in base sql query (see discussion in  [PR](https://github.com/ManageIQ/manageiq/pull/8547))

It looks that we had intention to recalculate **CPU Cores Used Metric** back to `v_derived_cpu_total_cores_used `  after chargeback metrics generation is done and **this is fixed in this PR**

Virtual column `v_derived_cpu_total_cores_used`  is using only values 
which are fetched by base chargeback metric rollup query - and we wanted to usage of `v_derived_cpu_total_cores_used` and calculate it later:

```ruby
#./app/models/metric/common.rb:130

def v_derived_cpu_total_cores_used
    return nil if cpu_usage_rate_average.nil? || derived_vm_numvcpus.nil? || derived_vm_numvcpus == 0
    (cpu_usage_rate_average * derived_vm_numvcpus) / 100.0
end
```

### Summary 
Fix is that we calculate `v_derived_cpu_total_cores_used`  after  metric rollup query in chargeback is run for processed interval.

**Before:**
<img width="368" alt="cores_before" src="https://user-images.githubusercontent.com/14937244/103897173-6bc0bb00-50f3-11eb-9eb4-2fd1764fa284.png">

**After:**
<img width="376" alt="cores_after" src="https://user-images.githubusercontent.com/14937244/103897159-65cada00-50f3-11eb-8981-1ee2bc5f308b.png">


### Links
- https://bugzilla.redhat.com/show_bug.cgi?id=1908558

