### PR TITLE
[WIP] Private v2 key

### DIFF
--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -39,11 +39,11 @@ module FixAuth
     end
 
     def generate_password
-      ManageIQ::Password.generate_symmetric("#{cert_dir}/v2_key")
+      ManageIQ::Password.generate_symmetric("#{cert_dir}/v2_key", ENV["APPLIANCE"] ? "manageiq" : nil)
     rescue Errno::EEXIST => e
       $stderr.puts
       $stderr.puts "Only generate one encryption_key (v2_key) per installation."
-      $stderr.puts "Chances are you did not want to overwrite this file."
+      $stderr.puts "Chances are you do not want to overwrite this file."
       $stderr.puts "If you do this all encrypted secrets in the database will not be readable."
       $stderr.puts "Please backup your key and run again."
       $stderr.puts


### PR DESCRIPTION
make a key not world readable
Also, on an appliance, make it group owned by group manageiq, so root and manageiq user can view it

this depends upon https://github.com/ManageIQ/manageiq-password/pull/22
I can rewrite to have this logic here