### PR TITLE
[WIP] Flatten worker settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1048,127 +1048,138 @@
   :authentication_timeout: 30.seconds
   :url:
 :workers:
+  :cockpit_ws_worker:
+    :count: 1
+    :inherits_from: worker_base
+  :ems_metrics_collector_worker:
+    :count: 2
+    :inherits_from: queue_worker_base
+    :nice_delta: 3
+    :poll_method: escalate
+  :ems_metrics_processor_worker:
+    :count: 2
+    :inherits_from: queue_worker_base
+    :memory_threshold: 800.megabytes
+    :nice_delta: 7
+    :poll_method: escalate
+  :ems_operations_worker:
+    :inherits_from: queue_worker_base
+  :ems_refresh_worker:
+    :dequeue_method: sql
+    :inherits_from: queue_worker_base
+    :memory_threshold: 2.gigabytes
+    :nice_delta: 7
+    :poll: 10.seconds
+    :poll_method: normal
+    :queue_timeout: 120.minutes
+  :event_catcher:
+    :ems_event_page_size: 100
+    :ems_event_thread_shutdown_timeout: 10.seconds
+    :flooding_events_per_minute: 30
+    :flooding_monitor_enabled: false
+    :inherits_from: worker_base
+    :memory_threshold: 2.gigabytes
+    :nice_delta: 1
+    :poll: 1.seconds
+  :event_handler:
+    :inherits_from: queue_worker_base
+    :nice_delta: 7
+  :generic_worker:
+    :count: 2
+    :inherits_from: queue_worker_base
+  :priority_worker:
+    :count: 2
+    :inherits_from: queue_worker_base
+    :nice_delta: 1
+    :poll: 1.seconds
+  :queue_worker_base:
+    :dequeue_method: drb
+    :inherits_from: worker_base
+    :poll_method: normal
+    :queue_timeout: 10.minutes
+  :remote_console_worker:
+    :connection_pool_size: 14
+    :inherits_from: worker_base
+    :memory_threshold: 1.gigabytes
+    :nice_delta: 1
+  :reporting_worker:
+    :count: 2
+    :inherits_from: queue_worker_base
+    :nice_delta: 7
+  :schedule_worker:
+    :audit_managed_resources: 1.days
+    :authentication_check_interval: 1.hour
+    :binary_blob_purge_interval: 1.hour
+    :chargeback_generation_interval: 1.day
+    :chargeback_generation_time_utc: 01:00:00
+    :compliance_purge_interval: 1.day
+    :container_entities_purge_interval: 1.day
+    :db_diagnostics_interval: 30.minutes
+    :drift_state_purge_interval: 1.day
+    :event_streams_purge_interval: 1.day
+    :evm_snapshot_delete_delay_for_job_not_found: 1.hour
+    :evm_snapshot_interval: 1.hour
+    :inherits_from: worker_base
+    :job_proxy_dispatcher_interval: 15.seconds
+    :job_proxy_dispatcher_stale_message_check_interval: 60.seconds
+    :job_proxy_dispatcher_stale_message_timeout: 2.minutes
+    :job_timeout_interval: 60.seconds
+    :log_active_configuration_interval: 1.days
+    :memory_threshold: 500.megabytes
+    :nice_delta: 3
+    :notifications_purge_interval: 1.day
+    :orchestration_stack_retired_interval: 10.minutes
+    :performance_collection_interval: 3.minutes
+    :performance_collection_start_delay: 5.minutes
+    :performance_realtime_purging_interval: 21.minutes
+    :performance_realtime_purging_start_delay: 5.minutes
+    :performance_rollup_purging_interval: 4.hours
+    :performance_rollup_purging_start_delay: 5.minutes
+    :policy_events_purge_interval: 1.day
+    :poll: 15.seconds
+    :queue_timeout_interval: 15.seconds
+    :report_result_purge_interval: 1.week
+    :server_log_stats_interval: 5.minutes
+    :server_stats_interval: 60.seconds
+    :service_retired_interval: 10.minutes
+    :session_timeout_interval: 30.seconds
+    :storage_file_collection_interval: 1.days
+    :storage_file_collection_time_utc: 21600
+    :task_purge_interval: 1.day
+    :task_timeout_check_frequency: 1.hour
+    :vim_performance_states_purge_interval: 1.day
+    :vm_retired_interval: 10.minutes
+    :yum_update_check: 12.hours
+  :smart_proxy_worker:
+    :count: 2
+    :heartbeat_thread_shutdown_timeout: 10.seconds
+    :inherits_from: queue_worker_base
+    :memory_threshold: 2.gigabytes
+    :queue_timeout: 20.minutes
+  :ui_worker:
+    :connection_pool_size: 8
+    :inherits_from: worker_base
+    :memory_threshold: 1.gigabytes
+    :nice_delta: 1
+  :web_service_worker:
+    :connection_pool_size: 8
+    :inherits_from: worker_base
+    :memory_threshold: 1.gigabytes
+    :nice_delta: 1
   :worker_base:
-    :defaults:
-      :count: 1
-      :cpu_request_percent: 15
-      :cpu_threshold_percent: 100
-      :gc_interval: 15.minutes
-      :heartbeat_freq: 10.seconds
-      :heartbeat_timeout: 2.minutes
-      :memory_request: 500.megabytes
-      :memory_threshold: 600.megabytes
-      :nice_delta: 10
-      :parent_time_threshold: 3.minutes
-      :poll: 3.seconds
-      :poll_escalate_max: 30.seconds
-      :poll_method: normal
-      :starting_timeout: 10.minutes
-      :stopping_timeout: 10.minutes
-      :systemd_enabled: true
-    :event_catcher:
-      :defaults:
-        :flooding_events_per_minute: 30
-        :flooding_monitor_enabled: false
-        :ems_event_page_size: 100
-        :ems_event_thread_shutdown_timeout: 10.seconds
-        :memory_threshold: 2.gigabytes
-        :nice_delta: 1
-        :poll: 1.seconds
-    :queue_worker_base:
-      :defaults:
-        :dequeue_method: drb
-        :poll_method: normal
-        :queue_timeout: 10.minutes
-      :ems_metrics_collector_worker:
-        :defaults:
-          :count: 2
-          :nice_delta: 3
-          :poll_method: escalate
-      :ems_metrics_processor_worker:
-        :count: 2
-        :memory_threshold: 800.megabytes
-        :nice_delta: 7
-        :poll_method: escalate
-      :ems_operations_worker: {}
-      :ems_refresh_worker:
-        :defaults:
-          :memory_threshold: 2.gigabytes
-          :nice_delta: 7
-          :poll: 10.seconds
-          :poll_method: normal
-          :queue_timeout: 120.minutes
-          :dequeue_method: sql
-      :event_handler:
-        :nice_delta: 7
-      :generic_worker:
-        :count: 2
-      :priority_worker:
-        :count: 2
-        :nice_delta: 1
-        :poll: 1.seconds
-      :reporting_worker:
-        :count: 2
-        :nice_delta: 7
-      :smart_proxy_worker:
-        :count: 2
-        :memory_threshold: 2.gigabytes
-        :queue_timeout: 20.minutes
-        :heartbeat_thread_shutdown_timeout: 10.seconds
-    :schedule_worker:
-      :audit_managed_resources: 1.days
-      :container_entities_purge_interval: 1.day
-      :binary_blob_purge_interval: 1.hour
-      :authentication_check_interval: 1.hour
-      :chargeback_generation_interval: 1.day
-      :chargeback_generation_time_utc: 01:00:00
-      :compliance_purge_interval: 1.day
-      :db_diagnostics_interval: 30.minutes
-      :drift_state_purge_interval: 1.day
-      :event_streams_purge_interval: 1.day
-      :evm_snapshot_delete_delay_for_job_not_found: 1.hour
-      :evm_snapshot_interval: 1.hour
-      :job_proxy_dispatcher_interval: 15.seconds
-      :job_proxy_dispatcher_stale_message_check_interval: 60.seconds
-      :job_proxy_dispatcher_stale_message_timeout: 2.minutes
-      :job_timeout_interval: 60.seconds
-      :log_active_configuration_interval: 1.days
-      :memory_threshold: 500.megabytes
-      :nice_delta: 3
-      :notifications_purge_interval: 1.day
-      :orchestration_stack_retired_interval: 10.minutes
-      :performance_collection_interval: 3.minutes
-      :performance_collection_start_delay: 5.minutes
-      :performance_realtime_purging_interval: 21.minutes
-      :performance_realtime_purging_start_delay: 5.minutes
-      :performance_rollup_purging_interval: 4.hours
-      :performance_rollup_purging_start_delay: 5.minutes
-      :policy_events_purge_interval: 1.day
-      :poll: 15.seconds
-      :queue_timeout_interval: 15.seconds
-      :report_result_purge_interval: 1.week
-      :server_log_stats_interval: 5.minutes
-      :server_stats_interval: 60.seconds
-      :service_retired_interval: 10.minutes
-      :session_timeout_interval: 30.seconds
-      :storage_file_collection_interval: 1.days
-      :storage_file_collection_time_utc: 21600
-      :task_purge_interval: 1.day
-      :task_timeout_check_frequency: 1.hour
-      :vim_performance_states_purge_interval: 1.day
-      :vm_retired_interval: 10.minutes
-      :yum_update_check: 12.hours
-    :ui_worker:
-      :connection_pool_size: 8
-      :memory_threshold: 1.gigabytes
-      :nice_delta: 1
-    :web_service_worker:
-      :connection_pool_size: 8
-      :memory_threshold: 1.gigabytes
-      :nice_delta: 1
-    :remote_console_worker:
-      :connection_pool_size: 14
-      :memory_threshold: 1.gigabytes
-      :nice_delta: 1
-    :cockpit_ws_worker:
-      :count: 1
+    :count: 1
+    :cpu_request_percent: 15
+    :cpu_threshold_percent: 100
+    :gc_interval: 15.minutes
+    :heartbeat_freq: 10.seconds
+    :heartbeat_timeout: 2.minutes
+    :memory_request: 500.megabytes
+    :memory_threshold: 600.megabytes
+    :nice_delta: 10
+    :parent_time_threshold: 3.minutes
+    :poll: 3.seconds
+    :poll_escalate_max: 30.seconds
+    :poll_method: :normal
+    :starting_timeout: 10.minutes
+    :stopping_timeout: 10.minutes
+    :systemd_enabled: true

--- a/lib/generators/manageiq/provider/templates/config/settings.yml
+++ b/lib/generators/manageiq/provider/templates/config/settings.yml
@@ -22,13 +22,10 @@
   :level_<%= provider_name %>: info
 <% if options[:scaffolding] -%>
 :workers:
-  :worker_base:
-    :event_catcher:
-      :event_catcher_<%= provider_name %>:
-        :poll: 20.seconds
-    :queue_worker_base:
-      :ems_metrics_collector_worker:
-        :ems_metrics_collector_worker_<%= provider_name %>: {}
-      :ems_refresh_worker:
-        :ems_refresh_worker_<%= provider_name %>: {}
+  :event_catcher_<%= provider_name %>:
+    :inherits_from: event_catcher
+  :ems_metrics_collector_worker_<%= provider_name %>:
+    :inherits_from: ems_metrics_collector_worker
+  :ems_refresh_worker_<%= provider_name %>:
+    :inherits_from: ems_refresh_worker
 <% end -%>

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -167,6 +167,19 @@ module Vmdb
 
         return valid, errors
       end
+
+      def workers(data)
+        valid, errors = true, []
+
+        data.each_pair do |worker, worker_settings|
+          if worker_settings.include?(:inherits_from) && worker_settings[:inherits_from] != ::Settings.workers[worker].inherits_from
+            valid = false
+            errors << ["#{worker}-inherits_from", "cannot be modified"]
+          end
+        end
+
+        return valid, errors
+      end
     end
   end
 end

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe Vmdb::Settings::Validator do
 
     {:smtp => {:from => "a@example.com"}}, true,
     {:smtp => {:from => "xxx"}},           false,
+
+    {:workers => {:worker_base => {:inherits_from => "xxx"}}},         false,
+    {:workers => {:ui_worker   => {:inherits_from => "worker_base"}}}, true,
+    {:workers => {:ui_worker   => {:inherits_from => "xxx"}}},         false,
   ].freeze
 
   VALIDATOR_CASES.each_slice(2) do |c, expected|

--- a/spec/models/miq_server/server_smart_proxy_spec.rb
+++ b/spec/models/miq_server/server_smart_proxy_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "MiqServer::ServerSmartProxy" do
     it "is the number of smart proxy workers when the role is active" do
       server.role = "smartproxy"
       server.assigned_server_roles.update(:active => true)
-      stub_settings(:workers => {:worker_base => {:queue_worker_base => {:smart_proxy_worker => {:count => 5}}}})
+      stub_settings_merge(:workers => {:smart_proxy_worker => {:count => 5}})
 
       expect(server.concurrent_job_max).to eq(5)
     end

--- a/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe PerEmsTypeWorkerMixin do
           configured = worker_class.workers_configured_count
           expect(worker_class.workers).to eq(configured)
 
-          stub_settings(:workers => {:worker_base => {:queue_worker_base => {:ems_metrics_collector_worker => {:count => configured + 1}}}})
+          stub_settings_merge(:workers => {:ems_metrics_collector_worker => {:count => configured + 1}})
           expect(worker_class.workers).to eq(configured + 1)
         end
 
         it "is 0 with the provider in the wrong zone" do
           other_zone = FactoryBot.create(:zone)
           provider.update(:zone => other_zone)
-          stub_settings(:workers => {:worker_base => {:queue_worker_base => {:ems_metrics_collector_worker => {:count => 5}}}})
+          stub_settings_merge(:workers => {:ems_metrics_collector_worker => {:count => 5}})
 
           expect(worker_class.workers).to eq(0)
         end

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -7,7 +7,7 @@ TYPES = %w(string integer boolean symbol float array).freeze
 opts = Optimist.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \
          "Example (String):  #{__FILE__} -s 1 -p reporting/history/keep_reports -v 3.months\n" \
-         "Example (Integer): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
+         "Example (Integer): #{__FILE__} -s 1 -p workers/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
          "Example (Boolean): #{__FILE__} -s 1 -p ui/mark_translated_strings -v true -t boolean\n" \
          "Example (Float):   #{__FILE__} -s 1 -p capacity/profile/1/vcpu_commitment_ratio -v 1.5 -t float" \
 


### PR DESCRIPTION
This PR flattens the complicated nesting of the worker settings in order to make it easier for end users to find what they are looking for.  In particular, since YAML is whitespace delimited, it can be very easy to mess up the yaml nesting, and this should fix that problem.  One downside of going from a tree structure to a flat structure is that you lose context of what is inherited.  As such, this PR introduces a new key in the settings, `:inherited_from` which acts more like a comment to the editor and cannot be modified by the end user.  However, with that information, they should be able to easily traverse up the inheritance chain to determine the values.

cc @jrafanie

WIP because
- [ ] Need more testing
- [ ] UI screens will have to compensate for the new format
  - [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7599
- [ ] Update provider settings
  - [ ] ManageIQ/manageiq-providers-amazon#677
  - [ ] ManageIQ/manageiq-providers-ansible_tower#251
  - [ ] ManageIQ/manageiq-providers-autosde#54
  - [ ] ManageIQ/manageiq-providers-azure#431
  - [ ] ManageIQ/manageiq-providers-azure_stack#55
  - [ ] ManageIQ/manageiq-providers-dummy_provider#32
  - [ ] ManageIQ/manageiq-providers-foreman#83
  - [ ] ManageIQ/manageiq-providers-google#177
  - [ ] ManageIQ/manageiq-providers-ibm_cloud#130
  - [ ] ManageIQ/manageiq-providers-ibm_terraform#57
  - [ ] ManageIQ/manageiq-providers-kubernetes#420
  - [ ] ManageIQ/manageiq-providers-kubevirt#180
  - [ ] ManageIQ/manageiq-providers-lenovo#327
  - [ ] ManageIQ/manageiq-providers-nsxt#33
  - [ ] ManageIQ/manageiq-providers-nuage#239
  - [ ] ManageIQ/manageiq-providers-openshift#202
  - [ ] ManageIQ/manageiq-providers-openstack#684
  - [ ] ManageIQ/manageiq-providers-ovirt#546
  - [ ] ManageIQ/manageiq-providers-redfish#135
  - [ ] ManageIQ/manageiq-providers-scvmm#179
  - [ ] ManageIQ/manageiq-providers-vmware#691
- [ ] Data migration needed for existing settings changes
  - [ ] https://github.com/ManageIQ/manageiq-schema/pull/555
- [ ] Update documentation - https://github.com/ManageIQ/manageiq-documentation/blame/master/general_configuration/_topics/configuration.md#L1565
- [ ] Update guides/architecture/source_code_layout.md
- [x] Update tools/configure_server_settings.rb
- [x] Change downstream overrides