### PR TITLE
Replace all kubernetes label unsafe characters with -

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -53,7 +53,9 @@ class MiqWorker
     end
 
     def zone_selector
-      {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone-#{MiqServer.my_zone}" => "true"}
+      product = Vmdb::Appliance.PRODUCT_NAME.downcase.gsub(/[^-a-z0-9\.]/, "-")
+      zone    = MiqServer.my_zone.chomp.strip.gsub(/[^-A-Za-z0-9_\.\/]/, "-")
+      {"#{product}/zone-#{zone}" => "true"}
     end
 
     def container_image


### PR DESCRIPTION
Otherwise your error looks like this.
```
[Kubeclient::HttpError]: Deployment.apps \"10-ui\" is invalid: [spec.template.spec.nodeSelector: Invalid value: \"cp4mcm:im/zone-Config Zone\": prefix part a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.spec.nodeSelector: Invalid value: \"cp4mcm:im/zone-Config Zone\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]
```