### PR TITLE
Avoid seeding ansible content in production

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/seeding.rb
+++ b/app/models/manageiq/providers/embedded_ansible/seeding.rb
@@ -20,7 +20,13 @@ module ManageIQ::Providers::EmbeddedAnsible::Seeding
         :resource => manager
       )
 
-      Ansible::Content.consolidate_plugin_playbooks
+      # In production mode, the RPM build takes cares of consolidating all of
+      #   the plugin content, which will not change, so this is unnecessary.
+      # In development mode, changes to content will be reconsolidated on every
+      #   seed for convenience.
+      unless Rails.env.production?
+        Ansible::Content.consolidate_plugin_content
+      end
     end
   end
 end

--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -1,23 +1,16 @@
 namespace :evm do
   namespace :ansible_runner do
-    desc "Seed galaxy roles for provider playbooks"
+    desc "Seed plugin ansible content and galaxy roles"
     task :seed do
-      require 'awesome_spawn'
-      require "vmdb/plugins"
-      require 'ansible/content'
+      require "ansible/content"
 
-      Vmdb::Plugins.ansible_runner_content.each do |plugin, content_dir|
-        content = Ansible::Content.new(content_dir)
+      puts "Fetching ansible galaxy roles for plugins..."
+      Ansible::Content.fetch_plugin_galaxy_roles
+      puts "Fetching ansible galaxy roles for plugins...Complete"
 
-        puts "Seeding roles for #{plugin.name}..."
-        begin
-          content.fetch_galaxy_roles
-          puts "Seeding roles for #{plugin.name}...Complete"
-        rescue AwesomeSpawn::CommandResultError => err
-          puts "Seeding roles for #{plugin.name}...Failed - #{err.result.error}"
-          raise
-        end
-      end
+      puts "Consolidating plugin ansible content..."
+      Ansible::Content.consolidate_plugin_content
+      puts "Consolidating plugin ansible content...Complete"
     end
   end
 end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -43,6 +43,8 @@ module Vmdb
       details.transform_values { |v| v[:version] }
     end
 
+    # Ansible content (roles) that come out-of-the-box, for use by both Automate
+    #   and ansible-runner
     def ansible_content
       @ansible_content ||= begin
         require_relative 'plugins/ansible_content'
@@ -52,6 +54,8 @@ module Vmdb
       end
     end
 
+    # Ansible content (playbooks and roles) for internal use by provider plugins,
+    #   not exposed to Automate, and to be run by ansible_runner
     def ansible_runner_content
       @ansible_runner_content ||= begin
         map do |engine|


### PR DESCRIPTION
Ansible content is already seeded at RPM build time, so to avoid the
need to hit the filesystem again, we should skip this in production
mode.

Additionally, this adds the consolidation of ansible content to seed
time, in addition to the fetching of galaxy roles.

@kbrock  @agrare Please review.

Note that the seeding happens at RPM build time here: https://github.com/ManageIQ/manageiq-rpm_build/blob/3173133b27375a26cc205c09d3d3c627e907c635/lib/manageiq/rpm_build/generate_core.rb#L63-L67