### PR TITLE
Bump brakeman to fix wrong loofah gem warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -276,7 +276,7 @@ unless ENV["APPLIANCE"]
   end
 
   group :test do
-    gem "brakeman",                     "~>4.8",             :require => false
+    gem "brakeman",                     "~>5.0",             :require => false
     gem "bundler-audit",                                     :require => false
     gem "capybara",                     "~>2.5.0",           :require => false
     gem "coveralls",                    "~>0.8.23",          :require => false


### PR DESCRIPTION
Pull in latest brakeman version to fix an invalid loofah gem security warning

https://github.com/presidentbeef/brakeman/pull/1607