### PR TITLE
Loosen bundler restrictions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be requi
 gem "ancestry",                         "~>3.0.7",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
-gem "bundler",                          "~> 2.1", ">=2.1.4", "<2.2.10", :require => false
+gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false


### PR DESCRIPTION
This effectively reverts the Gemfile change in 71e5a0bdf8

Note that updating rubygems locally automatically pulls in bundler 2.2.11, and
it cannot be uninstalled since it's a default gem, so if you do that you're
stuck. 2.2.11 is just a revert of the changes in 2.2.10, so 2.2.11 works with
ManageIQ.

@agrare Please review.