### PR TITLE
[POC] [MiqDefaults] Remove ActiveSupport dep

### DIFF
--- a/lib/workers/miq_defaults.rb
+++ b/lib/workers/miq_defaults.rb
@@ -1,10 +1,9 @@
-require "active_support/core_ext/numeric/time"
-
 module Workers
   class MiqDefaults
-    HEARTBEAT_TIMEOUT = 2.minutes.freeze
-    STARTING_TIMEOUT  = 10.minutes.freeze
-    STOPPING_TIMEOUT  = 10.minutes.freeze
+    MINUTES           = 60 # seconds in a minute
+    HEARTBEAT_TIMEOUT = 2 * MINUTES
+    STARTING_TIMEOUT  = 10 * MINUTES
+    STOPPING_TIMEOUT  = 10 * MINUTES
 
     def self.heartbeat_timeout
       HEARTBEAT_TIMEOUT


### PR DESCRIPTION
**Note**: Made this a "POC", since a) that is what it is, but b) I haven't validated it at all aside from the local tests on my work machine (shown below), so I think testing this in a container to see if we have an appreciable difference is worth considering.

This is a slow class to load, so just removing this class allow shaves off 4x of the slowness, for something that is just about as clean without it:

```
$ time ruby lib/workers/bin/heartbeat_check.rb

real    0m0.097s
user    0m0.070s
sys     0m0.021s
$ time ruby lib/workers/bin/heartbeat_check.rb

real    0m0.399s
user    0m0.270s
sys     0m0.124s
```

It is even faster if you run `ruby` with `--disable-gems`:

```
$ time ruby --disable-gems lib/workers/bin/heartbeat_check.rb

real    0m0.028s
user    0m0.016s
sys     0m0.008s
```


Links
-----

* Addressing this comment:  https://github.com/ManageIQ/manageiq-pods/pull/687#issuecomment-784513788
* PR that added this form of heartbeating:  https://github.com/ManageIQ/manageiq/pull/15494