### PR TITLE
locale:po_to_json - update for webpack compatibility

### DIFF
--- a/lib/tasks/gettext_task_override.rb
+++ b/lib/tasks/gettext_task_override.rb
@@ -1,13 +1,47 @@
 module GettextI18nRailsJs
   module Task
+    # use combined .po
     def files_list
       require "gettext_i18n_rails/tasks"
 
       ::Pathname.glob(::File.join(locale_path, 'combined', "**", "*.po"))
     end
 
+    # output to ui-classic, not Rails.root; oldjs, not assets/javascripts
     def output_path
-      ::ManageIQ::UI::Classic::Engine.root.join(GettextI18nRailsJs.config.output_path)
+      ::ManageIQ::UI::Classic::Engine.root.join('app/javascript/oldjs/locale')
+    end
+
+    # use path/lang.json instead of path/lang/app.js
+    def destination(lang)
+      output_path.mkpath
+
+      path = output_path.join("#{lang}.json")
+      path.open("w") do |f|
+        f.rewind
+        f.write yield
+      end
+
+      puts "Created #{path}"
+    end
+
+    # remove footer asset pipeline references; generate index.js
+    def print_footer
+      langs = files_list.map { |f| lang_for(f) }
+
+      output_path.join('index.js').open("w") do |f|
+        f.rewind
+
+        f.write "window.locales = {\n"
+        langs.sort.each do |lang|
+          f.write "  '#{lang}': require('./#{lang}.json'),\n"
+        end
+        f.write "};\n"
+      end
+
+      puts
+      puts "All files created, make sure to bin/webpack"
+      puts
     end
   end
 end

--- a/lib/tasks/gettext_task_override.rb
+++ b/lib/tasks/gettext_task_override.rb
@@ -18,7 +18,6 @@ module GettextI18nRailsJs
 
       path = output_path.join("#{lang}.json")
       path.open("w") do |f|
-        f.rewind
         f.write yield
       end
 
@@ -30,8 +29,6 @@ module GettextI18nRailsJs
       langs = files_list.map { |f| lang_for(f) }
 
       output_path.join('index.js').open("w") do |f|
-        f.rewind
-
         f.write "window.locales = {\n"
         langs.sort.each do |lang|
           f.write "  '#{lang}': require('./#{lang}.json'),\n"

--- a/lib/tasks/gettext_task_override.rb
+++ b/lib/tasks/gettext_task_override.rb
@@ -28,16 +28,16 @@ module GettextI18nRailsJs
     def print_footer
       langs =
         files_list
-          .map { |f| lang_for(f) }
-          .sort
-          .map { |lang| "  '#{lang}': require('./#{lang}.json')," }
-          .join("\n")
+        .map { |f| lang_for(f) }
+        .sort
+        .map { |lang| "  '#{lang}': require('./#{lang}.json')," }
+        .join("\n")
 
-      output_path.join('index.js').write(<<~EOF)
+      output_path.join('index.js').write(<<~JS)
         window.locales = {
         #{langs}
         };
-      EOF
+      JS
 
       puts
       puts "All files created, make sure to bin/webpack"

--- a/lib/tasks/gettext_task_override.rb
+++ b/lib/tasks/gettext_task_override.rb
@@ -26,15 +26,18 @@ module GettextI18nRailsJs
 
     # remove footer asset pipeline references; generate index.js
     def print_footer
-      langs = files_list.map { |f| lang_for(f) }
+      langs =
+        files_list
+          .map { |f| lang_for(f) }
+          .sort
+          .map { |lang| "  '#{lang}': require('./#{lang}.json')," }
+          .join("\n")
 
-      output_path.join('index.js').open("w") do |f|
-        f.write "window.locales = {\n"
-        langs.sort.each do |lang|
-          f.write "  '#{lang}': require('./#{lang}.json'),\n"
-        end
-        f.write "};\n"
-      end
+      output_path.join('index.js').write(<<~EOF)
+        window.locales = {
+        #{langs}
+        };
+      EOF
 
       puts
       puts "All files created, make sure to bin/webpack"

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -260,6 +260,7 @@ namespace :locale do
   task "po_to_json" => :environment do
     begin
       require_relative 'gettext_task_override.rb'
+      require_relative 'po_to_json_override.rb'
       require Rails.root.join('lib/manageiq/environment')
       require Rails.root.join("lib/vmdb/gettext/domains")
 

--- a/lib/tasks/po_to_json_override.rb
+++ b/lib/tasks/po_to_json_override.rb
@@ -1,0 +1,9 @@
+class PoToJson
+  # return just the JSON, instead of `var locales = locales || {}; locales['en'] = json`
+  def generate_for_jed(language, overwrite = {})
+    @options = parse_options(overwrite.merge(:language => language))
+    @parsed ||= inject_meta(parse_document)
+
+    build_json_for(build_jed_for(@parsed))
+  end
+end


### PR DESCRIPTION
This changes the `rake locale:po_to_json` task to:

* change generated files path from `app/assets/javascripts/locale/` to `app/javascript/oldjs/locale/`

* change generated file names from `#{lang}/app.js` to `#{lang}.json`

* change file content from `var locale = locale || {}; locale['en'] = data` to just the JSON data

* also generate an `index.js` which requires all the jsons and constructs a `window.locale` object

Overriding a few methods from `po_to_json-1.0.1/lib/po_to_json.rb` and `gettext_i18n_rails_js-1.3.0/lib/gettext_i18n_rails_js/task.rb`

---

The main reason for this change is that since https://github.com/ManageIQ/manageiq-ui-classic/pull/7576, `var locale` is no longer a global var, available from elsewhere - none of our JS locales are accessible now.

The result of this change is in https://github.com/ManageIQ/manageiq-ui-classic/pull/7590