### PR TITLE
VmScan transitions from before_scan -> start_scan

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -93,6 +93,11 @@ class VmScan < Job
     signal(:start_scan)
   end
 
+  def start_scan
+    scanning
+    call_scan
+  end
+
   def call_scan
     _log.info("Enter")
 
@@ -129,6 +134,9 @@ class VmScan < Job
     # Check if Policy returned scan profiles to use, otherwise use the default profile if available.
     scan_args["vmScanProfiles"] = options[:scan_profiles] || vm.scan_profile_list
     scan_args
+  end
+
+  def after_scan
   end
 
   def call_synchronize

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -137,6 +137,7 @@ class VmScan < Job
   end
 
   def after_scan
+    signal(:synchronize)
   end
 
   def call_synchronize
@@ -328,6 +329,7 @@ class VmScan < Job
   # All other signals
   alias_method :initializing,       :dispatch_start
   alias_method :start,              :call_check_policy
+  alias_method :synchronize,        :call_synchronize
   alias_method :abort_job,          :process_abort
   alias_method :cancel,             :process_cancel
   alias_method :finish,             :process_finished

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -1,4 +1,102 @@
 RSpec.describe VmScan do
+  context "A single VM Scan Job," do
+    let(:server) { EvmSpecHelper.local_miq_server(:has_vix_disk_lib => true) }
+    let(:user) { FactoryBot.create(:user_with_group, :userid => "tester") }
+    let(:ems) { FactoryBot.create(:ems_infra, :zone => server.zone) }
+    let(:vm) { FactoryBot.create(:vm_infra, :ext_management_system => ems, :host => host, :miq_group => user.current_group, :evm_owner => user) }
+    let(:host) { FactoryBot.create(:host, :ext_management_system => ems) }
+    let(:job) { described_class.first }
+
+    describe "#scan" do
+      before do
+        allow(MiqEventDefinition).to receive_messages(:find_by => true)
+        allow(server).to receive(:has_active_role?).with('automate').and_return(true)
+
+        vm.scan
+
+        job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
+        job_item.delivered(*job_item.deliver)
+      end
+
+      it "should start in a state of waiting_to_start" do
+        expect(job.state).to eq("waiting_to_start")
+      end
+
+      context "waiting_to_start" do
+        before { job.update!(:state => "waiting_to_start") }
+
+        it "#start should transit to state checking_policy" do
+          job.signal(:start)
+          expect(job.reload.state).to eq("checking_policy")
+        end
+
+        it "#start should call before_start after checking policy" do
+          job.signal(:start)
+
+          # check_policy raises an miq_event, deliver the raise_evm_job_event
+          job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
+          job_item.delivered(*job_item.deliver)
+
+          expect_any_instance_of(described_class).to receive(:before_scan)
+
+          # Then deliver the signal from that event
+          queue_item = MiqQueue.find_by(:class_name => job.class.name, :method_name => "signal")
+          queue_item.delivered(*queue_item.deliver)
+        end
+      end
+
+      context "checking_policy" do
+        before { job.update!(:state => "checking_policy") }
+
+        it "#before_scan should transit to state before_scan" do
+          allow_any_instance_of(described_class).to receive(:before_scan)
+
+          job.signal(:before_scan)
+          expect(job.reload.state).to eq("before_scan")
+        end
+
+        it "#before_scan should call start_scan" do
+          expect_any_instance_of(described_class).to receive(:start_scan)
+
+          job.signal(:before_scan)
+          expect(job.reload.state).to eq("scanning")
+        end
+      end
+
+      context "scanning" do
+        before { job.update!(:state => "scanning") }
+
+        it "#after_scan transits to state after_scan" do
+          allow_any_instance_of(described_class).to receive(:after_scan)
+
+          job.signal(:after_scan)
+          expect(job.reload.state).to eq("after_scan")
+        end
+
+        it "#data should call process_data and stay in state scanning" do
+          expect_any_instance_of(described_class).to receive(:process_data)
+
+          job.signal(:data)
+          expect(job.reload.state).to eq("scanning")
+        end
+
+        it "#after_scan should call synchronize" do
+          expect_any_instance_of(described_class).to receive(:synchronize)
+          job.signal(:after_scan)
+        end
+      end
+
+      context "synchronizing" do
+        before { job.update!(:state => "synchronizing") }
+
+        it "#finish from process_data transits to state finished" do
+          job.signal(:finish)
+          expect(job.reload.state).to eq("finished")
+        end
+      end
+    end
+  end
+
   # test cases for BZ #1454936
   context "A VM Scan job in multiple zones" do
     before do


### PR DESCRIPTION
Add missing state transition method `start_scan` which actually initiates the scan.

Follow-ups:
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/543
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/686