### PR TITLE
Improve the provider check for authentication status

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -149,6 +149,11 @@ module AuthenticationMixin
     !has_credentials?(type)
   end
 
+  def provider_authentication_status_ok?(type = nil)
+    authtype = [type, default_authentication_type].compact
+    authentication_for_providers.find_by(:authtype => authtype).try(:status) == "Valid"
+  end
+
   def authentication_status_ok?(type = nil)
     authentication_best_fit(type).try(:status) == "Valid"
   end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -151,7 +151,9 @@ module AuthenticationMixin
 
   def provider_authentication_status_ok?(type = nil)
     authtype = [type, default_authentication_type].compact
-    authentication_for_providers.find_by(:authtype => authtype).try(:status) == "Valid"
+
+    # Prioritize the requested authtype if it exists, otherwise fall back to the default
+    authentication_for_providers.where(:authtype => authtype).min_by { |a| a.authtype == type.to_s ? 0 : 1 }.try(:status) == "Valid"
   end
 
   def authentication_status_ok?(type = nil)

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -153,7 +153,7 @@ module AuthenticationMixin
     authtype = [type, default_authentication_type].compact
 
     # Prioritize the requested authtype if it exists, otherwise fall back to the default
-    authentication_for_providers.where(:authtype => authtype).min_by { |a| a.authtype == type.to_s ? 0 : 1 }.try(:status) == "Valid"
+    authentication_for_providers.where(:authtype => authtype).order(:id).min_by { |a| a.authtype == type.to_s ? 0 : 1 }.try(:status) == "Valid"
   end
 
   def authentication_status_ok?(type = nil)

--- a/app/models/mixins/provider_worker_mixin.rb
+++ b/app/models/mixins/provider_worker_mixin.rb
@@ -11,7 +11,7 @@ module ProviderWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      all_ems_in_zone.select { |e| e.enabled && e.authentication_status_ok? }
+      all_ems_in_zone.select { |e| e.enabled && e.provider_authentication_status_ok? }
     end
 
     def any_valid_ems_in_zone?

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -893,7 +893,7 @@ RSpec.describe AuthenticationMixin do
       end
     end
 
-    context "with one invalid provider authentication and a valid inentory authentication" do
+    context "with one invalid provider authentication and a valid inventory authentication" do
       before do
         FactoryBot.create(:authentication, :resource => ems, :status => "Invalid", :authtype => "default")
         FactoryBot.create(:authentication, :resource => ems, :status => "Valid", :authtype => nil)

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -847,4 +847,65 @@ RSpec.describe AuthenticationMixin do
       end
     end
   end
+
+  describe "#provider_authentication_status_ok?" do
+    before    { EvmSpecHelper.local_miq_server }
+    let(:ems) { FactoryBot.create(:ext_management_system) }
+
+    context "with no authentications" do
+      it "is falsey" do
+        expect(ems.provider_authentication_status_ok?).to be_falsey
+      end
+    end
+
+    context "with one valid authentication" do
+      before { FactoryBot.create(:authentication, :resource => ems, :status => "Valid", :authtype => "default") }
+
+      it "is truthy" do
+        expect(ems.provider_authentication_status_ok?).to be_truthy
+      end
+    end
+
+    context "with one invalid authentication" do
+      before { FactoryBot.create(:authentication, :resource => ems, :status => "Invalid", :authtype => "default") }
+
+      it "is falsey" do
+        expect(ems.provider_authentication_status_ok?).to be_falsey
+      end
+    end
+
+    context "with one valid and one invalid authentication" do
+      before do
+        FactoryBot.create(:authentication, :resource => ems, :status => "Invalid", :authtype => "default")
+        FactoryBot.create(:authentication, :resource => ems, :status => "Valid", :authtype => "metrics")
+      end
+
+      it "is truthy with metrics authtype" do
+        expect(ems.provider_authentication_status_ok?(:metrics)).to be_truthy
+      end
+
+      it "is falsey with default authtype" do
+        expect(ems.provider_authentication_status_ok?(:default)).to be_falsey
+      end
+
+      it "is falsey without passing authtype" do
+        expect(ems.provider_authentication_status_ok?).to be_falsey
+      end
+    end
+
+    context "with one invalid provider authentication and a valid inentory authentication" do
+      before do
+        FactoryBot.create(:authentication, :resource => ems, :status => "Invalid", :authtype => "default")
+        FactoryBot.create(:authentication, :resource => ems, :status => "Valid", :authtype => nil)
+      end
+
+      it "is falsey with default authtype" do
+        expect(ems.provider_authentication_status_ok?(:default)).to be_falsey
+      end
+
+      it "doesn't find the non-provider authtype" do
+        expect(ems.provider_authentication_status_ok?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rather than iterate through all of the authentications when checking for valid provider authentications (e.g.: `authentication_status_ok?`) we can use `authentication_for_provider` which uses an association to improve the performance.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/452
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/700