### PR TITLE
Fix ansible_runner content seeding

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -56,7 +56,7 @@ module Vmdb
       @ansible_runner_content ||= begin
         map do |engine|
           content_dir = engine.root.join("content", "ansible_runner")
-          next unless File.exist?(content_dir.join("requirements.yml"))
+          next unless File.exist?(content_dir.join("roles/requirements.yml"))
 
           [engine, content_dir]
         end.compact


### PR DESCRIPTION
The fetch_ansible_galaxy code, when called at run-time works correctly,
however, this method, meant for seeding galaxy roles at build time,
incorrectly looked at the root directory instead of the roles directory,
and so did nothing.

@agrare Please review.