### PR TITLE
Add Oracle Cloud provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,6 +152,10 @@ group :nuage, :manageiq_default do
   manageiq_plugin "manageiq-providers-nuage"
 end
 
+group :oracle_cloud, :manageiq_default do
+  manageiq_plugin "manageiq-providers-oracle_cloud"
+end
+
 group :redfish, :manageiq_default do
   manageiq_plugin "manageiq-providers-redfish"
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -53,8 +53,50 @@ RSpec.describe ExtManagementSystem do
     described_class.create_discovered_ems(ost)
   end
 
-  it ".types" do
-    expect(described_class.types).to include("ec2", "vmwarews")
+  describe ".types" do
+    context "on the base ExtManagementSystem class" do
+      it "returns both cloud and infra types" do
+        expect(described_class.types).to include("ec2", "vmwarews")
+      end
+    end
+
+    context "on the EmsCloud subclass" do
+      it "only returns cloud types" do
+        cloud_types = EmsCloud.types
+
+        expect(cloud_types).to     include("ec2")
+        expect(cloud_types).not_to include("vmwarews")
+      end
+    end
+
+    context "on the EmsInfra subclass" do
+      it "only returns infra types" do
+        infra_types = EmsInfra.types
+
+        expect(infra_types).to     include("vmwarews")
+        expect(infra_types).not_to include("ec2")
+      end
+    end
+  end
+
+  describe ".supported_subclasses" do
+    context "on the EmsCloud subclass" do
+      it "only returns cloud types" do
+        cloud_supported_subclasses = EmsCloud.supported_subclasses
+
+        expect(cloud_supported_subclasses).to     include(ManageIQ::Providers::Amazon::CloudManager)
+        expect(cloud_supported_subclasses).not_to include(ManageIQ::Providers::Vmware::InfraManager)
+      end
+    end
+
+    context "on the EmsInfra subclass" do
+      it "only returns infra types" do
+        infra_supported_subclasses = EmsInfra.supported_subclasses
+
+        expect(infra_supported_subclasses).to     include(ManageIQ::Providers::Vmware::InfraManager)
+        expect(infra_supported_subclasses).not_to include(ManageIQ::Providers::Amazon::CloudManager)
+      end
+    end
   end
 
   describe ".supported_types" do
@@ -66,6 +108,24 @@ RSpec.describe ExtManagementSystem do
       allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(true)
       allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(false)
       expect(described_class.supported_types).not_to include("vmwarews")
+    end
+
+    context "on the EmsCloud subclass" do
+      it "only returns cloud types" do
+        cloud_supported_types = EmsCloud.supported_types
+
+        expect(cloud_supported_types).to     include("ec2")
+        expect(cloud_supported_types).not_to include("vmwarews")
+      end
+    end
+
+    context "on the EmsInfra subclass" do
+      it "only returns infra types" do
+        infra_supported_types = EmsInfra.supported_types
+
+        expect(infra_supported_types).to     include("vmwarews")
+        expect(infra_supported_types).not_to include("ec2")
+      end
     end
   end
 

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -1,40 +1,4 @@
 RSpec.describe EmsCloud do
-  it ".types" do
-    expected_types = [ManageIQ::Providers::Amazon::CloudManager,
-                      ManageIQ::Providers::Azure::CloudManager,
-                      ManageIQ::Providers::AzureStack::CloudManager,
-                      ManageIQ::Providers::Openstack::CloudManager,
-                      ManageIQ::Providers::Google::CloudManager,
-                      ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager,
-                      ManageIQ::Providers::IbmCloud::VPC::CloudManager,
-                      ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
-    expect(described_class.types).to match_array(expected_types)
-  end
-
-  it ".supported_subclasses" do
-    expected_subclasses = [ManageIQ::Providers::Amazon::CloudManager,
-                           ManageIQ::Providers::Azure::CloudManager,
-                           ManageIQ::Providers::AzureStack::CloudManager,
-                           ManageIQ::Providers::Openstack::CloudManager,
-                           ManageIQ::Providers::Google::CloudManager,
-                           ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager,
-                           ManageIQ::Providers::IbmCloud::VPC::CloudManager,
-                           ManageIQ::Providers::Vmware::CloudManager]
-    expect(described_class.supported_subclasses).to match_array(expected_subclasses)
-  end
-
-  it ".supported_types" do
-    expected_types = [ManageIQ::Providers::Amazon::CloudManager,
-                      ManageIQ::Providers::Azure::CloudManager,
-                      ManageIQ::Providers::AzureStack::CloudManager,
-                      ManageIQ::Providers::Openstack::CloudManager,
-                      ManageIQ::Providers::Google::CloudManager,
-                      ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager,
-                      ManageIQ::Providers::IbmCloud::VPC::CloudManager,
-                      ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
-    expect(described_class.supported_types).to match_array(expected_types)
-  end
-
   context "OpenStack CloudTenant Mapping" do
     let(:ems_cloud) { FactoryBot.create(:ems_openstack_with_authentication, :tenant_mapping_enabled => true) }
     let(:ems_infra) { FactoryBot.create(:ext_management_system) }


### PR DESCRIPTION
Add the oracle cloud provider (https://github.com/ManageIQ/manageiq-providers-oracle_cloud) to the core Gemfile.

This provider fetches VM inventory from https://cloud.oracle.com/ using the [oci-ruby-sdk](https://rubygems.org/gems/oci) gem

Follow-up:
- [ ] https://github.com/ManageIQ/manageiq-release/pull/191