### PR TITLE
[miq_widget_spec.rb] Use add_member()

### DIFF
--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe MiqWidget do
         before do
           ws = FactoryBot.create(:miq_widget_set, :name => "Home", :owner => @user1, :userid => @user1.userid, :group => @group1)
 
-          @widget_report_vendor_and_guest_os.make_memberof(ws)
+          ws.add_member(@widget_report_vendor_and_guest_os)
         end
 
         it "returns non-empty array when widget has subscribers" do
@@ -154,7 +154,7 @@ RSpec.describe MiqWidget do
           (1..3).each do |_i|
             user_i = add_user(@group2)
             ws_i   = add_dashboard_for_user("Home", user_i.userid, @group2)
-            @widget_report_vendor_and_guest_os.make_memberof(ws_i)
+            ws_i.add_member(@widget_report_vendor_and_guest_os)
             users << user_i
           end
 
@@ -168,7 +168,7 @@ RSpec.describe MiqWidget do
         it 'ignores the user that does not exist any more' do
           user_temp = add_user(@group1)
           ws_temp   = add_dashboard_for_user("Home", user_temp.userid, @group1)
-          @widget_report_vendor_and_guest_os.make_memberof(ws_temp)
+          ws_temp.add_member(@widget_report_vendor_and_guest_os)
 
           user_temp.delete
           result = @widget_report_vendor_and_guest_os.grouped_subscribers
@@ -676,8 +676,8 @@ RSpec.describe MiqWidget do
 
     context "for non-self service user" do
       before do
-        widget.make_memberof(@ws1)
-        widget.make_memberof(@ws2)
+        @ws1.add_member(widget)
+        @ws2.add_member(widget)
       end
 
       it "queued based on group/TZs of User's in the group" do
@@ -730,8 +730,8 @@ RSpec.describe MiqWidget do
     context "for self service user" do
       before do
         @role.update(:settings => {:restrictions => {:vms => :user}})
-        widget.make_memberof(@ws1)
-        widget.make_memberof(@ws2)
+        @ws1.add_member(widget)
+        @ws2.add_member(widget)
         widget.queue_generate_content
       end
 
@@ -754,11 +754,10 @@ RSpec.describe MiqWidget do
       before do
         @role.update(:settings => {:restrictions => {:vms => :user_or_group}})
         @group2 = FactoryBot.create(:miq_group, :miq_user_role => @role)
-
         @ws3 = FactoryBot.create(:miq_widget_set, :name   => "HOME",
                                                   :userid => @user1.userid,
                                                   :owner  => @group2)
-        widget.make_memberof(@ws3)
+        @ws3.add_member(widget)
 
         @user1.miq_groups = [@group, @group2]
         @user1.save


### PR DESCRIPTION
Instead of using `#make_memberof` for these specs, us `#add_member` which works off of the set method instead of the members method.


Links
-----

* Pulled out of https://github.com/ManageIQ/manageiq/pull/21241