### PR TITLE
[KASPAROV] [session_extension.rb] Fix superclass mismatch

### DIFF
--- a/lib/extensions/session_extension.rb
+++ b/lib/extensions/session_extension.rb
@@ -2,6 +2,6 @@ class ActionDispatch::Request::Session
   include MoreCoreExtensions::Shared::Nested
 end
 
-class ActionController::TestSession < Rack::Session::Abstract::SessionHash
+class ActionController::TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
   include MoreCoreExtensions::Shared::Nested
 end


### PR DESCRIPTION
This is a backport of https://github.com/ManageIQ/manageiq/commit/d8114bfb24808a595f6fd4f66431691328eed1c3 which is from the [Rails 6.0 PR](https://github.com/ManageIQ/manageiq/pull/20778) since https://github.com/rails/rails/commit/13a07268160c1093d4b0ff40e45e487d635fa6b9 was backported to Rails 5.2 recently.

Original commit message below:

* * *

This was changed in new versions of `actionpack`, and without this change, the following error is given:

```
    TypeError:
      superclass mismatch for class TestSession
    # actionpack-6.0.3.3/lib/action_controller/test_case.rb:179:in `<module:ActionController>'
    # ...
    # ./spec/spec_helper.rb:11:in `<top (required)>'
    No examples found.
```


Links
-----

* Reported in gitter:  https://gitter.im/ManageIQ/manageiq?at=60633bb318ceb9198a93ae83
* Rails 6.0 PR:  https://github.com/ManageIQ/manageiq/pull/20778
* Rails commit:  https://github.com/rails/rails/commit/13a07268160c1093d4b0ff40e45e487d635fa6b9


Steps for Testing/QA
--------------------

Hopefully will make the tests pass.