### PR TITLE
Add translations for Host Initiator and Volume Mapping

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1480,6 +1480,7 @@ en:
       GuestApplication:               Guest Application
       GuestDevice:                    Guest Device
       Host:                           Host
+      HostInitiator:                  Host Initiators
       HostPerformance:                Performance - Host
       IsoDatastore:                   ISO Datastore
       IsoImage:                       ISO Image
@@ -1701,6 +1702,7 @@ en:
       VmCloud:                  Instance
       VmOrTemplate:             VM or Template
       VmPerformance:            Performance - VM
+      VolumeMapping:            Volume Mappings
       WindowsImage:             Windows Image
       Zone:                     Zone
 
@@ -1795,6 +1797,7 @@ en:
       guest_devices:               Devices
       host:                        Host
       hosts:                       Hosts
+      host_initiator:              Host Initiator
       host_services:               Services
       iso_datastore:               ISO Datastore
       iso_image:                   ISO Image
@@ -1866,6 +1869,7 @@ en:
       vm_or_template:              Virtual Machine
       vms:                         VMs
       volume:                      Volume
+      volume_mapping:              Volume Mapping
       zone:                        Zone
       zones:                       Zones
 


### PR DESCRIPTION
## Issue Details
### Steps to reproduce

1. Go to Storage - Block Storage - Host Initiators (see before attachments)
2. Go to Storage - Block Storage - Volume mappings (see before attachments)

### Expected behavior
Need to display translation string correct

### Before

<img width="1409" alt="Screen Shot 2021-04-07 at 9 20 55 PM" src="https://user-images.githubusercontent.com/37085529/113954240-7f111e80-97e7-11eb-8445-117390e090f1.png">
<img width="1043" alt="Screen Shot 2021-04-07 at 9 21 04 PM" src="https://user-images.githubusercontent.com/37085529/113954245-80424b80-97e7-11eb-9d04-0438862b12fb.png">
<img width="841" alt="Screen Shot 2021-04-07 at 9 21 22 PM" src="https://user-images.githubusercontent.com/37085529/113954246-80424b80-97e7-11eb-9db1-899f141cfb8b.png">
<img width="944" alt="Screen Shot 2021-04-07 at 9 21 37 PM" src="https://user-images.githubusercontent.com/37085529/113954248-80dae200-97e7-11eb-9cdb-5b864c456631.png">

### After

<img width="890" alt="Screen Shot 2021-04-07 at 9 15 49 PM" src="https://user-images.githubusercontent.com/37085529/113954266-8f28fe00-97e7-11eb-91a9-6e0ea1ee5d95.png">
<img width="1256" alt="Screen Shot 2021-04-07 at 9 15 58 PM" src="https://user-images.githubusercontent.com/37085529/113954268-905a2b00-97e7-11eb-81e2-b8e55ab74c7d.png">
<img width="1291" alt="Screen Shot 2021-04-07 at 9 16 13 PM" src="https://user-images.githubusercontent.com/37085529/113954272-90f2c180-97e7-11eb-8f74-4963715e8127.png">
<img width="945" alt="Screen Shot 2021-04-07 at 9 16 22 PM" src="https://user-images.githubusercontent.com/37085529/113954274-90f2c180-97e7-11eb-9f60-8f3eac4bbe4f.png">

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 