### PR TITLE
use ancestry in replace_children

### DIFF
--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -356,6 +356,36 @@ RSpec.describe RelationshipMixin do
         service2.save!
         expect(service6.with_relationship_type("custom") { service6.child_ids }).to eq([service2.id])
       end
+
+      context "#replace_children" do
+        it "with one child to keep and one to add" do
+          service = ancestry_class.create
+          service1.with_relationship_type("custom") { service1.replace_children(service, service4) }
+          expect(service1.with_relationship_type("custom") { service1.reload.children }).to contain_exactly(service, service4)
+        end
+
+        it "with all to remove" do
+          service1.with_relationship_type("custom") { service1.replace_children }
+          expect(service1.with_relationship_type("custom") { service1.replace_children }).to eq([])
+        end
+
+        it "with one child to keep" do
+          service1.with_relationship_type("custom") { service1.replace_children(service4) }
+          expect(service1.with_relationship_type("custom") { service1.reload.children }).to contain_exactly(service4)
+        end
+
+        it "with one child to remove" do
+          service = ancestry_class.create
+          service1.with_relationship_type("custom") { service1.replace_children(service) }
+          expect(service1.with_relationship_type("custom") { service1.reload.children }).to eq([service])
+        end
+
+        it "with no children to start adds them all" do
+          service = ancestry_class.create
+          service.with_relationship_type("custom") { service.replace_children(service4) }
+          expect(service.with_relationship_type("custom") { service.reload.children }).to eq([service4])
+        end
+      end
     end
 
     describe "#add_parent" do


### PR DESCRIPTION
the api uses `replace_children` (https://github.com/ManageIQ/manageiq-api/blob/01bb977042d6b75e73a0e568b4b3fd455b9d0ec7/app/controllers/api/vms_controller.rb#L107) which, as it isn't an ancestry method, wasn't extended to use the gem functionality. 

currently broken: any api call that's updating vm ancestry

thanks @agrare 
this fixes [the failing api specs](https://travis-ci.com/github/ManageIQ/manageiq-api/jobs/477507218#L2014)

@miq-bot assign @agrare 
@miq-bot add_label bug 

broken in https://github.com/ManageIQ/manageiq/pull/20274

related: https://github.com/ManageIQ/manageiq-api/pull/994