### PR TITLE
Lower the cpu request due to the simpler liveness probe

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1051,7 +1051,7 @@
   :worker_base:
     :defaults:
       :count: 1
-      :cpu_request_percent: 15
+      :cpu_request_percent: 5
       :cpu_threshold_percent: 100
       :gc_interval: 15.minutes
       :heartbeat_freq: 10.seconds


### PR DESCRIPTION
The liveness probe used to be in ruby and did more than it needed:
loaded some of the ruby / activesupport libraries it didn't really need, parsed
time needlessly, parsed options that were always the same, etc.

It was rewritten below to be more performant so we can now request less cpu.

https://github.com/ManageIQ/manageiq/pull/21079
https://github.com/ManageIQ/manageiq-pods/pull/688

Below are graphs provided by Thad Jennings showing how the steady state CPU usage has drastically decreased before and after the more performant liveness probe.  
![c3b17900-80c6-11eb-86a2-d916c56f2588](https://user-images.githubusercontent.com/19339/110656550-0ab67180-818e-11eb-9104-153b55b01f56.png)
![c6ac6980-80c6-11eb-8470-d78d3c66911c](https://user-images.githubusercontent.com/19339/110656549-0ab67180-818e-11eb-8ad3-3b0cb74c8569.png)