### PR TITLE
[Dictionary] Add .ui_lookup

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -34,6 +34,22 @@ class Dictionary
     opts[:plural] ? col.send(opts[:notfound]).send(:pluralize) : col.send(opts[:notfound])
   end
 
+  def self.ui_lookup(options = {})
+    if options[:table]
+      gettext(options[:table], :type => :table, :notfound => :titleize, :plural => false)
+    elsif options[:tables]
+      gettext(options[:tables], :type => :table, :notfound => :titleize, :plural => true)
+    elsif options[:model]
+      gettext(options[:model], :type => :model, :notfound => :titleize, :plural => false)
+    elsif options[:models]
+      gettext(options[:models], :type => :model, :notfound => :titleize, :plural => true)
+    elsif options[:ui_title]
+      gettext(options[:ui_title], :type => :ui_title)
+    else
+      ''
+    end
+  end
+
   def self.i18n_lookup(type, text)
     result = I18n.t("dictionary.#{type}.#{text}", :locale => "en")
     result.start_with?("translation missing:") ? nil : result

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -64,19 +64,7 @@ module Vmdb
 
     # Get dictionary name with default settings
     def ui_lookup(options = {})
-      if options[:table]
-        Dictionary.gettext(options[:table], :type => :table, :notfound => :titleize, :plural => false)
-      elsif options[:tables]
-        Dictionary.gettext(options[:tables], :type => :table, :notfound => :titleize, :plural => true)
-      elsif options[:model]
-        Dictionary.gettext(options[:model], :type => :model, :notfound => :titleize, :plural => false)
-      elsif options[:models]
-        Dictionary.gettext(options[:models], :type => :model, :notfound => :titleize, :plural => true)
-      elsif options[:ui_title]
-        Dictionary.gettext(options[:ui_title], :type => :ui_title)
-      else
-        ''
-      end
+      Dictionary.ui_lookup(options)
     end
 
     # Wrap a report html table body with html table tags and headers for the columns


### PR DESCRIPTION
Moves the logic from `.ui_lookup` from a "global method" to a method on the `Dictionary` class itself.

The global method will eventually be phased out, but is left in place for compatibility for now.


Links
-----

* Partially addressing https://github.com/ManageIQ/manageiq/issues/20900

Steps for Testing/QA
--------------------

Tests passing should be sufficient.