### PR TITLE
Moved and De-Explorized Templates accordion out of Ansible Tower Explorer

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5142,28 +5142,38 @@
         :description: Edit Configured Systems Tags
         :feature_type: control
         :identifier: automation_manager_configured_system_tag
-  - :name: Templates
-    :description: Everything under Templates accordion
-    :feature_type: node
-    :identifier: automation_manager_configuration_scripts_accord
+
+- :name: Templates
+  :description: Everything under Templates accordion
+  :feature_type: node
+  :identifier: configuration_script
+  :children:
+  - :name: View
+    :description: View Templates
+    :feature_type: view
+    :identifier: configuration_script_view
     :children:
-    - :name: View
-      :description: View Templates
+    - :name: List
+      :description: Display Lists of Configuration Scripts
       :feature_type: view
-      :identifier: automation_manager_configuration_script_view
-    - :name: Operate
-      :description: Perform Operations on Templates
+      :identifier: configuration_script_show_list
+    - :name: Show
+      :description: Display Individual Configuration Scripts
+      :feature_type: view
+      :identifier: configuration_script_show
+  - :name: Operate
+    :description: Perform Operations on Templates
+    :feature_type: control
+    :identifier: configuration_script_control
+    :children:
+    - :name: Create Service Dialog
+      :description: Create Service Dialog
+      :feature_type: admin
+      :identifier: configuration_script_service_dialog
+    - :name: Edit Tags
+      :description: Edit Job Templates Tags
       :feature_type: control
-      :identifier: automation_manager_configuration_script_control
-      :children:
-      - :name: Create Service Dialog
-        :description: Create Service Dialog
-        :feature_type: admin
-        :identifier: automation_manager_configuration_script_service_dialog
-      - :name: Edit Tags
-        :description: Edit Job Templates Tags
-        :feature_type: control
-        :identifier: automation_manager_configuration_script_tag
+      :identifier: configuration_script_tag
 
 # Configuration Jobs
 - :name: Configuration Jobs

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -484,6 +484,11 @@
   :url: /configuration_job
   :rbac_feature_name: configuration_job_show_list
   :startup: true
+- :name: configuration_script
+  :description: Automation / Ansible Tower / Templates
+  :url: /configuration_script
+  :rbac_feature_name: configuration_script_show_list
+  :startup: true
 - :name: miq_ae_class_explorer
   :description: Automation / Automate / Explorer
   :url: /miq_ae_class/explorer


### PR DESCRIPTION
Renamed features to match model name to support De-Explorization of Ansible Tower Explorer
- Renamed features to match the model/controller names to be consistent.
- Added startpage shortcut for the new screen

Data Migration [PR](https://github.com/ManageIQ/manageiq-schema/pull/560)
UI [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7638)
Cross Repo test [PR](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/330)