### PR TITLE
Upgrade dalli past 2.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :requ
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false
-gem "dalli",                            "=2.7.6",            :require => false
+gem "dalli",                            "~>2.7.8",           :require => false
 gem "default_value_for",                "~>3.3"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false


### PR DESCRIPTION
We were locked down to 2.7.6 due to issues with 2.7.7, but it was fixed in 2.7.8
This effectively reverts https://github.com/ManageIQ/manageiq/pull/17159 and sets the minimum to 2.7.8
2.7.8 includes https://github.com/petergoldstein/dalli/pull/679