### PR TITLE
Run workers without (root) login shell option

### DIFF
--- a/lib/generators/manageiq/provider/templates/build/systemd_units/%plugin_name%_%manager_path%_event_catcher@.service
+++ b/lib/generators/manageiq/provider/templates/build/systemd_units/%plugin_name%_%manager_path%_event_catcher@.service
@@ -5,7 +5,7 @@ WantedBy=<%= plugin_name %>_<%= manager_path %>_event_catcher.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::EventCatcher --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::EventCatcher --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_event_catcher.slice

--- a/lib/generators/manageiq/provider/templates/build/systemd_units/%plugin_name%_%manager_path%_metrics_collector@.service
+++ b/lib/generators/manageiq/provider/templates/build/systemd_units/%plugin_name%_%manager_path%_metrics_collector@.service
@@ -5,7 +5,7 @@ WantedBy=<%= plugin_name %>_<%= manager_path %>_metrics_collector.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_metrics_collector.slice

--- a/lib/generators/manageiq/provider/templates/build/systemd_units/%plugin_name%_%manager_path%_refresh@.service
+++ b/lib/generators/manageiq/provider/templates/build/systemd_units/%plugin_name%_%manager_path%_refresh@.service
@@ -5,7 +5,7 @@ WantedBy=<%= plugin_name %>_<%= manager_path %>_refresh.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::RefreshWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::RefreshWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_refresh.slice

--- a/systemd/manageiq-cockpit_ws@.service
+++ b/systemd/manageiq-cockpit_ws@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-cockpit_ws.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqCockpitWsWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqCockpitWsWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-cockpit_ws.slice

--- a/systemd/manageiq-ems_metrics_processor@.service
+++ b/systemd/manageiq-ems_metrics_processor@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-ems_metrics_processor.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-ems_metrics_processor.slice

--- a/systemd/manageiq-event_handler@.service
+++ b/systemd/manageiq-event_handler@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-event_handler.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-event_handler.slice

--- a/systemd/manageiq-generic@.service
+++ b/systemd/manageiq-generic@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-generic.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-generic.slice

--- a/systemd/manageiq-priority@.service
+++ b/systemd/manageiq-priority@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-priority.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-priority.slice

--- a/systemd/manageiq-remote_console@.service
+++ b/systemd/manageiq-remote_console@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-remote_console.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-remote_console.slice

--- a/systemd/manageiq-reporting@.service
+++ b/systemd/manageiq-reporting@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-reporting.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-reporting.slice

--- a/systemd/manageiq-schedule@.service
+++ b/systemd/manageiq-schedule@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-schedule.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-schedule.slice

--- a/systemd/manageiq-smart_proxy@.service
+++ b/systemd/manageiq-smart_proxy@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-smart_proxy.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-smart_proxy.slice

--- a/systemd/manageiq-ui@.service
+++ b/systemd/manageiq-ui@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-ui.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-ui.slice

--- a/systemd/manageiq-web_service@.service
+++ b/systemd/manageiq-web_service@.service
@@ -5,7 +5,7 @@ WantedBy=manageiq-web_service.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i'
+ExecStart=/bin/bash -c '. /etc/default/evm && exec ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i'
 Restart=no
 Type=notify
 Slice=manageiq-web_service.slice


### PR DESCRIPTION
We currently run a login shell which will use `source` to load the evm environment.

Instead, this directly loads the environment directly and does not rely upon a bash login shell.

We are making this change to get away from relying upon root's bashrc configuration and
eventually run these are a non-root user.

I would have liked to have used `EnvironmentFile` instead of sourcing the script
but that change was non-trivial

This is a continuation of #20983

I will add `User=` and make all of these in one sweeping change to the other 22 repos.