### PR TITLE
Container images rollups from container rollups

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -41,8 +41,9 @@ class Container < ApplicationRecord
 
   PERF_ROLLUP_CHILDREN = []
 
-  def perf_rollup_parents(_interval_name = nil)
-    # No rollups: nodes performance are collected separately
+  def perf_rollup_parents(interval_name = nil)
+    # No rollups for nodes performance - they are collected separately
+    [container_image].compact unless interval_name == 'realtime'
   end
 
   def disconnect_inv

--- a/app/models/manageiq/providers/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/container_manager/metrics_capture.rb
@@ -2,9 +2,12 @@ class ManageIQ::Providers::ContainerManager::MetricsCapture < ManageIQ::Provider
   def capture_ems_targets(_options = {})
     return [] unless ems.supports_metrics?
 
-    MiqPreloader.preload([ems], :container_nodes => :tags, :container_groups => [:tags, :containers => :tags])
+    MiqPreloader.preload([ems], :container_images => :tags, :container_nodes => :tags, :container_groups => [:tags, :containers => :tags])
 
-    with_archived(ems.all_container_nodes) + with_archived(ems.all_container_groups) + with_archived(ems.all_containers)
+    with_archived(ems.all_container_nodes) +
+      with_archived(ems.all_container_groups) +
+      with_archived(ems.all_containers) +
+      with_archived(ems.container_images)
   end
 
   private

--- a/app/models/metric/ci_mixin/state_finders.rb
+++ b/app/models/metric/ci_mixin/state_finders.rb
@@ -71,4 +71,8 @@ module Metric::CiMixin::StateFinders
   def miq_regions_from_vim_performance_state_for_ts(_ts)
     self.respond_to?(:miq_regions) ? miq_regions : []
   end
+
+  def containers_from_vim_performance_state_for_ts(timestamp)
+    vim_performance_state_for_ts(timestamp).containers
+  end
 end

--- a/app/models/metric/processing.rb
+++ b/app/models/metric/processing.rb
@@ -28,6 +28,7 @@ module Metric::Processing
     ContainerProject,
     ContainerReplicator,
     ContainerService,
+    ContainerImage,
     Host,
     AvailabilityZone,
     HostAggregate,

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -39,6 +39,12 @@ module Metric::Rollup
       :derived_vm_numvcpus,
       :derived_vm_used_disk_storage,
     ],
+    :ContainerImage_containers => [
+      :cpu_usage_rate_average,
+      :derived_vm_numvcpus,
+      :derived_memory_used,
+      :net_usage_rate_average
+    ],
     :ContainerProject_all_container_groups => [
       :cpu_usage_rate_average,
       :derived_vm_numvcpus,

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -6,7 +6,7 @@ class VimPerformanceState < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   ASSOCIATIONS = [:vms, :hosts, :ems_clusters, :ext_management_systems, :storages, :container_nodes, :container_groups,
-                  :all_container_groups]
+                  :all_container_groups, :containers]
 
   # Define accessors for state_data information
   [
@@ -133,6 +133,11 @@ class VimPerformanceState < ApplicationRecord
   def container_groups
     ids = get_assoc(:container_groups)
     ids.empty? ? [] : ContainerGroup.where(:id => ids).order(:id).to_a
+  end
+
+  def containers
+    ids = get_assoc(:containers)
+    ids.empty? ? [] : Container.where(:id => ids).order(:id).to_a
   end
 
   def all_container_groups

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -34,6 +34,7 @@ class VimPerformanceTagValue
     "ContainerNode"       => [],
     "Container"           => [],
     "ContainerGroup"      => [],
+    "ContainerImage"      => [:containers],
     "ContainerProject"    => [],
     "ContainerService"    => [],
     "ContainerReplicator" => [],


### PR DESCRIPTION
solves first point from https://github.com/ManageIQ/manageiq/issues/21074: 
- [ ]  Metrics rolled up to ContainerImage

###  Links 

- [x] https://github.com/ManageIQ/manageiq-schema/pull/561 - required schema change