### PR TITLE
no longer dump settings

### DIFF
--- a/lib/patches/config_patch.rb
+++ b/lib/patches/config_patch.rb
@@ -1,10 +1,6 @@
 module ConfigDecryptPasswords
   def reload!
-    Vmdb::Settings.decrypt_passwords!(super).tap do
-      # The following should only be done when loading/reloading the current
-      #   process' Settings, as opposed to a remote server's settings.
-      Vmdb::Settings.dump_to_log_directory(::Settings) if equal?(::Settings)
-    end
+    Vmdb::Settings.decrypt_passwords!(super)
   end
 
   alias load! reload!

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -19,7 +19,6 @@ module Vmdb
     end
 
     PASSWORD_FIELDS = Vmdb::SettingsWalker::PASSWORD_FIELDS
-    DUMP_LOG_FILE   = Rails.root.join("log/last_settings.txt").freeze
 
     # Magic value to reset a resource's setting to the parent's value
     RESET_COMMAND = "<<reset>>".freeze
@@ -29,7 +28,6 @@ module Vmdb
       ::Config.overwrite_arrays = true
       ::Config.merge_nil_values = false
       reset_settings_constant(for_resource(:my_server))
-      dump_to_log_directory(::Settings)
     end
 
     def self.reload!
@@ -101,10 +99,6 @@ module Vmdb
 
     def self.template_settings
       build_template.load!
-    end
-
-    def self.dump_to_log_directory(settings)
-      DUMP_LOG_FILE.write(mask_passwords!(settings.to_hash).to_yaml)
     end
 
     # This is a near copy of Config.load_and_set_settings, but we can't use that

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,28 +1,4 @@
 RSpec.describe Vmdb::Settings do
-  describe ".dump_to_log_directory" do
-    it "is called on top-level ::Settings.reload!" do
-      expect(described_class).to receive(:dump_to_log_directory)
-
-      ::Settings.reload!
-    end
-
-    it "writes them" do
-      ::Settings.api.token_ttl = "1.minute"
-      described_class.dump_to_log_directory(::Settings)
-
-      dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
-      expect(dumped_yaml.fetch_path(:api, :token_ttl)).to eq "1.minute"
-    end
-
-    it "masks passwords" do
-      ::Settings.authentication.bind_pwd = "pa$$w0rd"
-      described_class.dump_to_log_directory(::Settings)
-
-      dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
-      expect(dumped_yaml.fetch_path(:authentication, :bind_pwd)).to eq "********"
-    end
-  end
-
   describe ".walk" do
     it "traverses tree properly" do
       stub_settings(:a => {:b => 'c'}, :d => {:e => {:f => 'g'}}, :i => [{:j => 'k'}, {:l => 'm'}])


### PR DESCRIPTION
all services were dumping the settings.

we were running into privilege issues on the settings files
because sometimes a root writes it and other times a non-root writes it

this basically reverts #10705 -- which was introduced to answer the question "what were the settings when the logs were collected"

so I'm not sure if this is a conversation starter or an actual PR - bu