### PR TITLE
Patch PoToJson to emit strings with escapes properly

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -319,15 +319,8 @@ namespace :locale do
         end
       end
 
+      # This depends on PoToJson overrides as defined in lib/tasks/po_to_json_override.rb
       Rake::Task['gettext:po_to_json'].invoke
-
-      # Work-around for extraneous '\' symbols in json catalogs
-      # This can go away once https://github.com/webhippie/gettext_i18n_rails_js/issues/42 is resolved
-      Dir.glob(File.join(GettextI18nRailsJs::Task.output_path, "*.json")).each do |file|
-        text = File.read(file)
-        new_content = text.gsub(/\\\\\\\"|\\\\\\\\\\\\\\\"/, '\"')
-        File.open(file, "w") { |new_file| new_file.puts(new_content) }
-      end
     ensure
       system "rm -rf #{combined_dir} #{plugins_dir}"
     end

--- a/lib/tasks/po_to_json_override.rb
+++ b/lib/tasks/po_to_json_override.rb
@@ -1,9 +1,47 @@
 class PoToJson
-  # return just the JSON, instead of `var locales = locales || {}; locales['en'] = json`
+  #
+  # PoToJson's json generation method is current not public, and the generate_for_jed
+  #   method has extra stuff around it.  This override only returns the JSON.
+  #
+  # Overrides https://github.com/webhippie/po_to_json/blob/v1.0.1/lib/po_to_json.rb#L46-L65
   def generate_for_jed(language, overwrite = {})
     @options = parse_options(overwrite.merge(:language => language))
     @parsed ||= inject_meta(parse_document)
 
     build_json_for(build_jed_for(@parsed))
+  end
+
+  #
+  # The following two methods override the base methods to account for proper
+  # escaping of escape strings.
+  #
+
+  # Overrides https://github.com/webhippie/po_to_json/blob/v1.0.1/lib/po_to_json.rb#L90-L99
+  def parse_header
+    return if reject_header
+
+    values[""][0].split("\n").each do |line|
+      next if line.empty?
+      build_header_for(line)
+    end
+
+    values[""] = headers
+  end
+
+  protected
+
+  # Overrides https://github.com/webhippie/po_to_json/blob/v1.0.1/lib/po_to_json.rb#L175-L188
+  def push_buffer(value, key = nil)
+    value = JSON.load(value)
+
+    if key.nil?
+      buffer[lastkey] = [
+        buffer[lastkey],
+        value
+      ].join("")
+    else
+      buffer[key] = value
+      @lastkey = key
+    end
   end
 end


### PR DESCRIPTION
Ultimately, these changes should go into upstream such that the
overrides are not needed.

@DavidResende0 Please review.  This PR essentially replaces #21242 , but does so in a way that hopefully I can push these changes upstream and then toss our overrides.  If not, at least this makes it clear that it's the PoToJson gem that's incorrect.