### PR TITLE
Filtering by multiple tags for chargebackVm and ContainerProjects

### DIFF
--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -28,7 +28,7 @@ class ChargebackContainerProject < Chargeback
 
     @projects = if filter_tag.present?
                   # Get all ids of tagged projects
-                  ContainerProject.find_tagged_with(:all => filter_tag, :ns => "*")
+                  ContainerProject.find_tagged_with(:any => filter_tag, :ns => "*")
                 elsif provider_id == "all"
                   ContainerProject.all
                 elsif provider_id.present? && project_id == "all"


### PR DESCRIPTION
Backend changes for filtering by multiple tags in chargeback reports.

Interface of chargeback is basically ready for filtering by multiple tags thanks to method `find_tagged_with`.

# Links
- part of https://github.com/ManageIQ/manageiq/issues/20689
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7614 

@miq-bot assign @gtanzillo 
@miq-bot add_label chargeback, enhancement 
