### PR TITLE
Don't dynamically write systemd unit files

### DIFF
--- a/app/models/miq_server/at_startup.rb
+++ b/app/models/miq_server/at_startup.rb
@@ -5,7 +5,6 @@ module MiqServer::AtStartup
   module ClassMethods
     def startup!
       log_managed_entities
-      write_systemd_unit_files
       clean_all_workers
       clean_dequeued_messages
       purge_report_results
@@ -16,20 +15,6 @@ module MiqServer::AtStartup
       prefix = "#{_log.prefix} Region: [#{region.region}], name: [#{region.name}]"
       log_under_management(prefix)
       log_not_under_management(prefix)
-    end
-
-    def write_systemd_unit_files
-      return unless MiqEnvironment::Command.supports_systemd?
-
-      _log.info("Writing Systemd unit files...")
-      MiqWorkerType.worker_class_names.each do |class_name|
-        worker_klass = class_name.safe_constantize
-        worker_klass.ensure_systemd_files if worker_klass&.systemd_worker?
-      rescue => err
-        _log.warn("Failed to write systemd service files: #{err}")
-        _log.log_backtrace(err)
-      end
-      _log.info("Writing Systemd unit files...Complete")
     end
 
     # Delete and Kill all workers that were running previously

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -283,7 +283,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.systemd_worker?
-    MiqEnvironment::Command.supports_systemd? && supports_systemd?
+    MiqEnvironment::Command.supports_systemd?
   end
 
   def systemd_worker?

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -11,80 +11,12 @@ class MiqWorker
         false
       end
 
-      def ensure_systemd_files
-        target_file_path.write(target_file)
-        service_file_path.write(unit_file)
-      end
-
       def service_base_name
         minimal_class_name.underscore.tr("/", "_")
       end
 
-      def slice_base_name
-        "miq"
-      end
-
-      def service_name
-        "#{service_base_name}@"
-      end
-
-      def service_file_name
-        "#{service_name}.service"
-      end
-
-      def slice_name
-        "#{slice_base_name}-#{service_base_name}.slice"
-      end
-
-      def service_file_path
-        systemd_unit_dir.join(service_file_name)
-      end
-
-      def target_file_name
-        "#{service_base_name}.target"
-      end
-
-      def target_file_path
-        systemd_unit_dir.join(target_file_name)
-      end
-
       def systemd_unit_dir
-        Pathname.new("/etc/systemd/system")
-      end
-
-      def target_file
-        <<~TARGET_FILE
-          [Unit]
-          PartOf=miq.target
-        TARGET_FILE
-      end
-
-      def unit_file
-        <<~UNIT_FILE
-          [Unit]
-          PartOf=#{target_file_name}
-          [Install]
-          WantedBy=#{target_file_name}
-          [Service]
-          WorkingDirectory=#{working_directory}
-          Environment=BUNDLER_GROUPS=#{bundler_groups.join(",")}
-          ExecStart=/bin/bash -lc '#{exec_start}'
-          Restart=no
-          Type=notify
-          Slice=#{slice_name}
-        UNIT_FILE
-      end
-
-      def working_directory
-        Rails.root
-      end
-
-      def exec_start
-        "exec ruby lib/workers/bin/run_single_worker.rb #{name} #{run_single_worker_args}"
-      end
-
-      def run_single_worker_args
-        "--heartbeat --guid=%i"
+        Pathname.new("/lib/systemd/system")
       end
     end
 

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -3,14 +3,6 @@ class MiqWorker
     extend ActiveSupport::Concern
 
     class_methods do
-      def supports_systemd?
-        return unless worker_settings[:systemd_enabled]
-        require "dbus/systemd"
-        true
-      rescue LoadError
-        false
-      end
-
       def service_base_name
         minimal_class_name.underscore.tr("/", "_")
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1065,7 +1065,6 @@
       :poll_method: normal
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
-      :systemd_enabled: true
     :event_catcher:
       :defaults:
         :flooding_events_per_minute: 30


### PR DESCRIPTION
Use the statically defined unit files installed by the RPM rather than writing them out dynamically

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/20983
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/134