### PR TITLE
Use wim_parser gem instead of manageiq-gems-pending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ gem "sqlite3",                          "~>1.4.0",           :require => false
 gem "sync",                             "~>0.5",             :require => false
 gem "sys-filesystem",                   "~>1.3.4"
 gem "terminal",                                              :require => false
+gem "wim_parser",                       "~>1.0",             :require => false
 
 # Custom gem that replaces mime-types in order to redirect mime-types calls to mini_mime
 #   Source is located at https://github.com/ManageIQ/mime-types-redirector

--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -1,5 +1,5 @@
 class PxeServer < ApplicationRecord
-  autoload :WimParser, "win32/wim_parser" # via manageiq-gems-pending
+  autoload :WimParser, "wim_parser"
 
   include FileDepotMixin
 


### PR DESCRIPTION
wim_parser gem is extracted from manageiq-gems-pending.

Depends on
- [x] A published release of https://github.com/ManageIQ/wim_parser