### PR TITLE
Fix `uninitialized constant MiqEnvironment::Command::AwesomeSpawn`

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -92,9 +92,10 @@ module MiqEnvironment
     def self.supports_command?(cmd)
       return false unless EVM_KNOWN_COMMANDS.include?(cmd)
 
+      require "awesome_spawn"
+
       begin
         # If 'which apachectl' returns non-zero, it wasn't found
-        require "awesome_spawn"
         AwesomeSpawn.run!(which, :params => [cmd])
       rescue AwesomeSpawn::CommandResultError
         false

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -96,7 +96,7 @@ module MiqEnvironment
         # If 'which apachectl' returns non-zero, it wasn't found
         require "awesome_spawn"
         AwesomeSpawn.run!(which, :params => [cmd])
-      rescue
+      rescue AwesomeSpawn::CommandResultError
         false
       else
         true

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -94,6 +94,7 @@ module MiqEnvironment
 
       begin
         # If 'which apachectl' returns non-zero, it wasn't found
+        require "awesome_spawn"
         AwesomeSpawn.run!(which, :params => [cmd])
       rescue
         false


### PR DESCRIPTION
Fix `AwesomeSpawn` not being required by `MiqEnvironment` early on in the application boot.

This was causing `supports_command?("systemctl")` to return false even though the command was supported.  We were then caching that result and returning false for the rest of the app lifetime.

```
uninitialized constant MiqEnvironment::Command::AwesomeSpawn
/var/www/miq/vmdb/lib/miq_environment.rb:98:in `supports_command?'
/var/www/miq/vmdb/lib/miq_environment.rb:40:in `supports_systemd?'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:60:in `create_journald_logger'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:42:in `create_loggers'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:18:in `init'
/var/www/miq/vmdb/config/application.rb:134:in `<class:Application>'
/var/www/miq/vmdb/config/application.rb:35:in `<module:Vmdb>'
/var/www/miq/vmdb/config/application.rb:34:in `<top (required)>'
```