### PR TITLE
Loosen log message check in spec

### DIFF
--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -257,12 +257,12 @@ RSpec.describe ProcessTasksMixin do
           expect(api_collection).to receive(:find).with(0).and_return(Struct.new(:id).new(0))
           expect(api_collection).to receive(:find).with(1).and_return(double("Something that responds", :id => 0, :the_task => nil))
 
-          expect($log).to receive(:error).with("MIQ(ProcessTasksMixinTestClass.send_action) undefined method `the_task' for #<struct id=0>").and_call_original
+          expect($log).to receive(:error).with(a_string_including("undefined method `the_task' for #<struct id=0>")).and_call_original
           expect(test_class.invoke_api_tasks(api_connection, :ids => [0, 1], :task => "the_task")).to eq([0, 1])
         end
 
         it "collection" do
-          expect($log).to receive(:error).with("MIQ(ProcessTasksMixinTestClass.send_action) undefined method `the_task' for []:Array").and_call_original
+          expect($log).to receive(:error).with(a_string_including("undefined method `the_task' for []:Array")).and_call_original
           expect { test_class.invoke_api_tasks(api_connection, :task => "the_task") }.not_to raise_error
         end
       end


### PR DESCRIPTION
In development I use the [dead_end gem](https://github.com/zombocom/dead_end) that enhance error messages to help find the location of an NoMethodError (amongst other things).  This particular spec is checking a full string being logged, which fails for me locally.  Instead I've changed it to look for the part of the string it really cares about, allowing it to pass for me and still ensure the spec is working as expected.

@jrafanie Please review.