### PR TITLE
Add the progname to all loggers

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -7,8 +7,6 @@ Style/GlobalVars:
   # Loggers
   - $api_log
   - $audit_log
-  - $container_log
-  - $journald_log
   - $log
   - $policy_log
   - $rails_log


### PR DESCRIPTION
General idea is that instead of creating a single logger, then sharing it via broadcast, we instead just create multiple loggers.  This _should_ already handle any mutexing concerns.  We may choose to do this slightly different in conjunction with #21177 .

- [x] Depends on ManageIQ/manageiq-gems-pending#522
- [ ] Maybe depends on https://github.com/ManageIQ/manageiq-loggers/pull/36

@bdunne Please review.