### PR TITLE
Queue provider pause with high priority before destroy

### DIFF
--- a/app/models/mixins/async_delete_mixin.rb
+++ b/app/models/mixins/async_delete_mixin.rb
@@ -1,17 +1,17 @@
 module AsyncDeleteMixin
   extend ActiveSupport::Concern
   included do
-    def self._queue_task(task, ids, task_id = nil)
+    def self._queue_task(task, ids, task_id = nil, queue_options = {})
       ids.each do |id|
         ops = {
           :class_name  => name,
           :instance_id => id,
           :msg_timeout => 3600,
           :method_name => task.to_s,
-        }
-        if task_id
-          ops[:args] = [task_id]
-        end
+        }.merge(queue_options)
+
+        ops[:args] = [task_id] if task_id
+
         MiqQueue.put(ops)
       end
     end

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -125,12 +125,16 @@ RSpec.describe AsyncDeleteMixin do
     context "with 3 ems" do
       before do
         @objects, @obj = common_setup(:ems_vmware)
+
+        # Simplify destroying the EMSs so the pause record doesn't have to be
+        # delivered for the common tests to pass
+        @objects.each { |obj| obj.update!(:enabled => false) }
       end
 
       should_define_destroy_queue_instance_method
       should_define_destroy_queue_class_method
-      should_queue_destroy_on_instance
-      should_queue_destroy_on_class_with_many_ids
+      should_queue_destroy_on_instance("orchestrate_destroy")
+      should_queue_destroy_on_class_with_many_ids("orchestrate_destroy")
 
       should_define_delete_queue_instance_method
       should_define_delete_queue_class_method

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -743,7 +743,7 @@ RSpec.describe ExtManagementSystem do
       task_id = ems.destroy_queue
 
       deliver_queue_message # Deliver the `#pause!` queue item
-      deliver_queue_message # Deliver the `#destroy` queue item
+      deliver_queue_message # Deliver the `#orchestrate_destroy` queue item
 
       expect(MiqTask.find(task_id)).to have_attributes(
         :state  => "Finished",
@@ -757,7 +757,7 @@ RSpec.describe ExtManagementSystem do
       expect(MiqQueue.count).to eq(2)
 
       deliver_queue_message # Deliver the `#pause!` queue item
-      deliver_queue_message # Deliver the `#destroy` queue item
+      deliver_queue_message # Deliver the `#orchestrate_destroy` queue item
 
       expect(MiqQueue.count).to eq(0)
       expect(ExtManagementSystem.count).to eq(0)
@@ -769,7 +769,7 @@ RSpec.describe ExtManagementSystem do
 
       expect(MiqQueue.count).to eq(2)
       deliver_queue_message # ems pause! message
-      deliver_queue_message # ems destroy message
+      deliver_queue_message # ems orchestrate_destroy message
       deliver_queue_message # worker kill message
 
       expect(MiqQueue.count).to eq(0)


### PR DESCRIPTION
Destroying a provider is a queued operation since it involves ensuring that the workers are stopped prior to removing the ext_management_system record.

If a provider is running and generating a lot of queue messages it means that the destroy queue item gets "stuck" in the queue.  This leads to the provider workers continuing to run the entire time until the destroy queue item is run.

To resolve this we can queue a pause operation with high priority that will ensure the workers are shutdown relatively quickly until the destroy operation is reached.

Closes https://github.com/ManageIQ/manageiq/issues/21240