### PR TITLE
[KASPAROV] Bump Rails to 5.2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem "pg",                                              :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
 gem "psych",                          "~>3.1",         :require => false # This can be dropped once we drop ruby 2.5
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.2.4", ">=5.2.4.4"
+gem "rails",                          "~>5.2.6"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=12.3.3",      :require => false
 gem "rest-client",                    "~>2.1.0",       :require => false


### PR DESCRIPTION
Bump Rails to 5.2.6 to deal with mimemagic issues as well as CVEs fixed in newer versions.

Possible fix for https://github.com/ManageIQ/manageiq-appliance-build/issues/476 - I think we may have to also add shared-mime-info somewhere in appliance build

Note that I also need to update the Gemfile.lock.release, but I'm not sure the best way to - maybe @bdunne knows?