### PR TITLE
Remove unused method Vm#is_controllable?

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1542,10 +1542,6 @@ class Host < ApplicationRecord
     services.order(:name).uniq.pluck(:name)
   end
 
-  def control_supported?
-    !(is_vmware? && vmm_product == "Workstation")
-  end
-
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym
     when :ems_events, :event_streams

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1083,11 +1083,6 @@ class VmOrTemplate < ApplicationRecord
     host_id.present? && current_state != "never"
   end
 
-  # TODO: Vmware specfic
-  def is_controllable?
-    runnable? && !template? && host && host.control_supported?
-  end
-
   def self.refresh_ems(vm_ids)
     vm_ids = [vm_ids] unless vm_ids.kind_of?(Array)
     vm_ids = vm_ids.collect { |id| [base_class, id] }


### PR DESCRIPTION
There are [no callers](https://github.com/search?q=org%3AManageIQ+is_controllable%3F&type=code) of `Vm#is_controllable?`
There is only [1 caller](https://github.com/search?q=org%3AManageIQ+control_supported%3F&type=code) of `Host#control_supported?` method - and that is `Vm#is_controllable?` - so deleted this method as well.