### PR TITLE
Expose ems supports_cloud_subnet_create as an API queryable attribute

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -288,6 +288,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_volume_resizing, :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
   virtual_column :supports_cinder_volume_types, :type => :boolean
+  virtual_column :supports_cloud_subnet_create, :type => :boolean
   virtual_column :supports_cloud_volume, :type => :boolean
   virtual_column :supports_cloud_volume_create, :type => :boolean
   virtual_column :supports_create_flavor, :type => :boolean
@@ -829,6 +830,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_cinder_volume_types
     supports_cinder_volume_types?
+  end
+
+  def supports_cloud_subnet_create
+    supports_cloud_subnet_create?
   end
 
   def supports_cloud_volume

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -67,6 +67,7 @@ module SupportsFeatureMixin
     # FIXME: this is just a internal helper and should be refactored
     :control                             => 'Basic control operations',
     :cloud_tenants                       => 'CloudTenant',
+    :cloud_subnet_create                 => 'CloudSubnetCreate',
     :cloud_volume                        => 'Cloud Volume',
     :cloud_volume_create                 => 'Create Cloud Volume',
     :cloud_tenant_mapping                => 'CloudTenant mapping',


### PR DESCRIPTION
This is necessary for being able to query the providers that support the creation/editing of CloudSubnet entities.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6861

@miq-bot add_label enhancement
@miq-bot assign @agrare 