### PR TITLE
Feature changes to support  moving Configured Systems out of Ansible Tower Explorer

### DIFF
--- a/app/models/aliases/automation_manager_configured_system.rb
+++ b/app/models/aliases/automation_manager_configured_system.rb
@@ -1,0 +1,1 @@
+::AutomationManagerConfiguredSystem = ::ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5124,24 +5124,32 @@
         :description: Add a Provider
         :feature_type: admin
         :identifier: automation_manager_add_provider
-  - :name: Configured Systems
-    :description: Everything under Configured Systems accordion
-    :feature_type: node
-    :identifier: automation_manager_configured_system
+- :name: Configured Systems
+  :description: Everything under Configured Systems accordion
+  :feature_type: node
+  :identifier: automation_manager_configured_system
+  :children:
+  - :name: View
+    :description: View Configured Systems
+    :feature_type: view
+    :identifier: automation_manager_configured_system_view
     :children:
-    - :name: View
-      :description: View Configured Systems
+    - :name: List
+      :description: Display Lists of Configured Systems
+      :identifier: automation_manager_configured_system_show_list
+    - :name: Show
+      :description: Display Individual Configured Systems
       :feature_type: view
-      :identifier: automation_manager_configured_system_view
-    - :name: Operate
-      :description: Perform Operations on Configured Systems
+      :identifier: automation_manager_configured_system_show
+  - :name: Operate
+    :description: Perform Operations on Configured Systems
+    :feature_type: control
+    :identifier: automation_manager_configured_system_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Configured Systems Tags
       :feature_type: control
-      :identifier: automation_manager_configured_system_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Configured Systems Tags
-        :feature_type: control
-        :identifier: automation_manager_configured_system_tag
+      :identifier: automation_manager_configured_system_tag
 
 - :name: Templates
   :description: Everything under Templates accordion

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1522,7 +1522,7 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook:                     Playbook (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager:                                 Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                                          Configuration Manager
-      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem:             Configured System (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem:             Configured System
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem:               Configured System (Foreman)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Job:                          Ansible Tower Job
       ManageIQ::Providers::CloudManager:                                                  Cloud Provider


### PR DESCRIPTION
…Tower Explorer

- Added new alias to get Automation Manager Configured Systems

UI [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7640)
Cross repo [PR](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/333)

This PR does not need data migration as features were not renamed, features are only moved to be on folder level and 2 new features for show_list and show are added in this PR