### PR TITLE
replace autosde openAPI ( OAS) files with gem in Rubygem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "activerecord-virtual_attributes", "~>3.0.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false
+gem "autosde_openapi_client",         "=1.0.3"
 gem "aws-sdk-s3",                     "~>1.0",         :require => false # For FileDepotS3
 gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        "~> 2.1.4",      :require => false


### PR DESCRIPTION
this PR replace autosde OpenapiClient with its own autosde_oas SDK gem
for more info look inside: https://github.com/ManageIQ/manageiq-providers-autosde/issues/10