### PR TITLE
add translation for Configuration Profiles

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1442,6 +1442,7 @@ en:
       ContainerQuota:                 Container Quota
       CustomButton:                   Button
       CustomButtonSet:                Button Group
+      ConfigurationProfile:           Configuration Profiles
       ConfigurationScript:            Template (Ansible Tower)
       ConfigurationScriptSource:      Repository
       ConfiguredSystem:               Configured Systems


### PR DESCRIPTION
# Issue Details
### Steps to reproduce
1. Go to Automation - Configuration - Configuration Profiles (see before attachments).

### Expected behavior
Need to display translation string correct

### Before
<img width="1274" alt="Screen Shot 2021-04-21 at 10 51 43 AM" src="https://user-images.githubusercontent.com/82469658/115581160-bf67a680-a295-11eb-88cb-b22113c1cee1.png">


### After
<img width="1244" alt="Screen Shot 2021-04-21 at 10 51 01 AM" src="https://user-images.githubusercontent.com/82469658/115581018-a101ab00-a295-11eb-894c-4fe13c952fa3.png">

@miq-bot assign @kavyanekkalapu
@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug
@miq-bot add-label internationalization