### PR TITLE
Improve core persister support for combined manager refresh

### DIFF
--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -69,6 +69,18 @@ class ManageIQ::Providers::Inventory::Persister
     manager.presence
   end
 
+  def cloud_manager
+    manager.kind_of?(EmsCloud) ? manager : manager.parent_manager
+  end
+
+  def network_manager
+    manager.kind_of?(EmsNetwork) ? manager : manager.network_manager
+  end
+
+  def storage_manager
+    manager.kind_of?(EmsStorage) ? manager : manager.storage_manager
+  end
+
   def assert_graph_integrity?
     !Rails.env.production?
   end

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -17,8 +17,8 @@ module ManageIQ::Providers
             :manager_ref => %i(name)
           )
           add_default_values(
-            :resource_id   => ->(persister) { persister.manager.id },
-            :resource_type => ->(persister) { persister.manager.class.base_class }
+            :resource_id   => shared_properties[:parent].id,
+            :resource_type => shared_properties[:parent].class.base_class
           )
         end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -6,6 +6,14 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def cloud_tenants
+          add_common_default_values
+        end
+
+        def cloud_volumes
+          add_common_default_values
+        end
+
         def flavors
           add_common_default_values
         end

--- a/app/models/manageiq/providers/inventory/persister/builder/network_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/network_manager.rb
@@ -216,11 +216,7 @@ module ManageIQ::Providers
         protected
 
         def add_common_default_values
-          add_default_values(:ems_id => default_ems_id)
-        end
-
-        def default_ems_id
-          ->(persister) { persister.manager.try(:network_manager).try(:id) || persister.manager.id }
+          add_default_values(:ext_management_system => ->(persister) { persister.network_manager })
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -136,7 +136,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
 
   def add_collection_for_manager(manager_type, collection_name, extra_properties = {}, settings = {}, &block)
     parent_manager = send("#{manager_type}_manager")
-    extra_properties.reverse_merge!(:parent => parent_manager)
+    settings.reverse_merge!(:shared_properties => {:parent => parent_manager})
 
     builder_class = send(manager_type)
     add_collection(builder_class, collection_name, extra_properties, settings, &block)

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -36,6 +36,18 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
     collections[collection_name] = builder.to_inventory_collection
   end
 
+  def add_cloud_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    add_collection_for_manager("cloud", collection_name, extra_properties, settings, &block)
+  end
+
+  def add_network_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    add_collection_for_manager("network", collection_name, extra_properties, settings, &block)
+  end
+
+  def add_storage_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    add_collection_for_manager("storage", collection_name, extra_properties, settings, &block)
+  end
+
   # builder_class for add_collection()
   def cloud
     ::ManageIQ::Providers::Inventory::Persister::Builder::CloudManager
@@ -118,5 +130,15 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
   # @return [Array<String>]
   def name_references(collection)
     target.try(:manager_refs_by_association).try(:[], collection).try(:[], :name).try(:to_a) || []
+  end
+
+  private
+
+  def add_collection_for_manager(manager_type, collection_name, extra_properties = {}, settings = {}, &block)
+    parent_manager = send("#{manager_type}_manager")
+    extra_properties.reverse_merge!(:parent => parent_manager)
+
+    builder_class = send(manager_type)
+    add_collection(builder_class, collection_name, extra_properties, settings, &block)
   end
 end

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -184,7 +184,8 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     protected
 
     def add_common_default_values
-      add_default_values(:ems_id => shared_properties[:parent].id)
+      ems = shared_properties[:parent]&.id || ->(persister) { persister.manager.id }
+      add_default_values(:ems_id => ems)
     end
 
     def relationship_save_block(relationship_key:, relationship_type: :ems_metadata, parent_type: nil)

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -71,9 +71,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
         :custom_reconnect_block => INVENTORY_RECONNECT_BLOCK
       )
 
-      add_default_values(
-        :ems_id => ->(persister) { persister.manager.id }
-      )
+      add_common_default_values
     end
 
     def vm_and_template_labels
@@ -186,7 +184,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     protected
 
     def add_common_default_values
-      add_default_values(:ems_id => ->(persister) { persister.manager.id })
+      add_default_values(:ems_id => shared_properties[:parent].id)
     end
 
     def relationship_save_block(relationship_key:, relationship_type: :ems_metadata, parent_type: nil)


### PR DESCRIPTION
Traditionally full refreshes have been done at the ExtManagementSystem level, so for a provider that has multiple child managers (e.g. a CloudManager, NetworkManager, and StorageManager) you are actually doing three full refreshes everytime.

This is reflected in the fact that the persister mostly revolves around a single "parent".

This has been complicated for a while by the fact that targeted refreshes have been combined across all child managers for a long time now (originally to prevent race conditions between the different targeted child managers).

When doing a combined targeted refresh the `persister.parent` is the "main" manager (usually the CloudManager) and all of the child manager's have to override the `parent` and the `default_values[:ems_id]` for each of their inventory collections.

This ends up adding a lot of extra overrides that each provider has to add to include in their persisters to be able to support targeted refresh and always felt like an after-thought/workaround.

More recently some providers (foreman, ibm_cloud, oracle_cloud) have started doing "combined" full refreshes as well as this generally improves the performance and reduces the number of API calls that have to be made.

To be able to do this they essentially have to do the same workarounds as the other providers do for the parent and default_values but for every collection.

It would be cleaner instead to always provide the correct parent manager when the inventory collections are being built.  This would allow for a decent amount of code to be deleted from the provider persister classes and ensure consistency.

Cross-repo tests:

Dependent PRs:
* https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/152
* https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/12
* https://github.com/ManageIQ/manageiq-providers-google/pull/182

https://github.com/ManageIQ/manageiq/issues/20301