### PR TITLE
Make Host#refresh_firewall_rules operate via SupportsFeatureMixin

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -123,6 +123,7 @@ module SupportsFeatureMixin
     :refresh_ems                         => 'Refresh Relationships and Power States',
     :refresh_network_interfaces          => 'Refresh Network Interfaces for a Host',
     :refresh_new_target                  => 'Refresh non-existing record',
+    :refresh_firewall_rules              => 'Refresh Firewall Rules',
     :regions                             => 'Regions of a Provider',
     :remove_all_snapshots                => 'Remove all snapshots',
     :remove_host                         => 'Remove Host',


### PR DESCRIPTION
This is only supported for Vmware Infra provider (see https://github.com/search?q=org%3AManageIQ+refresh_firewall_rules&type=code)