### PR TITLE
Add Verbosity to ArgumentError in MiqWorker#resource_constraints

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -77,8 +77,8 @@ class MiqWorker
       mem_request   = self.class.worker_settings[:memory_request]
       cpu_request   = self.class.worker_settings[:cpu_request_percent]
 
-      raise ArgumentError, "cpu_request_percent cannot exceed cpu_threshold_percent" if (cpu_request || 0) > (cpu_limit || Float::INFINITY)
-      raise ArgumentError, "memory_request cannot exceed memory_threshold"           if (mem_request || 0) > (mem_limit || Float::INFINITY.megabytes)
+      raise ArgumentError, "#{self.class.name} - cpu_request_percent (#{cpu_request.inspect}) cannot exceed cpu_threshold_percent (#{cpu_limit.inspect})" if (cpu_request || 0) > (cpu_limit || Float::INFINITY)
+      raise ArgumentError, "#{self.class.name} - memory_request (#{mem_request.inspect}) cannot exceed memory_threshold (#{mem_limit.inspect})"           if (mem_request || 0) > (mem_limit || Float::INFINITY.megabytes)
 
       {}.tap do |h|
         h.store_path(:limits, :memory, format_memory_threshold(mem_limit)) if mem_limit


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/20865

Related work to prevent saving of invalid combinations of limits/requests:
https://github.com/ManageIQ/manageiq/pull/20889