### PR TITLE
Fix issue where all features may be filtered out

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -138,7 +138,7 @@ module EvmSpecHelper
     end
 
     filtered = filter_specific_features([hashes], features).first
-    MiqProductFeature.seed_from_hash(filtered)
+    MiqProductFeature.seed_from_hash(filtered) if filtered.present?
     MiqProductFeature.seed_tenant_miq_product_features
   end
 


### PR DESCRIPTION
@jrafanie Please review.

This is an initial fix to handle the case where the requested features may not exist.  Aside from "bad" features, this can happen legitimately if you only ask for dynamic tenant features (i.e. the filtered list will be empty, but then the `seed_tenant_miq_product_features` will pull in the correct feature right after).

This is only the first part of a "complete" fix.  Ultimately, I think this method should double-check that the features you asked for were actually created, which will prevent the "bad" features, but I'm hesitant to put that in first because it may create more breakage.  I will do that in a follow up.

This is needed so that the tenant_quota_specs will pass in https://github.com/ManageIQ/manageiq-api/pull/1037

Part of #21216 