### PR TITLE
Allow for bundler -v 2.2.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be require
 gem "ancestry",                       "~>3.0.7",       :require => false
 gem "aws-sdk-s3",                     "~>1.0",         :require => false # For FileDepotS3
 gem "bcrypt",                         "~> 3.1.10",     :require => false
-gem "bundler",                        "~> 2.1.4",      :require => false
+gem "bundler",                        "~> 2.1", ">=2.1.4", :require => false
 gem "byebug",                                          :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>2.2", ">=2.2.3", :require => false


### PR DESCRIPTION
Bundler 2.2.0 was released Dec 10 2020 and they're up to 2.2.7 now (https://rubygems.org/gems/bundler/versions)
I didn't want to force people to upgrade to 2.2 so I thought just allowing `~> 2.1` was a good step