### PR TITLE
Ruby 2.7: Replace URI.escape/encode and unescape/decode with URI::DEFAULT_PARSER escape/unescape

### DIFF
--- a/app/models/file_depot_ftp.rb
+++ b/app/models/file_depot_ftp.rb
@@ -125,7 +125,7 @@ class FileDepotFtp < FileDepot
 
   def base_path
     # uri: "ftp://ftp.example.com/incoming" => #<Pathname:incoming>
-    path = URI(URI.encode(uri)).path
+    path = URI(URI::Parser.new.escape(uri)).path
     Pathname.new(path)
   end
 

--- a/app/models/file_depot_ftp.rb
+++ b/app/models/file_depot_ftp.rb
@@ -125,7 +125,7 @@ class FileDepotFtp < FileDepot
 
   def base_path
     # uri: "ftp://ftp.example.com/incoming" => #<Pathname:incoming>
-    path = URI(URI::Parser.new.escape(uri)).path
+    path = URI(URI::DEFAULT_PARSER.escape(uri)).path
     Pathname.new(path)
   end
 

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -28,7 +28,7 @@ class LogFile < ApplicationRecord
   # Base is the URI defined by the user
   # loc_file is the name of the original file
   def build_log_uri(base_uri, loc_file)
-    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI::Parser.new.escape(base_uri))
+    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(base_uri))
 
     # Convert encoded spaces back to spaces
     path.gsub!('%20', ' ')
@@ -212,7 +212,7 @@ class LogFile < ApplicationRecord
     # Strip any leading and trailing whitespace
     uri.strip!
 
-    URI.split(URI::Parser.new.escape(uri))[0]
+    URI.split(URI::DEFAULT_PARSER.escape(uri))[0]
   end
 
   def legacy_depot_hash

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -28,7 +28,7 @@ class LogFile < ApplicationRecord
   # Base is the URI defined by the user
   # loc_file is the name of the original file
   def build_log_uri(base_uri, loc_file)
-    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI.encode(base_uri))
+    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI::Parser.new.escape(base_uri))
 
     # Convert encoded spaces back to spaces
     path.gsub!('%20', ' ')
@@ -212,7 +212,7 @@ class LogFile < ApplicationRecord
     # Strip any leading and trailing whitespace
     uri.strip!
 
-    URI.split(URI.encode(uri))[0]
+    URI.split(URI::Parser.new.escape(uri))[0]
   end
 
   def legacy_depot_hash

--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -39,7 +39,7 @@ module FileDepotMixin
       # Strip any leading and trailing whitespace
       uri_str.strip!
 
-      scheme, _userinfo, _host, _port, _registry, _path, _opaque, _query, _fragment = URI.split(URI::Parser.new.escape(uri_str))
+      scheme, _userinfo, _host, _port, _registry, _path, _opaque, _query, _fragment = URI.split(URI::DEFAULT_PARSER.escape(uri_str))
       scheme
     end
   end

--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -39,7 +39,7 @@ module FileDepotMixin
       # Strip any leading and trailing whitespace
       uri_str.strip!
 
-      scheme, _userinfo, _host, _port, _registry, _path, _opaque, _query, _fragment = URI.split(URI.encode(uri_str))
+      scheme, _userinfo, _host, _port, _registry, _path, _opaque, _query, _fragment = URI.split(URI::Parser.new.escape(uri_str))
       scheme
     end
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -382,7 +382,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :scheme   => 'ssh',
         :userinfo => 'root',
         :host     => source.host.miq_custom_get('TransformationIPAddress') || source.host.ipaddress,
-        :path     => "/vmfs/volumes/#{URI::Parser.new.escape(storage.name)}/#{URI::Parser.new.escape(source.location)}"
+        :path     => "/vmfs/volumes/#{URI::DEFAULT_PARSER.escape(storage.name)}/#{URI::DEFAULT_PARSER.escape(source.location)}"
       ).to_s,
       :vm_uuid              => source.uid_ems,
       :conversion_host_uuid => conversion_host.resource.ems_ref,

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -382,7 +382,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :scheme   => 'ssh',
         :userinfo => 'root',
         :host     => source.host.miq_custom_get('TransformationIPAddress') || source.host.ipaddress,
-        :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
+        :path     => "/vmfs/volumes/#{URI::Parser.new.escape(storage.name)}/#{URI::Parser.new.escape(source.location)}"
       ).to_s,
       :vm_uuid              => source.uid_ems,
       :conversion_host_uuid => conversion_host.resource.ems_ref,

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe FileDepotFtp do
     end
   end
 
+  context "#base_path" do
+    it "escaped characters" do
+      file_depot_ftp.uri = "ftp://ftpserver.com/path/abc 123 %^{}|\"<>\\.csv"
+      expect(file_depot_ftp.send(:base_path).to_s).to eq "path/abc%20123%20%25%5E%7B%7D%7C%22%3C%3E%5C.csv"
+    end
+
+    it "not escaped characters" do
+      file_depot_ftp.uri = "ftp://ftpserver.com/path/abc&$!@*()_+:-=;',./.csv"
+      expect(file_depot_ftp.send(:base_path).to_s).to eq "path/abc&$!@*()_+:-=;',./.csv"
+    end
+  end
+
   context "#merged_uri" do
     before do
       file_depot_ftp.uri = uri


### PR DESCRIPTION
Note:

URI::DEFAULT_PARSER == URI::Parser.new
https://github.com/ruby/ruby/blob/ruby_2_6/lib/uri/common.rb#L22

Fixes various warnings of this variety:
app/models/file_depot_ftp.rb:128: warning: URI.escape is obsolete
app/models/mixins/file_depot_mixin.rb:42: warning: URI.escape is obsolete

Ruby 2.7 prints this warning and they suggest the following from https://ruby-doc.org/stdlib-2.7.2/libdoc/uri/rdoc/URI/Escape.html#method-i-escape-label-Description:

```
This method is obsolete and should not be used. Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component depending on your specific use case.
```