### PR TITLE
Switch from postgresql.crt to root.crt

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -41,7 +41,7 @@ class ContainerOrchestrator
                 :secretName => "postgresql-secrets",
                 :items      => [
                   :key  => "rootcertificate",
-                  :path => "postgresql.crt",
+                  :path => "root.crt",
                 ],
               }
             }

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ContainerOrchestrator do
           :secretName => "postgresql-secrets",
           :items      => [
             :key  => "rootcertificate",
-            :path => "postgresql.crt",
+            :path => "root.crt",
           ],
         }
       )


### PR DESCRIPTION
It's already `root.crt` on the orchestrator (where it works), so let's be consistent