### PR TITLE
Allow nip.io for dev with external auth where hostnames are required

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,4 +53,7 @@ Vmdb::Application.configure do
   config.colorize_logging = true
 
   config.action_controller.allow_forgery_protection = true
+
+  # Allow nip.io for development with external auth where hostnames are required
+  config.hosts << "127.0.0.1.nip.io"
 end


### PR DESCRIPTION
@agrare @bdunne Please review.

Alternatively I can just add this to the oidc instructions?  What do you think? config.hosts is blocked to avoid DNS rebinding attacks - part of me wants to just keep the default.  See https://blog.saeloun.com/2019/10/31/rails-6-adds-guard-against-dns-rebinding-attacks.html