### PR TITLE
update ancestry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ manageiq_plugin "manageiq-schema"
 gem "activerecord-session_store",       "~>1.1"
 gem "activerecord-virtual_attributes",  "~>3.0.0"
 gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
-gem "ancestry",                         "~>3.0.7",           :require => false
+gem "ancestry",                         "~>4.1.0",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -769,7 +769,12 @@ module RelationshipMixin
 
   # this allows us to call similarly named ancestry or mixin methods
   def call_ancestry_method(method_name, *args)
-    bound_method = ((@ancestry_method ||= {})[method_name] ||= ::Ancestry::InstanceMethods.instance_method(method_name)).bind(self)
+    bound_method = if Ancestry::MaterializedPath::InstanceMethods.public_instance_methods.include?(method_name)
+                     ((@ancestry_method ||= {})[method_name] ||= ::Ancestry::MaterializedPath::InstanceMethods.instance_method(method_name)).bind(self)
+                   else
+                     ((@ancestry_method ||= {})[method_name] ||= ::Ancestry::InstanceMethods.instance_method(method_name)).bind(self)
+                   end
+
     args.empty? ? bound_method.call : bound_method.call(*args)
   end
 end

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -622,19 +622,22 @@ module RelationshipMixin
   alias_method :add_child, :add_children
 
   def parent=(parent)
-    if use_ancestry?
-      call_ancestry_method(:parent=, parent)
-      return
-    end
-
     if parent.nil?
-      remove_all_parents
+      if use_ancestry?
+        call_ancestry_method(:parent=, parent)
+      else
+        remove_all_parents
+      end
     else
       parent.with_relationship_type(relationship_type) do
-        parent_rel = parent.init_relationship
-        init_relationship(parent_rel)  # TODO: Deal with any multi-instances
+        if use_ancestry?
+          call_ancestry_method(:parent=, parent)
+        else
+          parent_rel = parent.init_relationship
+          init_relationship(parent_rel) # TODO: Deal with any multi-instances
 
-        parent.clear_relationships_cache
+          parent.clear_relationships_cache
+        end
       end
     end
 

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -217,10 +217,20 @@ RSpec.describe RelationshipMixin do
           self.table_name = "services"
           include RelationshipMixin
           self.skip_relationships += ["custom"]
+          self.default_relationship_type = "ems_metadata"
         end
       end
 
+      # ems_metadata:
+      #   1
+      #  2
+      # custom:
+      #   2
+      #  1
+      # 3 4
+
       before do
+        service2.update!(:parent => service1)
         service1.with_relationship_type("custom") { service1.update!(:parent => service2) }
         service3.with_relationship_type("custom") { service3.update!(:parent => service1) }
         service4.with_relationship_type("custom") { service4.update!(:parent => service1) }
@@ -352,6 +362,7 @@ RSpec.describe RelationshipMixin do
 
       it "#parent=" do
         service6 = ancestry_class.create
+        service6.update(:parent => service1)
         expect(service2.with_relationship_type("custom") { service2.parent=(service6) }).to eq(service6)
         service2.save!
         expect(service6.with_relationship_type("custom") { service6.child_ids }).to eq([service2.id])

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -366,7 +366,8 @@ RSpec.describe RelationshipMixin do
 
         it "with all to remove" do
           service1.with_relationship_type("custom") { service1.replace_children }
-          expect(service1.with_relationship_type("custom") { service1.replace_children }).to eq([])
+
+          expect(service1.with_relationship_type("custom") { service1.reload.children }).to eq([])
         end
 
         it "with one child to keep" do


### PR DESCRIPTION
fix the namespace for ancestor_ids because it changes in ancestry 3.1.0, and while we're at it, 4.0 is released

I'm sure there's a better way to do this, maybe @kbrock is willing to elucidate what that might be.

🐉 

