### PR TITLE
Handle Unicode characters in httpd auth headers

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -324,7 +324,7 @@ module Authenticator
     end
 
     def normalize_username(username)
-      username.downcase
+      (username || '').downcase
     end
 
     def debug_auth?

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe Authenticator::Httpd do
   subject { Authenticator::Httpd.new(config) }
 
-  let!(:alice) { FactoryBot.create(:user, :userid => 'alice') }
-  let!(:cheshire) { FactoryBot.create(:user, :userid => 'cheshire@example.com') }
-  let(:user_groups) { 'wibble@fqdn:bubble@fqdn' }
   let(:config) { {:httpd_role => false} }
   let(:request) do
     env = {}
@@ -87,8 +84,9 @@ RSpec.describe Authenticator::Httpd do
   end
 
   describe '#lookup_by_identity' do
-    let(:dn) { 'cn=towmater,ou=people,ou=prod,dc=example,dc=com' }
-    let!(:towmater_dn) { FactoryBot.create(:user, :userid => dn) }
+    let!(:alice)       { FactoryBot.create(:user, :userid => 'alice') }
+    let!(:cheshire)    { FactoryBot.create(:user, :userid => 'cheshire@example.com') }
+    let!(:towmater_dn) { FactoryBot.create(:user, :userid => 'cn=towmater,ou=people,ou=prod,dc=example,dc=com') }
 
     let(:headers) do
       {
@@ -98,7 +96,7 @@ RSpec.describe Authenticator::Httpd do
         'X-Remote-User-LastName'  => 'Cat',
         'X-Remote-User-Email'     => 'cheshire@example.com',
         'X-Remote-User-Domain'    => 'example.com',
-        'X-Remote-User-Groups'    => user_groups,
+        'X-Remote-User-Groups'    => 'wibble@fqdn:bubble@fqdn',
       }
     end
 
@@ -170,11 +168,13 @@ RSpec.describe Authenticator::Httpd do
         'X-Remote-User-LastName'  => 'Aardvark',
         'X-Remote-User-Email'     => 'alice@example.com',
         'X-Remote-User-Domain'    => 'example.com',
-        'X-Remote-User-Groups'    => user_groups,
+        'X-Remote-User-Groups'    => 'wibble@fqdn:bubble@fqdn',
       }
     end
 
     context "with user details" do
+      let!(:alice) { FactoryBot.create(:user, :userid => 'alice') }
+
       context "using local authorization" do
         it "succeeds" do
           expect(authenticate).to eq(alice)


### PR DESCRIPTION
Fixes ManageIQ/manageiq-ui-classic#7689

- [ ] Depends on https://github.com/ManageIQ/manageiq-api/pull/1031
- [ ] Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7720
- [x] Verify with a real KeyCloak
- [ ] We should also change manageiq-loggers ContainerLogger to not blow up when dealing with ASCII-8BIT strings during the JSON.generate phase.  (going to do this in a followup)

@jrafanie Please review.
cc @omersiar