### PR TITLE
[WIP] Don't `belongs_to :parent_manager` in base manager classes

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -2,8 +2,6 @@ module ManageIQ::Providers
   class NetworkManager < BaseManager
     include SupportsFeatureMixin
 
-    PROVIDER_NAME = "Network Manager".freeze
-
     class << model_name
       define_method(:route_key) { "ems_networks" }
       define_method(:singular_route_key) { "ems_network" }
@@ -38,46 +36,6 @@ module ManageIQ::Providers
 
     alias all_cloud_networks cloud_networks
 
-    belongs_to :parent_manager,
-               :foreign_key => :parent_ems_id,
-               :class_name  => "ManageIQ::Providers::BaseManager",
-               :autosave    => true
-
-    delegate :queue_name_for_ems_refresh, :to => :parent_manager
-
-    has_many :availability_zones,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :flavors,                       -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_database_flavors,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_resource_quotas,         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volumes,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volume_types,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volume_backups,          -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volume_snapshots,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_object_store_containers, -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_object_store_objects,    -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_services,                -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_databases,               -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :hosts,                         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :vms,                           -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :miq_templates,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :vms_and_templates,             -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-
-    virtual_total :total_vms, :vms
-    virtual_total :total_miq_templates, :miq_templates
-    virtual_total :total_vms_and_templates, :vms_and_templates
-
-    # Relationships delegated to parent manager
-    virtual_delegate :orchestration_stacks,
-                     :orchestration_stacks_resources,
-                     :direct_orchestration_stacks,
-                     :resource_groups,
-                     :key_pairs,
-                     :to        => :parent_manager,
-                     :allow_nil => true,
-                     :default   => []
-
     def self.display_name(number = 1)
       n_('Network Manager', 'Network Managers', number)
     end
@@ -86,15 +44,6 @@ module ManageIQ::Providers
       supported_subclasses.select(&:supports_ems_network_new?).each_with_object({}) do |klass, hash|
         hash[klass.ems_type] = klass.description
       end
-    end
-
-    def name
-      "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
-    end
-
-    def self.find_object_for_belongs_to_filter(name)
-      name.gsub!(" #{self::PROVIDER_NAME}", "")
-      includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
     end
   end
 end

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -1,8 +1,3 @@
-#
-# StorageManager (hsong)
-#
-#
-
 module ManageIQ::Providers
   class StorageManager < ManageIQ::Providers::BaseManager
     include SupportsFeatureMixin
@@ -21,13 +16,6 @@ module ManageIQ::Providers
 
     has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
     has_many :volume_availability_zones, :class_name => "AvailabilityZone", :foreign_key => :ems_id, :dependent => :destroy
-
-    belongs_to :parent_manager,
-               :foreign_key => :parent_ems_id,
-               :class_name  => "ManageIQ::Providers::BaseManager",
-               :autosave    => true
-
-    delegate :queue_name_for_ems_refresh, :to => :parent_manager
 
     def self.display_name(number = 1)
       n_('Storage Manager', 'Storage Managers', number)

--- a/app/models/mixins/belongs_to_parent_manager_mixin.rb
+++ b/app/models/mixins/belongs_to_parent_manager_mixin.rb
@@ -1,0 +1,9 @@
+module BelongsToParentManagerMixin
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :parent_manager, :foreign_key => :parent_ems_id, :class_name => "ManageIQ::Providers::BaseManager", :autosave => true
+
+    delegate :queue_name_for_ems_refresh, :to => :parent_manager
+  end
+end

--- a/app/models/mixins/child_network_manager_mixin.rb
+++ b/app/models/mixins/child_network_manager_mixin.rb
@@ -1,0 +1,46 @@
+module ChildNetworkManagerMixin
+  extend ActiveSupport::Concern
+
+  include BelongsToParentManagerMixin
+
+  PROVIDER_NAME = "Network Manager".freeze
+
+  included do
+    has_many :availability_zones,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :flavors,                       -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_database_flavors,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_resource_quotas,         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volumes,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volume_types,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volume_backups,          -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volume_snapshots,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_object_store_containers, -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_object_store_objects,    -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_services,                -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_databases,               -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :hosts,                         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :vms,                           -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :miq_templates,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :vms_and_templates,             -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+
+    virtual_total :total_vms, :vms
+    virtual_total :total_miq_templates, :miq_templates
+    virtual_total :total_vms_and_templates, :vms_and_templates
+
+    # Relationships delegated to parent manager
+    virtual_delegate :orchestration_stacks,
+                     :orchestration_stacks_resources,
+                     :direct_orchestration_stacks,
+                     :resource_groups,
+                     :key_pairs,
+                     :to        => :parent_manager,
+                     :allow_nil => true,
+                     :default   => []
+  end
+
+  def name
+    "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
+  end
+end

--- a/app/models/mixins/child_storage_manager_mixin.rb
+++ b/app/models/mixins/child_storage_manager_mixin.rb
@@ -1,0 +1,5 @@
+module ChildStorageManagerMixin
+  extend ActiveSupport::Concern
+
+  include BelongsToParentManagerMixin
+end


### PR DESCRIPTION
The base NetworkManager / StorageManager class shouldn't belong to a parent_manager as this makes it significantly more difficult to have standalone managers of those types.