### PR TITLE
Update the provider generator for the combined manager refresh pattern

### DIFF
--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/collector.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/collector.rb
@@ -1,3 +1,0 @@
-class <%= class_name %>::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :<%= manager_type %>
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector.rb
@@ -1,3 +1,14 @@
 class <%= class_name %>::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :<%= manager_type %>
+
+  def connection
+    @connection ||= manager.connect
+  end
+
+  def vms
+    [
+      OpenStruct.new(:id => '1', :name => 'funky', :location => 'dc-1', :vendor => 'unknown'),
+      OpenStruct.new(:id => '2', :name => 'bunch', :location => 'dc-1', :vendor => 'unknown')
+    ]
+  end
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector/%manager_path%.rb
@@ -1,12 +1,2 @@
 class <%= class_name %>::Inventory::Collector::<%= manager_type %> < <%= class_name %>::Inventory::Collector
-  def connection
-    @connection ||= manager.connect
-  end
-
-  def vms
-    [
-      OpenStruct.new(:id => '1', :name => 'funky', :location => 'dc-1', :vendor => 'unknown'),
-      OpenStruct.new(:id => '2', :name => 'bunch', :location => 'dc-1', :vendor => 'unknown')
-    ]
-  end
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser.rb
@@ -1,3 +1,16 @@
 class <%= class_name %>::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :<%= manager_type %>
+
+  def parse
+    vms
+  end
+
+  def vms
+    collector.vms.each do |inventory|
+      inventory_object = persister.vms.find_or_build(inventory.id.to_s)
+      inventory_object.name = inventory.name
+      inventory_object.location = inventory.location
+      inventory_object.vendor = inventory.vendor
+    end
+  end
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser/%manager_path%.rb
@@ -1,14 +1,2 @@
 class <%= class_name %>::Inventory::Parser::<%= manager_type %> < <%= class_name %>::Inventory::Parser
-  def parse
-    vms
-  end
-
-  def vms
-    collector.vms.each do |inventory|
-      inventory_object = persister.vms.find_or_build(inventory.id.to_s)
-      inventory_object.name = inventory.name
-      inventory_object.location = inventory.location
-      inventory_object.vendor = inventory.vendor
-    end
-  end
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister.rb
@@ -1,3 +1,7 @@
 class <%= class_name %>::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :<%= manager_type %>
+
+  def initialize_inventory_collections
+    add_cloud_collection(:vms)
+  end
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister/%manager_path%.rb
@@ -1,7 +1,2 @@
 class <%= class_name %>::Inventory::Persister::<%= manager_type %> < <%= class_name %>::Inventory::Persister
-  include <%= class_name %>::Inventory::Persister::Definitions::CloudCollections
-
-  def initialize_inventory_collections
-    initialize_cloud_inventory_collections
-  end
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister/definitions/cloud_collections.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister/definitions/cloud_collections.rb
@@ -1,9 +1,0 @@
-module <%= class_name %>::Inventory::Persister::Definitions::CloudCollections
-  extend ActiveSupport::Concern
-
-  def initialize_cloud_inventory_collections
-    %i(vms).each do |name|
-      add_collection(cloud, name)
-    end
-  end
-end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/parser.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/parser.rb
@@ -1,3 +1,0 @@
-class <%= class_name %>::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :<%= manager_type %>
-end


### PR DESCRIPTION
Rather than mixins with the inventory collections that get included into a TargetCollection class and separate full refreshes we've moved to a single refresh for the child managers

https://github.com/ManageIQ/manageiq/issues/20301