### PR TITLE
Ensure specified product features were actually seeded and exist

### DIFF
--- a/spec/lib/task_helpers/imports/roles_spec.rb
+++ b/spec/lib/task_helpers/imports/roles_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TaskHelpers::Imports::Roles do
                                                    host_edit
                                                    host_scan
                                                    host_show_list
-                                                   policy
+                                                   miq_policy
                                                    vm
                                                    about
                                                  ))

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe MiqUserRole do
         host_edit
         host_scan
         host_show_list
-        policy
+        miq_policy
         vm
         dialog_edit_editor
         rbac_tenant_manage_quotas
@@ -126,17 +126,17 @@ RSpec.describe MiqUserRole do
       expect(@role1.allows?(:identifier => "dashboard_admin")).to eq(true)
       expect(@role1.allows?(:identifier => "dashboard_add")).to eq(true)
       expect(@role1.allows?(:identifier => "dashboard_view")).to eq(false)
-      expect(@role1.allows?(:identifier => "policy")).to eq(false)
+      expect(@role1.allows?(:identifier => "miq_policy")).to eq(false)
 
       expect(@role2.allows?(:identifier => "dashboard_admin")).to eq(true)
       expect(@role2.allows?(:identifier => "dashboard_add")).to eq(true)
       expect(@role2.allows?(:identifier => "dashboard_view")).to eq(true)
-      expect(@role2.allows?(:identifier => "policy")).to eq(true)
+      expect(@role2.allows?(:identifier => "miq_policy")).to eq(true)
     end
 
     it "should return the correct answer calling allows_any? with default scope => :sub" do
-      expect(@role1.allows_any?(:identifiers => %w(dashboard_admin dashboard_add dashboard_view policy))).to eq(true)
-      expect(@role2.allows_any?(:identifiers => %w(dashboard_admin dashboard_add dashboard_view policy))).to eq(true)
+      expect(@role1.allows_any?(:identifiers => %w(dashboard_admin dashboard_add dashboard_view miq_policy))).to eq(true)
+      expect(@role2.allows_any?(:identifiers => %w(dashboard_admin dashboard_add dashboard_view miq_policy))).to eq(true)
       expect(@role3.allows_any?(:identifiers => ["host_view"])).to eq(true)
       expect(@role3.allows_any?(:identifiers => ["vm"])).to eq(false)
       expect(@role3.allows_any?(:identifiers => ["everything"])).to eq(true)

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -121,12 +121,6 @@ module EvmSpecHelper
     [server.guid, server, server.zone]
   end
 
-  def self.specific_product_features(*features)
-    features.flatten!
-    seed_specific_product_features(*features)
-    MiqProductFeature.find_all_by_identifier(features)
-  end
-
   def self.seed_specific_product_features(*features)
     features.flatten!
 
@@ -140,6 +134,17 @@ module EvmSpecHelper
     filtered = filter_specific_features([hashes], features).first
     MiqProductFeature.seed_from_hash(filtered) if filtered.present?
     MiqProductFeature.seed_tenant_miq_product_features
+
+    MiqProductFeature.where(:identifier => features).tap do |product_features|
+      invalid_features = features - product_features.map(&:identifier)
+      raise ArgumentError, "Expected features were not found: #{invalid_features.join(", ")}" if invalid_features.any?
+    end
+  end
+
+  # Temporary alias until the one caller is removed:
+  #   manageiq-ui-classic/spec/support/controller_helper.rb
+  class << self
+    alias specific_product_features seed_specific_product_features
   end
 
   def self.filter_specific_features(hashes, features)


### PR DESCRIPTION
Part of #21216 

- [x] Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7736

This also coincidentally implements the suggestion in https://github.com/ManageIQ/manageiq-api/pull/1037#discussion_r631288464 and in doing so dedups the extra helper method that is only called in one place anyway

@jrafanie Please review.

~~I full expect this PR to break places where invalid product features are specified.  Luckily we can find them all with cross-repo tests.~~  There shouldn't be any in the API after https://github.com/ManageIQ/manageiq-api/pull/1037. There shouldn't be any in the UI after https://github.com/ManageIQ/manageiq-ui-classic/pull/7736