### PR TITLE
[Exports::CustomButtons] Refactor/Simplify

### DIFF
--- a/lib/task_helpers/exports/custom_buttons.rb
+++ b/lib/task_helpers/exports/custom_buttons.rb
@@ -1,60 +1,68 @@
 module TaskHelpers
   class Exports
     class CustomButtons
-      class ExportArInstances
-        EXCLUDE_ATTRS = %w(id created_on updated_on created_at updated_at dialog_id resource_id).freeze
+      EXCLUDE_ATTRS = %w[id created_on updated_on created_at updated_at dialog_id resource_id].freeze
 
-        def self.export_object(obj, hash)
-          class_name = obj.class.name.underscore
-
-          $log.info("Exporting #{obj.class.name}: #{obj.try('name')} (ID: #{obj&.id})")
-          attrs = build_attr_list(obj.attributes)
-          # handle dialog label
-          attrs["dialog_label"] = obj.dialog&.label if obj.respond_to?(:dialog)
-          (hash[class_name] ||= []) << item = {'attributes' => attrs}
-          create_association_list(obj, item)
-          descendant_list(obj, item)
-        end
-
-        def self.build_attr_list(attrs)
-          attrs&.except(*EXCLUDE_ATTRS)
-        end
-
-        def self.create_association_list(obj, item)
-          associations = obj.class.try(:reflections)
-
-          if associations
-            associations = associations.collect { |model, assoc| {model => assoc.class.to_s.demodulize} }.select { |as| as.values.first != "BelongsToReflection" && as.keys.first != "all_relationships" }
-            associations.each do |assoc|
-              assoc.each do |a|
-                next if obj.try(a.first.to_sym).blank?
-                export_object(obj.try(a.first.to_sym), (item['associations'] ||= {}))
-              end
-            end
-          end
-        end
-
-        def self.descendant_list(obj, item)
-          obj.try(:children)&.each { |c| export_object(c, (item['children'] ||= {})) }
-        end
+      def initialize
+        @export_hash = {}
       end
 
       def export(options = {})
-        parent_id_list = []
-        objects = CustomButton.in_region(MiqRegion.my_region_number).order(:id).where.not(:applies_to_class => %w[ServiceTemplate GenericObject])
+        export_custom_buttons_sets
+        export_direct_custom_buttons
 
-        export = objects.each_with_object({}) do |obj, export_hash|
-          if obj.try(:parent).present?
-            next if parent_id_list.include?(obj.parent.id)
-            ExportArInstances.export_object(obj.parent, export_hash)
-            parent_id_list << obj.parent.id
-          else
-            ExportArInstances.export_object(obj, export_hash)
-          end
+        File.write("#{options[:directory]}/CustomButtons.yaml", YAML.dump(@export_hash))
+      end
+
+      def export_custom_buttons_sets
+        @export_hash["custom_button_set"] = []
+
+        CustomButtonSet.all.order(:id).each do |button_set|
+          log_export(button_set)
+
+          children = {}
+          export_direct_custom_buttons(button_set.custom_buttons, children)
+
+          @export_hash["custom_button_set"] << attrs_for(button_set, children)
+        end
+      end
+
+      def export_direct_custom_buttons(buttons = direct_custom_buttons, result = @export_hash)
+        result["custom_button"] = []
+
+        buttons.each do |custom_button|
+          log_export(custom_button)
+
+          result["custom_button"] << attrs_for(custom_button)
+        end
+      end
+
+      private
+
+      def direct_custom_buttons
+        CustomButton.select("custom_buttons.*, relationships.resource_id")
+                    .left_outer_joins(:all_relationships)
+                    .where(:relationships => {:resource_id => nil})
+      end
+
+      def attrs_for(object, children = nil)
+        attrs               = {}
+        attrs["attributes"] = object.attributes.except(*EXCLUDE_ATTRS)
+        attrs["children"]   = children if children
+
+        if (resource_action = object.try(:resource_action))
+          attrs["associations"] = {"resource_action" => [attrs_for(resource_action)]}
         end
 
-        export_dir = options[:directory]
-        File.write("#{export_dir}/CustomButtons.yaml", YAML.dump(export))
+        if (label = object.try(:dialog).try(:label))
+          attrs["attributes"]["dialog_label"] = label
+        end
+
+        attrs
+      end
+
+      def log_export(object)
+        $log.info("Exporting #{object.class.name}: #{object.try('name')} (ID: #{object&.id})")
       end
     end
   end

--- a/spec/lib/task_helpers/exports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/exports/custom_buttons_spec.rb
@@ -1,80 +1,289 @@
 RSpec.describe TaskHelpers::Exports::CustomButtons do
-  let!(:custom_button)     { FactoryBot.create(:custom_button, :name => "export_test_button", :description => "Export Test", :applies_to_class => "Vm") }
-  let!(:custom_button2)    { FactoryBot.create(:custom_button, :name => "export_test_button2", :description => "Export Test", :applies_to_class => "Service") }
-  let!(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "custom_button_set", :description => "Default Export Test") }
-  let(:export_dir)         { Dir.mktmpdir('miq_exp_dir') }
-
-  let(:custom_button_export_test) do
-    {"custom_button_set" => [{
-      "attributes" => {
-        "name"        => "custom_button_set",
-        "description" => "Default Export Test",
-        "set_type"    => "CustomButtonSet",
-        "guid"        => custom_button_set.guid,
-        "read_only"   => nil,
-        "set_data"    => {:button_order => []},
-        "mode"        => nil,
-        "owner_type"  => nil,
-        "owner_id"    => nil,
-        "userid"      => nil,
-        "group_id"    => nil
-      },
-      "children"   => {
-        "custom_button" => [{
-          "attributes" => {
-            "guid"                  => custom_button.guid,
-            "description"           => "Export Test",
-            "applies_to_class"      => "Vm",
-            "visibility_expression" => nil,
-            "options"               => {},
-            "userid"                => nil,
-            "wait_for_complete"     => nil,
-            "name"                  => "export_test_button",
-            "visibility"            => nil,
-            "applies_to_id"         => nil,
-            "enablement_expression" => nil,
-            "disabled_text"         => nil
-          }
-        }]
-      }
-    }],
-     "custom_button"     => [{
-       "attributes" => {
-         "guid"                  => custom_button2.guid,
-         "description"           => "Export Test",
-         "applies_to_class"      => "Service",
-         "visibility_expression" => nil,
-         "options"               => {},
-         "userid"                => nil,
-         "wait_for_complete"     => nil,
-         "name"                  => "export_test_button2",
-         "visibility"            => nil,
-         "applies_to_id"         => nil,
-         "enablement_expression" => nil,
-         "disabled_text"         => nil
-       }
-     }]}
-  end
-
-  before do
-    custom_button_set.add_member(custom_button)
-  end
+  let(:export_dir) { Dir.mktmpdir('miq_exp_dir') }
 
   after do
     FileUtils.remove_entry export_dir
   end
 
-  it 'exports custom buttons to a given directory' do
-    TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
-    file_contents = File.read("#{export_dir}/CustomButtons.yaml")
-    expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_export_test)
-    expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+  context "simple CustomButtonSet and direct CustomButton" do
+    let!(:custom_button)     { FactoryBot.create(:custom_button, :name => "export_test_button", :description => "Export Test", :applies_to_class => "Vm") }
+    let!(:custom_button2)    { FactoryBot.create(:custom_button, :name => "export_test_button2", :description => "Export Test", :applies_to_class => "Service") }
+    let!(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "custom_button_set", :description => "Default Export Test") }
+
+    let(:custom_button_export_test) do
+      {"custom_button_set" => [{
+        "attributes" => {
+          "name"        => "custom_button_set",
+          "description" => "Default Export Test",
+          "set_type"    => "CustomButtonSet",
+          "guid"        => custom_button_set.guid,
+          "read_only"   => nil,
+          "set_data"    => {:button_order => []},
+          "mode"        => nil,
+          "owner_type"  => nil,
+          "owner_id"    => nil,
+          "userid"      => nil,
+          "group_id"    => nil
+        },
+        "children"   => {
+          "custom_button" => [{
+            "attributes" => {
+              "guid"                  => custom_button.guid,
+              "description"           => "Export Test",
+              "applies_to_class"      => "Vm",
+              "visibility_expression" => nil,
+              "options"               => {},
+              "userid"                => nil,
+              "wait_for_complete"     => nil,
+              "name"                  => "export_test_button",
+              "visibility"            => nil,
+              "applies_to_id"         => nil,
+              "enablement_expression" => nil,
+              "disabled_text"         => nil
+            }
+          }]
+        }
+      }],
+       "custom_button"     => [{
+         "attributes" => {
+           "guid"                  => custom_button2.guid,
+           "description"           => "Export Test",
+           "applies_to_class"      => "Service",
+           "visibility_expression" => nil,
+           "options"               => {},
+           "userid"                => nil,
+           "wait_for_complete"     => nil,
+           "name"                  => "export_test_button2",
+           "visibility"            => nil,
+           "applies_to_id"         => nil,
+           "enablement_expression" => nil,
+           "disabled_text"         => nil
+         }
+       }]}
+    end
+
+    before do
+      custom_button_set.add_member(custom_button)
+    end
+
+    it 'exports custom buttons to a given directory' do
+      TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
+      file_contents = File.read("#{export_dir}/CustomButtons.yaml")
+
+      expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_export_test)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+    end
   end
 
-  it 'exports all custom buttons to a given directory' do
-    TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir, :all => true)
-    file_contents = File.read("#{export_dir}/CustomButtons.yaml")
-    expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_export_test)
-    expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+  context "with multiple button sets" do
+    let!(:custom_button1)     { FactoryBot.create(:custom_button,     :name => "button1", :description => "Button One", :applies_to_class => "Vm") }
+    let!(:custom_button2)     { FactoryBot.create(:custom_button,     :name => "button2", :description => "Button Two", :applies_to_class => "Vm") }
+    let!(:custom_button_set1) { FactoryBot.create(:custom_button_set, :name => "set1",    :description => "Set One") }
+    let!(:custom_button_set2) { FactoryBot.create(:custom_button_set, :name => "set2",    :description => "Set Two") }
+
+    before do
+      custom_button_set1.add_member(custom_button1)
+      custom_button_set2.add_member(custom_button2)
+    end
+
+    let(:multi_custom_button_export_test) do
+      {
+        "custom_button_set" => [
+          {
+            "attributes" => {
+              "name"        => "set1",
+              "description" => "Set One",
+              "set_type"    => "CustomButtonSet",
+              "guid"        => custom_button_set1.guid,
+              "read_only"   => nil,
+              "set_data"    => {:button_order => []},
+              "mode"        => nil,
+              "owner_type"  => nil,
+              "owner_id"    => nil,
+              "userid"      => nil,
+              "group_id"    => nil
+            },
+            "children"   => {
+              "custom_button" => [{
+                "attributes" => {
+                  "guid"                  => custom_button1.guid,
+                  "description"           => "Button One",
+                  "applies_to_class"      => "Vm",
+                  "visibility_expression" => nil,
+                  "options"               => {},
+                  "userid"                => nil,
+                  "wait_for_complete"     => nil,
+                  "name"                  => "button1",
+                  "visibility"            => nil,
+                  "applies_to_id"         => nil,
+                  "enablement_expression" => nil,
+                  "disabled_text"         => nil
+                }
+              }],
+            },
+          },
+          {
+            "attributes" => {
+              "name"        => "set2",
+              "description" => "Set Two",
+              "set_type"    => "CustomButtonSet",
+              "guid"        => custom_button_set2.guid,
+              "read_only"   => nil,
+              "set_data"    => {:button_order => []},
+              "mode"        => nil,
+              "owner_type"  => nil,
+              "owner_id"    => nil,
+              "userid"      => nil,
+              "group_id"    => nil
+            },
+            "children"   => {
+              "custom_button" => [{
+                "attributes" => {
+                  "guid"                  => custom_button2.guid,
+                  "description"           => "Button Two",
+                  "applies_to_class"      => "Vm",
+                  "visibility_expression" => nil,
+                  "options"               => {},
+                  "userid"                => nil,
+                  "wait_for_complete"     => nil,
+                  "name"                  => "button2",
+                  "visibility"            => nil,
+                  "applies_to_id"         => nil,
+                  "enablement_expression" => nil,
+                  "disabled_text"         => nil
+                }
+              }]
+            }
+          }
+        ],
+        "custom_button"     => []
+      }
+    end
+
+    it 'exports custom buttons to a given directory' do
+      TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
+      file_contents = File.read("#{export_dir}/CustomButtons.yaml")
+
+      expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*multi_custom_button_export_test)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+    end
+  end
+
+  context "with buttons with resource_actions and dialogs" do
+    let!(:custom_button1)     { FactoryBot.create(:custom_button,     :name => "button1", :description => "Button One", :applies_to_class => "Vm", :resource_action => resource_action1) }
+    let!(:custom_button2)     { FactoryBot.create(:custom_button,     :name => "button2", :description => "Button Two", :applies_to_class => "Vm", :resource_action => resource_action2) }
+    let!(:custom_button_set1) { FactoryBot.create(:custom_button_set, :name => "set1",    :description => "Set One") }
+
+    let(:resource_action1) do
+      FactoryBot.build(:resource_action,
+                       :ae_namespace => "NAMESPACE",
+                       :ae_class     => "CLASS",
+                       :ae_instance  => "INSTANCE")
+    end
+
+    let(:resource_action2) do
+      FactoryBot.build(:resource_action,
+                       :ae_namespace => "SYSTEM",
+                       :ae_class     => "PROCESS",
+                       :ae_instance  => "Request",
+                       :dialog       => FactoryBot.create(:dialog, :name => "label1"))
+    end
+
+    before do
+      custom_button_set1.add_member(custom_button1)
+    end
+
+    let(:custom_button_with_dialogs_export_test) do
+      {
+        "custom_button_set" => [{
+          "attributes" => {
+            "name"        => "set1",
+            "description" => "Set One",
+            "set_type"    => "CustomButtonSet",
+            "guid"        => custom_button_set1.guid,
+            "read_only"   => nil,
+            "set_data"    => {:button_order => []},
+            "mode"        => nil,
+            "owner_type"  => nil,
+            "owner_id"    => nil,
+            "userid"      => nil,
+            "group_id"    => nil
+          },
+          "children"   => {
+            "custom_button" => [{
+              "attributes"   => {
+                "guid"                  => custom_button1.guid,
+                "description"           => "Button One",
+                "applies_to_class"      => "Vm",
+                "visibility_expression" => nil,
+                "options"               => {},
+                "userid"                => nil,
+                "wait_for_complete"     => nil,
+                "name"                  => "button1",
+                "visibility"            => nil,
+                "applies_to_id"         => nil,
+                "enablement_expression" => nil,
+                "disabled_text"         => nil
+              },
+              "associations" => {
+                "resource_action" => [{
+                  "attributes" => {
+                    "action"                      => nil,
+                    "ae_namespace"                => "NAMESPACE",
+                    "ae_class"                    => "CLASS",
+                    "ae_instance"                 => "INSTANCE",
+                    "ae_message"                  => nil,
+                    "ae_attributes"               => {},
+                    "configuration_template_id"   => nil,
+                    "configuration_template_type" => nil,
+                    "resource_type"               => "CustomButton"
+                  }
+                }]
+              }
+            }],
+          },
+        }],
+        "custom_button" => [{
+          "attributes" => {
+            "guid"                  => custom_button2.guid,
+            "description"           => "Button Two",
+            "applies_to_class"      => "Vm",
+            "visibility_expression" => nil,
+            "options"               => {},
+            "userid"                => nil,
+            "wait_for_complete"     => nil,
+            "name"                  => "button2",
+            "visibility"            => nil,
+            "applies_to_id"         => nil,
+            "enablement_expression" => nil,
+            "disabled_text"         => nil
+          },
+          "associations" => {
+            "resource_action" => [{
+              "attributes" => {
+                "action"                      => nil,
+                "resource_type"               => "CustomButton",
+                "ae_namespace"                => "SYSTEM",
+                "ae_class"                    => "PROCESS",
+                "ae_instance"                 => "Request",
+                "ae_message"                  => nil,
+                "ae_attributes"               => {},
+                "configuration_template_id"   => nil,
+                "configuration_template_type" => nil,
+                "dialog_label"                => "label1"
+              }
+            }]
+          }
+        }]
+      }
+    end
+
+    it 'exports custom buttons to a given directory' do
+      TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
+      file_contents = File.read("#{export_dir}/CustomButtons.yaml")
+
+      expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_with_dialogs_export_test)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
The previous implementation of this exporter used very abstract logic to export the specific data items needed.  While incredibly DRY as a result, it is also very hard to parse and when the underlying DB structure changes, it is even harder to fix (#foreshadowing)

As a result, the change specifically makes it so the class is much more direct in what it is exporting, and hopefully makes it easier to digest on how it is working as well.


Links
-----

* Related to this effort:  https://github.com/ManageIQ/manageiq/pull/21241