### PR TITLE
Don't git ignore Gemfile.lock.release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ certs/v2_key
 config/secrets.yml*
 coverage/
 Gemfile.lock*
+!Gemfile.lock.release
 GUID
 openstack_environments.yml
 nbproject/


### PR DESCRIPTION
As per https://github.com/ManageIQ/manageiq/pull/20545#discussion_r488069662

Gemfile.lock.release will be added to each branch when it gets closer to the GA release.