### PR TITLE
Changed Policy Log start page url to new path

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -451,7 +451,7 @@
   :startup: true
 - :name: policy_logs
   :description: Control / Log
-  :url: /miq_policy/log
+  :url: /miq_policy_log
   :rbac_feature_name: policy_log
   :startup: true
 - :name: embedded_configuration_script_payload


### PR DESCRIPTION
Pre work for https://github.com/ManageIQ/manageiq-ui-classic/pull/7401

Split Control/Log sub menu code from Policy Controller into it's own controller for simplicity, due these changes, url has changed so this PR addresses that change. UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7557

@skateman please review.