### PR TITLE
Add supports feature :update to CloudVolume

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -28,6 +28,7 @@ class CloudVolume < ApplicationRecord
   supports_not :backup_restore
   supports_not :create
   supports_not :snapshot_create
+  supports_not :update
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
 


### PR DESCRIPTION
CloudVolumes currently use `validate_*` for most operations, start transitioning over to using `supports?`

https://github.com/ManageIQ/manageiq/issues/21179