### PR TITLE
Remove gems-pending runcmd references in favor of AwesomeSpawn

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -17,8 +17,7 @@ class EvmDatabaseOps
     FileUtils.mkdir_p(parent_directory)
 
     free_space = begin
-      cmd_args  = {:params => {:P => parent_directory}}
-      output    = MiqUtil.runcmd("df", cmd_args)
+      output    = AwesomeSpawn.run!("df", :params => {:P => parent_directory}, :combined_output => true).output
       data_line = output.split("\n")[1] if output.kind_of?(String)
       data_line.split[3].to_i * 1024 if data_line
     end

--- a/lib/miq_apache/control.rb
+++ b/lib/miq_apache/control.rb
@@ -1,7 +1,6 @@
 require 'fileutils'
 require 'logger'
 require 'active_support/core_ext/class/attribute_accessors'
-require 'util/runcmd'
 
 module MiqApache
   # Abstract Apache Error Class
@@ -60,7 +59,7 @@ module MiqApache
     def self.run_apache_cmd(command)
       Dir.mkdir(File.dirname(APACHE_CONTROL_LOG)) unless File.exist?(File.dirname(APACHE_CONTROL_LOG))
       begin
-        res = MiqUtil.runcmd("apachectl", :params => [[command]])
+        res = AwesomeSpawn.run!("apachectl", :params => [command], :combined_output => true).output
       rescue => err
         $log.warn("MIQ(MiqApache::Control.run_apache_cmd) Apache command #{command} with result: #{res} failed with error: #{err}") if $log
       end

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -83,11 +83,10 @@ module MiqEnvironment
 
     def self.supports_command?(cmd)
       return false unless EVM_KNOWN_COMMANDS.include?(cmd)
-      require "runcmd"
 
       begin
         # If 'which apachectl' returns non-zero, it wasn't found
-        MiqUtil.runcmd(which, :params => [[cmd]])
+        AwesomeSpawn.run!(which, :params => [cmd])
       rescue
         false
       else

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -1,4 +1,3 @@
-require 'runcmd'
 require 'linux_admin'
 
 module MiqMemcached
@@ -134,14 +133,14 @@ END_OF_CONFIG
     end
 
     def self.killall
-      MiqUtil.runcmd("killall -9 memcached")
+      AwesomeSpawn.run!("killall", :params => ["-9", "memcached"], :combined_output => true)
     rescue AwesomeSpawn::CommandResultError => err
       raise unless err.result.output =~ /memcached: no process/
     end
 
     def self.status
       begin
-        res = MiqUtil.runcmd('service memcached status').to_s.chomp
+        res = AwesomeSpawn.run!("service", :params => ["memcached", "status"], :combined_output => true).output.to_s.chomp
       rescue AwesomeSpawn::CommandResultError => err
         return false, err.result.output.chomp
       rescue => err

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -1,4 +1,3 @@
-require 'util/runcmd'
 RSpec.describe EvmDatabaseOps do
   let(:file_storage) { double("MiqSmbSession", :disconnect => nil) }
   let(:local_backup) { "/tmp/backup_1" }
@@ -95,7 +94,6 @@ RSpec.describe EvmDatabaseOps do
       allow(file_storage).to  receive(:uri_to_local_path).and_return(tmpdir.join("share").to_s)
       allow(file_storage).to  receive(:add).and_yield(input_path)
 
-      allow(MiqUtil).to        receive(:runcmd)
       allow(PostgresAdmin).to  receive(:runcmd_with_logging)
       allow(FileUtils).to      receive(:mv).and_return(true)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(200.megabytes)

--- a/spec/lib/miq_apache/control_spec.rb
+++ b/spec/lib/miq_apache/control_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe MiqApache::Control do
   it "should make the apache control log's directory if missing when calling run_apache_cmd" do
     allow(File).to receive(:exist?).and_return(false)
     expect(Dir).to receive(:mkdir).with(File.dirname(MiqApache::Control::APACHE_CONTROL_LOG))
-    allow(MiqUtil).to receive(:runcmd)
+    allow(AwesomeSpawn).to receive(:run!)
     MiqApache::Control.start
   end
 
   it "should not make the apache control log's directory if it exists when calling run_apache_cmd" do
     allow(File).to receive(:exist?).and_return(true)
     expect(Dir).to receive(:mkdir).with(File.dirname(MiqApache::Control::APACHE_CONTROL_LOG)).never
-    allow(MiqUtil).to receive(:runcmd)
+    allow(AwesomeSpawn).to receive(:run!)
     MiqApache::Control.start
   end
 
@@ -34,7 +34,7 @@ RSpec.describe MiqApache::Control do
     allow(File).to receive(:exist?).and_return(true)
     $log = Logger.new(STDOUT) unless $log
     allow($log).to receive(:debug?).and_return(false)
-    expect(MiqUtil).to receive(:runcmd).with("apachectl", :params => [[cmd]])
+    expect(AwesomeSpawn).to receive(:run!).with("apachectl", a_hash_including(:params => [cmd]))
     MiqApache::Control.start
   end
 
@@ -43,7 +43,7 @@ RSpec.describe MiqApache::Control do
     allow(File).to receive(:exist?).and_return(true)
     $log = Logger.new(STDOUT) unless $log
     allow($log).to receive(:debug?).and_return(true)
-    expect(MiqUtil).to receive(:runcmd).with("apachectl", :params => [[cmd]])
+    expect(AwesomeSpawn).to receive(:run!).with("apachectl", a_hash_including(:params => [cmd]))
     MiqApache::Control.start
   end
 
@@ -51,7 +51,7 @@ RSpec.describe MiqApache::Control do
     allow(File).to receive(:exist?).and_return(true)
     $log = Logger.new(STDOUT) unless $log
     allow($log).to receive(:debug?).and_return(false)
-    allow(MiqUtil).to receive(:runcmd).and_raise("warn")
+    expect(AwesomeSpawn).to receive(:run!).and_raise("warn")
     expect($log).to receive(:warn)
     MiqApache::Control.start
   end


### PR DESCRIPTION
This removes a dependenct on gems-pending.

@jrafanie Please review.

cc @chessbyte 

For reference, this is the source of runcmd for comparison... https://github.com/ManageIQ/manageiq-gems-pending/blob/f984beaecc995a311d2f6e4b59cb57feb7003d75/lib/gems/pending/util/runcmd.rb#L3-L19