### PR TITLE
Fix cc_test_reporter placed in wrong directory

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -25,7 +25,7 @@ module ManageIQ
 
       setup_test_environment(:task_prefix => 'app:', :root => plugin_root)
 
-      prepare_codeclimate_test_reporter if ENV["CI"]
+      prepare_codeclimate_test_reporter(plugin_root) if ENV["CI"]
     end
 
     def self.ensure_config_files
@@ -120,10 +120,10 @@ module ManageIQ
       system!(%q(psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres))
     end
 
-    def self.prepare_codeclimate_test_reporter
-      system!("curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter")
-      system!("chmod +x ./cc-test-reporter")
-      system!("./cc-test-reporter before-build")
+    def self.prepare_codeclimate_test_reporter(root = APP_ROOT)
+      system!("curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter", :chdir => root)
+      system!("chmod +x ./cc-test-reporter", :chdir => root)
+      system!("./cc-test-reporter before-build", :chdir => root)
     end
 
     def self.update_ui


### PR DESCRIPTION
When downloading the cc_test_reporter for the plugins the binary is put
in the spec/manageiq directory not in the plugin's root directory.

This leads to: https://travis-ci.com/github/ManageIQ/manageiq-providers-openstack/jobs/475232465#L2658
```
after_script
bin/ci/after_script
bin/ci/after_script: line 3: ./cc-test-reporter: No such file or directory
```