### PR TITLE
Fix spec failures/fallout from removing `MiqUtil.runcmd`

### DIFF
--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe EvmDatabaseOps do
       allow(file_storage).to  receive(:uri_to_local_path).and_return(tmpdir.join("share").to_s)
       allow(file_storage).to  receive(:add).and_yield(input_path)
 
-      allow(PostgresAdmin).to  receive(:runcmd_with_logging)
+      allow(PostgresAdmin).to  receive(:run_command_with_logging)
       allow(FileUtils).to      receive(:mv).and_return(true)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(200.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(100.megabytes)
@@ -155,7 +155,7 @@ RSpec.describe EvmDatabaseOps do
       allow(file_storage).to  receive(:magic_number_for).and_return(:pgdump)
       allow(file_storage).to  receive(:download).and_yield(input_path)
 
-      allow(PostgresAdmin).to receive(:runcmd_with_logging)
+      allow(PostgresAdmin).to receive(:run_command_with_logging)
 
       allow(VmdbDatabaseConnection).to receive(:count).and_return(1)
     end


### PR DESCRIPTION
This was changed as part of an effort in `manageiq-gems-pending` to remove `MiqUtil.runcmd`:

https://github.com/ManageIQ/manageiq-gems-pending//commit/729d5c00ac877a12aca72ac2efff3beda8eda9cd

And as part of that, the method `runcmd_with_logging` was changed to `run_command_with_logging` in the `PostgresAdmin` class.

While an alias exists for it, the internal method inside of the class was changed, and this spec stubs the internals of that class (in otherwords... not the best test in the world...).

Simply stubbing the proper method allows the tests to pass, and making the spec more resilient can be left for another day.  #punt


Links
-----

* https://github.com/ManageIQ/manageiq-gems-pending/pull/510


Steps for Testing/QA
--------------------

Let's hope that tests pass now.  :smile: