### PR TITLE
Validate requested FirmwareRegistry type

### DIFF
--- a/app/models/firmware_registry.rb
+++ b/app/models/firmware_registry.rb
@@ -32,7 +32,10 @@ class FirmwareRegistry < ApplicationRecord
   end
 
   def self.create_firmware_registry(options)
-    klass = options.delete(:type).constantize
+    type = options.delete(:type)
+    raise ArgumentError, _("Invalid firmware registry type [#{type}]") unless descendants.map(&:name).include?(type)
+
+    klass = type.constantize
     options = klass.validate_options(options.deep_symbolize_keys)
     klass.do_create_firmware_registry(options).tap(&:sync_fw_binaries_queue)
   end

--- a/spec/models/firmware_registry_spec.rb
+++ b/spec/models/firmware_registry_spec.rb
@@ -69,11 +69,16 @@ RSpec.describe FirmwareRegistry do
 
   describe '.create_firmware_registry' do
     let(:registry) { double('registry') }
+
     it 'creates registry and triggers refresh' do
       expect(FirmwareRegistry::RestApiDepot).to receive(:validate_options) { |options| options }
       expect(FirmwareRegistry::RestApiDepot).to receive(:do_create_firmware_registry).with(:a => 'A').and_return(registry)
       expect(registry).to receive(:sync_fw_binaries_queue)
       described_class.create_firmware_registry(:type => 'FirmwareRegistry::RestApiDepot', :a => 'A')
+    end
+
+    it 'raises an ArgumentError with an invalid type' do
+      expect { described_class.create_firmware_registry(:type => 'MyFirmwareRegistry') }.to raise_error(ArgumentError, 'Invalid firmware registry type [MyFirmwareRegistry]')
     end
   end
 end


### PR DESCRIPTION
When creating a firmware registry with `FirmwareRegistry.create_firmware_registry` validate the reqeusted type is valid.