### PR TITLE
Add 2.7 support/drop 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: ruby
 rvm:
-- 2.5.8
 - 2.6.6
+- 2.7.2
 cache: bundler
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-raise "Ruby versions < 2.5.3 are unsupported!" if RUBY_VERSION < "2.5.3"
+raise "Ruby versions < 2.6.0 are unsupported!" if RUBY_VERSION < "2.6.0"
 raise "Ruby versions >= 3.0.0 are unsupported!" if RUBY_VERSION >= "3.0.0"
 
 source 'https://rubygems.org'


### PR DESCRIPTION
Part of #19678

To be backported to lasker and then further locked down to test only on ruby 2.6 on lasker.

- [x] [Talk article announcing dropping of ruby 2.5 support](https://talk.manageiq.org/t/fyi-ruby-2-5-on-master-lasker-branch-will-soon-be-unsupported/5324)