### PR TITLE
Implement define host initiator

### DIFF
--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -9,4 +9,60 @@ class HostInitiator < ApplicationRecord
   has_many :san_addresses, :as => :owner, :dependent => :destroy
 
   virtual_total :v_total_addresses, :san_addresses
+
+  supports :refresh_ems
+  supports_not :create
+  acts_as_miq_taggable
+
+  def self.class_by_ems(ext_management_system)
+    # TODO(lsmola) taken from Orchestration stacks, correct approach should be to have a factory on ExtManagementSystem
+    # side, that would return correct class for each provider
+    ext_management_system && ext_management_system.class::HostInitiator
+  end
+
+  def refresh_ems
+    unless ext_management_system
+      raise _("No Provider defined")
+    end
+    unless ext_management_system.has_credentials?
+      raise _("No Provider credentials defined")
+    end
+    unless ext_management_system.authentication_status_ok?
+      raise _("Provider failed last authentication check")
+    end
+
+    EmsRefresh.queue_refresh(ext_management_system)
+  end
+
+  def self.create_host_initiator_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "creating HostInitiator for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => 'HostInitiator',
+      :method_name => 'create_host_initiator',
+      :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => ext_management_system.my_zone,
+      :args        => [ext_management_system.id, options]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def self.create_host_initiator(ems_id, options = {})
+    raise ArgumentError, _("ems_id cannot be nil") if ems_id.nil?
+
+    ext_management_system = ExtManagementSystem.find_by(:id => ems_id)
+    raise ArgumentError, _("ext_management_system cannot be found") if ext_management_system.nil?
+
+    klass = class_by_ems(ext_management_system)
+    klass.raw_create_host_initiator(ext_management_system, options)
+  end
+
+  def self.raw_create_host_initiator(_ext_management_system, _options = {})
+    raise NotImplementedError, _("raw_create_host_initiator must be implemented in a subclass")
+  end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6066,11 +6066,23 @@
     :feature_type: control
     :identifier: host_initiator_control
     :children:
+    - :name: Refresh
+      :description: Refresh relationships and power states for all items related to Host Initiators
+      :feature_type: control
+      :identifier: host_initiator_refresh
     - :name: Edit Tags
       :description: Edit Tags of Host Initiators
       :feature_type: control
       :identifier: host_initiator_tag
-
+  - :name: Modify
+    :description: Modify Host Initiator
+    :feature_type: admin
+    :identifier: host_initiator_admin
+    :children:
+    - :name: Add
+      :description: Add a Host Initiator
+      :feature_type: admin
+      :identifier: host_initiator_new
 
 # EmsPhysicalInfra
 - :name: Physical Infrastructure Providers


### PR DESCRIPTION
Host Initiators (AKA physical storage hosts) are virtual entities that only exists as a set of definitions within the `PhysicalStorage' and hold the information about consumers/hosts that use (defined) the physical storage.

This PR includes the work for adding action of define new host initiator to miq

![Screenshot 2021-01-17 063206](https://user-images.githubusercontent.com/53213107/104831077-0193dd00-588e-11eb-8e3d-cb1ca4e798af.jpg)
![Screenshot 2021-01-17 063326](https://user-images.githubusercontent.com/53213107/104831076-00fb4680-588e-11eb-9cb6-35f0b3a83f3c.jpg)

Host-initiators example data
---------
Below are diagrams that shows how we'd represent rather standard scenario. 

<img width="941" alt="111" src="https://user-images.githubusercontent.com/53213107/102864880-91846980-443d-11eb-8211-351df62ecab2.png">

All items in white are already part of miq:
We have a single IRL storage-system Called SVC Storage 1.
It has 2 storage pools: Pool1 and Pool2.
Pool1 has two volumes: Volume1 and Volume2.

All items in blue are changes done in this PR:
The Physical Storage has a single host-initiator defined in it. It has been defined with two addresses: iqn-addr-1, and wwpn-addr-1. For the sake of brevity I won't use real IQN and WWPN addresses as they are too long. 

All items in peach are future drafts pending changes (not part of this PR):
The host-initiator in the storage-system has been mapped to Volume1.
A DB server consumes Volume1.
One of the FC addresses of the DB server is wwpn-addr-2. Remeber that this address was defined on the host-initiator above. This, together with the fact that the host-initiator was mapped to Volume1 allows the DB server to consume it.

In this diagram, the addresses are implemented as an STI.
There's a general SAN (Storage Area Network) Address table that holds all possible info for all address. It's expected to be a sparse table as concrete addresses will only populate their specific fields. 
So FcAddresses will have nil for their iscsi values such as IQN and CHAP. And the reverse holds true for IscsiAddresses.

links
-----
https://github.com/ManageIQ/manageiq-api/pull/985
https://github.com/ManageIQ/manageiq-providers-autosde/pull/51
https://github.com/ManageIQ/manageiq-ui-classic/pull/7587