### PR TITLE
Make availability_zone a virtual column for HostAggregate

### DIFF
--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -18,6 +18,7 @@ class HostAggregate < ApplicationRecord
   has_many   :vim_performance_states, :as => :resource
 
   virtual_total :total_vms, :vms
+  virtual_column :availability_zone, :type => :string
 
   PERF_ROLLUP_CHILDREN = [:vms]
 


### PR DESCRIPTION
I'm not sure if I'm doing it right, but something like this is necessary for the [new HA form](https://github.com/ManageIQ/manageiq-ui-classic/pull/7598)

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6867

@miq-bot assign @agrare 