### PR TITLE
Fix notification missing substituted values, log deprecation if other places do this

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -168,7 +168,15 @@ module MiqServer::WorkerManagement::Monitor
 
       msg = "#{w.format_full_log_msg} is being stopped because system resources exceeded threshold, it will be restarted once memory has freed up"
       _log.warn(msg)
-      MiqEvent.raise_evm_event_queue_in_region(w.miq_server, "evm_server_memory_exceeded", :event_details => msg, :type => w.class.name)
+
+      notification_options = {
+        :name             => name,
+        :memory_usage     => memory_usage.to_i,
+        :memory_threshold => memory_threshold,
+        :pid              => pid
+      }
+
+      MiqEvent.raise_evm_event_queue_in_region(w.miq_server, "evm_server_memory_exceeded", :event_details => msg, :type => w.class.name, :full_data => notification_options)
       stop_worker(w, MiqServer::MEMORY_EXCEEDED)
       break
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe Notification, :type => :model do
 
   describe '.of_type' do
     it "only returns notification of the given type" do
-      types = NotificationType.all
-      type_name_one   = types[0].name
-      type_name_two   = types[1].name
-      type_name_three = types[2].name
+      type_name_one   = "request_approved"
+      type_name_two   = "request_denied"
+      type_name_three = "vm_retired"
 
-      Notification.create(:type => type_name_one, :initiator => user)
-      Notification.create(:type => type_name_one, :initiator => user)
-      Notification.create(:type => type_name_two, :initiator => user)
+      Notification.create(:type => type_name_one, :initiator => user, :options => {:subject => "Request 1"})
+      Notification.create(:type => type_name_one, :initiator => user, :options => {:subject => "Request 2"})
+      Notification.create(:type => type_name_two, :initiator => user, :options => {:subject => "Request 3"})
 
       expect(Notification.of_type(type_name_one).count).to eq(2)
       expect(Notification.of_type(type_name_two).count).to eq(1)
@@ -95,7 +94,7 @@ RSpec.describe Notification, :type => :model do
         let!(:peer) { FactoryBot.create(:user_with_group, :tenant => tenant) }
         let!(:non_peer) { FactoryBot.create(:user) }
 
-        subject { Notification.create(:initiator => user, :type => 'automate_tenant_info') }
+        subject { Notification.create(:initiator => user, :type => 'automate_tenant_info', :options => {:message => "This is not the message you are looking for."}) }
 
         it 'sends notification to the tenant of initiator' do
           expect(subject.recipients).to match_array([user, peer])


### PR DESCRIPTION
Fixes #20977 

https://talk.manageiq.org/t/how-can-i-solve-this-issue-the-server-name-memory-usage-memory-usage-exceeded-limit-memory-threshold-the-server-process-pid-exited-and-will-be-restarted/5261

cc @djberg96 @himdel (thanks Martin for the deep dive)