### PR TITLE
Fix deleted provider definition mixins

### DIFF
--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -101,7 +101,6 @@ module ManageIQ
       template "app/models/%plugin_path%/inventory/persister.rb"
       template "app/models/%plugin_path%/inventory/collector/%manager_path%.rb"
       template "app/models/%plugin_path%/inventory/parser/%manager_path%.rb"
-      template "app/models/%plugin_path%/inventory/persister/definitions/cloud_collections.rb"
       template "app/models/%plugin_path%/inventory/persister/%manager_path%.rb"
       template "app/models/%plugin_path%/inventory/persister.rb"
       template "app/models/%plugin_path%/%manager_path%.rb"


### PR DESCRIPTION
I missed the templated directory in the provider generator when making the changes for https://github.com/ManageIQ/manageiq/pull/21153