### PR TITLE
Added GUI cross-ref between host-initiator and cloud-volume.

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -22,6 +22,7 @@ class CloudVolume < ApplicationRecord
   has_many   :hardwares, :through => :attachments
   has_many   :vms, :through => :hardwares, :foreign_key => :vm_or_template_id
   has_many   :volume_mappings, :dependent => :destroy
+  has_many   :host_initiators, :through => :volume_mappings
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
 

--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -9,6 +9,7 @@ class HostInitiator < ApplicationRecord
 
   has_many :san_addresses, :as => :owner, :dependent => :destroy
   has_many :volume_mappings, :dependent => :destroy
+  has_many :cloud_volumes, :through => :volume_mappings
 
   virtual_total :v_total_addresses, :san_addresses
 


### PR DESCRIPTION
This is a pre-req for https://github.com/ManageIQ/manageiq-ui-classic/pull/7648

Please see https://github.com/ManageIQ/manageiq-ui-classic/pull/7648 for more details.