### PR TITLE
The spec checking for systemd units is backwards

### DIFF
--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MiqWorker::SystemdCommon do
         [service_file, target_file]
       end
 
-      expect(found_units).to match_array(expected_units)
+      expect(expected_units).to match_array(found_units)
     end
   end
 end


### PR DESCRIPTION
This is printing missing unit files as "extra elements" rather than "missing elements"

https://github.com/ManageIQ/manageiq/pull/21149#discussion_r620278790