### PR TITLE
AIO Container: Ensure that the postgres directory has the correct permissions.

### DIFF
--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -36,6 +36,7 @@ else
   echo "** DB has not been initialized"
 
   echo "** Launching initdb"
+  chown -R postgres:postgres ${APPLIANCE_PG_DATA}
   su postgres -c "initdb -D ${APPLIANCE_PG_DATA}"
   test $? -ne 0 && echo "!! Failed to initdb" && exit 1
 


### PR DESCRIPTION
Reported in [gitter](https://gitter.im/ManageIQ/manageiq?at=606b80f5db595f5599d8e33c) cc @jaywcarman 

Without this, you'll see the following error since the directory was owned by `root` and the `postgres` user didn't have permission to write to it.
```
$ podman run -p 8443:443 manageiq/manageiq:latest-kasparov
== Checking MIQ database status ==
** DB has not been initialized
** Launching initdb
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.UTF-8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

initdb: could not access directory "/var/lib/pgsql/data": Permission denied
!! Failed to initdb
```
