### PR TITLE
Automation providers features changes to support De-explorization of Ansible Tower Explorer

### DIFF
--- a/app/models/aliases/ems_automation.rb
+++ b/app/models/aliases/ems_automation.rb
@@ -1,0 +1,1 @@
+::EmsAutomation = ::ManageIQ::Providers::AnsibleTower::AutomationManager

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -36,4 +36,8 @@ class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
   def total_configured_systems
     Rbac.filtered(configured_systems).count
   end
+
+  def total_inventory_groups
+    Rbac.filtered(inventory_groups).count
+  end
 end

--- a/app/models/manageiq/providers/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/automation_manager/configured_system.rb
@@ -1,2 +1,7 @@
 class ManageIQ::Providers::AutomationManager::ConfiguredSystem < ::ConfiguredSystem
+  virtual_column  :inventory_root_group_name, :type => :string
+
+  def inventory_root_group_name
+    inventory_root_group.name
+  end
 end

--- a/app/models/manageiq/providers/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/automation_manager/configured_system.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::AutomationManager::ConfiguredSystem < ::ConfiguredSystem
-  virtual_column  :inventory_root_group_name, :type => :string
+  virtual_column  :inventory_root_group_name, :type => :string, :uses => :inventory_root_group
 
   def inventory_root_group_name
     inventory_root_group.name

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5073,57 +5073,52 @@
 
 # Automation Manager
 - :name: Ansible Tower
-  :description: Everything under Ansible Tower
+  :description: Everything under Providers
   :feature_type: node
-  :identifier: automation_manager
+  :identifier: ems_automation
   :children:
-  - :name: Ansible Tower Providers
-    :description: Everything under the Providers accordion
-    :feature_type: node
-    :identifier: automation_manager_providers
+  - :name: View
+    :description: View Providers, Inventory Groups, Configured Systems
+    :feature_type: view
+    :identifier: ems_automation_view
+  - :name: Operate
+    :description: Perform Operations on Providers and Configured Systems
+    :feature_type: control
+    :identifier: ems_automation_control
     :children:
-    - :name: View
-      :description: View Providers, Inventory Groups, Configured Systems
-      :feature_type: view
-      :identifier: automation_manager_providers_view
-    - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
+    - :name: Edit Tags
+      :description: Edit Tags of Ansible Tower Provider
       :feature_type: control
-      :identifier: automation_manager_providers_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Tags of Ansible Tower Provider
-        :feature_type: control
-        :identifier: automation_manager_provider_tag
-      - :name: Refresh Providers
-        :description: Refresh relationships for all items related of Provider
-        :feature_type: control
-        :identifier: automation_manager_refresh_provider
-    - :name: Modify
-      :description: Modify Providers
+      :identifier: ems_automation_tag
+    - :name: Refresh Providers
+      :description: Refresh relationships for all items related of Provider
+      :feature_type: control
+      :identifier: ems_automation_refresh_provider
+  - :name: Modify
+    :description: Modify Providers
+    :feature_type: admin
+    :identifier: ems_automation_admin
+    :children:
+    - :name: Remove Providers
+      :description: Remove Provier
       :feature_type: admin
-      :identifier: automation_manager_admin
-      :children:
-      - :name: Remove Providers
-        :description: Remove Provier
-        :feature_type: admin
-        :identifier: automation_manager_delete_provider
-      - :name: Edit Provider
-        :description: Edit a Provider
-        :feature_type: admin
-        :identifier: automation_manager_edit_provider
-      - :name: Pause
-        :description: Pause a Provider
-        :feature_type: admin
-        :identifier: automation_manager_pause
-      - :name: Resume
-        :description: Resume a Provider
-        :feature_type: admin
-        :identifier: automation_manager_resume
-      - :name: Add Provider
-        :description: Add a Provider
-        :feature_type: admin
-        :identifier: automation_manager_add_provider
+      :identifier: ems_automation_delete_provider
+    - :name: Edit Provider
+      :description: Edit a Provider
+      :feature_type: admin
+      :identifier: ems_automation_edit_provider
+    - :name: Pause
+      :description: Pause a Provider
+      :feature_type: admin
+      :identifier: ems_automation_pause
+    - :name: Resume
+      :description: Resume a Provider
+      :feature_type: admin
+      :identifier: ems_automation_resume
+    - :name: Add Provider
+      :description: Add a Provider
+      :feature_type: admin
+      :identifier: ems_automation_add_provider
 - :name: Configured Systems
   :description: Everything under Configured Systems accordion
   :feature_type: node

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5078,11 +5078,19 @@
   :identifier: ems_automation
   :children:
   - :name: View
-    :description: View Providers, Inventory Groups, Configured Systems
+    :description: View Providers
     :feature_type: view
     :identifier: ems_automation_view
+    :children:
+    - :name: List
+      :description: Display Lists of Providers
+      :identifier: ems_automation_manager_show_list
+    - :name: Show
+      :description: Display Individual Providers
+      :feature_type: view
+      :identifier: ems_automation_manager_show
   - :name: Operate
-    :description: Perform Operations on Providers and Configured Systems
+    :description: Perform Operations on Providers
     :feature_type: control
     :identifier: ems_automation_control
     :children:
@@ -5120,7 +5128,7 @@
       :feature_type: admin
       :identifier: ems_automation_add_provider
 - :name: Configured Systems
-  :description: Everything under Configured Systems accordion
+  :description: Everything under Configured Systems
   :feature_type: node
   :identifier: automation_manager_configured_system
   :children:
@@ -5147,7 +5155,7 @@
       :identifier: automation_manager_configured_system_tag
 
 - :name: Templates
-  :description: Everything under Templates accordion
+  :description: Everything under Templates
   :feature_type: node
   :identifier: configuration_script
   :children:

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -474,10 +474,10 @@
   :url: /ansible_credential
   :rbac_feature_name: embedded_automation_manager_credentials
   :startup: true
-- :name: automation_manager
-  :description: Automation / Ansible Tower / Explorer
-  :url: /automation_manager/explorer
-  :rbac_feature_name: automation_manager
+- :name: ems_automation
+  :description: Automation / Ansible Tower / Providers
+  :url: /ems_automation/show_list
+  :rbac_feature_name: ems_automation
   :startup: true
 - :name: configuration_job
   :description: Automation / Ansible Tower / Jobs

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -11,7 +11,9 @@
   - about
   - add_global_filter
   - all_vm_rules
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - embedded_automation_manager
   - availability_zone
   - host_aggregate
@@ -190,7 +192,7 @@
   :read_only: true
   :miq_product_feature_identifiers:
   - about
-  - automation_manager
+  - ems_automation
   - embedded_automation_manager
   - chargeback
   - chargeback_reports
@@ -290,7 +292,9 @@
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - ems_configuration
   - configuration_profile
   - configured_system
@@ -363,7 +367,9 @@
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - embedded_automation_manager
   - chargeback
   - chargeback_reports
@@ -888,7 +894,9 @@
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - embedded_automation_manager
   - ems_physical_infra_console
   - catalog_items_view
@@ -950,7 +958,9 @@
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - ems_configuration
   - configuration_profile
   - configured_system
@@ -1016,7 +1026,9 @@
   :read_only: true
   :miq_product_feature_identifiers:
   - about
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - embedded_automation_manager
   - availability_zone
   - host_aggregate
@@ -1080,7 +1092,9 @@
   :read_only: true
   :miq_product_feature_identifiers:
   - about
-  - automation_manager
+  - ems_automation
+  - automation_manager_configured_system
+  - configuration_script
   - embedded_automation_manager
   - availability_zone
   - host_aggregate

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1753,6 +1753,8 @@ en:
       container_templates:         Templates
       custom_button:               Button
       custom_button_set:           Button Group
+      ems_automation:              Automation Manager
+      ems_automations:             Automation Managers
       ems_block_storage:           Block Storage Manager
       ems_block_storages:          Block Storage Managers
       ems_cloud:                   Cloud Provider


### PR DESCRIPTION
- This PR has feature renaming of Automation Providers related features
- Updates startpage URL for Ansible Tower explorer to point to the new location in second level menus
- Updates OOTB user roles that by default had access to Ansible Tower explorer to have access to all three new sub menus.
- Also includes changes to display count of Inventory Groups/Folders in Configured Systems list view as well as name of folder on the details view screen.

for https://github.com/ManageIQ/manageiq-ui-classic/issues/6819

Data Migration [PR](https://github.com/ManageIQ/manageiq-schema/pull/564)
UI [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7662)
Cross Repo [PR](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/343)