### PR TITLE
DatabaseBackup.supported_depots: Use model names rather than prefixes

### DIFF
--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -1,13 +1,8 @@
 class DatabaseBackup < ApplicationRecord
-  SUPPORTED_DEPOTS = {
-    'smb'   => 'Samba',
-    'nfs'   => 'Network File System',
-    's3'    => 'AWS S3',
-    'swift' => 'OpenStack Swift'
-  }.freeze
+  SUPPORTED_DEPOTS = %w[FileDepotSmb FileDepotNfs FileDepotS3 FileDepotSwift].freeze
 
   def self.supported_depots
-    SUPPORTED_DEPOTS
+    SUPPORTED_DEPOTS.map { |model| [model, model.constantize.display_name] }.to_h
   end
 
   def self.backup(options)

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -12,7 +12,7 @@ class FileDepot < ApplicationRecord
   attr_accessor         :file
 
   def self.supported_depots
-    @supported_depots ||= descendants.each_with_object({}) { |klass, hash| hash[klass.name] = klass.display_name }.freeze
+    descendants.each_with_object({}) { |klass, hash| hash[klass.name] = klass.display_name }
   end
 
   def self.supported_protocols

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -19,11 +19,6 @@ class FileDepot < ApplicationRecord
     @supported_protocols ||= subclasses.each_with_object({}) { |klass, hash| hash[klass.uri_prefix] = klass.name }.freeze
   end
 
-  def self.depot_description_to_class(description)
-    class_name = supported_depots.key(description)
-    class_name.try(:constantize)
-  end
-
   def self.requires_credentials?
     true
   end

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -12,7 +12,7 @@ class FileDepot < ApplicationRecord
   attr_accessor         :file
 
   def self.supported_depots
-    @supported_depots ||= descendants.each_with_object({}) { |klass, hash| hash[klass.name] = Dictionary.gettext(klass.name, :type => :model, :notfound => :titleize, :translate => false) }.freeze
+    @supported_depots ||= descendants.each_with_object({}) { |klass, hash| hash[klass.name] = klass.display_name }.freeze
   end
 
   def self.supported_protocols

--- a/spec/models/file_depot_spec.rb
+++ b/spec/models/file_depot_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe FileDepot do
-  it ".depot_description_to_class" do
-    expect(described_class.depot_description_to_class("FTP")).to eq(FileDepotFtp)
-    expect(described_class.depot_description_to_class("NFS")).to eq(FileDepotNfs)
-    expect(described_class.depot_description_to_class("Samba")).to eq(FileDepotSmb)
-    expect(described_class.depot_description_to_class("Anonymous FTP")).to eq(FileDepotFtpAnonymous)
-    expect(described_class.depot_description_to_class("OpenStack Swift")).to eq(FileDepotSwift)
-  end
-end


### PR DESCRIPTION
The motivation behind this PR was to get rid of `FileDepot.depot_description_to_class()` routine, used by UI controller code when creating / modifying log file depot. The routine takes a class display name such as `"AWS S3"` and returns a class name for it: `"FileDepotS3"`. We want to get rid of this routine, because:
1. in the UI code, we should be working with `class_identifier: class_display_name` pairs, not with just display names and then ask backend what the class name for that particular display name is
2. we had to introduce a hack into `Dictionary.gettext()` just to make this strange concept work for non-English locales
3. point 2 above blocks me from switching to rendering class display names in a pluggable manner (right now we render it from a dictionary file `locale/en.yml`)

Part of this PR is making `FileDepot.supported_depots()` and `DatabaseBackup.supported_depots()` work consistently: both should return `className: classDisplayName` pairs. In case we need a `uri_prefix` for a given class, we can obtain it using `.uri_prefix()` class method. This change is needed so that:
1. we don't duplicate prefixes in class definitions
2. the four UI forms which deal with creating / modifying file / database depots can work consistently (this is not the case now) 


To be merged with https://github.com/ManageIQ/manageiq-ui-classic/pull/7555