### PR TITLE
Use standard ruby for services

### DIFF
--- a/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_event_catcher@.service
+++ b/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_event_catcher@.service
@@ -5,7 +5,8 @@ WantedBy=<%= plugin_name %>_<%= manager_path %>_event_catcher.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::EventCatcher --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::EventCatcher --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_event_catcher.slice

--- a/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_metrics_collector@.service
+++ b/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_metrics_collector@.service
@@ -5,7 +5,8 @@ WantedBy=<%= plugin_name %>_<%= manager_path %>_metrics_collector.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_metrics_collector.slice

--- a/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_refresh@.service
+++ b/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_refresh@.service
@@ -5,7 +5,8 @@ WantedBy=<%= plugin_name %>_<%= manager_path %>_refresh.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::RefreshWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::RefreshWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_refresh.slice

--- a/systemd/manageiq-cockpit_ws@.service
+++ b/systemd/manageiq-cockpit_ws@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-cockpit_ws.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqCockpitWsWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqCockpitWsWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-cockpit_ws.slice

--- a/systemd/manageiq-ems_metrics_processor@.service
+++ b/systemd/manageiq-ems_metrics_processor@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-ems_metrics_processor.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-ems_metrics_processor.slice

--- a/systemd/manageiq-event_handler@.service
+++ b/systemd/manageiq-event_handler@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-event_handler.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-event_handler.slice

--- a/systemd/manageiq-generic@.service
+++ b/systemd/manageiq-generic@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-generic.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-generic.slice

--- a/systemd/manageiq-priority@.service
+++ b/systemd/manageiq-priority@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-priority.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-priority.slice

--- a/systemd/manageiq-remote_console@.service
+++ b/systemd/manageiq-remote_console@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-remote_console.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-remote_console.slice

--- a/systemd/manageiq-reporting@.service
+++ b/systemd/manageiq-reporting@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-reporting.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-reporting.slice

--- a/systemd/manageiq-schedule@.service
+++ b/systemd/manageiq-schedule@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-schedule.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-schedule.slice

--- a/systemd/manageiq-smart_proxy@.service
+++ b/systemd/manageiq-smart_proxy@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-smart_proxy.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-smart_proxy.slice

--- a/systemd/manageiq-ui@.service
+++ b/systemd/manageiq-ui@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-ui.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-ui.slice

--- a/systemd/manageiq-web_service@.service
+++ b/systemd/manageiq-web_service@.service
@@ -5,7 +5,8 @@ WantedBy=manageiq-web_service.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
-ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i'
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i
 Restart=no
 Type=notify
 Slice=manageiq-web_service.slice


### PR DESCRIPTION
no need to run bash to run services
Before, bash was used to load the user shell, which loaded the /etc/default/evm properties.
Now, load the properties files directly so there is no need to run the bash shell

this has a few advantages:

1. this is no longer depending upon root's shell
2. removes the complexity of the exec
3. explicitly points to properties as a dependency (rather than rely upon developer knowledge to know how the properties values are loaded - and what the values become)
4. old bash load of properties was slow - sped up as part of these PRs but not this pr specifically
5. paves the way to running this as non-root

This is part of running services as non root.