### PR TITLE
Change in code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,52 +2,34 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*                                               @fryguy @gtanzillo
+*                                               @fryguy
 #
 /app/models/manageiq/providers/                 @agrare @fryguy
 /app/models/manageiq/providers/inventory/       @agrare @fryguy
-/app/channels                                   @skateman
-/app/mailers                                    @skateman
 /app/models                                     @agrare @fryguy @kbrock
-/app/models/authenticator*                      @jvlcek
-/app/models/chargeback*                         @lpichler
+/app/models/authenticator*                      @kbrock
 /app/models/cloud*                              @agrare
-/app/models/compliance*                         @lfu
 /app/models/container*                          @agrare
 /app/models/conversion_host*                    @fdupont-redhat
-/app/models/dialog*                             @tinaafitz
 /app/models/ems_event*                          @agrare
 /app/models/ems_refresh*                        @agrare
-/app/models/event_stream*                       @agrare @lfu
-/app/models/file_depot*                         @NickLaMuro @jerryk55
+/app/models/event_stream*                       @agrare
+/app/models/file_depot*                         @NickLaMuro
 /app/models/firmware_registry*                  @agrare
-/app/models/generic_object_definition*          @lfu
 /app/models/job*                                @agrare
 /app/models/manageiq/providers                  @agrare
 /app/models/metric*                             @agrare
 /app/models/miq_cockpit_ws_worker*              @jrafanie
-/app/models/miq_dialog*                         @tinaafitz
 /app/models/miq_ems_metrics_processor_worker*   @agrare
 /app/models/miq_event_handler*                  @agrare
-/app/models/miq_policy*                         @lfu
-/app/models/miq_product_feature*                @h-kataria
-/app/models/miq_provision*                      @gmcullough
-/app/models/miq_remote_console_worker*          @skateman
-/app/models/miq_report*                         @kbrock @lpichler
-/app/models/miq_request*                        @gmcullough
+/app/models/miq_product_feature*                @kavyanekkalapu
+/app/models/miq_report*                         @kbrock
 /app/models/miq_schedule*                       @jrafanie
-/app/models/miq_search*                         @lpichler
 /app/models/miq_server*                         @jrafanie
 /app/models/miq_template*                       @agrare
-/app/models/miq_widget*                         @yrudman
 /app/models/miq_worker*                         @jrafanie
-/app/models/notification*                       @skateman
-/app/models/orchestration_stack*                @lfu
-/app/models/orchestration_template*             @lfu
 /app/models/physical_server*                    @agrare
-/app/models/policy_event*                       @lfu
 /app/models/scan_item*                          @agrare
-/app/models/service*                            @gmcullough
 /app/models/transformation_mapping*             @fdupont-redhat
 /app/models/vim_performance_state*              @agrare
 /app/models/vm                                  @agrare
@@ -59,4 +41,4 @@
 /db                                             @agrare @bdunne
 /lib/generators                                 @agrare
 /lib/manageiq/reporting                         @jrafanie
-/product*                                       @h-kataria
+/product/*                                      @kavyanekkalapu


### PR DESCRIPTION
a few people are being notified for code that they no longer own.

There are a few options that I see:
- leave people as code owners and have them pinged for most PRs.
- change the owners of these particular sections of the code to people on the team.
- remove the line entries with developers no longer responsible for the individual code areas of our product.

This will need to be done in other repos too, but putting here as a conversation starter.