### PR TITLE
Cleanup BinaryBlobPart filtering

### DIFF
--- a/app/models/binary_blob_part.rb
+++ b/app/models/binary_blob_part.rb
@@ -5,20 +5,8 @@ class BinaryBlobPart < ApplicationRecord
     @default_part_size ||= 1.megabyte
   end
 
-  def inspect
-    # Clean up inspect so that we don't flood script/console
-    attrs = attribute_names.inject("{") do |s, n|
-      s << "#{n.inspect}=>#{n == "data" ? "\"...\"" : read_attribute(n).inspect}, "
-      s
-    end
-    attrs.chomp!(", ")
-    attrs << "}"
-    iv = instance_variables.inject(" ") do |s, v|
-      s << "#{v}=#{v == "@attributes" ? attrs : instance_variable_get(v).inspect}, "
-      s
-    end
-    iv.chomp!(", ")
-    iv.rstrip!
-    "#{to_s.chop}#{iv}>"
+  # Clean up inspect so that we don't flood rails console
+  def self.filter_attributes
+    super + [:data]
   end
 end

--- a/spec/models/binary_blob_part_spec.rb
+++ b/spec/models/binary_blob_part_spec.rb
@@ -21,4 +21,14 @@ RSpec.describe BinaryBlobPart do
       expect(subject.bytes.to_a).to eq(@data.bytes.to_a)
     end
   end
+
+  it "#inspect has data filtered out" do
+    str = "REALLY LONG STRING"
+    part = FactoryBot.create(:binary_blob_part, :data => str)
+    expect(part.inspect).to_not include(str)
+
+    # Also check for how str is stored as raw binary in the database (as in
+    # data_before_type_cast), in case that leaks through to inspect
+    expect(part.inspect).to_not include(str.unpack1("H*"))
+  end
 end


### PR DESCRIPTION
Rails 6 adds support for `filter_parameters` in inspect, so we don't need this custom code anymore.  This custom code wasn't actually working correctly since somewhere in the Rails 5 range, about when `@attributes` changed to be an AttributeSet, and the logic to filter out the data didn't work.

Before

```ruby
[1] pry(main)> BinaryBlobPart.first
  BinaryBlobPart Load (0.2ms)  SELECT "binary_blob_parts".* FROM "binary_blob_parts" ORDER BY "binary_blob_parts"."id" ASC LIMIT $1  [["LIMIT", 1]]
  BinaryBlobPart Inst Including Associations (0.0ms - 1rows)
=> #<BinaryBlobPart:0x00007f84e3994638 @new_record=false, @attributes=#<ActiveModel::AttributeSet:0x00007f84e3994660 @attributes=#<ActiveModel::LazyAttributeHash:0x00007f84e39946b0 @types={"id"=>#<ActiveM
odel::Type::Integer:0x00007f84e39058c0 @precision=nil, @scale=nil, @limit=8, @range=-9223372036854775808...9223372036854775808>, "data"=>#<ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea:0x00007f
84e3904cb8 @precision=nil, @scale=nil, @limit=nil>, "binary_blob_id"=>#<ActiveModel::Type::Integer:0x00007f84e39058c0 @precision=nil, @scale=nil, @limit=8, @range=-9223372036854775808...922337203685477580
8>, "href_slug"=>#<ActiveModel::Type::String:0x00007f84e397c3f8 @precision=nil, @scale=nil, @limit=nil>, "region_number"=>#<ActiveModel::Type::Integer:0x00007f84e3984828 @precision=nil, @scale=nil, @limit
=nil, @range=-2147483648...2147483648>, "region_description"=>#<ActiveModel::Type::String:0x00007f84e398ca00 @precision=nil, @scale=nil, @limit=nil>}, @values={"id"=>2, "data"=>"\\x5245414c4c59204c4f4e472
0535452494e47", "binary_blob_id"=>1}, @additional_types={}, @materialized=true, @delegate_hash={"id"=>#<ActiveModel::Attribute::FromDatabase:0x00007f84e39fd7a0 @name="id", @value_before_type_cast=2, @type
=#<ActiveModel::Type::Integer:0x00007f84e39058c0 @precision=nil, @scale=nil, @limit=8, @range=-9223372036854775808...9223372036854775808>, @original_attribute=nil, @value=2>, "data"=>#<ActiveModel::Attrib
ute::FromDatabase:0x00007f84e39fd778 @name="data", @value_before_type_cast="\\x5245414c4c59204c4f4e4720535452494e47", @type=#<ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea:0x00007f84e3904cb8 @p
recision=nil, @scale=nil, @limit=nil>, @original_attribute=nil>, "binary_blob_id"=>#<ActiveModel::Attribute::FromDatabase:0x00007f84e39fd728 @name="binary_blob_id", @value_before_type_cast=1, @type=#<Acti
veModel::Type::Integer:0x00007f84e39058c0 @precision=nil, @scale=nil, @limit=8, @range=-9223372036854775808...9223372036854775808>, @original_attribute=nil, @value=1>, "href_slug"=>#<ActiveModel::Attribut
e::Uninitialized:0x00007f84e39fd700 @name="href_slug", @value_before_type_cast=nil, @type=#<ActiveModel::Type::String:0x00007f84e397c3f8 @precision=nil, @scale=nil, @limit=nil>, @original_attribute=nil>, 
"region_number"=>#<ActiveModel::Attribute::Uninitialized:0x00007f84e39fd6d8 @name="region_number", @value_before_type_cast=nil, @type=#<ActiveModel::Type::Integer:0x00007f84e3984828 @precision=nil, @scale
=nil, @limit=nil, @range=-2147483648...2147483648>, @original_attribute=nil>, "region_description"=>#<ActiveModel::Attribute::Uninitialized:0x00007f84e39fd6b0 @name="region_description", @value_before_typ
e_cast=nil, @type=#<ActiveModel::Type::String:0x00007f84e398ca00 @precision=nil, @scale=nil, @limit=nil>, @original_attribute=nil>}, @default_attributes={"id"=>#<ActiveModel::Attribute::FromDatabase:0x000
07f84e3974748 @name="id", @value_before_type_cast=nil, @type=#<ActiveModel::Type::Integer:0x00007f84e39058c0 @precision=nil, @scale=nil, @limit=8, @range=-9223372036854775808...9223372036854775808>, @orig
inal_attribute=nil>}>>, @association_cache={}, @primary_key="id", @readonly=false, @destroyed=false, @marked_for_destruction=false, @destroyed_by_association=nil, @_start_transaction_state=nil, @transacti
on_state=nil>
```

After

```ruby
[1] pry(main)> BinaryBlobPart.first
  BinaryBlobPart Load (0.3ms)  SELECT "binary_blob_parts".* FROM "binary_blob_parts" ORDER BY "binary_blob_parts"."id" ASC LIMIT $1  [["LIMIT", 1]]
  BinaryBlobPart Inst Including Associations (3.7ms - 1rows)
=> #<BinaryBlobPart:0x00007faa5f66aee8 id: 1, data: [FILTERED], binary_blob_id: 1>
```