### PR TITLE
Safe delete for cloud-volume

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -139,6 +139,7 @@ module SupportsFeatureMixin
     :resize                              => 'Resizing',
     :retire                              => 'Retirement',
     :revert_to_snapshot                  => 'Revert Snapshot Operation',
+    :safe_delete                         => 'CloudVolume safe delete',
     :smartstate_analysis                 => 'Smartstate Analysis',
     :snapshot_create                     => 'Create Snapshot',
     :snapshots                           => 'Snapshots',

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -823,6 +823,14 @@
       :description: Remove Volumes
       :feature_type: admin
       :identifier: cloud_volume_delete
+    - :name: Safe Remove
+      :description: Safely Remove Volumes
+      :feature_type: admin
+      :identifier: cloud_volume_safe_delete
+    - :name: Reload
+      :description: Reload the current display
+      :feature_type: admin
+      :identifier: cloud_volume_reload
 
 # AuthKeyPair
 - :name: Auth Key Pairs

--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -3,6 +3,12 @@ FactoryBot.define do
     sequence(:volume_type) { |n| "volume_type_#{seq_padded_for_sorting(n)}" }
   end
 
+  factory :cloud_volume_autosde,
+          :class  => "ManageIQ::Providers::Autosde::StorageManager::CloudVolume",
+          :parent => :cloud_volume do
+    status { "available" }
+  end
+
   factory :cloud_volume_openstack,
           :class  => "ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume",
           :parent => :cloud_volume do


### PR DESCRIPTION
This PR adds the safe_delete feature and adds safe delete method and queue to VolumeMapping.

Part of https://github.com/ManageIQ/manageiq/issues/21055