### PR TITLE
Add resource_groups to the core cloud persister collections

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -89,6 +89,16 @@ module ManageIQ::Providers
           )
         end
 
+        def resource_groups
+          # NOTE: This model is different in that it isn't namespaced under a specific
+          # manager (e.g. ManageIQ::Providers::Vendor::CloudManager::ResourceGroup) but
+          # rather directly under the vendor.
+          model_class = "#{manager_class&.module_parent}::ResourceGroup".safe_constantize
+
+          add_common_default_values
+          add_properties(:model_class => model_class) if model_class
+        end
+
         def vm_and_miq_template_ancestry
           skip_auto_inventory_attributes
           skip_model_class


### PR DESCRIPTION
Two providers currently collect resource_groups and we are adding a third.

Without this definition in core each provider has to duplicate the inventory collection definition rather than simply reference it by name.

Follow-ups:
* https://github.com/ManageIQ/manageiq-providers-azure/pull/455
* https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/62
* https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/195/files#r621309191