### PR TITLE
Remove eval in favor of const_set

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -60,7 +60,7 @@ class MiqAction < ApplicationRecord
 
   RB_PREAMBLE = "
     RC_HASH = #{RC_HASH.inspect}
-    RC_HASH.each {|k, v| eval(\"\#{v} = \#{k}\")}
+    RC_HASH.each { |k, v| Object.const_set(v, k) }
   "
 
   virtual_column :v_synchronicity,         :type => :string


### PR DESCRIPTION
@gtanzillo Please review.  While there is no security issue here we can do the same thing without an eval.