### PR TITLE
[Zone] accepts_nested_attributes_for :authentication

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -35,8 +35,6 @@ class Zone < ApplicationRecord
   before_destroy :check_zone_in_use_on_destroy
   after_create :create_server_if_podified
 
-  include AuthenticationMixin
-
   include SupportsFeatureMixin
   include Metric::CiMixin
   include AggregationMixin
@@ -44,6 +42,12 @@ class Zone < ApplicationRecord
 
   scope :visible, -> { where(:visible => true) }
   default_value_for :visible, true
+
+  def self.has_one_type
+    :windows_domain
+  end
+
+  include AuthenticationMixin
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)


### PR DESCRIPTION
**Requires change in UI at the same time**

- Introduces code into the `AuthenticationMixin` to allow the including class to choose whether the relationship is a `has_one` or a `has_many`
- Allows saving attributes for an authentication with the `Zone` record (via `accepts_nested_attributes_for`)
- Implements the changes into `Zone`, where the relationship has indirectly been a `has_one` all along

Part of the alternative to https://github.com/ManageIQ/manageiq-api/pull/916

Links
-----

* Cross Repo Tests:  ~~https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/318~~ https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/319
* Changes required in UI classic:  https://github.com/ManageIQ/manageiq-ui-classic/pull/7629
* Alternative to https://github.com/ManageIQ/manageiq-api/pull/916
* Addresses https://github.com/ManageIQ/manageiq-api/issues/898


QA Steps
--------

You can test that this works in he API by using the following post body:

```
# POST /api/zones/X
{
  "action": "edit",
  "resource": {
    "description": "Updated Zone Description",
    "authentication_attributes": {
      "userid": "from",
      "password": "curl"
    }
  }
}
```