### PR TITLE
Set the `:manager` when building a TargetCollection

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -251,7 +251,8 @@ module ManageIQ
             if ems.allow_targeted_refresh?
               # We can disable targeted refresh with a setting, then we will just do full ems refresh on any event
               ems_event_collection = InventoryRefresh::TargetCollection.new(:targets    => sub_ems_targets,
-                                                                            :manager_id => ems_id)
+                                                                            :manager_id => ems_id,
+                                                                            :manager    => ems)
               all_targets << ems_event_collection
             else
               all_targets << @ems_by_ems_id[ems_id]


### PR DESCRIPTION
The `InventoryRefresh::TargetCollection` has a `:manager` and
`:manager_id` property.  We were only setting the `:manager_id` even
though we had the `ems` already looked up.  This saves us a query later
and makes it easier to use the EMS class name for building class names
based on target type.