### PR TITLE
Automatically set the miq_templates model_class

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -56,6 +56,9 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       add_default_values(
         :template => true
       )
+
+      template_class = "#{manager_class}::Template".safe_constantize
+      add_properties(:model_class => template_class) if template_class
     end
 
     def vm_template_shared


### PR DESCRIPTION
Since the association for miq_templates doesn't match the subclass `...CloudManager::Template` every provider has to manually set this in their persister subclass.

It is much more efficient to set this in core than to force all of the providers to set this manually.

This can be merged independently of any provider PRs, but these two are examples of what we can do after this:
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/688
* https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/10