### PR TITLE
debug sql queries works with nil ar logger

### DIFF
--- a/config/initializers/instantiation_listener.rb
+++ b/config/initializers/instantiation_listener.rb
@@ -1,6 +1,6 @@
 ActiveSupport::Notifications.subscribe('instantiation.active_record') do |name, start, finish, _id, payload|
   logger = ActiveRecord::Base.logger
-  if logger.debug?
+  if logger&.debug?
     elapsed = finish - start
     name = payload[:class_name]
     count = payload[:record_count]


### PR DESCRIPTION
Sometimes in the console you need to turn active record logging off.

This no longer blows up when you set `ActiveRecord::Base.logger = nil`

(There is probably a better way but...)