### PR TITLE
Fix undefined local variable or method `ensure_pod_monitor_started'

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -59,7 +59,7 @@ module MiqServer::WorkerManagement::Monitor
 
   def sync_from_system
     if podified?
-      ensure_pod_monitor_started
+      ensure_kube_monitors_started
     end
 
     cleanup_orphaned_worker_rows

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -35,17 +35,17 @@ RSpec.describe MiqServer::WorkerManagement::Monitor do
     end
 
     context "#sync_from_system" do
-      context "#ensure_pod_monitor_started" do
+      context "#ensure_kube_monitors_started" do
         it "podified, ensures pod monitor started and orphaned rows are removed" do
           allow(server).to receive(:podified?).and_return(true)
-          expect(server).to receive(:ensure_pod_monitor_started)
+          expect(server).to receive(:ensure_kube_monitors_started)
           expect(server).to receive(:cleanup_orphaned_worker_rows)
           server.sync_from_system
         end
 
         it "non-podified, orphaned rows are removed" do
           allow(server).to receive(:podified?).and_return(false)
-          expect(server).to receive(:ensure_pod_monitor_started).never
+          expect(server).to receive(:ensure_kube_monitors_started).never
           expect(server).to receive(:cleanup_orphaned_worker_rows)
           server.sync_from_system
         end


### PR DESCRIPTION
Introduced in #20792 
Fixes #20951

@jrafanie Please confirm that this is what was intended.