### PR TITLE
Kafka errors shouldn't cause perf_process to fail

### DIFF
--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -222,5 +222,8 @@ module Metric::CiMixin::Processing
         :payload => metric
       )
     end
+  rescue => err
+    _log.warn("Failed to publish metrics: #{err}")
+    _log.log_backtrace(err)
   end
 end


### PR DESCRIPTION
If we are unable to publish metrics to kafka for whatever reason this
shouldn't cause the whole perf_process step to fail.

```
[----] I, [2021-04-09T08:24:09.934891 #8:2b06ae44796c]  INFO -- : Exception in realtime_block :total_time - Timings: {:process_counter_values=>0.008991003036499023, :db_find_prev_perfs=>0.005721330642700195, :preload_vim_performance_state_for_ts=>0.002819538116455078, :process_perfs=>0.07761883735656738, :process_build_ics=>0.009922981262207031, :process_perfs_db=>0.2598254680633545, :total_time=>3.008639097213745}
[----] E, [2021-04-09T08:24:09.935884 #8:2b06ae44796c] ERROR -- : MIQ(MiqQueue#deliver) Message id: [24000050740198], Error: [Failed to send messages to manageiq.metrics/0]
[----] E, [2021-04-09T08:24:09.936227 #8:2b06ae44796c] ERROR -- : [Kafka::DeliveryFailed]: Failed to send messages to manageiq.metrics/0  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2021-04-09T08:24:09.936724 #8:2b06ae44796c] ERROR -- : /usr/share/gems/gems/ruby-kafka-1.3.0/lib/kafka/producer.rb:438:in `deliver_messages_with_retries'
/usr/share/gems/gems/ruby-kafka-1.3.0/lib/kafka/producer.rb:261:in `block in deliver_messages'
/usr/share/gems/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:170:in `instrument'
/usr/share/gems/gems/ruby-kafka-1.3.0/lib/kafka/instrumenter.rb:21:in `instrument'
/usr/share/gems/gems/ruby-kafka-1.3.0/lib/kafka/producer.rb:254:in `deliver_messages'
/usr/share/gems/gems/manageiq-messaging-0.1.6/lib/manageiq/messaging/kafka/common.rb:48:in `raw_publish'
/usr/share/gems/gems/manageiq-messaging-0.1.6/lib/manageiq/messaging/kafka/topic.rb:8:in `publish_topic_impl'
/usr/share/gems/gems/manageiq-messaging-0.1.6/lib/manageiq/messaging/client.rb:174:in `publish_topic'
/var/www/miq/vmdb/app/models/metric/ci_mixin/processing.rb:218:in `block in publish_metrics'
/var/www/miq/vmdb/app/models/metric/ci_mixin/processing.rb:206:in `each_value'
/var/www/miq/vmdb/app/models/metric/ci_mixin/processing.rb:206:in `publish_metrics'
/var/www/miq/vmdb/app/models/metric/ci_mixin/processing.rb:98:in `block in perf_process'
/usr/share/gems/bundler/gems/manageiq-gems-pending-4026507c32b7/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/usr/share/gems/bundler/gems/manageiq-gems-pending-4026507c32b7/lib/gems/pending/util/extensions/miq-benchmark.rb:35:in `realtime_block'
/var/www/miq/vmdb/app/models/metric/ci_mixin/processing.rb:19:in `perf_process'
/var/www/miq/vmdb/app/models/metric/ci_mixin/capture.rb:39:in `perf_capture'
/var/www/miq/vmdb/app/models/metric/ci_mixin/capture.rb:13:in `perf_capture_realtime'
```