### PR TITLE
Extract all_ems/all_valid_ems/any_valid? methods

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::BaseManager::EventCatcher < MiqWorker
   require_nested :Runner
 
+  include ProviderWorkerMixin
   include PerEmsWorkerMixin
 
   self.required_roles = ["event"]

--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqQueueWorkerB
 
   require_nested :Runner
 
+  include ProviderWorkerMixin
   include PerEmsTypeWorkerMixin
 
   self.required_roles = ["ems_metrics_collector"]

--- a/app/models/manageiq/providers/base_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::BaseManager::OperationsWorker < MiqQueueWorkerBase
   require_nested :Runner
 
+  include ProviderWorkerMixin
   include PerEmsWorkerMixin
 
   self.required_roles = %w[ems_operations]

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
   require_nested :Runner
 
+  include ProviderWorkerMixin
   include PerEmsWorkerMixin
 
   # Don't allow multiple refresh workers to run at once

--- a/app/models/mixins/per_ems_type_worker_mixin.rb
+++ b/app/models/mixins/per_ems_type_worker_mixin.rb
@@ -7,17 +7,5 @@ module PerEmsTypeWorkerMixin
 
       super
     end
-
-    def ems_class
-      module_parent
-    end
-
-    def emses_in_zone
-      ems_class.where(:zone_id => MiqServer.my_server.zone.id)
-    end
-
-    def any_valid_ems_in_zone?
-      emses_in_zone.any?(&:authentication_status_ok?)
-    end
   end
 end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -10,18 +10,6 @@ module PerEmsWorkerMixin
   end
 
   module ClassMethods
-    def ems_class
-      module_parent
-    end
-
-    def all_ems_in_zone
-      ems_class.where(:zone_id => MiqServer.my_server.zone.id)
-    end
-
-    def all_valid_ems_in_zone
-      all_ems_in_zone.select { |e| e.enabled && e.authentication_status_ok? }
-    end
-
     def desired_queue_names
       all_valid_ems_in_zone.collect { |e| queue_name_for_ems(e) }
     end

--- a/app/models/mixins/provider_worker_mixin.rb
+++ b/app/models/mixins/provider_worker_mixin.rb
@@ -1,0 +1,21 @@
+module ProviderWorkerMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def ems_class
+      module_parent
+    end
+
+    def all_ems_in_zone
+      ems_class.where(:zone_id => MiqServer.my_server.zone.id)
+    end
+
+    def all_valid_ems_in_zone
+      all_ems_in_zone.select { |e| e.enabled && e.authentication_status_ok? }
+    end
+
+    def any_valid_ems_in_zone?
+      all_valid_ems_in_zone.any?
+    end
+  end
+end


### PR DESCRIPTION
These methods were essentially duplicated in the PerEmsWorkerMixin and PerEmsTypeWorkerMixin, as well as being required by provider workers that aren't PerEms or PerEmsType (e.g. the old VimBroker and the current AmazonCoordinator)