### PR TITLE
Fixes bug where filtering by tag was returning all metric rollups regardless of assigned tags

### DIFF
--- a/app/models/chargeback_configured_system.rb
+++ b/app/models/chargeback_configured_system.rb
@@ -29,7 +29,7 @@ class ChargebackConfiguredSystem < Chargeback
     scope = records.where(:resource_type => "ConfiguredSystem")
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
       scope_with_current_tags = scope.where(:resource => ConfiguredSystem.find_tagged_with(:any => @options[:tag], :ns => '*'))
-      scope.for_tag_names(Array(options[:tag]).flatten.flat_map { |t| t.split("/")[2..-1] }).or(scope_with_current_tags)
+      scope.for_tag_names(Array(options[:tag]).flatten.map { |t| t.split("/")[2..-1] }).or(scope_with_current_tags)
     else
       scope.where(:resource => configured_systems(region))
     end

--- a/app/models/chargeback_configured_system.rb
+++ b/app/models/chargeback_configured_system.rb
@@ -29,7 +29,7 @@ class ChargebackConfiguredSystem < Chargeback
     scope = records.where(:resource_type => "ConfiguredSystem")
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
       scope_with_current_tags = scope.where(:resource => ConfiguredSystem.find_tagged_with(:any => @options[:tag], :ns => '*'))
-      scope.for_tag_names(options[:tag].split("/")[2..-1]).or(scope_with_current_tags)
+      scope.for_tag_names(Array(options[:tag]).flatten.flat_map { |t| t.split("/")[2..-1] }).or(scope_with_current_tags)
     else
       scope.where(:resource => configured_systems(region))
     end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -91,7 +91,7 @@ class ChargebackVm < Chargeback
     scope = records.where(:resource_type => "VmOrTemplate")
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
       scope_with_current_tags = scope.where(:resource => Vm.find_tagged_with(:any => @options[:tag], :ns => '*'))
-      scope.for_tag_names(Array(options[:tag]).flatten.flat_map { |t| t.split("/")[2..-1] }).or(scope_with_current_tags)
+      scope.for_tag_names(Array(options[:tag]).flatten.map { |t| t.split("/")[2..-1] }).or(scope_with_current_tags)
     else
       scope.where(:resource => vms(region))
     end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -91,7 +91,7 @@ class ChargebackVm < Chargeback
     scope = records.where(:resource_type => "VmOrTemplate")
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
       scope_with_current_tags = scope.where(:resource => Vm.find_tagged_with(:any => @options[:tag], :ns => '*'))
-      scope.for_tag_names(options[:tag].split("/")[2..-1]).or(scope_with_current_tags)
+      scope.for_tag_names(Array(options[:tag]).flatten.flat_map { |t| t.split("/")[2..-1] }).or(scope_with_current_tags)
     else
       scope.where(:resource => vms(region))
     end

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -150,8 +150,8 @@ module Metric::Common
   end
 
   class_methods do
-    def for_tag_names(*args)
-      where("tag_names like ?", args.flat_map { |t| "%" + t.join("/") + "%" })
+    def for_tag_names(args)
+      where(args.map { |t| "tag_names like ?" }.join(" OR "), *(args.map { |t| "%" + t.join("/") + "%" }))
     end
 
     def for_time_range(start_time, end_time)

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -151,7 +151,7 @@ module Metric::Common
 
   class_methods do
     def for_tag_names(*args)
-      where("tag_names like ?", "%" + args.join("/") + "%")
+      where("tag_names like ?", args.flat_map { |t| "%" + t.join("/") + "%" })
     end
 
     def for_time_range(start_time, end_time)

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -127,7 +127,7 @@ class VimPerformanceTagValue
   def self.get_metrics(resources, timestamp, capture_interval_name, vim_performance_daily, category)
     if vim_performance_daily
       MetricRollup.with_interval_and_time_range("hourly", (timestamp)..(timestamp+1.day)).where(:resource => resources)
-          .for_tag_names(category, "") # append trailing slash
+          .for_tag_names([category, ""]) # append trailing slash
     else
       Metric::Helper.class_for_interval_name(capture_interval_name).where(:resource => resources)
           .with_interval_and_time_range(capture_interval_name, timestamp)

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -127,7 +127,7 @@ class VimPerformanceTagValue
   def self.get_metrics(resources, timestamp, capture_interval_name, vim_performance_daily, category)
     if vim_performance_daily
       MetricRollup.with_interval_and_time_range("hourly", (timestamp)..(timestamp+1.day)).where(:resource => resources)
-          .for_tag_names([category, ""]) # append trailing slash
+          .for_tag_names([[category, ""]]) # append trailing slash
     else
       Metric::Helper.class_for_interval_name(capture_interval_name).where(:resource => resources)
           .with_interval_and_time_range(capture_interval_name, timestamp)

--- a/lib/before_session_middleware.rb
+++ b/lib/before_session_middleware.rb
@@ -1,0 +1,26 @@
+# Add to config/application.rb:
+#
+#     config.middleware.use 'BeforeSessionMiddleware'
+#
+class BeforeSessionMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    session_id = cookies(env)['_vmdb_session']
+    Rails.logger.info("Session ID: #{session_id.inspect}")
+
+    @app.call(env)
+  end
+
+  private
+
+  def cookies(env)
+    env["HTTP_COOKIE"].split(/\s*;\s*/).map do |keyval|
+      keyval.split('=')
+    end.to_h
+  rescue StandardError
+    {}
+  end
+end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -383,6 +383,7 @@ RSpec.describe ChargebackVm do
 
         let(:development_vm) { FactoryBot.create(:vm_vmware, :created_on => month_beginning) }
         let(:other_vm)       { FactoryBot.create(:vm_vmware, :created_on => month_beginning) }
+        let(:another_vm)     { FactoryBot.create(:vm_vmware, :created_on => month_beginning) }
 
         before do
           environment_category = Classification.find_by(:description => "Environment")
@@ -390,8 +391,10 @@ RSpec.describe ChargebackVm do
 
           development_vm.tag_with(tag_development.tag.name, :ns => '*')
 
-          metric_rollup_params.delete(:tag_names)
+          metric_rollup_params[:tag_names] = ""
           add_metric_rollups_for(other_vm, start_time...finish_time, 1.hour, metric_rollup_params)
+          metric_rollup_params.delete(:tag_names)
+          add_metric_rollups_for(another_vm, start_time...finish_time, 1.hour, metric_rollup_params)
           metric_rollup_params[:tag_names] = "environment/dev"
           add_metric_rollups_for(development_vm, start_time...finish_time, 1.hour, metric_rollup_params)
         end
@@ -401,7 +404,7 @@ RSpec.describe ChargebackVm do
         end
 
         it "doesn't filter resources without filter" do
-          expect(subject).to match_array([@vm1.id, development_vm.id, other_vm.id])
+          expect(subject).to match_array([@vm1.id, development_vm.id, other_vm.id, another_vm.id])
         end
 
         context "with filter" do

--- a/spec/models/vim_performance_tag_value_spec.rb
+++ b/spec/models/vim_performance_tag_value_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe VimPerformanceTagValue do
+  include Spec::Support::ChargebackHelper
+
   context "#get_metrics" do
     let(:ts) { Time.zone.now }
     let(:category) { [] }
@@ -22,6 +24,29 @@ RSpec.describe VimPerformanceTagValue do
       vim_performance_daily = true
       metrics = VimPerformanceTagValue.send('get_metrics', resources, ts, interval, vim_performance_daily, category)
       expect(metrics).to be_empty
+    end
+
+    context "with metrics and a category" do
+      let(:development_vm) { FactoryBot.create(:vm_vmware, :created_on => report_run_time) }
+
+      let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
+      let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(:tz => 'UTC')) }
+      let(:report_run_time) { ts.end_of_month.utc }
+
+      let(:start_time)  { report_run_time - 17.hours }
+      let(:finish_time) { report_run_time - 14.hours }
+
+      before do
+        metric_rollup_params = { :tag_names => "environment/dev" }
+        add_metric_rollups_for(development_vm, start_time...finish_time, 1.hour, metric_rollup_params)
+      end
+
+      it "finds metrics" do
+        interval = nil
+        vim_performance_daily = true
+        metrics = VimPerformanceTagValue.send('get_metrics', [development_vm], start_time, interval, vim_performance_daily, "environment")
+        expect(metrics).not_to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Adding scope for tag names in `for_tag_names` was not expecting an array of tag, which was changed when support for filtering by multiple tags introduced
