### PR TITLE
Fix MiqEnvironment.local_ip_address to not prefer loopback

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -11,7 +11,7 @@ module MiqEnvironment
   # Return the local IP v4 address of the local host
   #
   def self.local_ip_address
-    ipv4_addrs = Socket.ip_address_list.select(&:ipv4?)
+    ipv4_addrs = Socket.ip_address_list.select(&:ipv4?).sort_by(&:ip_address)
 
     # Prioritize "public" aka non-loopback non-private addresses first, then
     # prefer private addresses, then take whatever we can get

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -8,10 +8,18 @@ module MiqEnvironment
     Socket.gethostbyname(Socket.gethostname).first
   end
 
-  # Return the local IP v4 address of the local host, ignoring private addresses.
+  # Return the local IP v4 address of the local host
   #
   def self.local_ip_address
-    Socket.ip_address_list.detect { |addr| addr.ipv4? && !addr.ipv4_private? }&.ip_address
+    ipv4_addrs = Socket.ip_address_list.select(&:ipv4?)
+
+    # Prioritize "public" aka non-loopback non-private addresses first, then
+    # prefer private addresses, then take whatever we can get
+    local_addr   = ipv4_addrs.detect { |ip| !ip.ipv4_loopback? && !ip.ipv4_private? }
+    local_addr ||= ipv4_addrs.detect { |ip| !ip.ipv4_loopback? }
+    local_addr ||= ipv4_addrs.first
+
+    local_addr&.ip_address
   end
 
   class Command

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe MiqEnvironment do
       example "local_ip_address" do
         expect(described_class.local_ip_address).to be_in(Socket.ip_address_list.map(&:ip_address))
       end
+
+      context "multiple private addresses" do
+        it "always returns the same address" do
+          allow(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip("192.168.1.10"), Addrinfo.ip("10.1.2.3")])
+          expect(described_class.local_ip_address).to eq("10.1.2.3")
+          allow(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip("10.1.2.3"), Addrinfo.ip("192.168.1.10")])
+          expect(described_class.local_ip_address).to eq("10.1.2.3")
+        end
+      end
     end
 
     context "Command" do

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MiqEnvironment do
       end
 
       example "local_ip_address" do
-        expect(described_class.local_ip_address).to eq(`hostname -i`.chomp.split.first)
+        expect(described_class.local_ip_address).to be_in(Socket.ip_address_list.map(&:ip_address))
       end
     end
 

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -1,14 +1,20 @@
 require 'socket'
 
 RSpec.describe "Server Environment Management" do
-  let(:mac_address) { 'a:1:b:2:c:3:d:4' }
-  let(:hostname) { Socket.gethostbyname(Socket.gethostname).first }
-  let(:ip_address) { Socket.ip_address_list.select(&:ipv4?).sort_by(&:ip_address).detect(&:ipv4_private?)&.ip_address }
-
   context ".get_network_information" do
-    it "when in non-production mode" do
+    let(:mac_address) { 'a:1:b:2:c:3:d:4' }
+    let(:hostname)    { "localhost.localdomain" }
+    let(:ip_address)  { "10.1.2.3" }
+
+    before do
       require "uuidtools"
       allow(UUIDTools::UUID).to receive(:mac_address).and_return(mac_address)
+      allow(Socket).to receive(:gethostname).and_return("localhost")
+      allow(Socket).to receive(:gethostbyname).with("localhost").and_return([hostname])
+      allow(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip(ip_address)])
+    end
+
+    it "when in non-production mode" do
       expect(MiqServer.get_network_information).to eq([ip_address, hostname, mac_address])
     end
   end

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -2,14 +2,14 @@ require 'socket'
 
 RSpec.describe "Server Environment Management" do
   let(:mac_address) { 'a:1:b:2:c:3:d:4' }
-  let(:hostname) { Socket.gethostname }
-  let(:loopback) { '127.0.0.1' }
+  let(:hostname) { Socket.gethostbyname(Socket.gethostname).first }
+  let(:ip_address) { Socket.ip_address_list.select(&:ipv4?).sort_by(&:ip_address).detect(&:ipv4_private?)&.ip_address }
 
   context ".get_network_information" do
     it "when in non-production mode" do
       require "uuidtools"
       allow(UUIDTools::UUID).to receive(:mac_address).and_return(mac_address)
-      expect(MiqServer.get_network_information).to eq([loopback, hostname, mac_address])
+      expect(MiqServer.get_network_information).to eq([ip_address, hostname, mac_address])
     end
   end
 


### PR DESCRIPTION
`#local_ip_address` currently prefers loopback addresses since it filters out "private" addresses and not "loopback" addresses.

IMO we should prefer public, then private, then loopback.

https://github.com/ManageIQ/manageiq/pull/20341/files#r566198984
https://github.com/ManageIQ/manageiq/pull/20812#discussion_r566178752
https://github.com/ManageIQ/manageiq/issues/20986