### PR TITLE
Fix Amazon-specific provider_tag_mapping_spec

### DIFF
--- a/spec/models/provider_tag_mapping_spec.rb
+++ b/spec/models/provider_tag_mapping_spec.rb
@@ -198,8 +198,8 @@ RSpec.describe ProviderTagMapping do
     let(:vm_inventory_object) { amazon_persister.vms.find_or_build("some_ems_ref") }
 
     let(:taggings_collections) do
-      vm_collection       = amazon_persister.inventory_collections[9]
-      taggings_collection = amazon_persister.inventory_collections[8]
+      vm_collection       = amazon_persister.inventory_collections.detect { |c| c.model_class == ManageIQ::Providers::Amazon::CloudManager::Vm }
+      taggings_collection = amazon_persister.inventory_collections.detect { |c| c.model_class == Tagging }
       tags_collection     = mapper.tags_to_resolve_collection
 
       [tags_collection, vm_collection, taggings_collection]


### PR DESCRIPTION
Due to a change in ManageIQ/manageiq-providers-amazon#684, flavors are
now in the list of objects in the inventory collection. This code
however had hardcoded indexes into the collections list, which broke
because of that addition. Instead, this changes the lookup to find the
correct object type making it more resilient to changes.

@jrafanie @agrare Please review.  This fixes the broken master from ManageIQ/manageiq-providers-amazon#684