### PR TITLE
Improve the Spec::Support::EmsRefreshHelper

### DIFF
--- a/spec/support/ems_refresh_helper.rb
+++ b/spec/support/ems_refresh_helper.rb
@@ -20,7 +20,17 @@ module Spec
         end
       end
 
-      def assert_inventory_not_changed(before, after)
+      def assert_inventory_not_changed(before = nil, after = nil)
+        if block_given?
+          before ||= serialize_inventory
+
+          yield
+
+          after ||= serialize_inventory
+        elsif before.nil? || after.nil?
+          raise ArgumentError, "You must pass before and after without a block"
+        end
+
         expect(before.keys).to match_array(after.keys)
 
         before.each_key do |model|
@@ -39,6 +49,13 @@ module Spec
             SPEC_FAILURE
           end
         end
+      end
+
+      def with_vcr(suffix = nil, &block)
+        path = described_class.name.dup
+        path << "::#{suffix}" if suffix
+
+        VCR.use_cassette(path.underscore, &block)
       end
     end
   end


### PR DESCRIPTION
Allow the `assert_inventory_not_changed` test to be called with a block automatically serializing before and after yielding.

Also add a `with_vcr` method which makes calling refresh in the context of a VCR cassette simpler.