### PR TITLE
Fix sporadic test failure when MiqEvent is not yet defined

### DIFF
--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe EvmDatabaseOps do
       allow(FileUtils).to      receive(:mv).and_return(true)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(200.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(100.megabytes)
+
+      MiqEvent # ensure the MiqEvent class is defined so we can verify raised events
     end
 
     it "locally" do
@@ -98,6 +100,8 @@ RSpec.describe EvmDatabaseOps do
       allow(FileUtils).to      receive(:mv).and_return(true)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(200.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(100.megabytes)
+
+      MiqEvent # ensure the MiqEvent class is defined so we can verify raised events
     end
 
     it "locally" do


### PR DESCRIPTION
The test is checking that MiqEvents were raised to the queue when space
is not available for the backup/dump feature, however depending on test
loading order, it's possible that MiqEvent is not defined.  The code
that raises the event has an explicit check for `defined?(::MiqEvent)`
because it can run outside of the Rails environment context from a rake
task.

This commit changes the test to ensure that the MiqEvent class is
defined, so we can verify that the event is raised.

Closes #20986
