### PR TITLE
[WIP] hide ancestry from the api

### DIFF
--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -2,6 +2,8 @@ require 'ancestry'
 
 class MiqAeNamespace < ApplicationRecord
   has_ancestry
+  hide_attribute :ancestry
+
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
   include RelativePathMixin

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -17,6 +17,7 @@ class OrchestrationStack < ApplicationRecord
   acts_as_miq_taggable
 
   has_ancestry
+  hide_attribute :ancestry
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :tenant

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -2,6 +2,7 @@ require 'ancestry'
 
 class Relationship < ApplicationRecord
   has_ancestry
+  hide_attribute :ancestry
 
   belongs_to :resource, :polymorphic => true
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -21,6 +21,7 @@ class Service < ApplicationRecord
   }.freeze
 
   has_ancestry :orphan_strategy => :destroy
+  hide_attribute :ancestry
 
   belongs_to :service_template # Template this service was cloned from
   belongs_to :tenant

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -20,6 +20,7 @@ class Tenant < ApplicationRecord
   before_destroy :ensure_can_be_destroyed
 
   has_ancestry(:orphan_strategy => :restrict)
+  hide_attribute :ancestry
 
   has_many :providers
   has_many :ext_management_systems


### PR DESCRIPTION
### Goal

Hide the ancestry column from the api

### Why

1. This is a private field with an internal implementation.
2. It is easy to mess up this field if a customer edits it directly.
3. Customers have already complained about this field.
4. For templates, the tree is sometimes defined in this field and other times with relationships. Better for us to expose the hierarchy with the correct logic rather than have customers inferring things, possibly incorrectly.

### Solution

Do not advertise this field in the API and miq expression builder.

1. This will not prevent access to this field.
2. Existing scripts will continue to work.
3. Future customer implementations will be encouraged to use fields that are documented (e.g.: `parent_id`) and are not part of an internal implementation.

