### PR TITLE
Fix unsupported_reason_add with wrong the feature

### DIFF
--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -12,7 +12,7 @@ module Vm::Operations::Lifecycle
       reason   = _("Publish not supported because VM is blank")    if blank?
       reason ||= _("Publish not supported because VM is orphaned") if orphaned?
       reason ||= _("Publish not supported because VM is archived") if archived?
-      unsupported_reason_add(:retire, reason) if reason
+      unsupported_reason_add(:publish, reason) if reason
     end
 
     api_relay_method :retire do |options|

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -8,7 +8,7 @@ module VmOrTemplate::Operations::Relocation
       reason   = _("Migrate not supported because VM is blank")    if blank?
       reason ||= _("Migrate not supported because VM is orphaned") if orphaned?
       reason ||= _("Migrate not supported because VM is archived") if archived?
-      unsupported_reason_add(:retire, reason) if reason
+      unsupported_reason_add(:migrate, reason) if reason
     end
   end
 


### PR DESCRIPTION
The unsupported_reason_add method takes a feature which is being marked as unsupported.  In some cases this doesn't match the feature that is being checked which will incorrectly mark that feature supported and the other unsupported.