### PR TITLE
Use a more specific rescue to avoid hiding unexpected errors

### DIFF
--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -76,8 +76,9 @@ module Vmdb
       end
 
       def database_connectivity?
-        conn = ActiveRecord::Base.connection rescue nil
-        conn && ActiveRecord::Base.connected?
+        ActiveRecord::Base.connection && ActiveRecord::Base.connected?
+      rescue ActiveRecord::NoDatabaseError
+        false
       end
     end
   end


### PR DESCRIPTION
Follow up to #21037 

If this code were in place prior to the Rails 6 upgrade, then we would have found the accidental override at that time.

To test, we can do the following:

```
$ bin/rake db:drop
$ bin/rails c # should not blow up

$ bin/rake db:create
$ bin/rails c
> Settings.log.level # => "info"

$ bin/rake db:migrate
$ bin/rails c
> Settings.log.level # => "info"

$ bin/rake db:seed
$ bin/rails c
> Settings.log.level # => "info"
> Vmdb::Settings.save!(MiqServer.my_server, :log => {:level => "debug"})
> Settings.reload!
> Settings.log.level # => "debug"

$ bin/rails c
> Settings.log.level # => "debug"
```

@NickLaMuro @agrare Please review.