### PR TITLE
Run systemd worker and container deployment name specs in provider plugins

### DIFF
--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       test_cases.each { |test| expect(test[:subject].worker_deployment_name).to eq(test[:name]) }
     end
 
-    it "no worker deployment names are over 60 characters" do
+    it "no worker deployment names are over 60 characters", :providers_common => true do
       # OpenShift does not allow deployment names over 63 characters
       # We also want to leave some for the ems_id so we compare against 60 to be safe
       MiqWorkerType.seed

--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MiqWorker::SystemdCommon do
   describe ".service_base_name" do
     before { MiqWorkerType.seed }
 
-    it "every worker has a matching systemd target and service file" do
+    it "every worker has a matching systemd target and service file", :providers_common => true do
       expected_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
 
       expected_units.delete("manageiq.target")
@@ -17,7 +17,7 @@ RSpec.describe MiqWorker::SystemdCommon do
         [service_file, target_file]
       end
 
-      expect(expected_units).to match_array(found_units)
+      expect(found_units).to match_array(expected_units)
     end
   end
 end


### PR DESCRIPTION
These specs ensure that workers from other plugins don't break core assumptions (like the deployment name length or having systemd unit files) and so should run as part of the providers_common specs.