### PR TITLE
[MiqPolicy] Add virtual_column :display_name

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -47,6 +47,8 @@ class MiqPolicy < ApplicationRecord
 
   serialize :expression
 
+  virtual_column :display_name, :type => :string
+
   @@associations_to_get_policies = [:parent_enterprise, :ext_management_system, :parent_datacenter, :ems_cluster, :parent_resource_pool, :host]
 
   attr_accessor :reserved
@@ -93,6 +95,10 @@ class MiqPolicy < ApplicationRecord
   def self.clean_attrs(attrs)
     CLEAN_ATTRS.each { |a| attrs.delete(a) }
     attrs
+  end
+
+  def display_name
+    "#{towhat.constantize.display_name} #{mode.capitalize}: #{description}"
   end
 
   def copy(new_fields)

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe MiqPolicy do
       end
     end
 
+    describe "#display_name" do
+      it "renders a combination of towhat, mode, and description" do
+        expected = "VM and Instance Control: #{policy.description}"
+        expect(policy.display_name).to eq(expected)
+      end
+    end
+
     describe "#events" do
       it "lists miq_event_definition assigned to the policy" do
         expect(policy.events).to eq([event])


### PR DESCRIPTION
~~**Requires https://github.com/ManageIQ/manageiq/pull/20988 to be merged first**~~

Note:  Decided to not make this reliant on #20988 based on https://github.com/ManageIQ/manageiq/issues/20900#issuecomment-768967738 so this should be a standalone PR now.

This is a followup to https://github.com/ManageIQ/manageiq/pull/20988 and adds a `virtual_column` for `display_name` to `MiqPolicy`.

~~Should allow access when an API endpoint is in place.~~

I lied on this as well...  there is actually already a API endpoint in place, it just isn't `/api/miq_policies` but `/api/policies`.

Example Request
---------------

```
$ curl -u admin:smartvm http://localhost:3000?expand=resources&attributes=display_name
```


Links
-----

* Partially addressing #20900
* https://github.com/ManageIQ/manageiq/pull/20988