### PR TITLE
Prefer mocking invalid domains over VCR

### DIFF
--- a/spec/models/firmware_registry/rest_api_depot_spec.rb
+++ b/spec/models/firmware_registry/rest_api_depot_spec.rb
@@ -33,9 +33,8 @@ RSpec.describe FirmwareRegistry::RestApiDepot do
 
     context 'when bad host' do
       it 'managed error is raised' do
-        with_vcr('when-bad-host') do
-          expect { described_class.fetch_from_remote('http://bad.host', 'user', 'pass') }.to raise_error(MiqException::Error)
-        end
+        stub_request(:get, "example.invalid").to_raise(SocketError)
+        expect { described_class.fetch_from_remote('http://example.invalid', 'user', 'pass') }.to raise_error(MiqException::Error)
       end
     end
 


### PR DESCRIPTION
spec/models/firmware_registry/rest_api_depot_spec.rb:36 was using a
vcr cassette, but that cassette was never committed.  As such, when
this spec runs it a) reaches out to DNS and b) in the case of home
users where the ISP intercepts invalid domains (e.g. https://searchassist.verizon.com)
it will create an untracked VCR file locally.

VCR will not write a cassette for invalid domains, since it raises a
SocketError.  So, this commit uses webmock to stub the request and
force a SocketError, which is what a normal, non-intercepted, invalid
domain request will look like.

Additionally, this commit changes from bad.host to example.invalid,
which is a recognized "invalid domain" as per RFC2606.

@bdunne Please review.  This is a replacement PR for #21041 