### PR TITLE
Adding translation for "Configured Systems"

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1444,6 +1444,7 @@ en:
       CustomButtonSet:                Button Group
       ConfigurationScript:            Template (Ansible Tower)
       ConfigurationScriptSource:      Repository
+      ConfiguredSystem:               Configured Systems
       Container:                      Container
       ContainerPerformance:           Performance - Container
       ContainerGroup:                 Container Pod


### PR DESCRIPTION
# Issue Details

### Steps to reproduce

Go to Automation - Configuration - Configured Systems (see before attachments). 

### Expected behavior

To display the translated string correctly.

### Before 

<img width="827" alt="Screen Shot 2021-04-20 at 3 36 27 PM" src="https://user-images.githubusercontent.com/29209973/115454138-6e50a780-a1ee-11eb-80f8-6a742b7434b3.png">

### After 

<img width="827" alt="Screen Shot 2021-04-20 at 3 37 04 PM" src="https://user-images.githubusercontent.com/29209973/115454121-6a248a00-a1ee-11eb-8706-a70344f7b4fe.png">



@miq-bot assign @kavyanekkalapu
@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug
@miq-bot add-label internationalization