### PR TITLE
Add pam_initgroups_scheme = always to sssd.conf

### DIFF
--- a/spec/tools/miq_config_sssd_ldap/sssd_conf_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/sssd_conf_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe MiqConfigSssdLdap::SssdConf do
       SSSD_CONF_ERB
     end
 
-    let(:sssd_conf) do
-      <<-SSSD_CONF_ERB.strip_heredoc
+    let(:sssd_conf_shell) do
+      <<-SSSD_CONF_INITIAL.strip_heredoc
         [domain/default]
         autofs_provider = ldap
         ldap_schema = rfc2307bis
@@ -50,11 +50,62 @@ RSpec.describe MiqConfigSssdLdap::SssdConf do
         domains = default
         [pam]
         [ifp]
-      SSSD_CONF_ERB
+      SSSD_CONF_INITIAL
+    end
+
+    let(:sssd_conf_updated) do
+      <<-SSSD_CONF_UPDATED.strip_heredoc
+
+        [domain/]
+
+        [application/]
+        autofs_provider = ldap
+        ldap_schema = rfc2307bis
+        ldap_search_base = my_basedn
+        id_provider = ldap
+        auth_provider = ldap
+        chpass_provider = ldap
+        ldap_uri = ldap://ldap_host:2
+        ldap_id_use_start_tls = false
+        cache_credentials = true
+        ldap_tls_cacertdir = /etc/openldap/cacerts/
+        entry_cache_timeout = 600
+        ldap_auth_disable_tls_never_use_in_production = true
+        ldap_default_bind_dn = 
+        ldap_default_authtok = 
+        ldap_group_member = member
+        ldap_group_name = cn
+        ldap_group_object_class = groupOfNames
+        ldap_group_search_base = my_basedn
+        ldap_network_timeout = 3
+        ldap_pwd_policy = none
+        ldap_tls_cacert = 
+        ldap_user_extra_attrs = mail, givenname, sn, displayname, domainname
+        ldap_user_gid_number = gidNumber
+        ldap_user_name = cn
+        ldap_user_object_class = person
+        ldap_user_search_base = 
+        ldap_user_uid_number = uidNumber
+
+        [sssd]
+        services = nss, pam, ifp
+        domains = 
+        config_file_version = 2
+        default_domain_suffix = 
+        sbus_timeout = 30
+
+        [pam]
+        pam_app_services = httpd-auth
+        pam_initgroups_scheme = always
+
+        [ifp]
+        allowed_uids = apache, root
+        user_attributes = +mail, +givenname, +sn, +displayname, +domainname
+      SSSD_CONF_UPDATED
     end
 
     before do
-      @initial_settings = {:mode => "ldap", :ldaphost => ["ldap_host"], :ldapport => "2", :basedn => "my_basedn" }
+      @initial_settings = {:mode => "ldap", :ldaphost => ["ldap_host"], :ldapport => "2", :basedn => "my_basedn", :user_type => "dn-cn"}
 
       @test_dir = "#{Dir.tmpdir}/#{@spec_name}"
       @template_dir = "#{@test_dir}/TEMPLATE"
@@ -77,7 +128,15 @@ RSpec.describe MiqConfigSssdLdap::SssdConf do
 
       described_class.new(@initial_settings)
 
-      expect(File.read("#{@sssd_conf_dir}/sssd.conf")).to eq(sssd_conf)
+      expect(File.read("#{@sssd_conf_dir}/sssd.conf")).to eq(sssd_conf_shell)
+    end
+
+    it 'will populate the PAM section' do
+      File.open("#{@sssd_template_dir}/sssd.conf.erb", "w") { |f| f.write(sssd_conf_erb) }
+
+      described_class.new(@initial_settings).update
+
+      expect(File.read("#{@sssd_conf_dir}/sssd.conf")).to eq(sssd_conf_updated)
     end
   end
 end

--- a/tools/miq_config_sssd_ldap/sssd_conf/pam.rb
+++ b/tools/miq_config_sssd_ldap/sssd_conf/pam.rb
@@ -3,11 +3,15 @@ require 'sssd_conf/common'
 module MiqConfigSssdLdap
   class Pam < Common
     def initialize(initial_settings)
-      super(%w[pam_app_services], initial_settings)
+      super(%w(pam_app_services pam_initgroups_scheme), initial_settings)
     end
 
     def pam_app_services
       "httpd-auth"
+    end
+
+    def pam_initgroups_scheme
+      "always"
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/21129

SSSD version 2.3.0 changed the default behavior for pam_initgroups_scheme.

This new behavior  broke the miq_config_sssd_ldap tool

The [pam] section of the sssd.conf file needs to now include: pam_initgroups_scheme = always

This PR adds this new pam parameter.

