### PR TITLE
Remove ManageIQ::Password alt-keys usage from FixAuth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -231,7 +231,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.8.0",           :require => false
+  gem "manageiq-smartstate",            "~>0.8.1",           :require => false
 end
 
 group :consumption, :manageiq_default do

--- a/Gemfile
+++ b/Gemfile
@@ -48,9 +48,9 @@ gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "log_decorator",                    "~>0.1",             :require => false
 gem "manageiq-api-client",              "~>0.3.4",           :require => false
-gem "manageiq-loggers",                 "~>0.7.0",           :require => false
+gem "manageiq-loggers",                 "~>0.7",             :require => false
 gem "manageiq-messaging",               "~>1.0", ">=1.0.3",  :require => false
-gem "manageiq-password",                "~>0.3",             :require => false
+gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.1",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false
 gem "memoist",                          "~>0.16.0",          :require => false

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe MiqQueue do
     # Some reasonably accurate test data.
     args_test = [
       "[datastore1] test-cfme-vddk2/test-cfme-vddk2.vmx",
-      "---ems: ems: :address: 16.16.52.50 :hostname: 16.16.52.50 :ipaddress: 16.16.52.50 :username: administrator :password: v2:{lalala} :class_name: ManageIQ::Providers::Vmware::InfraManager host: :address: 16.16.52.50 :hostname: myhost.redhat.com :ipaddress: 16.16.52.50 :username: root :password: v1:{lalala} :class_name: ManageIQ::Providers::Vmware::InfraManager::HostEsx connect_to: host snapshot: use_existing: false"
+      "---ems: ems: :address: 16.16.52.50 :hostname: 16.16.52.50 :ipaddress: 16.16.52.50 :username: administrator :password: v2:{lalala} :class_name: ManageIQ::Providers::Vmware::InfraManager host: :address: 16.16.52.50 :hostname: myhost.redhat.com :ipaddress: 16.16.52.50 :username: root :password: v2:{lalala} :class_name: ManageIQ::Providers::Vmware::InfraManager::HostEsx connect_to: host snapshot: use_existing: false"
     ]
 
     args_cleaned_password = [

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -6,19 +6,12 @@ require "fix_auth/models"
 
 RSpec.describe FixAuth::AuthConfigModel do
   let(:pass)    { "password" }
-  let(:enc_old) { ManageIQ::Password.new.encrypt(pass, "v2", legacy_key) }
+
+  let(:enc_old) { ManageIQ::Password.encrypt(pass, legacy_key) }
   let(:enc_new) { ManageIQ::Password.encrypt(pass) }
 
   let(:legacy_key) { ManageIQ::Password::Key.new }
   let(:options)    { {:legacy_key => legacy_key} }
-
-  before do
-    ManageIQ::Password.keys["alt"] = legacy_key
-  end
-
-  after do
-    ManageIQ::Password.clear_keys
-  end
 
   context "#recrypt" do
     subject { FixAuth::FixMiqRequest }
@@ -41,7 +34,7 @@ RSpec.describe FixAuth::AuthConfigModel do
       let(:legacy_key) { ManageIQ::Password::Key.new(nil, "XamduEwrkgMSeLjl+LQeutAWsLgKi3tR1mdEtclDPyM=") }
 
       it "should upgrade the column" do
-        subject.fix_passwords(request)
+        subject.fix_passwords(request, options)
         expect(request).to be_changed
         new_options = YAML.load(request.options)
 
@@ -68,7 +61,7 @@ RSpec.describe FixAuth::AuthConfigModel do
     end
 
     it "upgrades request (find with prefix, do not stringify keys)" do
-      subject.fix_passwords(request)
+      subject.fix_passwords(request, options)
       expect(request).to be_changed
       new_options = YAML.load(request.options)
       expect(new_options[:dialog]['password::special'.to_sym]).to be_encrypted(pass)
@@ -96,7 +89,7 @@ RSpec.describe FixAuth::AuthConfigModel do
     end
 
     it "upgrades request (find with prefix, do not stringify keys)" do
-      subject.fix_passwords(request)
+      subject.fix_passwords(request, options)
       expect(request).to be_changed
       new_options = YAML.load(request.options)
       expect(new_options[:dialog]['password::special'.to_sym]).to be_encrypted(pass)

--- a/tools/fix_auth/auth_model.rb
+++ b/tools/fix_auth/auth_model.rb
@@ -34,7 +34,7 @@ module FixAuth
         if options[:hardcode]
           hardcode(old_value, options[:hardcode])
         else
-          recrypt_password(old_value)
+          recrypt_password(old_value, options[:legacy_key])
         end
       rescue
         if options[:invalid]
@@ -44,8 +44,8 @@ module FixAuth
         end
       end
 
-      private def recrypt_password(old_value)
-        new_value = ManageIQ::Password.new.recrypt(old_value)
+      private def recrypt_password(old_value, legacy_key)
+        new_value = ManageIQ::Password.recrypt(old_value, legacy_key)
 
         # Handle rare case where, when the old_value is already encrypted with
         #   the new key, during recrypt, the decryption with the legacy key
@@ -56,7 +56,7 @@ module FixAuth
         new_value
       end
 
-      def fix_passwords(obj, options = {})
+      def fix_passwords(obj, options)
         available_columns.each do |column|
           if (old_value = obj.send(column)).present?
             new_value = recrypt(old_value, options)

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -84,17 +84,17 @@ module FixAuth
 
     def set_passwords
       ManageIQ::Password.key_root = cert_dir if cert_dir
-      if options[:legacy_key]
-        if (legacy_key = ManageIQ::Password.load_key_file(options[:legacy_key]))
-          ManageIQ::Password.keys["alt"] = legacy_key
-        else
-          puts "WARNING: key #{options[:legacy_key]} not found"
-        end
-      end
+    end
+
+    def set_legacy_key
+      key = ManageIQ::Password.load_key_file(options[:legacy_key])
+      puts "WARNING: legacy key #{options[:legacy_key]} not found" unless key
+      options[:legacy_key] = key
     end
 
     def run
       set_passwords unless options[:key]
+      set_legacy_key if options[:legacy_key]
 
       generate_password if options[:key]
       fix_database_yml if options[:databaseyml]


### PR DESCRIPTION
We want to bump to manageiq-password 1.0 both for currency and in order to fix #21042. However, we need to remove the usage of alt-keys since that interface changed with the major release of manageiq-password.

I had this branch from a long time ago, but for some reason never made a PR.  It works with the 1.0 release of manageiq-password.

Depends on
- [x] https://github.com/ManageIQ/manageiq-loggers/pull/37
  - [x] and subsequent release (v0.7.0)
- [x] https://github.com/ManageIQ/manageiq-smartstate/pull/161
  - [x] and subsequent release (v0.8.1)
- [x] https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/26
  - [x] and subsequent release (v3.1.3)
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/171
  - [x] and subsequent release (v0.7.2)
- [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/524
- [x] https://github.com/ManageIQ/manageiq-schema/pull/579

Only dependent for build purposes:
- [ ] https://github.com/ManageIQ/manageiq-appliance/pull/340

cc @kbrock 

Hoping this can fix some of the issues in https://github.com/ManageIQ/manageiq/issues/21042