### PR TITLE
Module#parent is deprecated, replaced with module_parent

### DIFF
--- a/app/models/manageiq/providers/base_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::BaseManager::OperationsWorker < MiqQueueWorkerBase
   end
 
   def self.ems_class
-    parent
+    module_parent
   end
 
   def self.normalized_type


### PR DESCRIPTION
```
WARN -- manageiq: DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1. (called from ems_class at /var/www/miq/vmdb/app/models/manageiq/providers/base_manager/operations_worker.rb:21)
```