### PR TITLE
[console_methods.rb] Add translation helpers

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -24,6 +24,20 @@ module Vmdb
       caller.select { |path| include_external || path.start_with?(Rails.root.to_s) }
     end
 
+    def set_translation_locale(locale = "en")
+      I18n.locale = locale
+    end
+
+    def set_user_translation_locale(userid: "admin", locale: "en")
+      user = User.find_by_userid(userid)
+
+      user.settings[:display] = {:locale => locale}
+      user.save!
+
+      User.current_user = user
+      set_translation_locale(user.settings[:display][:locale])
+    end
+
     # Development helper method for Rails console for simulating queue workers.
     def simulate_queue_worker(break_on_complete: false, quiet_polling: true)
       raise NotImplementedError, "not implemented in production mode" if Rails.env.production?


### PR DESCRIPTION
Adds some helper methods to the console for handling swapping translation locales on the fly in the console.

Useful for being able to debug translation errors that happen in the UI from the console.

This was spawned off of some investigation that myself and @Fryguy when trying to replicate an issue in https://github.com/ManageIQ/manageiq-ui-classic/pull/7706 and some codified helper methods on showing how the settings can be changed in practice.


Usage
-----

```ruby
irb(main):001:0> _('Maximum')
=> "Maximum"
irb(main):002:0> set_user_translation_locale userid: 'admin', locale: :es
=> :es
irb(main):003:0> _('Maximum')
=> "Máximo"
```

Note:  For the purposes of the console, most of the work is done with just the `set_translation_locale` method, which just calls `I18n.locale=`.  But the `set_user_translation_locale` will also update the user settings, which might be useful if you are trying to swap translations quickly in the UI, and don't want to go to the settings page every time to swtich.


Links
-----

* https://github.com/ManageIQ/manageiq-ui-classic/pull/7706
* https://github.com/ManageIQ/guides/blob/master/i18n.md