### PR TITLE
Heartbeat to file as unix time to avoid parsing

### DIFF
--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -1,6 +1,10 @@
 module MiqServer::WorkerManagement::Heartbeat
   extend ActiveSupport::Concern
 
+  # Note, this entire file assumes the server process is running on the same filesystem as the workers
+  # which isn't true in podified.  Therefore, we can't clean_heartbeat_files or get the workers_last_heartbeat
+  # by reading the heartbeat_file.  Instead, we assume the liveness check is working and if it's still running
+  # in podified, the row will exist and if so, we'll update the worker row with the current time.
   def persist_last_heartbeat(w)
     last_heartbeat = workers_last_heartbeat(w)
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -313,7 +313,7 @@ class MiqWorker::Runner
     return if skip_heartbeat?
 
     timeout ||= worker_settings[:heartbeat_timeout] || Workers::MiqDefaults.heartbeat_timeout
-    File.write(@worker.heartbeat_file, (Time.now.utc + timeout).to_s)
+    File.write(@worker.heartbeat_file, (Time.now.to_i + timeout))
   end
 
   def config_out_of_date?

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -243,7 +243,7 @@ class EvmServer
     #############################################################
     # Start all the configured workers
     #############################################################
-    @current_server.clean_heartbeat_files
+    @current_server.clean_heartbeat_files # Appliance specific
     @current_server.sync_config
     @current_server.start_drb_server
     @current_server.sync_workers


### PR DESCRIPTION
Whether processed on the other side in ruby or bash, it's a lot faster
to assume a well known unix time seconds since epoch than to parse it.

 - [ ] Must be merged along with [manageiq-pods](https://github.com/ManageIQ/manageiq-pods/pull/688)