### PR TITLE
List all known server GUIDs if the deployment status is new replica

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -100,7 +100,7 @@ namespace :evm do
     status = EvmApplication.deployment_status
     if status == "new_replica"
       puts "Database contains the following server records:"
-      MiqServer.all.each { |server| puts "  #{server.id} : #{server.guid}" }
+      MiqServer.all.each { |server| puts "  #{server.guid}: id: #{server.id}, name: #{server.name}, zone: #{server.zone.description}" }
     end
 
     puts "Deployment status is #{status}"

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -96,7 +96,13 @@ namespace :evm do
       "redeployment"   => 5,
       "upgrade"        => 6
     }
+
     status = EvmApplication.deployment_status
+    if status == "new_replica"
+      puts "Database contains the following server records:"
+      MiqServer.all.each { |server| puts "  #{server.id} : #{server.guid}" }
+    end
+
     puts "Deployment status is #{status}"
     exit status_to_code[status]
   end


### PR DESCRIPTION
This simplifies fixing the serverGUID in the podified CR.  Otherwise people need to exec into postgres to get the server GUID since network policies make it impossible to `oc debug` the orchestrator.

I'm happy to add any other server information that people think will be helpful.  Maybe hostname, IP or zone name?

Example:
```
$ rake evm:deployment_status
** ManageIQ master; Database: adapter=postgresql, name=vmdb_development, host=
** ManageIQ master, codename: Morphy
Database contains the following server records:
  1 : 1e8535f0-349a-4b61-9b3f-071e99788e2b
Deployment status is new_replica
```