### PR TITLE
Add YAML Files to locale_task_config

### DIFF
--- a/config/locale_task_config.yaml
+++ b/config/locale_task_config.yaml
@@ -4,6 +4,14 @@ yaml_strings_to_extract:
   - description
   db/fixtures/chargeback_rates.yml:
   - description
+  db/fixtures/miq_event_definition_events.yml:
+  - name
+  - description
+  - event_type
+  - set_type
+  db/fixtures/miq_event_definition_sets.yml:
+  - name
+  - description
   db/fixtures/miq_product_features{.yml,.yaml,/*.yml,/*.yaml}:
   - name
   - description


### PR DESCRIPTION
Adds two yaml files (`miq_event_definition_events.yml` and `miq_event_definition_sets.yml`) to `locale_task_config.yaml` so their strings are translated.