### PR TITLE
Fix missing routes in product.yaml

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1464,14 +1464,14 @@
     :description: View Dashboard
     :feature_type: view
     :identifier: dashboard_view
-  - :name: Modify
-    :description: Modify Dashboard
-    :feature_type: admin
-    :identifier: dashboard_admin
   - :name: Tag
     :description: Tag in Dashboard
     :feature_type: control
     :identifier: dashboard_tag
+  - :name: Modify
+    :description: Modify Dashboard
+    :feature_type: admin
+    :identifier: dashboard_admin
     :children:
     - :name: Add and Remove a Widget
       :description: Add and Remove Dashboard Widgets

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1468,6 +1468,10 @@
     :description: Modify Dashboard
     :feature_type: admin
     :identifier: dashboard_admin
+  - :name: Tag
+    :description: Tag in Dashboard
+    :feature_type: control
+    :identifier: dashboard_tag
     :children:
     - :name: Add and Remove a Widget
       :description: Add and Remove Dashboard Widgets


### PR DESCRIPTION
This issue fixes messing privileges for `Edit tags` in dashboard pages.
**Before**
<img width="1309" alt="Screen Shot 2021-05-27 at 8 54 08 AM" src="https://user-images.githubusercontent.com/37085529/119829436-3b729100-bec9-11eb-8b90-ce4d145a2a0f.png">

**After**
<img width="1445" alt="Screen Shot 2021-05-27 at 8 52 10 AM" src="https://user-images.githubusercontent.com/37085529/119829456-40374500-bec9-11eb-88d4-bcab1f4f954d.png">

@miq-bot assign @jrafanie 
@miq-bot add-label bug
@miq-bot add-label Lasker/yes?
@miq-bot add_reviewer @jrafanie 
