### PR TITLE
Change belongsto2object_list to be more performant

### DIFF
--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1464,7 +1464,7 @@ RSpec.describe Rbac::Filterer do
           @host1.update(:ext_management_system => @ems)
           @host2.update(:ext_management_system => @ems)
 
-          @vfolder        = FactoryBot.create(:ems_folder, :name => "vm")
+          @vfolder        = FactoryBot.create(:ems_folder, :name => "vm", :ext_management_system => @ems)
           @vfolder.parent = dc
           @host1.parent   = hfolder
           @vm_folder_path = "/belongsto/ExtManagementSystem|#{@ems.name}/EmsFolder|#{root.name}/EmsFolder|#{dc.name}/EmsFolder|#{@vfolder.name}"
@@ -1532,8 +1532,8 @@ RSpec.describe Rbac::Filterer do
           context "deleted cluster from belongsto filter" do
             let!(:group)   { FactoryBot.create(:miq_group, :tenant => default_tenant) }
             let!(:user)    { FactoryBot.create(:user, :miq_groups => [group]) }
-            let(:cluster_1) { FactoryBot.create(:ems_cluster, :name => "MTC Development 1").tap { |cluster| cluster.parent = hfolder } }
-            let(:cluster_2) { FactoryBot.create(:ems_cluster, :name => "MTC Development 2").tap { |cluster| cluster.parent = hfolder } }
+            let(:cluster_1) { FactoryBot.create(:ems_cluster, :name => "MTC Development 1", :ext_management_system => @ems).tap { |cluster| cluster.parent = hfolder } }
+            let(:cluster_2) { FactoryBot.create(:ems_cluster, :name => "MTC Development 2", :ext_management_system => @ems).tap { |cluster| cluster.parent = hfolder } }
             let(:vm_folder_path) { "/belongsto/ExtManagementSystem|#{@ems.name}/EmsFolder|#{root.name}/EmsFolder|#{dc.name}/EmsFolder|#{hfolder.name}/EmsCluster|#{cluster_1.name}" }
 
             it "honors ems_id conditions" do
@@ -1667,21 +1667,21 @@ RSpec.describe Rbac::Filterer do
         before do
           @ems = FactoryBot.create(:ems_vmware, :name => 'ems')
           @ems_folder_path = "/belongsto/ExtManagementSystem|#{@ems.name}"
-          @root = FactoryBot.create(:ems_folder, :name => "Datacenters")
+          @root = FactoryBot.create(:ems_folder, :name => "Datacenters", :ext_management_system => @ems)
           @root.parent = @ems
-          @mtc = FactoryBot.create(:datacenter, :name => "MTC")
+          @mtc = FactoryBot.create(:datacenter, :name => "MTC", :ext_management_system => @ems)
           @mtc.parent = @root
           @mtc_folder_path = "/belongsto/ExtManagementSystem|#{@ems.name}/EmsFolder|#{@root.name}/EmsFolder|#{@mtc.name}"
 
-          @hfolder         = FactoryBot.create(:ems_folder, :name => "host")
+          @hfolder         = FactoryBot.create(:ems_folder, :name => "host", :ext_management_system => @ems)
           @hfolder.parent  = @mtc
 
-          @cluster = FactoryBot.create(:ems_cluster, :name => "MTC Development")
+          @cluster = FactoryBot.create(:ems_cluster, :name => "MTC Development", :ext_management_system => @ems)
           @cluster.parent = @hfolder
 
           @cluster_folder_path = "#{@mtc_folder_path}/EmsFolder|#{@hfolder.name}/EmsCluster|#{@cluster.name}"
 
-          @rp = FactoryBot.create(:resource_pool, :name => "Default for MTC Development")
+          @rp = FactoryBot.create(:resource_pool, :name => "Default for MTC Development", :ext_management_system => @ems)
           @rp.parent = @cluster
 
           @host_1 = FactoryBot.create(:host, :name => "Host_1", :ems_cluster => @cluster, :ext_management_system => @ems)


### PR DESCRIPTION
The previous implementation walks the tree from root to leaf, but brings
back all the children at each level, filters in Ruby, then continues
querying down the tree, which is expensive. Instead, this commit does
the reverse by starting at the leaf and querying up the tree to the
root. This prevents bringing back a lot of unnecessary records, and also
takes advantage of the `path` method from ancestry which can query the
entire chain in a single query from the relationships table.

The specs have two tests that can show the difference in the number of
queries. One is for a shallow tree (ems/folder/folder), and another is
for a deeper tree (ems/folder/folder/folder/host). The number of queries
for the shallow tree dropped from 7 to 6 and the number of queries for
the deeper tree dropped from 13 to 7. The deeper you go in the tree, the
more savings will be had. Note that the specs have very few records at
each level in the hierarchy, but real world trees can have many objects
at each hierarchy. The new querying only brings back a single record
from each level, whereas the old query brings back all of the records at
each level, and this is where significant savings will be found.

Part of #21249

- [x] Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7753

---
Example queries seen with the 2 tests in question

**shallow tree (ems/folder/folder)**

```diff
- ExtManagementSystem Load (0.2ms)  SELECT "ext_management_systems".* FROM "ext_management_systems" WHERE "ext_management_systems"."name" = $1 LIMIT $2  [["name", "ems"], ["LIMIT", 1]]
- Relationship Load (0.1ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3  [["resource_id", 28000000000137], ["resource_type", "ExtManagementSystem"], ["relationship", "ems_metadata"]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '28000000000366'
- EmsFolder Load (0.1ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" = $1  [["id", 28000000000214]]
- Relationship Load (16.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3  [["resource_id", 28000000000214], ["resource_type", "EmsFolder"], ["relationship", "ems_metadata"]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '28000000000366/28000000000367'
- EmsFolder Load (0.2ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" = $1  [["id", 28000000000215]]
+ ExtManagementSystem Load (0.2ms)  SELECT "ext_management_systems".* FROM "ext_management_systems" WHERE "ext_management_systems"."name" = $1 LIMIT $2  [["name", "ems"], ["LIMIT", 1]]
+ EmsFolder Load (0.3ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."name" = $1 AND "ems_folders"."ems_id" = $2  [["name", "MTC"], ["ems_id", 28000000001458]]
+ Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_type" = $1 AND "relationships"."resource_id" = $2  [["resource_type", "EmsFolder"], ["resource_id", 28000000000861]]
+ Relationship Load (14.1ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."id" IN (28000000001484, 28000000001485, 28000000001486) ORDER BY COALESCE("relationships"."ancestry", '') ASC
+ ExtManagementSystem Load (0.2ms)  SELECT "ext_management_systems".* FROM "ext_management_systems" WHERE "ext_management_systems"."id" = $1  [["id", 28000000001458]]
+ EmsFolder Load (0.3ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" IN ($1, $2)  [["id", 28000000000860], ["id", 28000000000861]]
```

**deeper tree (ems/folder/folder/folder/host)**

```diff
- ExtManagementSystem Load (0.2ms)  SELECT "ext_management_systems".* FROM "ext_management_systems" WHERE "ext_management_systems"."name" = $1 LIMIT $2  [["name", "ems"], ["LIMIT", 1]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3  [["resource_id", 28000000000136], ["resource_type", "ExtManagementSystem"], ["relationship", "ems_metadata"]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '28000000000361'
- EmsFolder Load (0.4ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" = $1  [["id", 28000000000211]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3  [["resource_id", 28000000000211], ["resource_type", "EmsFolder"], ["relationship", "ems_metadata"]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '28000000000361/28000000000362'
- EmsFolder Load (0.1ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" = $1  [["id", 28000000000212]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3  [["resource_id", 28000000000212], ["resource_type", "EmsFolder"], ["relationship", "ems_metadata"]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '28000000000361/28000000000362/28000000000363'
- EmsFolder Load (0.3ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" = $1  [["id", 28000000000213]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_id" = $1 AND "relationships"."resource_type" = $2 AND "relationships"."relationship" = $3  [["resource_id", 28000000000213], ["resource_type", "EmsFolder"], ["relationship", "ems_metadata"]]
- Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '28000000000361/28000000000362/28000000000363/28000000000364'
- Host Load (0.6ms)  SELECT "hosts".* FROM "hosts" WHERE "hosts"."id" = $1  [["id", 28000000000076]]
+ ExtManagementSystem Load (0.2ms)  SELECT "ext_management_systems".* FROM "ext_management_systems" WHERE "ext_management_systems"."name" = $1 LIMIT $2  [["name", "ems"], ["LIMIT", 1]]
+ Host Load (0.5ms)  SELECT "hosts".* FROM "hosts" WHERE "hosts"."name" = $1 AND "hosts"."ems_id" = $2  [["name", "Host_1"], ["ems_id", 28000000001459]]
+ Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_type" = $1 AND "relationships"."resource_id" = $2  [["resource_type", "Host"], ["resource_id", 28000000000803]]
+ Relationship Load (0.4ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."id" IN (28000000001487, 28000000001488, 28000000001489, 28000000001490, 28000000001491) ORDER BY COALESCE("relationships"."ancestry", '') ASC
+ ExtManagementSystem Load (0.2ms)  SELECT "ext_management_systems".* FROM "ext_management_systems" WHERE "ext_management_systems"."id" = $1  [["id", 28000000001459]]
+ EmsFolder Load (0.3ms)  SELECT "ems_folders".* FROM "ems_folders" WHERE "ems_folders"."id" IN ($1, $2, $3)  [["id", 28000000000862], ["id", 28000000000863], ["id", 28000000000864]]
+ Host Load (0.2ms)  SELECT "hosts".* FROM "hosts" WHERE "hosts"."id" = $1  [["id", 28000000000803]]
```