### PR TITLE
Add a setting to enable or disable syndicating events and metrics

### DIFF
--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -95,7 +95,7 @@ module Metric::CiMixin::Processing
         resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
       end
 
-      publish_metrics(rt_rows)
+      publish_metrics(rt_rows) if syndicate_metrics?
     end
     _log.info("#{log_header} Processing for #{log_specific_targets(resources)}, for range [#{start_time} - #{end_time}]...Complete - Timings: #{t.inspect}")
 
@@ -201,8 +201,6 @@ module Metric::CiMixin::Processing
   end
 
   def publish_metrics(metrics)
-    return if MiqQueue.messaging_type == "miq_queue"
-
     metrics.each_value do |metric|
       resource = metric.delete(:resource)
 
@@ -225,5 +223,9 @@ module Metric::CiMixin::Processing
   rescue => err
     _log.warn("Failed to publish metrics: #{err}")
     _log.log_backtrace(err)
+  end
+
+  def syndicate_metrics?
+    Settings.performance.syndicate_metrics && MiqQueue.messaging_type != "miq_queue"
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,6 +109,7 @@
   :history:
     :keep_events: 6.months
     :purge_window_size: 1000
+  :syndicate_events: true
 :ems_refresh:
   :debug_trace: false
   :capture_vm_created_on_date: false
@@ -889,6 +890,7 @@
   :host_overhead:
     :memory: 2.01.percent
     :cpu: 0.15.percent
+  :syndicate_metrics: true
   :targets:
     :archived_for: 8.hours
   :vim_cache_ttl: 1.hour

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -141,6 +141,15 @@ RSpec.describe EmsEvent do
 
           described_class.add_queue('add', ems.id, event_hash)
         end
+
+        context "event_streams.syndicate_events false" do
+          before { stub_settings_merge(:event_streams => {:syndicate_events => false}) }
+
+          it "doesn't add event to Artemis queue" do
+            expect(MiqQueue).not_to receive(:messaging_client)
+            described_class.add_queue('add', ems.id, event_hash)
+          end
+        end
       end
 
       context "messaging_type: kafka" do
@@ -163,6 +172,15 @@ RSpec.describe EmsEvent do
           expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client)
 
           described_class.add_queue('add', ems.id, event_hash)
+        end
+
+        context "event_streams.syndicate_events false" do
+          before { stub_settings_merge(:event_streams => {:syndicate_events => false}) }
+
+          it "doesn't add event to kafka topic" do
+            expect(MiqQueue).not_to receive(:messaging_client)
+            described_class.add_queue('add', ems.id, event_hash)
+          end
         end
       end
 


### PR DESCRIPTION
Currently we are using the fact of having kafka or artemis configured as an indication that we should syndicate events and metrics.
As we start to use kafka internally we might want to disable syndication while still maintaining a kafka broker connection.