### PR TITLE
Fix unintentional override of base adapter's database_version method

### DIFF
--- a/lib/extensions/ar_adapter/ar_dba.rb
+++ b/lib/extensions/ar_adapter/ar_dba.rb
@@ -3,7 +3,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
     select_value("SELECT pg_database_size(#{quote(name)})").to_i
   end
 
-  def database_version
+  def database_version_details
     select_value("SELECT version()")
   end
 

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -140,8 +140,7 @@ class EvmServer
     ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection(spec_name))
 
     # Log the Versions
-    _log.info("Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], version: [#{ActiveRecord::Base.connection.database_version}]")                   if ActiveRecord::Base.connection.respond_to?(:database_version)
-    _log.info("Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], detailed version: [#{ActiveRecord::Base.connection.detailed_database_version}]") if ActiveRecord::Base.connection.respond_to?(:detailed_database_version)
+    _log.info("Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], version: [#{ActiveRecord::Base.connection.database_version_details}]") if ActiveRecord::Base.connection.respond_to?(:database_version_details)
   end
 
   def check_migrations_up_to_date


### PR DESCRIPTION
In Rails 5.2, the database_version method did not exist.  However, in
Rails 6 it does, and it returns an integer representing the version
number.  Our override breaks some core Rails code when it tries to
verify the minimum version number, and ends up comparing a String to an
Integer.

Rails method:
`ActiveRecord::Base.connection.database_version # => 100015`
Our method:
`ActiveRecord::Base.connection.database_version # => "PostgreSQL 10.15 on x86_64-apple-darwin19.6.0, compiled by Apple clang version 12.0.0 (clang-1200.0.32.27), 64-bit"`

This manifests during the boot process when we are initializing
Settings.  There, we check for database connectivity, which now blows
up.  Because of this, we don't load any settings changes from the
database on boot.

Fixes #21035

@NickLaMuro @agrare Please review

Note: Unfortunately, I cannot find a way to add specs for this.  This happens so early in the application boot that I can't find a way to intercept it early enough with RSpec.