### PR TITLE
Remove unused Vm.lookup_by_path method

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1219,21 +1219,6 @@ class VmOrTemplate < ApplicationRecord
     return storage_id, location
   end
 
-  # TODO: Vmware specific
-  # Finds a Vm by a full path of the Storage and location
-  def self.lookup_by_path(path)
-    begin
-      storage_id, location = parse_path(path)
-    rescue
-      _log.warn("Invalid path specified [#{path}]")
-      return nil
-    end
-    VmOrTemplate.find_by(:storage_id => storage_id, :location => location)
-  end
-
-  singleton_class.send(:alias_method, :find_by_path, :lookup_by_path)
-  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_path => :lookup_by_path)
-
   def state
     (power_state || "unknown").downcase
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1201,24 +1201,6 @@ class VmOrTemplate < ApplicationRecord
     File.join('/rhev/data-center', datacenter.uid_ems, 'mastersd/master/vms', uid_ems, location)
   end
 
-  # TODO: Vmware specific
-  # Parses a full path into the Storage and location
-  def self.parse_path(path)
-    # TODO: Review the name of this method such that the return types don't conflict with those of self.repository_parse_path
-    storage_name, relative_path = repository_parse_path(path)
-
-    storage = Storage.find_by(:name => storage_name)
-    if storage.nil?
-      storage_id = nil
-      location   = location2uri(relative_path)
-    else
-      storage_id = storage.id
-      location   = relative_path
-    end
-
-    return storage_id, location
-  end
-
   def state
     (power_state || "unknown").downcase
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -625,17 +625,6 @@ class VmOrTemplate < ApplicationRecord
     location
   end
 
-  def self.uri2location(location)
-    uri = URI.parse(location)
-    location = URI.decode(uri.path)
-    location = location[1..-1] if location[2..2] == ':'
-    location
-  end
-
-  def uri2location
-    self.class.uri2location(location)
-  end
-
   def save_scan_history(datahash)
     result = scan_histories.build(
       :status      => datahash['status'],

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -86,16 +86,6 @@ RSpec.describe VmOrTemplate do
     end
   end
 
-  describe ".lookup_by_path" do
-    it "should lookup vm by path" do
-      storage = Storage.new(:name => "//test/storage")
-      vm = FactoryBot.create(:vm_vmware, :name => 'vm', :vendor => 'vmware', :storage => storage, :location => 'test_location')
-
-      expect(storage.save!).to be_truthy
-      expect(VmOrTemplate.lookup_by_path("#{storage.name}/#{vm.location}")).to eq(vm)
-    end
-  end
-
   describe "save_genealogy_information" do
     let(:vm) { FactoryBot.create(:vm_vmware) }
     let(:parent) { FactoryBot.create(:vm_vmware) }


### PR DESCRIPTION
Cannot find any callers of [lookup_by_path](https://github.com/search?q=org%3AManageIQ+lookup_by_path&type=code) nor of its deprecated alias [find_by_path](https://github.com/search?q=org%3AManageIQ+find_by_path&type=code)