### PR TITLE
Modified Translations to Prevent Saved Reports from Rendering

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -73,7 +73,7 @@ class MiqReportResult < ApplicationRecord
     if miq_task
       miq_task.human_status
     else
-      report_results_blank? ? _("Error") : _("Complete")
+      report_results_blank? ? N_("Error") : N_("Complete")
     end
   end
 

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -368,7 +368,7 @@ class MiqTask < ApplicationRecord
   end
 
   def self.human_status(state_or_status)
-    _(HUMAN_STATUS[state_or_status] || STATUS_UNKNOWN)
+    HUMAN_STATUS[state_or_status] || STATUS_UNKNOWN
   end
 
   def process_cancel


### PR DESCRIPTION
Found in: Overview->Reports/Chargeback->Reports

Undoes a change made in https://github.com/ManageIQ/manageiq/pull/21069 that was causing certain tables in saved reports and chargeback reports from rendering when in non-English locales.

Before:
![image](https://user-images.githubusercontent.com/64800041/114902095-7d48eb80-9de3-11eb-90f1-0c298f1fed0d.png)

After:
![image](https://user-images.githubusercontent.com/64800041/114902308-b3866b00-9de3-11eb-8f7f-7034879bc36a.png)


