### PR TITLE
Only queue perf_capture for supported providers

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -36,6 +36,10 @@ class ExtManagementSystem < ApplicationRecord
     supported_subclasses.each_with_object({}) { |klass, hash| hash[klass.ems_type] = klass.description }
   end
 
+  def self.subclasses_supports?(feature)
+    supported_subclasses.select { |subclass| subclass.supports?(feature) }
+  end
+
   def self.api_allowed_attributes
     %w[]
   end
@@ -176,6 +180,7 @@ class ExtManagementSystem < ApplicationRecord
   supports_not :ems_network_new
   supports_not :ems_storage_new
   supports_not :label_mapping
+  supports_not :metrics
   supports_not :object_storage
   supports_not :provisioning
   supports_not :publish

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -201,7 +201,8 @@ class Zone < ApplicationRecord
 
   # @return [Array<ExtManagementSystem>] All emses that can collect Capacity and Utilization metrics
   def ems_metrics_collectable
-    ext_management_systems.select { |e| e.kind_of?(EmsCloud) || e.kind_of?(EmsInfra) || e.kind_of?(ManageIQ::Providers::ContainerManager) }
+    supported_ems_types = ExtManagementSystem.subclasses_supports?(:metrics).map(&:name)
+    ext_management_systems.where(:type => supported_ems_types).select { |e| e.supports?(:metrics) }
   end
 
   def ems_networks

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -94,6 +94,23 @@ RSpec.describe Zone do
     end
   end
 
+  describe "#ems_metrics_collectable" do
+    let(:zone)                       { FactoryBot.create(:zone) }
+    let(:ems_supporting_metrics)     { FactoryBot.create(:ems_infra, :zone => zone) }
+    let(:ems_not_supporting_metrics) { FactoryBot.create(:ems_cloud, :zone => zone) }
+
+    before do
+      allow_any_instance_of(ExtManagementSystem).to receive(:supports?).with(:metrics).and_return(true)
+      allow(ems_supporting_metrics.class).to receive(:supports?).with(:metrics).and_return(true)
+      allow(ems_not_supporting_metrics.class).to receive(:supports?).with(:metrics).and_return(false)
+    end
+
+    it "only returns EMSs which support metrics collection" do
+      expect(zone.ems_metrics_collectable).to include(ems_supporting_metrics)
+      expect(zone.ems_metrics_collectable).not_to include(ems_not_supporting_metrics)
+    end
+  end
+
   context ".determine_queue_zone" do
     subject           { described_class }
 


### PR DESCRIPTION
Not every cloud/infra/container provider supports metrics capture and a simple subclass check is not sufficient to determine this.

Queueing perf_capture_timer for a provider which doesn't support metrics means that there is no worker to dequeue the work and the queue items begin to pile up.