### PR TITLE
Added missing dictionary entry for 'miq_event'

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1635,6 +1635,7 @@ en:
       MiqAlertSet:              Alert Profile
       MiqDialog:                Dialog
       MiqEnterprise:            Enterprise
+      MiqEvent:                 Event
       MiqEventDefinition:       Event
       MiqGroup:                 EVM Group
       MiqPolicy:                Policy
@@ -1804,6 +1805,7 @@ en:
       miq_approvals:               Approvals
       miq_custom_attribute:        EVM Custom Attribute
       miq_custom_attributes:       EVM Custom Attributes
+      miq_event:                   Event
       miq_event_definition:        Event
       manageiq_providers_cloud_manager: Cloud Manager
       manageiq_providers_cloud_manager_vms: Instances


### PR DESCRIPTION


Fixes the title in the tab, needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/7569

before
![Screenshot from 2021-02-01 19-18-46](https://user-images.githubusercontent.com/3450808/106534554-5e180e80-64c2-11eb-8f07-5612991a6923.png)

after
![Screenshot from 2021-02-01 19-17-09](https://user-images.githubusercontent.com/3450808/106534540-59535a80-64c2-11eb-9526-2e9a2c606a79.png)
