### PR TITLE
Add missing supports_not features for CloudVolume

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -26,6 +26,8 @@ class CloudVolume < ApplicationRecord
 
   supports_not :backup_create
   supports_not :backup_restore
+  supports_not :create
+  supports_not :snapshot_create
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
 


### PR DESCRIPTION
Both the Amazon EBS CloudVolume [[ref]](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb#L2-L3) and Openstack Cinder CloudVolumes [[ref]](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb#L7-L10) support snapshot_create and create features.  We must have these in the base class for `supports?(feature)` to work properly.

Introduced by: https://github.com/ManageIQ/manageiq/pull/21046