### PR TITLE
Add and expose the supports create_network_router through the API

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -290,6 +290,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_volume_availability_zones, :type => :boolean
   virtual_column :supports_create_security_group, :type => :boolean
   virtual_column :supports_create_host_aggregate, :type => :boolean
+  virtual_column :supports_create_network_router, :type => :boolean
   virtual_column :supports_storage_services, :type => :boolean
 
   virtual_sum :total_vcpus,        :hosts, :total_vcpus
@@ -816,6 +817,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_create_host_aggregate
     supports_create_host_aggregate?
+  end
+
+  def supports_create_network_router
+    supports_create_network_router?
   end
 
   def supports_cinder_volume_types

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -82,6 +82,7 @@ module SupportsFeatureMixin
     :create_flavor                       => 'Flavor Creation',
     :create_floating_ip                  => 'Floating IP Creation',
     :create_host_aggregate               => 'Host Aggregate Creation',
+    :create_network_router               => 'Network Router Creation',
     :create_security_group               => 'Security Group Creation',
     :console                             => 'Remote Console',
     :external_logging                    => 'Launch External Logging UI',


### PR DESCRIPTION
Related issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6862

@miq-bot add_label enhancement
@miq-bot assign @agrare 