### PR TITLE
Allow ActsAsStiLeafClass for MiqWorker subclassing

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -79,6 +79,10 @@ class MiqWorker < ApplicationRecord
     count
   end
 
+  def self.concrete_subclasses
+    leaf_subclasses | descendants.select { |d| d.try(:acts_as_sti_leaf_class?) }
+  end
+
   class_attribute :default_queue_name, :required_roles, :maximum_workers_count, :include_stopping_workers_on_synchronize
   self.include_stopping_workers_on_synchronize = false
   self.required_roles = []

--- a/app/models/miq_worker_type.rb
+++ b/app/models/miq_worker_type.rb
@@ -33,7 +33,7 @@ class MiqWorkerType < ApplicationRecord
   end
 
   private_class_method def self.classes_for_seed
-    @classes_for_seed ||= MiqWorker.descendants.select { |w| w.subclasses.empty? }
+    @classes_for_seed ||= MiqWorker.concrete_subclasses
   end
 
   private_class_method def self.seed_worker(klass)


### PR DESCRIPTION
If a provider inherits another provider and uses ActsAsStiLeafClass on any of the worker records it was causing MiqWorkerType.seed to not skip the inherited worker classes due to there being subclases.

Fix this by adding a `:concrete_subclasses` method to `MiqWorker` similar to `ExtManagementSystem`

This wasn't needed for K8s -> OCP/EKS because those providers didn't subclass the worker class only the runner class.  Openstack however has some logic in the worker class which is useful and shouldn't have to be copied into the subclassed provider workers.