### PR TITLE
Add chargeback report for Configured Systems

### DIFF
--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -24,12 +24,21 @@ class Chargeback
       resource.id
     end
 
+    def tag_prefix
+      klass_prefix = case resource
+                     when VmOrTemplate     then 'vm'
+                     when ConfiguredSystem then 'configured_system'
+                     end
+
+      "#{klass_prefix}/tag/managed/"
+    end
+
     def tag_list_with_prefix
-      tag_names.map { |t| "vm/tag/managed/#{t}" }
+      tag_names.map { |t| "#{tag_prefix}#{t}" }
     end
 
     def parents_determining_rate
-      [resource.host, resource.ems_cluster, resource.storage, resource.try(:cloud_volumes), parent_ems, resource.tenant,
+      [resource.try(:host), resource.try(:ems_cluster), resource.try(:storage), resource.try(:cloud_volumes), parent_ems, resource.try(:tenant),
        MiqEnterprise.my_enterprise].flatten.compact
     end
 

--- a/app/models/chargeback_configured_system.rb
+++ b/app/models/chargeback_configured_system.rb
@@ -1,0 +1,96 @@
+class ChargebackConfiguredSystem < Chargeback
+  set_columns_hash(
+    :configured_system_id    => :integer,
+    :configured_system_name  => :string,
+    :configured_system_uid   => :string,
+    :configured_system_guid  => :string,
+    :provider_name           => :string,
+    :tenant_name             => :string,
+    :provider_uid            => :string,
+    :cpu_allocated_metric    => :float,
+    :cpu_allocated_cost      => :float,
+    :cpu_cost                => :float,
+    :fixed_compute_1_cost    => :float,
+    :fixed_compute_2_cost    => :float,
+    :memory_allocated_cost   => :float,
+    :memory_allocated_metric => :float,
+    :memory_cost             => :float,
+    :total_cost              => :float
+  )
+
+  def self.build_results_for_report_ChargebackConfiguredSystem(options)
+    @report_user = User.find_by(:userid => options[:userid])
+
+    @configured_systems = nil
+    build_results_for_report_chargeback(options)
+  end
+
+  def self.where_clause(records, options, region)
+    scope = records.where(:resource_type => "ConfiguredSystem")
+    if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
+      scope_with_current_tags = scope.where(:resource => ConfiguredSystem.find_tagged_with(:any => @options[:tag], :ns => '*'))
+      scope.for_tag_names(options[:tag].split("/")[2..-1]).or(scope_with_current_tags)
+    else
+      scope.where(:resource => configured_systems(region))
+    end
+  end
+
+  def self.extra_resources_without_rollups(region)
+    scope = ConfiguredSystem.eager_load(:hardware, :taggings, :tags)
+
+    if @options[:tag] && (@report_user.nil? || !@report_user.self_service?)
+      scope.find_tagged_with(:any => @options[:tag], :ns => '*')
+    else
+      scope.where(:id => configured_systems(region))
+    end
+  end
+
+  def self.report_static_cols
+    %w[configured_system_name]
+  end
+
+  def self.report_col_options
+    {
+      "cpu_allocated_cost"      => {:grouping => [:total]},
+      "cpu_allocated_metric"    => {:grouping => [:total]},
+      "cpu_cost"                => {:grouping => [:total]},
+      "fixed_compute_metric"    => {:grouping => [:total]},
+      "fixed_compute_1_cost"    => {:grouping => [:total]},
+      "fixed_compute_2_cost"    => {:grouping => [:total]},
+      "fixed_cost"              => {:grouping => [:total]},
+      "memory_allocated_cost"   => {:grouping => [:total]},
+      "memory_allocated_metric" => {:grouping => [:total]},
+      "memory_cost"             => {:grouping => [:total]},
+      "total_cost"              => {:grouping => [:total]}
+    }
+  end
+
+  def self.configured_systems(region)
+    @configured_systems ||= {}
+    @configured_systems[region] ||=
+      begin
+        if @options[:entity_id]
+          ConfiguredSystem.where(:id => @options[:entity_id])
+        elsif @options[:tag]
+          ConfiguredSystem.find_tagged_with(:all => @options[:tag], :ns => '*')
+        else
+          raise _('Unable to find strategy for Configured Systems selection')
+        end
+      end
+  end
+
+  def self.display_name(number = 1)
+    n_('Chargeback for Configured Systems', 'Chargebacks for Configured Systems', number)
+  end
+
+  private
+
+  def init_extra_fields(consumption, _region)
+    self.configured_system_id   = consumption.resource_id
+    self.configured_system_name = consumption.resource_name
+    self.configured_system_uid  = consumption.resource.try(:manager_ref)
+    self.configured_system_guid = consumption.resource.try(:virtual_instance_ref)
+    self.provider_name          = consumption.parent_ems.try(:name)
+    self.provider_uid           = consumption.parent_ems.try(:guid)
+  end
+end

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -1,6 +1,7 @@
 class ConfiguredSystem < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
+  include CustomAttributeMixin
 
   acts_as_miq_taggable
   belongs_to :configuration_location
@@ -14,8 +15,10 @@ class ConfiguredSystem < ApplicationRecord
   belongs_to :operating_system_flavor
   belongs_to :orchestration_stack
   has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
+  has_one    :hardware, :through => :computer_system
   has_and_belongs_to_many :configuration_tags
 
+  alias ext_management_system manager
   alias_attribute :name,    :hostname
   alias_method    :configuration_manager, :manager
 

--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -3,6 +3,7 @@
 - AuditEvent
 - AvailabilityZone
 - BottleneckEvent
+- ChargebackConfiguredSystem
 - ChargebackVm
 - ChargebackContainerProject
 - ChargebackContainerImage

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1420,6 +1420,7 @@ en:
       AvailabilityZone:               Availability Zone
       BottleneckEvent:                Bottleneck Event
       HostAggregate:                  Host Aggregate
+      ChargebackConfiguredSystem:     Chargeback for Configured Systems
       ChargebackVm:                   Chargeback for Vms
       ChargebackContainerImage:       Chargeback for Image
       ChargebackContainerProject:     Chargeback for Projects

--- a/spec/models/chargeback_configured_system_spec.rb
+++ b/spec/models/chargeback_configured_system_spec.rb
@@ -1,0 +1,111 @@
+RSpec.describe ChargebackConfiguredSystem do
+  include Spec::Support::ChargebackHelper
+
+  let(:admin) { FactoryBot.create(:user_admin) }
+  let(:base_options) do
+    {:interval_size       => 2,
+     :end_interval_offset => 0,
+     :tag                 => '/managed/environment/prod',
+     :ext_options         => {:tz => 'UTC'},
+     :userid              => admin.userid}
+  end
+  let(:hourly_rate)               { 0.01 }
+  let(:count_hourly_rate)         { 1.00 }
+  let(:cpu_count)                 { 1.0 }
+  let(:memory_available)          { 1000.0 }
+  let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
+  let(:report_run_time) { month_end }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
+  let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) { FactoryBot.create(:ems_vmware) }
+
+  let(:hourly_variable_tier_rate)       { {:variable_rate => hourly_rate.to_s} }
+  let(:count_hourly_variable_tier_rate) { {:variable_rate => count_hourly_rate.to_s} }
+  let(:fixed_compute_tier_rate)         { {:fixed_rate => hourly_rate.to_s} }
+
+  let(:detail_params) do
+    {
+      :chargeback_rate_detail_cpu_allocated      => {:tiers => [count_hourly_variable_tier_rate]},
+      :chargeback_rate_detail_memory_allocated   => {:tiers => [hourly_variable_tier_rate]},
+      :chargeback_rate_detail_fixed_compute_cost => {:tiers => [fixed_compute_tier_rate]}
+    }
+  end
+
+  let!(:chargeback_rate) do
+    FactoryBot.create(:chargeback_rate, :detail_params => detail_params)
+  end
+
+  before do
+    MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
+    ManageIQ::Showback::InputMeasure.seed
+    MiqEnterprise.seed
+
+    EvmSpecHelper.create_guid_miq_server_zone
+    cat = FactoryBot.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
+    c = FactoryBot.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
+    @tag = c.tag
+    ChargebackRate.set_assignments(:compute, [{:cb_rate => chargeback_rate, :object => MiqEnterprise.first}])
+
+    @cs = FactoryBot.create(:configured_system, :created_at => report_run_time - 1.day, :computer_system =>
+            FactoryBot.create(:computer_system,
+                              :hardware => FactoryBot.create(:hardware,
+                                                             :cpu_total_cores => cores,
+                                                             :memory_mb       => mem_mb)))
+    @cs.tag_with(@tag.name, :ns => '*')
+
+    @cs2 = FactoryBot.create(:configured_system, :created_at => report_run_time - 1.day, :computer_system =>
+             FactoryBot.create(:computer_system,
+                               :hardware => FactoryBot.create(:hardware,
+                                                              :cpu_total_cores => cores,
+                                                              :memory_mb       => mem_mb)))
+    @cs2.tag_with(@tag.name, :ns => '*')
+    Timecop.travel(report_run_time)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context 'without metric rollups' do
+    let(:cores)               { 7 }
+    let(:mem_mb)              { 1777 }
+
+    let(:fixed_cost) { hourly_rate * 24 }
+    let(:mem_cost) { mem_mb * hourly_rate * 24 }
+    let(:cpu_cost) { cores * count_hourly_rate * 24 }
+
+    context 'for Configured System' do
+      let(:options) { base_options.merge(:interval => 'daily') }
+
+      subject { ChargebackConfiguredSystem.build_results_for_report_ChargebackConfiguredSystem(options).first.first }
+
+      it 'fixed compute/allocated metrics is calculated properly' do
+        expect(subject.chargeback_rates).to eq(chargeback_rate.description)
+        expect(subject.fixed_compute_metric).to eq(1) # One day of fixed compute metric
+        expect(subject.fixed_compute_1_cost).to eq(fixed_cost)
+      end
+
+      it 'allocated metrics are calculated properly' do
+        expect(subject.memory_allocated_metric).to  eq(mem_mb)
+        expect(subject.memory_allocated_cost).to    eq(mem_cost)
+        expect(subject.cpu_allocated_metric).to     eq(cores)
+        expect(subject.cpu_allocated_cost).to       eq(cpu_cost)
+        expect(subject.total_cost).to               eq(fixed_cost + cpu_cost + mem_cost)
+      end
+
+      context "group by date" do
+        let(:options) { base_options.merge(:groupby => ["date"], :interval => 'daily') }
+
+        subject { ChargebackConfiguredSystem.build_results_for_report_ChargebackConfiguredSystem(options).first.map { |x| x.entity.id } }
+
+        it "groups report by date" do
+          expect(subject).to match_array([@cs.id, @cs2.id])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new chargeback report for Configured Systems - implementation for https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/55

<img width="1920" alt="ChargeBackReport-ConfiguredSystem2" src="https://user-images.githubusercontent.com/41962815/107585668-a921d800-6bcc-11eb-9cd4-2310bf8c1082.png">

<img width="1920" alt="ChargeBackReport-ConfiguredSystem1" src="https://user-images.githubusercontent.com/41962815/107585690-b048e600-6bcc-11eb-967b-dc3048759075.png">

