### PR TITLE
Add rack-attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "pg",                                                    :require => false
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "psych",                            "~>3.1",             :require => false # This can be dropped once we drop ruby 2.5
 gem "query_relation",                   "~>0.1.0",           :require => false
+gem "rack-attack",                      "~>6.5.0",           :require => false
 gem "rails",                            "~>6.0.3", ">=6.0.3.7"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,37 @@
+if defined?(Rails::Server) && !Rails.env.test?
+  require 'rack/attack'
+
+  # The `rack/attack/railtie.rb` creates a `initializer` call, which is loaded
+  # too late because of the `:require => false` in our Gemfile, so this needs
+  # to be done manually.
+  Rails.application.middleware.use(Rack::Attack)
+
+  api_login_limit  = proc { ::Settings.server.rate_limiting.api_login.limit }
+  api_login_period = proc { ::Settings.server.rate_limiting.api_login.period.to_i_with_method }
+  request_limit    = proc { ::Settings.server.rate_limiting.request.limit }
+  request_period   = proc { ::Settings.server.rate_limiting.request.period.to_i_with_method }
+  ui_login_limit   = proc { ::Settings.server.rate_limiting.ui_login.limit }
+  ui_login_period  = proc { ::Settings.server.rate_limiting.ui_login.period.to_i_with_method }
+
+  # Throttle all requests by IP
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  Rack::Attack.throttle('req/ip', :limit => request_limit, :period => request_period) do |req| # rubocop:disable Style/SymbolProc
+    req.ip
+  end
+
+  # Throttle POST requests to /login by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  Rack::Attack.throttle('logins/ip', :limit => api_login_limit, :period => api_login_period) do |req|
+    if req.path == "/api/auth" && req.post?
+      req.ip
+    end
+  end
+
+  Rack::Attack.throttle('logins/ip', :limit => ui_login_limit, :period => ui_login_period) do |req|
+    if req.path == "/dashboard/authenticate" && req.post?
+      req.ip
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -950,6 +950,16 @@
   :prefetch_max_per_worker_dequeue: 100
   :prefetch_min_per_worker_dequeue: 10
   :prefetch_stale_threshold: 30.seconds
+  :rate_limiting:
+    :api_login:
+      :limit: 5
+      :period: 20.seconds
+    :request:
+      :limit: 300
+      :period: 5.minutes
+    :ui_login:
+      :limit: 5
+      :period: 20.seconds
   :role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,remote_console,web_services,automate
   :server_dequeue_frequency: 5.seconds
   :server_log_frequency: 5.minutes

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -31,6 +31,23 @@ module Vmdb
 
       private
 
+      def integer_with_method?(num)
+        if is_integer?(num.to_i_with_method) && num.present?
+          # handling the "Five".to_i == 0 case
+          #
+          # Allows:
+          #
+          #   - 0
+          #   - 0.minutes (always will be zero)
+          #   - any integer
+          #   - any integer + method
+          #
+          num.to_i_with_method != 0 || num.to_s.match?(/^0(?=\..*|$)/)
+        else
+          num.blank?
+        end
+      end
+
       def webservices(data)
         valid, errors = true, []
 

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -51,6 +51,27 @@ RSpec.describe Vmdb::Settings::Validator do
     {:server => {:listening_port => nil}},   true,
     {:server => {:listening_port => "xxx"}}, false,
 
+    {:server => {:rate_limiting => {:api_login => {:limit => 5, :period => 5.minutes}}}}, true,
+    {:server => {:rate_limiting => {:api_login => {:limit => 5, :period => "30.seconds"}}}}, true,
+    {:server => {:rate_limiting => {:api_login => {:limit => "Five", :period => 30.seconds}}}}, false,
+    {:server => {:rate_limiting => {:api_login => {:limit => 5, :period => "Five minutes"}}}}, false,
+    {:server => {:rate_limiting => {:api_login => {:limit => 5, :period => nil}}}}, false,
+    {:server => {:rate_limiting => {:api_login => {:limit => nil, :period => 5}}}}, false,
+
+    {:server => {:rate_limiting => {:request => {:limit => 5, :period => 5.minutes}}}}, true,
+    {:server => {:rate_limiting => {:request => {:limit => 5, :period => "30.seconds"}}}}, true,
+    {:server => {:rate_limiting => {:request => {:limit => "Five", :period => 30.seconds}}}}, false,
+    {:server => {:rate_limiting => {:request => {:limit => 5, :period => "Five minutes"}}}}, false,
+    {:server => {:rate_limiting => {:request => {:limit => 5, :period => nil}}}}, false,
+    {:server => {:rate_limiting => {:request => {:limit => nil, :period => 5}}}}, false,
+
+    {:server => {:rate_limiting => {:ui_login => {:limit => 5, :period => 5.minutes}}}}, true,
+    {:server => {:rate_limiting => {:ui_login => {:limit => 5, :period => "30.seconds"}}}}, true,
+    {:server => {:rate_limiting => {:ui_login => {:limit => "Five", :period => 30.seconds}}}}, false,
+    {:server => {:rate_limiting => {:ui_login => {:limit => 5, :period => "Five minutes"}}}}, false,
+    {:server => {:rate_limiting => {:ui_login => {:limit => 5, :period => nil}}}}, false,
+    {:server => {:rate_limiting => {:ui_login => {:limit => nil, :period => 5}}}}, false,
+
     {:server => {:session_store => "cache"}}, true,
     {:server => {:session_store => "xxx"}},   false,
 


### PR DESCRIPTION
Uses a modified default config from here:

https://github.com/rack/rack-attack/blob/6-stable/docs/example_configuration.md

And leverages `Settings` to allow for user configuration.  Disabled in `RAILS_ENV=test`


Steps for Testing/QA
--------------------

I ran a quick script to test that this worked on the login routes:

```ruby
require 'net/http'

10.times do
  puts Net::HTTP.post(URI("http://localhost:3000/dashboard/authenticate"), "").inspect
end
```