### PR TITLE
[KASPAROV] Improve the provider check for authentication status

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -149,6 +149,13 @@ module AuthenticationMixin
     !has_credentials?(type)
   end
 
+  def provider_authentication_status_ok?(type = nil)
+    authtype = [type, default_authentication_type].compact
+
+    # Prioritize the requested authtype if it exists, otherwise fall back to the default
+    authentication_for_providers.where(:authtype => authtype).order(:id).min_by { |a| a.authtype == type.to_s ? 0 : 1 }.try(:status) == "Valid"
+  end
+
   def authentication_status_ok?(type = nil)
     authentication_best_fit(type).try(:status) == "Valid"
   end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -19,7 +19,7 @@ module PerEmsWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      all_ems_in_zone.select { |e| e.enabled && e.authentication_status_ok? }
+      all_ems_in_zone.select { |e| e.enabled && e.provider_authentication_status_ok? }
     end
 
     def desired_queue_names


### PR DESCRIPTION
Direct backport of https://github.com/ManageIQ/manageiq/pull/21138

The provider_worker_mixin refactoring caused this to not be able to be cleanly cherry-picked, which means we also need a PR to replace `authentication_status_ok?` in the amazon coordinator worker which wasn't necessary because of that refactoring.

Dependants:
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/456
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/702