### PR TITLE
Work-around for extraneous escapes in json catalogs

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -320,6 +320,14 @@ namespace :locale do
       end
 
       Rake::Task['gettext:po_to_json'].invoke
+
+      # Work-around for extraneous '\' symbols in json catalogs
+      # This can go away once https://github.com/webhippie/gettext_i18n_rails_js/issues/42 is resolved
+      Dir.glob(File.join(GettextI18nRailsJs::Task.output_path, "*.json")).each do |file|
+        text = File.read(file)
+        new_content = text.gsub(/\\\\\\\"|\\\\\\\\\\\\\\\"/, '\"')
+        File.open(file, "w") { |new_file| new_file.puts(new_content) }
+      end
     ensure
       system "rm -rf #{combined_dir} #{plugins_dir}"
     end


### PR DESCRIPTION
Continuation of: https://github.com/ManageIQ/manageiq/pull/17950

> To get translated strings to javascript, we always have to:
> 
> 1. extract the strings from javascript sources
> 2. translate them
> 3. the translated strings (catalogs) need to be converted into a json file, so that the translations can be consumed by javascript
> 
> Say you have the following two strings in javascript:
> 
> ```js
> var v1 = 'first "string"';
> var v2 = 'second \"string\"';
> ```
> 
> Once you extract these two strings into a catalog for translation, you'll get the following in the catalog:
> 
> ```
> msgid "first \"string\""
> msgid "2second \\\"string\\\""
> ```
> 
> Once you convert the above (after the translations are done) into json, you'll get the following in the json catalog:
> 
> ```
> "1first \\\"string\\\"" : [""],
> "2second \\\\\\\"string\\\\\\\"":[""]
> ```
> 
> What this means that after this, `'first "string"'` was transformed into `"1first \\\"string\\\""` and `__('first "string"');` that you have somewhere in your javascript sources will no longer be working (since such string doesn't exist in the catalogs).
> 
> This issue has been filed upstream: [webhippie/gettext_i18n_rails_js#42](https://github.com/webhippie/gettext_i18n_rails_js/issues/42) nonetheless a fix in the gem is currently not available.
> 
> My fix here should serve as a temporary workaround for the issue: during `po_to_json` conversion, my work-around will remove those extraneous escapes so that the translations won't go in vain.
> 
> https://bugzilla.redhat.com/show_bug.cgi?id=1525525
> https://bugzilla.redhat.com/show_bug.cgi?id=1538176
> https://bugzilla.redhat.com/show_bug.cgi?id=1538192

@miq-bot assign @Fryguy
@miq-bot add_reviewer @Fryguy, @kavyanekkalapu 
@chessbyte 

