### PR TITLE
Fix MiqWorker service_base_name to match unit file prefix

### DIFF
--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -4,7 +4,7 @@ class MiqWorker
 
     class_methods do
       def service_base_name
-        minimal_class_name.underscore.tr("/", "_")
+        "manageiq-#{minimal_class_name.underscore.tr("/", "_")}"
       end
 
       def systemd_unit_dir

--- a/app/models/mixins/provider_worker_mixin.rb
+++ b/app/models/mixins/provider_worker_mixin.rb
@@ -17,5 +17,9 @@ module ProviderWorkerMixin
     def any_valid_ems_in_zone?
       all_valid_ems_in_zone.any?
     end
+
+    def service_base_name
+      "manageiq-providers-#{minimal_class_name.underscore.tr("/", "_")}"
+    end
   end
 end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -87,6 +87,12 @@ module Vmdb
       end
     end
 
+    def systemd_units
+      @systemd_units ||= begin
+        flat_map { |engine| engine.root.join("systemd").glob("*.*") }
+      end
+    end
+
     def load_inflections
       each do |engine|
         file = engine.root.join("config", "initializers", "inflections.rb")

--- a/spec/models/miq_server/worker_management/monitor/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/systemd_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Systemd do
 
   context "#cleanup_failed_systemd_services" do
     context "with no failed services" do
-      let(:units) { [{:name => "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
+      let(:units) { [{:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
 
       it "doesn't call DisableUnitFiles" do
         expect(systemd_manager).not_to receive(:DisableUnitFiles)
@@ -20,7 +20,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Systemd do
     end
 
     context "with failed services" do
-      let(:service_name) { "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
+      let(:service_name) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
       let(:units) { [{:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "failed", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
 
       it "calls DisableUnitFiles with the service name" do
@@ -36,8 +36,8 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Systemd do
   context "#systemd_all_miq_services" do
     let(:units) do
       [
-        {:name => "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
-        {:name => "ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service",      :active_state => "active"},
+        {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
+        {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service",      :active_state => "active"},
         {:name => "ssh.service",                                          :active_state => "active"}
       ]
     end
@@ -50,8 +50,8 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Systemd do
   context "#systemd_failed_miq_services" do
     let(:units) do
       [
-        {:name => "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
-        {:name => "ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service",      :active_state => "active"}
+        {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
+        {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service",      :active_state => "active"}
       ]
     end
 
@@ -62,15 +62,15 @@ RSpec.describe MiqServer::WorkerManagement::Monitor::Systemd do
 
   context "#systemd_miq_service_base_names (private)" do
     it "returns the minimal_class_name" do
-      expect(server.send(:systemd_miq_service_base_names)).to include("generic", "ui")
+      expect(server.send(:systemd_miq_service_base_names)).to include("manageiq-generic", "manageiq-ui")
     end
   end
 
   context "#systemd_services (private)" do
     let(:units) do
       [
-        {:name => "generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service"},
-        {:name => "miq.slice"}
+        {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service"},
+        {:name => "manageiq-miq.slice"}
       ]
     end
 

--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe MiqWorker::SystemdCommon do
+  describe ".service_base_name" do
+    before { MiqWorkerType.seed }
+
+    it "every worker has a matching systemd target and service file" do
+      all_systemd_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
+
+      all_systemd_units.delete("manageiq.target")
+
+      MiqWorkerType.worker_class_names.each do |klass_name|
+        klass = klass_name.constantize
+        service_base_name = klass.service_base_name
+
+        service_file = "#{service_base_name}@.service"
+        target_file  = "#{service_base_name}.target"
+
+        expect(all_systemd_units).to include(service_file)
+        expect(all_systemd_units).to include(target_file)
+
+        all_systemd_units -= [service_file, target_file]
+      end
+
+      expect(all_systemd_units).to be_empty
+    end
+  end
+end

--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -3,24 +3,21 @@ RSpec.describe MiqWorker::SystemdCommon do
     before { MiqWorkerType.seed }
 
     it "every worker has a matching systemd target and service file" do
-      all_systemd_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
+      expected_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
 
-      all_systemd_units.delete("manageiq.target")
+      expected_units.delete("manageiq.target")
 
-      MiqWorkerType.worker_class_names.each do |klass_name|
+      found_units = MiqWorkerType.worker_class_names.flat_map do |klass_name|
         klass = klass_name.constantize
         service_base_name = klass.service_base_name
 
         service_file = "#{service_base_name}@.service"
         target_file  = "#{service_base_name}.target"
 
-        expect(all_systemd_units).to include(service_file)
-        expect(all_systemd_units).to include(target_file)
-
-        all_systemd_units -= [service_file, target_file]
+        [service_file, target_file]
       end
 
-      expect(all_systemd_units).to be_empty
+      expect(expected_units).to match_array(found_units)
     end
   end
 end


### PR DESCRIPTION
After we renamed the systemd services to have "manageiq-" and "manageiq-providers-" prefixes the service_base_name wasn't updated to match the new names.

Also adds a spec test to ensure all workers have systemd unit files and that there are no extra unit files without workers.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/693
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/23