### PR TITLE
Fix issue with provider generator where logger names are wrong

### DIFF
--- a/lib/generators/manageiq/plugin/plugin_generator.rb
+++ b/lib/generators/manageiq/plugin/plugin_generator.rb
@@ -67,18 +67,40 @@ module ManageIQ
 
     INDENT = "  ".freeze
 
+    # The path to the plugin
+    #
+    # Example (with a plugin called ManageIQ::MyHelper):
+    #   # => "manageiq/my_helper"
     alias plugin_path file_path
 
+    # The name of the plugin
+    #
+    # Example (with a plugin called ManageIQ::MyHelper):
+    #   # => "manageiq-my_helper"
     def plugin_name
       @plugin_name ||= plugin_path.tr("/", "-")
     end
 
+    # The name of the plugin for display purposes
+    #
+    # Example (with a plugin called ManageIQ::MyHelper):
+    #   # => "ManageIQ My Helper"
     def plugin_human_name
       @plugin_human_name ||= class_name.titleize.tr("/", " ")
     end
 
+    # The short name of the plugin
+    #
+    # Example (with a plugin called ManageIQ::MyHelper):
+    #   # => "my_helper"
+    alias plugin_short_name file_name
+
+    # The description of the plugin
+    #
+    # Example (with a plugin called ManageIQ::MyHelper):
+    #   # => "My Helper plugin for ManageIQ."
     def plugin_description
-      @plugin_description ||= "#{file_name.titleize} plugin for #{Vmdb::Appliance.PRODUCT_NAME}."
+      @plugin_description ||= "#{plugin_short_name.titleize} plugin for #{Vmdb::Appliance.PRODUCT_NAME}."
     end
 
     def empty_directory_with_keep_file(destination, config = {})

--- a/lib/generators/manageiq/plugin/templates/config/settings.yml
+++ b/lib/generators/manageiq/plugin/templates/config/settings.yml
@@ -1,0 +1,2 @@
+:log:
+  :level_<%= plugin_short_name %>: info

--- a/lib/generators/manageiq/plugin/templates/lib/%plugin_path%/engine.rb
+++ b/lib/generators/manageiq/plugin/templates/lib/%plugin_path%/engine.rb
@@ -13,11 +13,11 @@
     end
 
     def self.init_loggers
-      $<%= plugin_name %>_log ||= Vmdb::Loggers.create_logger("<%= plugin_name %>.log")
+      $<%= plugin_short_name %>_log ||= Vmdb::Loggers.create_logger("<%= plugin_short_name %>.log")
     end
 
     def self.apply_logger_config(config)
-      Vmdb::Loggers.apply_config_value(config, $<%= plugin_name %>_log, :level_<%= plugin_name %>)
+      Vmdb::Loggers.apply_config_value(config, $<%= plugin_short_name %>_log, :level_<%= plugin_short_name %>)
     end
   end
 <% end %>

--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -41,14 +41,26 @@ module ManageIQ
 
     private
 
-    alias provider_name file_name
+    # The short name of the provider
+    #
+    # Example (with a plugin called ManageIQ::Providers::MyCloud):
+    #   # => "my_cloud"
+    alias provider_name plugin_short_name
 
+    # The name of the plugin for display purposes
+    #
+    # Example (with a plugin called ManageIQ::Providers::MyCloud):
+    #   # => "My Cloud Provider"
     def plugin_human_name
-      @plugin_human_name ||= "#{file_name.titleize} Provider"
+      @plugin_human_name ||= "#{provider_name.titleize} Provider"
     end
 
+    # The description of the plugin
+    #
+    # Example (with a plugin called ManageIQ::Providers::MyCloud):
+    #   # => "ManageIQ plugin for the My Cloud provider."
     def plugin_description
-      @plugin_description ||= "#{Vmdb::Appliance.PRODUCT_NAME} plugin for the #{file_name.titleize} provider."
+      @plugin_description ||= "#{Vmdb::Appliance.PRODUCT_NAME} plugin for the #{provider_name.titleize} provider."
     end
 
     def validate_manager_type!


### PR DESCRIPTION
Fix issue with provider generator where logger names are wrong

Also add settings.yml file for regular plugins that was missing.

Fixes #21066

@agrare Please review.  I also added documentation for the existing helper methods.  I have a feeling this mistake would have been less likely if I had seen the examples.

