### PR TITLE
Add cloud_volume_types to storage manager persister

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
@@ -10,6 +10,10 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def cloud_volume_types
+          add_common_default_values
+        end
+
         def cloud_object_store_objects
           add_common_default_values
         end


### PR DESCRIPTION
We should add this inventory collection to the core persister definition so that providers don't have to fully re-define it

Required for: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/176

https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/175