### PR TITLE
Allow kafka to be used for EmsEvents

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -197,7 +197,7 @@ class EmsEvent < EventStream
   private_class_method :event_blacklisted_keys
 
   def self.create_event(event)
-    event.delete_if { |k,| event.event_blacklisted_keys.include?(k) || (k.to_s.ends_with?("_ems_ref") && !event_allowed_ems_ref_keys.include?(k.to_s)) }
+    event.delete_if { |k,| event_blacklisted_keys.include?(k) || (k.to_s.ends_with?("_ems_ref") && !event_allowed_ems_ref_keys.include?(k.to_s)) }
 
     new_event = EmsEvent.create(event) unless EmsEvent.exists?(
       :event_type  => event[:event_type],

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -35,7 +35,7 @@ class EmsEvent < EventStream
       )
     else
       MiqQueue.messaging_client('event_handler')&.publish_topic(
-        :service => MiqEventHandler.default_queue_name,
+        :service => "manageiq.#{MiqEventHandler.default_queue_name}",
         :sender  => ems_id,
         :event   => event[:event_type],
         :payload => event

--- a/app/models/miq_event_handler.rb
+++ b/app/models/miq_event_handler.rb
@@ -3,8 +3,9 @@ class MiqEventHandler < MiqQueueWorkerBase
 
   require_nested :Runner
 
-  self.required_roles       = ["event"]
-  self.default_queue_name   = "ems"
+  self.required_roles               = ["event"]
+  self.default_queue_name           = "ems"
+  self.miq_messaging_subscribe_mode = "topic"
 
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_EVENT_HANDLERS

--- a/app/models/miq_event_handler/runner.rb
+++ b/app/models/miq_event_handler/runner.rb
@@ -1,8 +1,4 @@
 class MiqEventHandler::Runner < MiqQueueWorkerBase::Runner
-  def self.miq_messaging_service
-    "manageiq.ems-events"
-  end
-
   def process_miq_messaging_message(msg)
     EmsEvent.add(msg.sender, msg.payload.deep_symbolize_keys)
   end

--- a/app/models/miq_event_handler/runner.rb
+++ b/app/models/miq_event_handler/runner.rb
@@ -1,2 +1,5 @@
 class MiqEventHandler::Runner < MiqQueueWorkerBase::Runner
+  def self.kafka_service
+    "manageiq.ems-events"
+  end
 end

--- a/app/models/miq_event_handler/runner.rb
+++ b/app/models/miq_event_handler/runner.rb
@@ -1,5 +1,15 @@
 class MiqEventHandler::Runner < MiqQueueWorkerBase::Runner
-  def self.kafka_service
+  def self.miq_messaging_service
     "manageiq.ems-events"
+  end
+
+  def deliver_message(msg)
+    return process_miq_messaging_message(msg) if msg.kind_of?(ManageIQ::Messaging::ReceivedMessage)
+
+    super
+  end
+
+  def process_miq_messaging_message(msg)
+    EmsEvent.add(msg.sender, msg.payload.deep_symbolize_keys)
   end
 end

--- a/app/models/miq_event_handler/runner.rb
+++ b/app/models/miq_event_handler/runner.rb
@@ -3,12 +3,6 @@ class MiqEventHandler::Runner < MiqQueueWorkerBase::Runner
     "manageiq.ems-events"
   end
 
-  def deliver_message(msg)
-    return process_miq_messaging_message(msg) if msg.kind_of?(ManageIQ::Messaging::ReceivedMessage)
-
-    super
-  end
-
   def process_miq_messaging_message(msg)
     EmsEvent.add(msg.sender, msg.payload.deep_symbolize_keys)
   end

--- a/app/models/miq_queue_worker_base.rb
+++ b/app/models/miq_queue_worker_base.rb
@@ -1,6 +1,8 @@
 class MiqQueueWorkerBase < MiqWorker
   require_nested :Runner
 
+  class_attribute :miq_messaging_subscribe_mode
+
   def self.queue_priority
     MiqQueue::MIN_PRIORITY
   end

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -14,7 +14,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def dequeue_method_via_miq_messaging?
-    @dequeue_method != :miq_queue && miq_messaging_dequeue_available?
+    @dequeue_method == :miq_messaging && miq_messaging_dequeue_available?
   end
 
   def get_message_via_drb

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -119,14 +119,18 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def deliver_message(msg)
-    return deliver_queue_message(msg)         if msg.kind_of?(MiqQueue)
-    return process_miq_messaging_message(msg) if msg.kind_of?(ManageIQ::Messaging::ReceivedMessage)
-    return process_message(msg)               if msg.kind_of?(String)
-
-    _log.error("#{log_prefix} Message <#{msg.inspect}> is of unknown type <#{msg.class}>")
-    raise _("%{log} Message <%{message}> is of unknown type <%{type}>") % {:log     => log_prefix,
-                                                                           :message => msg.inspect,
-                                                                           :type    => msg.class}
+    case msg
+    when MiqQueue
+      deliver_queue_message(msg)
+    when ManageIQ::Messaging::ReceivedMessage
+      process_miq_messaging_message(msg)
+    when String
+      process_message(msg)
+    else
+      _log.error("#{log_prefix} Message <#{msg.inspect}> is of unknown type <#{msg.class}>")
+      raise _("%{log} Message <%{message}> is of unknown type <%{type}>") %
+            {:log => log_prefix, :message => msg.inspect, :type => msg.class}
+    end
   end
 
   def do_work

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -119,8 +119,9 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def deliver_message(msg)
-    return deliver_queue_message(msg) if msg.kind_of?(MiqQueue)
-    return process_message(msg)       if msg.kind_of?(String)
+    return deliver_queue_message(msg)         if msg.kind_of?(MiqQueue)
+    return process_miq_messaging_message(msg) if msg.kind_of?(ManageIQ::Messaging::ReceivedMessage)
+    return process_message(msg)               if msg.kind_of?(String)
 
     _log.error("#{log_prefix} Message <#{msg.inspect}> is of unknown type <#{msg.class}>")
     raise _("%{log} Message <%{message}> is of unknown type <%{type}>") % {:log     => log_prefix,
@@ -160,6 +161,10 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
 
   def miq_messaging_dequeue_available?
     MiqQueue.messaging_type != "miq_queue" && MiqQueue.messaging_client(self.class.name).present?
+  end
+
+  def process_miq_messaging_message(_msg)
+    raise NotImplementedError, 'Must be implemented in subclass'
   end
 
   # Only for file based heartbeating

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -6,7 +6,10 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def sync_dequeue_method
+    previous_dequeue_method = @dequeue_method
     @dequeue_method = (worker_settings[:dequeue_method] || :sql).to_sym
+
+    dequeue_method_changed(previous_dequeue_method) if @dequeue_method != previous_dequeue_method
   end
 
   def dequeue_method_via_drb?
@@ -15,6 +18,10 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
 
   def dequeue_method_via_miq_messaging?
     @dequeue_method == :miq_messaging && miq_messaging_dequeue_available?
+  end
+
+  def dequeue_method_changed(previous_dequeue_method)
+    @listener_thread&.kill if previous_dequeue_method == :miq_messaging
   end
 
   def get_message_via_drb

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -78,7 +78,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
     @listener_thread = nil if @listener_thread && !@listener_thread.alive?
     @listener_thread ||= Thread.new do
       MiqQueue.messaging_client(self.class.name)
-              .subscribe_topic(:service => self.class.miq_messaging_service, :persist_ref => @worker.guid) do |msg|
+              .subscribe_topic(:service => @worker.queue_name, :persist_ref => @worker.guid) do |msg|
         @message_queue << msg
       end
     end

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -187,12 +187,12 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
 
   def miq_messaging_subscribe_topic(&block)
     messaging_client = MiqQueue.messaging_client(self.class.name)
-    messaging_client.subscribe_topic(:service => @worker.queue_name, :persist_ref => @worker.guid, &block)
+    messaging_client.subscribe_topic(:service => "manageiq.#{@worker.queue_name}", :persist_ref => @worker.guid, &block)
   end
 
   def miq_messaging_subscribe_queue(&block)
     messaging_client = MiqQueue.messaging_client(self.class.name)
-    messaging_client.subscribe_messages(:service => @worker.queue_name) do |messages|
+    messaging_client.subscribe_messages(:service => "manageiq.#{@worker.queue_name}") do |messages|
       messages.each(&block)
     end
   end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -127,28 +127,16 @@ RSpec.describe EmsEvent do
           messaging_client = double("ManageIQ::Messaging")
 
           expected_queue_payload = {
-            :service => "manageiq.ems-events",
+            :service => "ems",
             :sender  => ems.id,
             :event   => event_hash[:event_type],
-            :payload => event_hash.merge(
-              :ems_type => ems.class.ems_type,
-              :ems_uid  => ems.uid_ems
-            )
+            :payload => event_hash
           }
 
           expect(messaging_client).to receive(:publish_topic).with(expected_queue_payload)
           expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client)
 
           described_class.add_queue('add', ems.id, event_hash)
-        end
-
-        context "event_streams.syndicate_events false" do
-          before { stub_settings_merge(:event_streams => {:syndicate_events => false}) }
-
-          it "doesn't add event to Artemis queue" do
-            expect(MiqQueue).not_to receive(:messaging_client)
-            described_class.add_queue('add', ems.id, event_hash)
-          end
         end
       end
 
@@ -159,28 +147,16 @@ RSpec.describe EmsEvent do
           messaging_client = double("ManageIQ::Messaging")
 
           expected_queue_payload = {
-            :service => "manageiq.ems-events",
+            :service => "ems",
             :sender  => ems.id,
             :event   => event_hash[:event_type],
-            :payload => event_hash.merge(
-              :ems_type => ems.class.ems_type,
-              :ems_uid  => ems.uid_ems
-            )
+            :payload => event_hash
           }
 
           expect(messaging_client).to receive(:publish_topic).with(expected_queue_payload)
           expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client)
 
           described_class.add_queue('add', ems.id, event_hash)
-        end
-
-        context "event_streams.syndicate_events false" do
-          before { stub_settings_merge(:event_streams => {:syndicate_events => false}) }
-
-          it "doesn't add event to kafka topic" do
-            expect(MiqQueue).not_to receive(:messaging_client)
-            described_class.add_queue('add', ems.id, event_hash)
-          end
         end
       end
 

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe EmsEvent do
           messaging_client = double("ManageIQ::Messaging")
 
           expected_queue_payload = {
-            :service => "ems",
+            :service => "manageiq.ems",
             :sender  => ems.id,
             :event   => event_hash[:event_type],
             :payload => event_hash
@@ -147,7 +147,7 @@ RSpec.describe EmsEvent do
           messaging_client = double("ManageIQ::Messaging")
 
           expected_queue_payload = {
-            :service => "ems",
+            :service => "manageiq.ems",
             :sender  => ems.id,
             :event   => event_hash[:event_type],
             :payload => event_hash


### PR DESCRIPTION
This adds the option for kafka to be used as the backend mechanism for publishing and consuming ems_events instead of MiqQueue.

https://github.com/ManageIQ/manageiq/issues/20027