### PR TITLE
Default to :local_db_find_missing_references strategy for targeted refresh

### DIFF
--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -52,8 +52,16 @@ class ManageIQ::Providers::Inventory::Persister
     collections.keys
   end
 
+  # Defines how inventory objects will be loaded from the database
+  #
+  # Allowed values are:
+  # * nil - Default strategy, InventoryObjects will be saved and only objects in
+  #         an InventoryCollection can be referenced.  Best used for full refreshes.
+  # * :local_db_find_missing_references - InventoryObjects will be saved and
+  #         lazy_find references will be loaded from the database.  Best used
+  #         for targeted refreshes.
   def strategy
-    nil
+    targeted? ? :local_db_find_missing_references : nil
   end
 
   def saver_strategy


### PR DESCRIPTION
The inventory_collection.strategy defines if lazy_finds are loaded from the inventory collections (full refresh) or looked up from the database (targeted refresh).

Currently this has to be defined in every provider persister subclass along with `def targeted?; true; end`.

We can simplify the provider subclasses by moving this logic into core.