### PR TITLE
Remove unused Vm.lookup_by_full_location method

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -650,25 +650,6 @@ class VmOrTemplate < ApplicationRecord
     result
   end
 
-  # TODO: Vmware specific
-  def self.lookup_by_full_location(path)
-    return nil if path.blank?
-    vm_hash = {}
-    begin
-      vm_hash[:name], vm_hash[:location] = repository_parse_path(path)
-    rescue => err
-      _log.warn("Warning: [#{err.message}]")
-      vm_hash[:location] = location2uri(path)
-    end
-    _log.info("vm_hash [#{vm_hash.inspect}]")
-    store = Storage.find_by(:name => vm_hash[:name])
-    return nil unless store
-    VmOrTemplate.find_by(:location => vm_hash[:location], :storage_id => store.id)
-  end
-
-  singleton_class.send(:alias_method, :find_by_full_location, :lookup_by_full_location)
-  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_full_location => :lookup_by_full_location)
-
   def self.repository_parse_path(path)
     path.gsub!(/\\/, "/")
     #it's empty string for local type

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -86,16 +86,6 @@ RSpec.describe VmOrTemplate do
     end
   end
 
-  describe ".lookup_by_full_location" do
-    it "should lookup vm by full location" do
-      storage = Storage.new(:name => "//test/storage")
-      vm = FactoryBot.create(:vm_vmware, :name => 'vm', :vendor => 'vmware', :storage => storage, :location => 'test_location')
-
-      expect(storage.save!).to be_truthy
-      expect(VmOrTemplate.lookup_by_full_location("#{storage.name}/#{vm.location}")).to eq(vm)
-    end
-  end
-
   describe ".lookup_by_path" do
     it "should lookup vm by path" do
       storage = Storage.new(:name => "//test/storage")


### PR DESCRIPTION
Cannot find any callers of [lookup_by_full_location](https://github.com/search?q=org%3AManageIQ+lookup_by_full_location&type=code) nor of its deprecated alias [find_by_full_location](https://github.com/search?q=org%3AManageIQ+find_by_full_location&type=code)