### PR TITLE
Lock down bundler to pre-2.2.10 and fix ManageIQ::Environment.bundler_version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be requi
 gem "ancestry",                         "~>3.0.7",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
-gem "bundler",                          "~> 2.1", ">=2.1.4", :require => false
+gem "bundler",                          "~> 2.1", ">=2.1.4", "<2.2.10", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -132,7 +132,13 @@ module ManageIQ
 
     def self.bundler_version
       gemfile = APP_ROOT.join("Gemfile")
-      File.read(gemfile).match(/gem\s+['"]bundler['"],\s+['"](.+?)['"]/)[1]
+
+      require "bundler"
+      gemfile_dependencies = Bundler::Definition.build(gemfile, nil, {}).dependencies
+      bundler_dependency   = gemfile_dependencies.detect { |dep| dep.name == "bundler" }
+
+      version_requirements = bundler_dependency.requirement.requirements
+      version_requirements.map { |req| req.join(" ") }.join(", ")
     end
 
     def self.run_rake_task(task, root: APP_ROOT)


### PR DESCRIPTION
Bundler 2.2.10 has a bug causing bundle install to fail with gems being installed from one source that depend on gems from another.  Until that is resolved we should lockdown bundler to max 2.2.9.

Also the `ManageIQ::Environment.bundler_version` regex isn't able to properly parse all gem requirements other than the first on.  We can use the `Bundler::Definition` to parse the Gemfile "properly"

Alternative to: https://github.com/ManageIQ/manageiq-ui-classic/pull/7634#issuecomment-779384428