### PR TITLE
Ensure the relationship target is using same ancestry model

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -580,9 +580,13 @@ module RelationshipMixin
   end
 
   def add_parent(parent)
-    return update(:parent => parent) if use_ancestry?
-
-    parent.with_relationship_type(relationship_type) { parent.add_child(self) }
+    parent.with_relationship_type(relationship_type) do
+      if use_ancestry?
+        update(:parent => parent)
+      else
+        parent.add_child(self)
+      end
+    end
   end
 
   def add_children(*child_objs)
@@ -621,6 +625,7 @@ module RelationshipMixin
   end
   alias_method :add_child, :add_children
 
+  # for ancestry, make sure the parent also has the proper with_relationship_type set
   def parent=(parent)
     if use_ancestry?
       call_ancestry_method(:parent=, parent)

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -216,11 +216,20 @@ RSpec.describe RelationshipMixin do
           has_ancestry
           self.table_name = "services"
           include RelationshipMixin
+          self.default_relationship_type = "ems_metadata"
           self.skip_relationships += ["custom"]
         end
       end
 
+      # ems_metadata:
+      #   1
+      #  2
+      # custom:
+      #   2
+      #  1
+      # 3 4
       before do
+        service2.update!(:parent => service1)
         service1.with_relationship_type("custom") { service1.update!(:parent => service2) }
         service3.with_relationship_type("custom") { service3.update!(:parent => service1) }
         service4.with_relationship_type("custom") { service4.update!(:parent => service1) }
@@ -352,6 +361,7 @@ RSpec.describe RelationshipMixin do
 
       it "#parent=" do
         service6 = ancestry_class.create
+        service6.update(:parent => service1)
         expect(service2.with_relationship_type("custom") { service2.parent=(service6) }).to eq(service6)
         service2.save!
         expect(service6.with_relationship_type("custom") { service6.child_ids }).to eq([service2.id])


### PR DESCRIPTION
a bunch of changes have gone in to make sure that the `parent` or the
path_ids are either both using ancestry or both not using ancestry

recent changes to `ancestry` gem start to use the ancestor_ids more, so we need to
be double sure that it is using the correct ancestor_ids method

/cc @agrare @d-m-u related to https://github.com/ManageIQ/manageiq/pull/21226
/cc @d-m-u can you validate that this makes sense and fixes your bug? you can pull this into your PR if that makes it easier for you