### PR TITLE
[MiqSet] Rework to use miq_set_memberships

### DIFF
--- a/app/models/miq_set_membership.rb
+++ b/app/models/miq_set_membership.rb
@@ -1,0 +1,4 @@
+class MiqSetMembership < ApplicationRecord
+  # NOTE:  Can't set `belongs_to :miq_set` here because `MiqSet` is not a model
+  belongs_to :member, :polymorphic => true
+end

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -25,19 +25,22 @@ module CustomActionsMixin
   end
 
   def generic_button_group
-    generic_custom_buttons.select { |button| !button.parent.nil? }
+    generic_custom_buttons.includes(:custom_button_sets)
+                          .select { |button| button.custom_button_sets.present? }
   end
 
   def custom_button_sets_with_generics
-    custom_button_sets + generic_button_group.map(&:parent).uniq.flatten
+    custom_button_sets + generic_button_group.flat_map(&:custom_button_sets).uniq
   end
 
   def custom_buttons
-    generic_custom_buttons.select { |button| button.parent.nil? } + direct_custom_buttons
+    generic_custom_buttons.includes(:custom_button_sets)
+                          .select { |b| b.custom_button_sets.blank? } + direct_custom_buttons
   end
 
   def direct_custom_buttons
-    CustomButton.buttons_for(self).select { |b| b.parent.nil? }
+    CustomButton.buttons_for(self).includes(:custom_button_sets)
+                .select { |b| b.custom_button_sets.blank? }
   end
 
   def filter_by_visibility(buttons, applies_to = self)

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -34,14 +34,6 @@ module RelationshipMixin
     memoize(*MEMOIZED_METHODS)
   end
 
-  module ClassMethods
-    def alias_with_relationship_type(m_new, m_old, rel_type = nil)
-      define_method(m_new) do |*args|
-        with_relationship_type(rel_type || default_relationship_type) { send(m_old, *args) }
-      end
-    end
-  end
-
   def reload(*args)
     clear_relationships_cache
     super

--- a/lib/extensions/ar_miq_set.rb
+++ b/lib/extensions/ar_miq_set.rb
@@ -13,12 +13,15 @@ module ActsAsMiqSetMember
              :source     => miq_set_class.name.underscore.to_sym,
              :through    => :miq_set_memberships
 
-    has_many miq_set_class.name.underscore.pluralize.to_sym,
+    has_many :memberof,
              :class_name => miq_set_class.to_s, # rubocop:disable Rails/ReflectionClassName
              :source     => miq_set_class.name.underscore.to_sym,
              :through    => :miq_set_memberships
 
-    alias memberof miq_sets
+    has_many miq_set_class.name.underscore.pluralize.to_sym,
+             :class_name => miq_set_class.to_s, # rubocop:disable Rails/ReflectionClassName
+             :source     => miq_set_class.name.underscore.to_sym,
+             :through    => :miq_set_memberships
   end
 
   module ClassMethods
@@ -33,6 +36,10 @@ module ActsAsMiqSetMember
 
   def make_memberof(set)
     set.add_member(self)
+  end
+
+  def make_not_memberof(set)
+    set.remove_member(self)
   end
 end # module ActsAsMiqSetMember
 

--- a/lib/extensions/ar_miq_set.rb
+++ b/lib/extensions/ar_miq_set.rb
@@ -132,6 +132,8 @@ module ActsAsMiqSet
   alias remove_all_children remove_all_members
 
   def add_members(*members)
+    added = []
+
     transaction do
       existing = miq_set_memberships.index_by { |ms| [ms.member_type, ms.member_id] }
 
@@ -140,8 +142,11 @@ module ActsAsMiqSet
         next if existing.include?([member.class.base_class.name, member.id])
 
         miq_set_memberships.create!(:member => member)
+        added << member
       end
     end
+
+    added
   end
   alias add_children add_members
   alias add_member add_members

--- a/lib/extensions/ar_miq_set.rb
+++ b/lib/extensions/ar_miq_set.rb
@@ -1,25 +1,24 @@
-module ActiveRecord
-  class Base
-    def self.acts_as_miq_set_member
-      include ActsAsMiqSetMember
-    end
-
-    def self.acts_as_miq_set(model_class = nil)
-      include ActsAsMiqSet
-
-      self.model_class = model_class unless model_class.nil?
-    end
-  end
-end
-
 module ActsAsMiqSetMember
   extend ActiveSupport::Concern
-  included do
-    include RelationshipMixin
-    self.default_relationship_type = "membership"
 
-    alias_with_relationship_type :memberof,          :parents
-    alias_with_relationship_type :make_not_memberof, :remove_parent
+  included do
+    MiqSetMembership.send(:belongs_to, miq_set_class.name.underscore.to_sym, :foreign_key => :miq_set_id)
+
+    has_many :miq_set_memberships,
+             :as        => :member,
+             :dependent => :delete_all
+
+    has_many :miq_sets,
+             :class_name => miq_set_class.to_s, # rubocop:disable Rails/ReflectionClassName
+             :source     => miq_set_class.name.underscore.to_sym,
+             :through    => :miq_set_memberships
+
+    has_many miq_set_class.name.underscore.pluralize.to_sym,
+             :class_name => miq_set_class.to_s, # rubocop:disable Rails/ReflectionClassName
+             :source     => miq_set_class.name.underscore.to_sym,
+             :through    => :miq_set_memberships
+
+    alias memberof miq_sets
   end
 
   module ClassMethods
@@ -37,42 +36,51 @@ module ActsAsMiqSetMember
   end
 end # module ActsAsMiqSetMember
 
+module ActiveRecord
+  class Base
+    def self.acts_as_miq_set_member
+      include ActsAsMiqSetMember
+    end
+
+    def self.acts_as_miq_set(model_class = nil)
+      include ActsAsMiqSet
+
+      self.model_class = model_class unless model_class.nil?
+    end
+  end
+end
+
 module ActsAsMiqSet
   extend ActiveSupport::Concern
   included do
-    include RelationshipMixin
-    self.default_relationship_type ||= "membership"
-
     include UuidMixin
 
     self.table_name         = "miq_sets"
     self.inheritance_column = :set_type
 
-    serialize  :set_data
+    serialize :set_data
 
-    validates  :name,
-               :presence                => true,
-               :uniqueness_when_changed => {
-                 :scope => [:set_type, :userid, :group_id],
-                 :if    => proc { |c| c.class.in_my_region.exists?(:name => c.name) }
-               }
-    validates  :description,
-               :presence => true
+    validates :name,
+              :presence                => true,
+              :uniqueness_when_changed => [:set_type, :userid, :group_id],
+              :if                      => proc { |c| c.class.in_my_region.exists?(:name => c.name) }
+    validates :description,
+              :presence => true
 
     belongs_to :owner,
                :polymorphic => true
+    has_many   :miq_set_memberships,
+               :foreign_key => :miq_set_id,
+               :dependent   => :delete_all
 
     acts_as_miq_taggable
 
-    alias_with_relationship_type :members,            :children
-    alias_with_relationship_type :miq_sets,           :children
-    alias_with_relationship_type :remove_member,      :remove_child
-    alias_with_relationship_type :remove_all_members, :remove_all_children
-    alias_with_relationship_type :add_members,        :add_children
-
-    alias_method model_table_name.to_sym, :children
-
-    virtual_has_many model_table_name.to_sym, :uses => :all_relationships
+    [:members, :miq_sets, :children, model_table_name.to_sym].each do |hm_relation|
+      has_many hm_relation,
+               :through     => :miq_set_memberships,
+               :source      => :member,
+               :source_type => model_class.name.to_s
+    end
   end
 
   module ClassMethods
@@ -96,8 +104,37 @@ module ActsAsMiqSet
     end
   end
 
-  def add_member(member)
-    raise "object of type #{member.class} may not be a member of a set of type #{self.class}" unless member.kind_of?(self.class.model_class)
-    with_relationship_type("membership") { add_child(member) }
+  def members=(*members)
+    transaction do
+      remove_all_members
+      add_members(*members)
+    end
   end
+  alias replace_children members=
+
+  def remove_member(member)
+    miq_set_memberships.where(:member => member).delete_all
+  end
+  alias remove_child remove_member
+
+  def remove_all_members
+    miq_set_memberships.delete_all
+  end
+  alias remove_all_children remove_all_members
+
+  def add_members(*members)
+    transaction do
+      existing = miq_set_memberships.index_by { |ms| [ms.member_type, ms.member_id] }
+
+      members.flatten.each do |member|
+        raise ArgumentError, "object of type #{member.class} may not be a member of a set of type #{self.class}" unless member.kind_of?(self.class.model_class)
+        next if existing.include?([member.class.base_class.name, member.id])
+
+        miq_set_memberships.create!(:member => member)
+      end
+    end
+  end
+  alias add_children add_members
+  alias add_member add_members
+  alias add_child add_members
 end # module ActsAsMiqSet

--- a/lib/extensions/ar_miq_set.rb
+++ b/lib/extensions/ar_miq_set.rb
@@ -62,8 +62,10 @@ module ActsAsMiqSet
 
     validates :name,
               :presence                => true,
-              :uniqueness_when_changed => [:set_type, :userid, :group_id],
-              :if                      => proc { |c| c.class.in_my_region.exists?(:name => c.name) }
+              :uniqueness_when_changed => {
+                :scope => [:set_type, :userid, :group_id],
+                :if    => proc { |c| c.class.in_my_region.exists?(:name => c.name) }
+              }
     validates :description,
               :presence => true
 

--- a/lib/task_helpers/exports/custom_buttons.rb
+++ b/lib/task_helpers/exports/custom_buttons.rb
@@ -1,7 +1,7 @@
 module TaskHelpers
   class Exports
     class CustomButtons
-      EXCLUDE_ATTRS = %w[id created_on updated_on created_at updated_at dialog_id resource_id].freeze
+      EXCLUDE_ATTRS = %w[id miq_set_id created_on updated_on created_at updated_at dialog_id resource_id].freeze
 
       def initialize
         @export_hash = {}
@@ -40,9 +40,9 @@ module TaskHelpers
       private
 
       def direct_custom_buttons
-        CustomButton.select("custom_buttons.*, relationships.resource_id")
-                    .left_outer_joins(:all_relationships)
-                    .where(:relationships => {:resource_id => nil})
+        CustomButton.select("custom_buttons.*, miq_set_memberships.miq_set_id")
+                    .left_outer_joins(:miq_set_memberships)
+                    .where(:miq_set_memberships => {:miq_set_id => nil})
       end
 
       def attrs_for(object, children = nil)

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe MiqEventDefinition do
-  let(:event_defs) { MiqEventDefinition.all.group_by(&:name) }
+  def event_defs
+    MiqEventDefinition.all.group_by(&:name)
+  end
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_event_definition)

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -522,34 +522,6 @@ RSpec.describe RelationshipMixin do
     end
   end
 
-  context ".alias_with_relationship_type" do
-    let(:miq_widget) { FactoryBot.create(:miq_widget) }
-
-    let(:set_data) do
-      {:col1             => [miq_widget.id],
-       :reset_upon_login => false,
-       :locked           => false}
-    end
-
-    before do
-      group = FactoryBot.create(:miq_group)
-      # NOTE: widget_sets are created with one widget
-      @ws = FactoryBot.create(:miq_widget_set, :owner => group)
-      @widget = FactoryBot.create(:miq_widget)
-
-      @ws.add_member(@widget)
-    end
-
-    it "of a method with arguments" do
-      @ws.remove_member(@widget)
-      expect(@ws.members.length).to eq(1)
-    end
-
-    it "of a method without arguments" do
-      expect(@ws.members.length).to eq(2)
-    end
-  end
-
   describe "#root" do
     it "is self with with no relationships" do
       host # execute the query

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -99,7 +99,8 @@ RSpec.describe ServiceTemplate do
           )
         ]
       }
-      expect(service_template.custom_actions(service)).to match(expected)
+      actual = service_template.custom_actions(service)
+      expect(actual).to match(expected)
     end
 
     context "expression evaluation" do
@@ -183,7 +184,8 @@ RSpec.describe ServiceTemplate do
           )
         ]
       }
-      expect(service_template.custom_actions(service)).to match(expected)
+      actual = service_template.custom_actions(service)
+      expect(actual).to match(expected)
     end
   end
 


### PR DESCRIPTION
**Requires https://github.com/ManageIQ/manageiq-schema/pull/576**

High Level
----------

- Adds the `MiqSetMembership` class (join table)
- Removes the use of `RelationshipMixin` from `ActsAsMiqSet`/`ActsAsMiqSetMember`
- Adds related scopes for `ActsAsMiqSet`/`ActsAsMiqSetMember` to use `MiqSetMembership`


Implementation Details
----------------------

The original approach for this effort was to create a `MiqSet` class that would be used as the `base_class` for the rest of the models that used to call `acts_as_miq_set_member`. However, the default behavior of `ActiveRecord` when dealing with a polymorphic association is to set the value of the `_type` column to `.polymorphic_name`:

```ruby
module ActiveRecord
  module Associations
    class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:

      private
        def replace_keys(record)
          super
          owner[reflection.foreign_type] = record ? record.class.polymorphic_name : nil
        end
```

Which by default for that is `base_class.name`:

```ruby
module ActiveRecord
  module Inheritance

    module ClassMethods

      def polymorphic_name
        base_class.name
      end
```

Classes like `MiqAlertSet` also make use of the `AssignmentMixin`, which uses the `Tag`/`Taggings` classes to handle assignments.  When the subclass approach was used, this broke many pieces of that as it would save the `taggable_type` column as `"MiqSet"`, but try and find based on the type of `"MiqAlertSet"`

With `acts_as_miq_set`, it doesn't subclass anything, just shares a table, so it would be saved as `self.class.name`.  A lot of code relies on this behavior, many other classes follow this properly, and it would probably require a migration to fix old records if we were to change it now.

By retaining the use of `ActsAsMiqSet`, this preserves with previous behavior without mucking with the cases with `Tags` (Vms for example) where this is done using normal `ActiveRecord` conventions.  A further migration would also probably be required to do this correctly, so that has been deferred for now.


Links
-----

* Requires: https://github.com/ManageIQ/manageiq-schema/pull/576 
* Previous attempts:
  - https://github.com/ManageIQ/manageiq/pull/21227
  - https://github.com/ManageIQ/manageiq/pull/20665