### PR TITLE
Fix issue with fix_auth and rare key collision during recrypt

### DIFF
--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -20,6 +20,37 @@ RSpec.describe FixAuth::AuthConfigModel do
     ManageIQ::Password.clear_keys
   end
 
+  context "#recrypt" do
+    subject { FixAuth::FixMiqRequest }
+    let(:request) do
+      subject.create(
+        :type    => 'MiqProvisionRequest',
+        :options => YAML.dump(
+          :sysprep_password        => enc_old,
+          :sysprep_domain_password => enc_new
+        )
+      )
+    end
+
+    context "with the rare case where recryption succeeds but returns garbage" do
+      # NOTE: This legacy key only returns garbage specifically with the
+      #   built-in v2_key.dev and the plaintext string "password", which is
+      #   why it is redeclared here.  If this password is changed, a new
+      #   colliding legacy key will need to be found.
+      let(:pass)       { "password" }
+      let(:legacy_key) { ManageIQ::Password::Key.new(nil, "XamduEwrkgMSeLjl+LQeutAWsLgKi3tR1mdEtclDPyM=") }
+
+      it "should upgrade the column" do
+        subject.fix_passwords(request)
+        expect(request).to be_changed
+        new_options = YAML.load(request.options)
+
+        expect(new_options[:sysprep_password]).to be_encrypted(pass)
+        expect(new_options[:sysprep_domain_password]).to be_encrypted(pass)
+      end
+    end
+  end
+
   context "#requests" do
     subject { FixAuth::FixMiqRequest }
     let(:request) do

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe FixAuth::AuthModel do
         subject.fix_passwords(bad, :invalid => "other")
         expect(bad.password).to be_encrypted("other")
       end
+
+      context "with the rare case where recryption succeeds but returns garbage" do
+        # NOTE: This legacy key only returns garbage specifically with the
+        #   built-in v2_key.dev and the plaintext string "password", which is
+        #   why it is redeclared here.  If this password is changed, a new
+        #   colliding legacy key will need to be found.
+        let(:pass)       { "password" }
+        let(:legacy_key) { ManageIQ::Password::Key.new(nil, "XamduEwrkgMSeLjl+LQeutAWsLgKi3tR1mdEtclDPyM=") }
+
+        it "should upgrade the column" do
+          subject.fix_passwords(old_new)
+          expect(old_new.password).to be_encrypted(pass)
+          expect(old_new.auth_key).to be_encrypted(pass)
+        end
+      end
     end
 
     context "#hardcode" do


### PR DESCRIPTION
This commit handles the rare case where, during recrypt, the old value is
already encrypted with the new key, and when calling
ManageIQ::Password.recrypt, the decryption with the legacy key doesn't raise
an Exception as expected, but instead successfully decrypts and returns
garbage.

Fixes #21042

@jrafanie @kbrock Please review.