### PR TITLE
Fix for Module#parent deprecation warning

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -161,7 +161,7 @@ module ManageIQ
       private
 
       def self.ems_type
-        @ems_type ||= parent.ems_type.to_sym
+        @ems_type ||= module_parent.ems_type.to_sym
       end
 
       def inventory_class_for(klass)


### PR DESCRIPTION
```
DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1. (called from ems_type at /home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:164)
```