### PR TITLE
Add missing my_zone func to host_initiator model

### DIFF
--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -14,6 +14,11 @@ class HostInitiator < ApplicationRecord
   supports_not :create
   acts_as_miq_taggable
 
+  def my_zone
+    ems = ext_management_system
+    ems ? ems.my_zone : MiqServer.my_zone
+  end
+
   def self.class_by_ems(ext_management_system)
     # TODO(lsmola) taken from Orchestration stacks, correct approach should be to have a factory on ExtManagementSystem
     # side, that would return correct class for each provider


### PR DESCRIPTION
my_zone function was missing from host_inititor model. This cause host_initiators refresh to fail.

links
-----
https://github.com/ManageIQ/manageiq-api/pull/985