### PR TITLE
database_connectivity? should handle not-running database

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -12,6 +12,7 @@ namespace :test do
     ENV['VERBOSE'] ||= "false"
   end
 
+  desc "Verifies that the rails environment does not require DB access"
   task :verify_no_db_access_loading_rails_environment do
     if Rake::Task['environment'].already_invoked
       raise "Failed to verify database access when loading rails because the 'environment' rake task has already been invoked!"

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -77,7 +77,7 @@ module Vmdb
 
       def database_connectivity?
         ActiveRecord::Base.connection && ActiveRecord::Base.connected?
-      rescue ActiveRecord::NoDatabaseError
+      rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad
         false
       end
     end


### PR DESCRIPTION
To reproduce, disable your local postgres instance and run
`bundle exec rake test:verify_no_db_access_loading_rails_environment`

Follow up to 76731ae9 (https://github.com/ManageIQ/manageiq/pull/21038)

In the original pass, we didn't handle when the database just isn't running at all, which raises a different exception.  As such, this is blocking builds, because they are blowing up trying to check if the database is connectable or not.

@NickLaMuro Please review.
cc @simaishi @agrare 