### PR TITLE
Fix key collision with Thread[:current_request]

### DIFF
--- a/lib/request_started_on_middleware.rb
+++ b/lib/request_started_on_middleware.rb
@@ -14,13 +14,13 @@ class RequestStartedOnMiddleware
     complete_request
   end
 
-  def start_request(path, started_on)
-    Thread.current[:current_request] = path
+  def start_request(path_info, started_on)
+    Thread.current[:current_request_path_info]  = path_info
     Thread.current[:current_request_started_on] = started_on
   end
 
   def complete_request
-    Thread.current[:current_request] = nil
+    Thread.current[:current_request_path_info]  = nil
     Thread.current[:current_request_started_on] = nil
   end
 
@@ -29,7 +29,7 @@ class RequestStartedOnMiddleware
     allowable_request_start_time = long_request.ago
 
     relevant_thread_list.each do |thread|
-      request    = thread[:current_request]
+      request    = thread[:current_request_path_info]
       started_on = thread[:current_request_started_on]
 
       # There's a race condition where the complete_request method runs in another

--- a/spec/lib/request_started_on_middleware_spec.rb
+++ b/spec/lib/request_started_on_middleware_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RequestStartedOnMiddleware do
     let(:fake_threads) { [@fake_thread] }
 
     it "returns request, duration and thread" do
-      @fake_thread = {:current_request => "/api/ping", :current_request_started_on => 3.minutes.ago}
+      @fake_thread = {:current_request_path_info => "/api/ping", :current_request_started_on => 3.minutes.ago}
       long_requests = described_class.long_running_requests.first
       expect(long_requests[0]).to eql "/api/ping"
       expect(long_requests[1]).to be_within(0.1).of(Time.now.utc - 3.minutes.ago)
@@ -15,7 +15,7 @@ RSpec.describe RequestStartedOnMiddleware do
     end
 
     it "skips threads that haven't timed out yet" do
-      @fake_thread = {:current_request => "/api/ping", :current_request_started_on => 30.seconds.ago}
+      @fake_thread = {:current_request_path_info => "/api/ping", :current_request_started_on => 30.seconds.ago}
       expect(described_class.long_running_requests).to be_empty
     end
 


### PR DESCRIPTION
Now that we've moved to manageiq-loggers, the [ContainerLogger has code](https://github.com/ManageIQ/manageiq-loggers/blob/4e3f3c7280c51b822a1d4db6f392a24188bd6d8b/lib/manageiq/loggers/container.rb#L68)
that expects that if Thread[:current_request] is set, it will be a
request object that responds to :request_id.  The
RequestStartedOnMiddleware, however, happens to use the same key and
stores only the request path, leading to `undefined method request_id
for "/path/to/wherever"`

Since this particular key's usage is isolated to the middleware, we can
name it whatever we want, so this commit chooses a name that is less
likely to collide.
