### PR TITLE
Fix spec issue after upgrade of mini_portile2

### DIFF
--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -620,7 +620,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     it 'rejects invalid datetime for warm migration' do
       service_template = described_class.create_catalog_item(updated_catalog_item_options_with_warm_migration)
       service_template.miq_requests = []
-      expect { service_template.update_catalog_item(:config_info => {:warm_migration_cutover_datetime => 'nonsense'}) }.to raise_exception(StandardError, 'Error parsing datetime: invalid date: "nonsense"')
+      expect { service_template.update_catalog_item(:config_info => {:warm_migration_cutover_datetime => 'nonsense'}) }.to raise_exception(RuntimeError, /Error parsing datetime.+"nonsense"/)
     end
   end
 end


### PR DESCRIPTION
mini_portile2 2.5.2 was released, which brought in net-ftp as a
dependency, which, in turn, brings in the time 0.1.0 gem.  The time gem
has an error message that is worded sligtly differently that before,
failing this spec.

See https://github.com/flavorjones/mini_portile/commit/a6c83cf4f5124ff5f0c01ce0c035e14201b86318
