### PR TITLE
 Set parent manager in properties for targeted/combined manager refresh

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -43,7 +43,7 @@ module ManageIQ::Providers
         builder
       end
 
-      attr_accessor :name, :persister_class, :properties, :inventory_object_attributes,
+      attr_accessor :name, :parent, :persister_class, :properties, :inventory_object_attributes,
                     :default_values, :dependency_attributes, :options, :adv_settings, :shared_properties
 
       # @see prepare_data()
@@ -62,6 +62,7 @@ module ManageIQ::Providers
 
         @adv_settings = options[:adv_settings] # Configuration/Advanced settings in GUI
         @shared_properties = options[:shared_properties] # From persister
+        @parent = options[:parent]
       end
 
       def manager_class
@@ -80,7 +81,7 @@ module ManageIQ::Providers
       # Yields for overwriting provider-specific properties
       def construct_data
         add_properties(:association => @name)
-
+        add_properties(:parent => parent)
         add_properties(@adv_settings, :if_missing)
         add_properties(@shared_properties, :if_missing)
 

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -25,8 +25,8 @@ module ManageIQ::Providers
             :manager_ref => %i(name)
           )
           add_default_values(
-            :resource_id   => shared_properties[:parent].id,
-            :resource_type => shared_properties[:parent].class.base_class
+            :resource_id   => parent.id,
+            :resource_type => parent.class.base_class
           )
         end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -103,6 +103,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
 
     opts[:adv_settings] = options.try(:[], :inventory_collections).try(:to_hash) || {}
     opts[:shared_properties] = shared_options
+    opts[:parent] = parent
     opts[:auto_inventory_attributes] = true
     opts[:without_model_class] = false
 
@@ -115,7 +116,6 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
       :strategy               => strategy,
       :saver_strategy         => saver_strategy,
       :targeted               => targeted?,
-      :parent                 => parent,
       :assert_graph_integrity => assert_graph_integrity?,
     }
   end
@@ -135,8 +135,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
   private
 
   def add_collection_for_manager(manager_type, collection_name, extra_properties = {}, settings = {}, &block)
-    parent_manager = send("#{manager_type}_manager")
-    settings.reverse_merge!(:shared_properties => {:parent => parent_manager})
+    settings[:parent] ||= send("#{manager_type}_manager")
 
     builder_class = send(manager_type)
     add_collection(builder_class, collection_name, extra_properties, settings, &block)

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -184,7 +184,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     protected
 
     def add_common_default_values
-      ems = shared_properties[:parent]&.id || ->(persister) { persister.manager.id }
+      ems = parent&.id || ->(persister) { persister.manager.id }
       add_default_values(:ems_id => ems)
     end
 


### PR DESCRIPTION
The extra_properties takes precedence over settings so we can override the parent without changing the shared settings.

Required for:
- [ ] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/14

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/344