### PR TITLE
Prefer rollup records with tags to grouping in chargeback

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -62,6 +62,7 @@ class Chargeback < ActsAsArModel
           key = result_key[:key]
           _log.debug("Report row key #{key}")
 
+          consumption.tag_filter_for_rollup_records(result_key[:key_object].tag) if result_key[:key_object]&.tag
           data[key] ||= new(options, consumption, region.region, result_key)
 
           chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -45,6 +45,13 @@ class Chargeback
       [Time.current, @end_time].min
     end
 
+    def rollup_records_tag_names
+      tag_names
+    end
+
+    def tag_filter_for_rollup_records(_tag)
+    end
+
     private
 
     def hours_in_interval


### PR DESCRIPTION
This is applicable only for tag group feature in chargeback reports.

Each group on result report is calculated with all metric rollups in the consumptions.
But it is possible that all metric rollups don't have tag names in whole consumptions.
For example: When Vm was untagged in middle of month then we need to reflect it in chargeback calculation for each group on report result and we should use only metric rollups with tag name (in `MetricRollup#tag_names`)

When we have resource tagged - this is no applied. We use all metric rollups of resource in the consumption.


@miq-bot assign @gtanzillo 

@miq-bot add_label bug, chargeback

