### PR TITLE
Optionally publish inventory to kafka

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "listen",                           "~>3.2",             :require => false
 gem "log_decorator",                    "~>0.1",             :require => false
 gem "manageiq-api-client",              "~>0.3.4",           :require => false
 gem "manageiq-loggers",                 "~>0.6.0",           :require => false
-gem "manageiq-messaging",               "~>1.0",             :require => false
+gem "manageiq-messaging",               "~>1.0", ">=1.0.3",  :require => false
 gem "manageiq-password",                "~>0.3",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.1",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -206,7 +206,7 @@ module ManageIQ
       end
 
       def publish_inventory?
-        options[:publish_inventory] && MiqQueue.messaging_type != "miq_queue"
+        options[:syndicate_inventory] && MiqQueue.messaging_type != "miq_queue"
       end
 
       def group_targets_by_ems(targets)

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -94,7 +94,7 @@ module ManageIQ
           inventory = nil # clear to help GC
 
           Benchmark.realtime_block(:save_inventory) { save_inventory(ems, target, parsed) }
-          Benchmark.realtime_block(:publish_inventory) { publish_inventory(ems, target, parsed) } if options[:publish_inventory]
+          Benchmark.realtime_block(:publish_inventory) { publish_inventory(ems, target, parsed) }
 
           _log.info "#{log_header} Refreshing target #{target.class} [#{target.name}] id [#{target.id}]...Complete"
         end
@@ -141,19 +141,37 @@ module ManageIQ
       end
 
       def publish_inventory(ems, target, persister)
-        return if MiqQueue.messaging_type == "miq_queue"
+        return unless publish_inventory?
 
-        log_header = format_ems_for_logging(ems)
-        target_identifier = "#{target.class}__#{target.name}__#{target.id}"
+        ems_identifier = "#{ems.emstype}__#{ems.id}"
 
-        MiqQueue.messaging_client('event_handler')&.publish_topic(
-          :service => "manageiq.ems-inventory",
-          :sender  => ems.id,
-          :event   => target_identifier,
-          :payload => persister.to_json
-        )
+        messaging_client = MiqQueue.messaging_client(ems_identifier)
+        return if messaging_client.nil?
+
+        persister.collections.each_value do |collection|
+          inventory_objects = collection.to_hash[:data].to_a
+
+          payloads = inventory_objects.map do |inventory_object_hash|
+            reference         = inventory_object_hash.values_at(*collection.manager_ref).join("__")
+            target_identifier = "#{ems_identifier}__#{collection.name}__#{reference}"
+
+            {
+              :service => "manageiq.ems-inventory",
+              :sender  => ems_identifier,
+              :event   => target_identifier,
+              :payload => {
+                :ems_id         => ems.id,
+                :ems_identifier => ems_identifier,
+                :collection     => collection.name,
+                :data           => inventory_object_hash
+              }
+            }
+          end
+
+          messaging_client.publish_topic(payloads) if payloads.present?
+        end
       rescue => err
-        _log.warn("#{log_header} Failed to publish inventory for target #{target.class} [#{target.name}] id [#{target.id}]: #{err}")
+        _log.warn("Failed to publish inventory for target #{target.class} [#{target.name}] id [#{target.id}]: #{err}")
       end
 
       def post_refresh_ems_cleanup(_ems, _targets)
@@ -185,6 +203,10 @@ module ManageIQ
       def inventory_class_for(klass)
         provider_module = ManageIQ::Providers::Inflector.provider_module(klass)
         "#{provider_module}::Inventory".constantize
+      end
+
+      def publish_inventory?
+        options[:publish_inventory] && MiqQueue.messaging_type != "miq_queue"
       end
 
       def group_targets_by_ems(targets)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -114,7 +114,7 @@
   :debug_trace: false
   :capture_vm_created_on_date: false
   :full_refresh_threshold: 100
-  :publish_inventory: true
+  :syndicate_inventory: true
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours
 :event_handling:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -114,6 +114,7 @@
   :debug_trace: false
   :capture_vm_created_on_date: false
   :full_refresh_threshold: 100
+  :publish_inventory: true
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours
 :event_handling:

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -91,16 +91,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
 
   context "#publish_inventory" do
     # Create a simple persister class with just two collections
-    class MyPersister < ManageIQ::Providers::Inventory::Persister
-      def initialize_inventory_collections
-        add_collection(infra, :vms)
-        add_collection(infra, :hosts)
-      end
-    end
+    require_relative "test_persister"
 
     let(:ems) { FactoryBot.create(:ext_management_system, :name => "my-ems") }
     let(:messaging_client) { double("ManageIQ::Messaging::Client") }
-    let(:persister) { MyPersister.new(ems) }
+    let(:persister) { ManageIQ::Providers::BaseManager::Refresher::TestPersister.new(ems) }
 
     before do
       stub_settings_merge(:prototype => {:messaging_type => 'kafka'})
@@ -124,8 +119,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
           array_including(
             hash_including(
               :service => "manageiq.ems-inventory",
-              :sender  => "#{ems.emstype}__#{ems.name}",
-              :event   => "#{ems.emstype}__#{ems.name}__vms__vm-1",
+              :sender  => "#{ems.emstype}__#{ems.id}",
+              :event   => "#{ems.emstype}__#{ems.id}__vms__vm-1",
               :payload => hash_including(
                 :collection => :vms,
                 :data       => hash_including(
@@ -152,8 +147,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
           array_including(
             hash_including(
               :service => "manageiq.ems-inventory",
-              :sender  => "#{ems.emstype}__#{ems.name}",
-              :event   => "#{ems.emstype}__#{ems.name}__vms__vm-1",
+              :sender  => "#{ems.emstype}__#{ems.id}",
+              :event   => "#{ems.emstype}__#{ems.id}__vms__vm-1",
               :payload => hash_including(
                 :collection => :vms,
                 :data       => hash_including(
@@ -172,8 +167,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
           array_including(
             hash_including(
               :service => "manageiq.ems-inventory",
-              :sender  => "vmwarews__my-ems",
-              :event   => "#{ems.emstype}__#{ems.name}__hosts__host-1",
+              :sender  => "#{ems.emstype}__#{ems.id}",
+              :event   => "#{ems.emstype}__#{ems.id}__hosts__host-1",
               :payload => hash_including(
                 :collection => :hosts,
                 :data       => hash_including(

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -91,11 +91,10 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
 
   context "#publish_inventory" do
     # Create a simple persister class with just two collections
-    require_relative "test_persister"
 
     let(:ems) { FactoryBot.create(:ext_management_system, :name => "my-ems") }
     let(:messaging_client) { double("ManageIQ::Messaging::Client") }
-    let(:persister) { ManageIQ::Providers::BaseManager::Refresher::TestPersister.new(ems) }
+    let(:persister) { Spec::Support::EmsRefreshHelper::TestPersister.new(ems) }
 
     before do
       stub_settings_merge(:ems_refresh => {:syndicate_inventory => true}, :prototype => {:messaging_type => 'kafka'})

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
     let(:persister) { ManageIQ::Providers::BaseManager::Refresher::TestPersister.new(ems) }
 
     before do
-      stub_settings_merge(:prototype => {:messaging_type => 'kafka'})
+      stub_settings_merge(:ems_refresh => {:syndicate_inventory => true}, :prototype => {:messaging_type => 'kafka'})
       allow(MiqQueue).to receive(:messaging_client).and_return(messaging_client)
     end
 

--- a/spec/models/manageiq/providers/base_manager/test_persister.rb
+++ b/spec/models/manageiq/providers/base_manager/test_persister.rb
@@ -1,0 +1,8 @@
+module ManageIQ::Providers
+  class BaseManager::Refresher::TestPersister < ManageIQ::Providers::Inventory::Persister
+    def initialize_inventory_collections
+      add_collection(infra, :vms)
+      add_collection(infra, :hosts)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/base_manager/test_persister.rb
+++ b/spec/models/manageiq/providers/base_manager/test_persister.rb
@@ -1,8 +1,0 @@
-module ManageIQ::Providers
-  class BaseManager::Refresher::TestPersister < ManageIQ::Providers::Inventory::Persister
-    def initialize_inventory_collections
-      add_collection(infra, :vms)
-      add_collection(infra, :hosts)
-    end
-  end
-end

--- a/spec/support/ems_refresh_helper/test_persister.rb
+++ b/spec/support/ems_refresh_helper/test_persister.rb
@@ -1,0 +1,12 @@
+module Spec
+  module Support
+    module EmsRefreshHelper
+      class TestPersister < ManageIQ::Providers::Inventory::Persister
+        def initialize_inventory_collections
+          add_collection(infra, :vms)
+          add_collection(infra, :hosts)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Publish inventory to kafka after save_inventory

TODO:
- [x] Is `persister.to_json` useful?  Is there enough info to make sense of the data if you aren't hitting the MIQ API (e.g. IDs)
- [x] Spec tests
- [x] Add a bulk-producer to ManageIQ::Messaging (https://github.com/ManageIQ/manageiq-messaging/pull/63)