### PR TITLE
Add Oracle as a vendor and OS Type

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -28,6 +28,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_coreos",    %w(coreos)],
     ["linux_esx",       %w(vmnixx86 vmwareesxserver esxserver vmwareesxi)],
     ["linux_solaris",   %w(solaris)],
+    ["linux_oracle",    %w(oracle)],
     ["linux_generic",   %w(linux)],
     ["unix_aix",        %w(aix)],
     ["ibm_i",           %w(ibmi)]

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -44,6 +44,7 @@ class VmOrTemplate < ApplicationRecord
     "amazon"      => "Amazon",
     "redhat"      => "RedHat",
     "openstack"   => "OpenStack",
+    "oracle"      => "Oracle",
     "google"      => "Google",
     "kubevirt"    => "KubeVirt",
     "ibm"         => "IBM",


### PR DESCRIPTION
Add Oracle as a supported vendor and oracle linux as a supported OperatingSystem type

Required for:
- [ ] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/4