### PR TITLE
WidgetSet - fix db:seed, don't blow up when set_data is a HashWithIndifferentAccess

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -94,7 +94,7 @@ class MiqWidgetSet < ApplicationRecord
     lookup_attributes = {}
     lookup_attributes[:name] = attrs["name"]
     lookup_attributes[:userid] = nil
-    lookup_attributes[:group_id] = nil
+    lookup_attributes[:read_only] = true
 
     ws = find_by(lookup_attributes)
 
@@ -111,8 +111,12 @@ class MiqWidgetSet < ApplicationRecord
         h
       end
 
-      owner = attrs.delete("owner_description")
-      attrs["owner_id"] = MiqGroup.find_by(:description => owner).try(:id) if owner
+      owner_description = attrs.delete("owner_description")
+      owner = MiqGroup.find_by(:description => owner_description) if owner_description
+      if owner
+        attrs["owner_type"] = "MiqGroup"
+        attrs["owner_id"] = owner.id
+      end
     end
 
     if ws

--- a/app/models/miq_widget_set/set_data.rb
+++ b/app/models/miq_widget_set/set_data.rb
@@ -22,15 +22,15 @@ module MiqWidgetSet::SetData
     private
 
     def init_set_data
-      self.set_data ||= {}
-      new_set_data ||= {}
-      self.set_data.symbolize_keys!
+      old_set_data = self.set_data&.symbolize_keys || {}
+      new_set_data = {}
+
       SET_DATA_COLS.each do |col_key|
-        new_set_data[col_key] = self.set_data[col_key] || []
+        new_set_data[col_key] = old_set_data[col_key] || []
       end
 
-      new_set_data[:reset_upon_login] = !!set_data[:reset_upon_login]
-      new_set_data[:locked] = !!set_data[:locked]
+      new_set_data[:reset_upon_login] = !!old_set_data[:reset_upon_login]
+      new_set_data[:locked] = !!old_set_data[:locked]
       self.set_data = new_set_data
     end
 

--- a/app/models/miq_widget_set/set_data.rb
+++ b/app/models/miq_widget_set/set_data.rb
@@ -22,7 +22,7 @@ module MiqWidgetSet::SetData
     private
 
     def init_set_data
-      old_set_data = self.set_data&.symbolize_keys || {}
+      old_set_data = self.set_data.to_h.symbolize_keys
       new_set_data = {}
 
       SET_DATA_COLS.each do |col_key|

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -103,6 +103,12 @@ RSpec.describe MiqWidgetSet do
       widget_set = MiqWidgetSet.create(:read_only => true)
       expect(widget_set.errors.messages).not_to include(:set_data => ["can't be blank"])
     end
+
+    it "works with HashWithIndifferentAccess set_data" do
+      widget_set = MiqWidgetSet.create(:set_data => HashWithIndifferentAccess.new({:col1 => []}))
+
+      expect(widget_set.errors.messages).to include(:set_data => ["One widget must be selected(set_data)"])
+    end
   end
 
   it "when a group dashboard is deleted" do


### PR DESCRIPTION
there's no `HashWithIndifferentAccess#symbolize_keys!`, but we do use `HashWithIndifferentAccess` for at least some `set_data` values in `WidgetSet`.

Leading to..

```
> MiqWidgetSet.all.reject { |x| x.valid? }                                                                                                                                                                                                                         

Traceback (most recent call last):
       16: from (irb):3:in `block in irb_binding'
       15: from activerecord (6.0.3.4) lib/active_record/validations.rb:68:in `valid?'
       14: from activemodel (6.0.3.4) lib/active_model/validations.rb:337:in `valid?'
       13: from activemodel (6.0.3.4) lib/active_model/validations/callbacks.rb:117:in `run_validations!'
       12: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:825:in `_run_validation_callbacks'
       11: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:134:in `run_callbacks'
       10: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:513:in `invoke_before'
        9: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:513:in `each'
        8: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:513:in `block in invoke_before'
        7: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:201:in `block in halting'
        6: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:604:in `block in default_terminator'
        5: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:604:in `catch'
        4: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:605:in `block (2 levels) in default_terminator'
        3: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:200:in `block (2 levels) in halting'
        2: from activesupport (6.0.3.4) lib/active_support/callbacks.rb:428:in `block in make_lambda'
        1: from app/models/miq_widget_set/set_data.rb:27:in `init_set_data'
NoMethodError (undefined method `symbolize_keys!' for #<ActiveSupport::HashWithIndifferentAccess:0x000056411ba4e3b0>)
```

And this also fixes `db:seed` - 

the seeded widget sets set `owner_id` to be a group from the yaml,
then `keep_group_when_saving` sets `group_id` to be the same

so, when looking up the same widget set, `sync_from_file` wouldn't find it by `group_id = nil`.
But we can use `read_only` instead, to limit this to seeded widget sets.


Cc @lpichler @kbrock - related to https://github.com/ManageIQ/manageiq/pull/20890 + https://github.com/ManageIQ/manageiq/pull/20972