### PR TITLE
Stop logging to files in production deployments

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -28,39 +28,10 @@ module Vmdb
       Vmdb::Plugins.each { |p| p.try(:apply_logger_config, config) }
     end
 
-    def self.create_logger(log_file, logger_class = ManageIQ::Loggers::Base)
-      log_file = Pathname.new(log_file) if log_file.kind_of?(String)
-      log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
-      progname = log_file.try(:basename, ".*").to_s
-
-      logger_class.new(log_file, :progname => progname).tap do |logger|
-        ensure_log_file_permissions!(log_file)
-
-        broadcast_logger = create_broadcast_logger
-        if broadcast_logger
-          logger.extend(ActiveSupport::Logger.broadcast(broadcast_logger))
-          broadcast_logger.progname = progname
-
-          # HACK: In order to access the broadcast logger in test, we inject it
-          #   as an instance var.
-          logger.instance_variable_set(:@broadcast_logger, broadcast_logger) if Rails.env.test?
-        end
-      end
-    end
-
-    private_class_method def self.ensure_log_file_permissions!(log_file)
-      return unless log_file.kind_of?(Pathname)
-      return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_podified?
-
-      file_perm = 0o660 # Allow members of the manageiq group to write to log files
-      file_uid  = MiqEnvironment.manageiq_uid
-      file_gid  = MiqEnvironment.manageiq_gid
-
-      stat = File.stat(log_file)
-
-      File.chmod(file_perm, log_file)          unless stat.mode & file_perm == file_perm
-      File.chown(file_uid, file_gid, log_file) unless stat.uid == file_uid && stat.gid == file_gid
-    rescue Errno::EPERM
+    def self.create_logger(log_file_name, logger_class = ManageIQ::Loggers::Base)
+      create_container_logger(log_file_name, logger_class) ||
+        create_journald_logger(log_file_name, logger_class) ||
+        create_file_logger(log_file_name, logger_class)
     end
 
     private_class_method def self.create_loggers
@@ -73,24 +44,70 @@ module Vmdb
       configure_external_loggers
     end
 
-    private_class_method def self.create_broadcast_logger
-      create_container_logger || create_journald_logger
+    private_class_method def self.create_file_logger(log_file_name, logger_class)
+      log_file_name = ManageIQ.root.join("log", log_file_name)
+      progname      = progname_from_file(log_file_name)
+
+      logger_class.new(log_file_name, :progname => progname)
     end
 
-    private_class_method def self.create_container_logger
+    private_class_method def self.create_container_logger(log_file_name, logger_class)
+      return nil unless (logger = create_raw_container_logger)
+
+      create_wrapper_logger(log_file_name, logger_class, logger)
+    end
+
+    private_class_method def self.create_raw_container_logger
       return unless ENV["CONTAINER"]
 
       require "manageiq/loggers/container"
       ManageIQ::Loggers::Container.new
     end
 
-    private_class_method def self.create_journald_logger
+    private_class_method def self.create_journald_logger(log_file_name, logger_class)
+      return nil unless (logger = create_raw_journald_logger)
+
+      create_wrapper_logger(log_file_name, logger_class, logger)
+    end
+
+    private_class_method def self.create_raw_journald_logger
       return unless MiqEnvironment::Command.supports_systemd?
 
       require "manageiq/loggers/journald"
       ManageIQ::Loggers::Journald.new
     rescue LoadError
       nil
+    end
+
+    private_class_method def self.progname_from_file(log_file_name)
+      File.basename(log_file_name, ".*")
+    end
+
+    private_class_method def self.create_wrapper_logger(log_file_name, logger_class, wrapped_logger)
+      log_file_name = Pathname.new(log_file_name) unless log_file_name.kind_of?(Pathname)
+      progname      = progname_from_file(log_file_name)
+
+      logger_class.new(nil, :progname => progname).tap do |logger|
+        # HACK: In order to access the "filename" of the wrapped logger, we inject it as an instance var.
+        logger.instance_variable_set(:@log_file_name, log_file_name)
+
+        def logger.filename
+          @log_file_name
+        end
+
+        # HACK: In order to access the wrapped logger in test, we inject it as an instance var.
+        if Rails.env.test?
+          logger.instance_variable_set(:@wrapped_logger, wrapped_logger)
+
+          def logger.wrapped_logger
+            @wrapped_logger
+          end
+        end
+
+        logger.extend(ActiveSupport::Logger.broadcast(wrapped_logger))
+
+        wrapped_logger.progname = progname
+      end
     end
 
     private_class_method def self.configure_external_loggers

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -63,10 +63,6 @@ RSpec.describe Vmdb::Loggers do
         expect(subject).to respond_to(:unknown)
       end
 
-      it "#filename" do
-        expect(subject.filename).to eq Pathname.new(log_file)
-      end
-
       it "#logdev" do
         if container_log
           expect(subject.logdev).to be_nil

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Vmdb::Loggers do
 
           subject.info("test message")
 
-          expect(log_file.read).to include("test message")
+          expect(log_file.read).to include("test message") unless container_log
         end
       end
 
@@ -174,7 +174,7 @@ RSpec.describe Vmdb::Loggers do
 
           subject.info("test message")
 
-          expect(File.read(log_file)).to include("test message")
+          expect(File.read(log_file)).to include("test message") unless container_log
         end
       end
     end

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Vmdb::Loggers do
 
       subject { described_class.create_logger(log_file) }
 
-      let(:container_log) { subject.instance_variable_get(:@broadcast_logger) }
+      let(:container_log) { subject.try(:wrapped_logger) }
 
       before do
         # Hide the container logger output to STDOUT
@@ -63,6 +63,18 @@ RSpec.describe Vmdb::Loggers do
         expect(subject).to respond_to(:unknown)
       end
 
+      it "#filename" do
+        expect(subject.filename).to eq Pathname.new(log_file)
+      end
+
+      it "#logdev" do
+        if container_log
+          expect(subject.logdev).to be_nil
+        else
+          expect(subject.logdev).to be_a Logger::LogDevice
+        end
+      end
+
       describe "#datetime_format" do
         it "return nil" do
           expect(subject.datetime_format).to be nil
@@ -90,8 +102,12 @@ RSpec.describe Vmdb::Loggers do
           end
 
           it "only forwards the message if the severity is correct" do
-            expect(subject.logdev).not_to       receive(:write).with("test message")
-            expect(container_log.logdev).not_to receive(:write).with("test message") if container_log
+            if container_log
+              expect(subject.logdev).to           be_nil
+              expect(container_log.logdev).not_to receive(:write).with("test message")
+            else
+              expect(subject.logdev).not_to       receive(:write).with("test message")
+            end
 
             subject.debug("test message")
           end
@@ -214,7 +230,7 @@ RSpec.describe Vmdb::Loggers do
 
       it "will honor the log level in the container logger" do
         log = described_class.create_logger(log_file_name)
-        container_log = log.instance_variable_get(:@broadcast_logger)
+        container_log = log.wrapped_logger
 
         described_class.apply_config_value({:level_foo => :error}, log, :level_foo)
 

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Vmdb::Loggers do
 
           subject.info("test message")
 
-          expect(log_file.string).to include("test message")
+          expect(log_file.string).to include("test message") unless container_log
         end
       end
 
@@ -185,20 +185,6 @@ RSpec.describe Vmdb::Loggers do
       end
 
       include_examples "has basic logging functionality"
-    end
-
-    context "in an appliance environment" do
-      around { |example| in_appliance_env(example) }
-
-      it "sets the log file owner and permissions" do
-        expect(MiqEnvironment).to receive(:manageiq_uid).and_return(1000)
-        expect(MiqEnvironment).to receive(:manageiq_gid).and_return(1000)
-
-        expect(File).to receive(:chown).with(1000, 1000, log_file_path)
-        expect(File).to receive(:chmod).with(0o660, log_file_path)
-
-        described_class.create_logger(log_file_name)
-      end
     end
 
     context "in a container environment" do


### PR DESCRIPTION
In our production deployments, we don't need the log files, and, in fact, they
create issues. In appliances, we now use journald and the logs are duplicated
in both /var/www/miq/vmdb/log as well as /var/log/messages (see also #21211).
In containers, the logs fill up the local volume unnecessarily as they are
also output to STDOUT, and STDOUT is preferable because it can be scraped by
a log aggregator. As such, this PR stops logging to the log files in
production.

Resolves #21004, #21211

Co-authored-by: Keenan Brock <keenan@thebrocks.net>

Depends on
- [x] https://github.com/ManageIQ/vmware_web_service/pull/106
- [x] Release of a new vmware_web_service
- [x] Documentation on how to fetch logs using journald and how to fetch logs in containers https://github.com/ManageIQ/manageiq-documentation/pull/1683

WIP:
- [ ] Figure out if there are code paths that scrape the logs directly (for example to present them in the UI)
- [x] Verify if the tools/collect_logs/* utilities to pull the /var/log/journal/* files ? (see https://github.com/ManageIQ/manageiq/blob/5c54ed67a5285de5e2ef79bc70111b08c451c85c/config/settings.yml#L849)