### PR TITLE
Add pxe_tag feature to allow tagging of pxe_servers and all children that support it

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3406,6 +3406,15 @@
   :feature_type: node
   :identifier: pxe
   :children:
+  - :name: Operate
+    :description: Perform Operations on PXE
+    :feature_type: control
+    :identifier: pxe_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of PXE
+      :feature_type: control
+      :identifier: pxe_tag
   # Pxe Servers
   - :name: PXE Servers
     :description: Everything under PXE Servers


### PR DESCRIPTION
pxe/tagging_edit is the entrypoint route for all tagging on pxe servers, etc.:

```
rake routes |grep -E "pxe.+tag"
                                                              GET              /pxe/tagging_edit(/:id)(.:format)                                                                pxe#tagging_edit
                                                              POST             /pxe/tagging_edit(/:id)(.:format)                                                                pxe#tagging_edit
```

tagging_edit defaults to looking for a product feature built from the controller
for common methods followed by "_tag" or in this case, `pxe_tag`:
https://github.com/ManageIQ/manageiq-ui-classic/blob/7f0739dd6bfb98027af227f59210b9d2c30acd2c/app/controllers/application_controller/tags.rb#L6

Followup to #21222
This will fix the last failure on https://github.com/ManageIQ/manageiq-ui-classic/pull/7740
