### PR TITLE
Faster migrations

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -31,10 +31,10 @@ module ArPglogicalMigrationHelper
       end
 
       to_add.each do |v|
-        ActiveRecord::Base.connection.execute("INSERT INTO schema_migrations_ran (version, created_at) VALUES ('#{v}', '#{Time.now.utc.iso8601(6)}')")
+        ActiveRecord::Base.connection.exec_insert("INSERT INTO schema_migrations_ran (version, created_at) VALUES ($1, $2)", "SQL", [[nil, v], [nil, Time.now.utc.iso8601(6)]])
       end
     else
-      ActiveRecord::Base.connection.execute("DELETE FROM schema_migrations_ran WHERE version = '#{version}'")
+      ActiveRecord::Base.connection.exec_delete("DELETE FROM schema_migrations_ran WHERE version = $1", "SQL", [[nil, version]])
     end
   end
 

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -27,7 +27,7 @@ module ArPglogicalMigrationHelper
       end
 
       to_add.each do |v|
-        ActiveRecord::Base.connection.execute("INSERT INTO schema_migrations_ran (version, created_at) VALUES ('#{v}', '#{Time.now.utc.iso8601}')")
+        ActiveRecord::Base.connection.execute("INSERT INTO schema_migrations_ran (version, created_at) VALUES ('#{v}', '#{Time.now.utc.iso8601(6)}')")
       end
     else
       ActiveRecord::Base.connection.execute("DELETE FROM schema_migrations_ran WHERE version = '#{version}'")

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -21,7 +21,6 @@ module ArPglogicalMigrationHelper
     if direction == :up
       if version == SCHEMA_MIGRATIONS_RAN_MIGRATION
         to_add = ActiveRecord::SchemaMigration.normalized_versions << version
-        puts "Seeding :schema_migrations_ran table..."
       else
         to_add = [version]
       end

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,11 +1,11 @@
 module ArPglogicalMigrationHelper
   SCHEMA_MIGRATIONS_RAN_MIGRATION = "20171031010000".freeze
-  def self.schema_migrations_ran_exists?(version)
+  def self.schema_migrations_ran_exists?
     ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
   end
 
-  def self.discover_schema_migrations_ran_class(version)
-    return unless schema_migrations_ran_exists?(version)
+  def self.discover_schema_migrations_ran_class
+    return unless schema_migrations_ran_exists?
 
     Class.new(ActiveRecord::Base) do
       require 'active_record-id_regions'
@@ -16,7 +16,7 @@ module ArPglogicalMigrationHelper
   end
 
   def self.update_local_migrations_ran(version, direction)
-    return unless schema_migrations_ran_exists?(version)
+    return unless schema_migrations_ran_exists?
 
     if direction == :up
       if version == SCHEMA_MIGRATIONS_RAN_MIGRATION
@@ -40,7 +40,7 @@ module ArPglogicalMigrationHelper
     attr_reader :subscription, :version, :schema_migrations_ran_class
 
     def initialize(subscription, version)
-      @schema_migrations_ran_class = ArPglogicalMigrationHelper.discover_schema_migrations_ran_class(version)
+      @schema_migrations_ran_class = ArPglogicalMigrationHelper.discover_schema_migrations_ran_class
       @subscription                = subscription
       @version                     = version
     end

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -22,9 +22,7 @@ module ArPglogicalMigrationHelper
 
     if direction == :up
       if version == "20171031010000"
-        new_migrations = ActiveRecord::SchemaMigration.normalized_versions
-        new_migrations << version
-        to_add = (new_migrations - schema_migrations_ran_class.pluck(:version))
+        to_add = ActiveRecord::SchemaMigration.normalized_versions << version
         puts "Seeding :schema_migrations_ran table..."
       else
         to_add = [version]

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,15 +1,7 @@
 module ArPglogicalMigrationHelper
   SCHEMA_MIGRATIONS_RAN_MIGRATION = "20171031010000".freeze
   def self.schema_migrations_ran_exists?(version)
-    # Schema versions less than 20171031010000 certainly don't have the table, so we can
-    # avoid excessive queries but since this method is called both before AND after a migration
-    # from the ArPglogicalMigration prepended module, 20171031010000 is different based on direction:
-    #   migrate up   - before: missing, after: exists
-    #   migrate down - before: exists,  after: missing
-    # Therefore, we need to query the table for that migration.
-    return false if version < SCHEMA_MIGRATIONS_RAN_MIGRATION
-    return false if version == SCHEMA_MIGRATIONS_RAN_MIGRATION && !ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
-    true
+    ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
   end
 
   def self.discover_schema_migrations_ran_class(version)

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,5 +1,10 @@
 module ArPglogicalMigrationHelper
   SCHEMA_MIGRATIONS_RAN_MIGRATION = "20171031010000".freeze
+
+  def self.subscriptions
+    @subscriptions ||= PglogicalSubscription.all
+  end
+
   def self.schema_migrations_ran_exists?
     ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
   end
@@ -90,7 +95,7 @@ end
 
 module ArPglogicalMigration
   def migrate(direction)
-    PglogicalSubscription.all.each do |s|
+    ArPglogicalMigrationHelper.subscriptions.each do |s|
       ArPglogicalMigrationHelper::RemoteRegionMigrationWatcher.new(s, version.to_s).wait_for_remote_region_migration
     end
     ret = super

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -29,10 +29,10 @@ module ArPglogicalMigrationHelper
       end
 
       to_add.each do |v|
-        schema_migrations_ran_class.create!(:version => v)
+        ActiveRecord::Base.connection.execute("INSERT INTO schema_migrations_ran (version, created_at) VALUES ('#{v}', '#{Time.now.utc.iso8601}')")
       end
     else
-      schema_migrations_ran_class.where(:version => version).delete_all
+      ActiveRecord::Base.connection.execute("DELETE FROM schema_migrations_ran WHERE version = '#{version}'")
     end
   end
 


### PR DESCRIPTION
### Summary

We eliminated much of the needless queries, work that was only needed for `up` direction also happening in `down`, activerecord issues with our constant cache clearing, and caching of pg logical subscriptions [1].  

- [x] Still need to test with regions and subscriptions

Results with a local database:

```
rake up:   ~100 seconds before, 42 seconds after
rake down: ~70 seconds before, 27 seconds after
```

### Timings

```
git checkout poc_faster_migrations

for z in `seq 0 4`
do
 dropdb vmdb_test
 createdb vmdb_test
 time (RAILS_ENV=test bundle exec rake db:migrate > /dev/null)
 time (RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null)
done

echo
echo

git checkout master

for z in `seq 0 4`
do
 dropdb vmdb_test
 createdb vmdb_test
 time (RAILS_ENV=test bundle exec rake db:migrate > /dev/null)
 time (RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null)
done
```


```
Already on 'poc_faster_migrations'
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  11.19s user 7.56s system 58% cpu 31.799 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  9.70s user 6.51s system 60% cpu 26.591 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  11.93s user 6.67s system 43% cpu 42.693 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  9.98s user 6.56s system 59% cpu 27.875 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  11.97s user 6.67s system 44% cpu 42.245 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  9.61s user 6.50s system 58% cpu 27.322 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  11.84s user 6.77s system 43% cpu 42.805 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  9.79s user 6.51s system 58% cpu 27.667 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  11.71s user 6.65s system 44% cpu 41.443 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  9.47s user 6.75s system 64% cpu 25.263 total


Switched to branch 'master'
Your branch is up to date with 'upstream/master'.
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  72.02s user 8.01s system 63% cpu 2:06.99 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  49.30s user 6.90s system 81% cpu 1:09.35 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  61.80s user 6.97s system 77% cpu 1:28.80 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  50.36s user 7.02s system 77% cpu 1:13.96 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  71.07s user 7.40s system 68% cpu 1:53.99 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  49.69s user 7.04s system 80% cpu 1:10.72 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  69.11s user 7.40s system 71% cpu 1:47.16 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  50.79s user 7.10s system 77% cpu 1:14.43 total
( RAILS_ENV=test bundle exec rake db:migrate > /dev/null; )  71.27s user 7.76s system 69% cpu 1:53.19 total
( RAILS_ENV=test bundle exec rake db:migrate VERSION=0 > /dev/null; )  49.91s user 7.04s system 79% cpu 1:11.43 total
```

[1] We'll still need https://github.com/ManageIQ/pg-logical_replication/pull/6 but the change here to cache subscription information makes sense as it shouldn't change once you start migrating the database.

