### PR TITLE
Publications better identify the replication_type

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -144,10 +144,17 @@ class MiqRegion < ApplicationRecord
   end
 
   def self.replication_type
-    if global_replication_type?
-      :global
-    elsif remote_replication_type?
+    # From: https://www.postgresql.org/docs/10/catalog-pg-subscription.html
+    # "Unlike most system catalogs, pg_subscription is shared across all databases of a cluster:
+    # There is only one copy of pg_subscription per cluster, not one per database."
+    #
+    # If replication is enabled between databases in the same cluster, such as in development, we
+    # need to check if the current database has a publication first as global_replication_type?
+    # will be true in each database of the cluster.
+    if remote_replication_type?
       :remote
+    elsif global_replication_type?
+      :global
     else
       :none
     end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe MiqRegion do
       expect(described_class.replication_type).to eq(:remote)
     end
 
+    it "returns :remote when configured as both a provider and a subscriber since subscriptions are shared across all databases of a cluster" do
+      pgl = double(:provider? => true, :subscriber? => true, :node? => true)
+      allow(MiqPglogical).to receive(:new).and_return(pgl)
+
+      expect(described_class.replication_type).to eq(:remote)
+    end
+
     it "returns :none if pglogical is not configured" do
       pgl = double(:provider? => false, :subscriber? => false, :node? => false)
       allow(MiqPglogical).to receive(:new).and_return(pgl)


### PR DESCRIPTION
From: https://www.postgresql.org/docs/10/catalog-pg-subscription.html
"Unlike most system catalogs, pg_subscription is shared across all databases of a cluster:
There is only one copy of pg_subscription per cluster, not one per database."

For two basic installations:

2 cluster 2 databases:
global db: subscription is visible
global db: publication is NOT visible
remote db: subscription is NOT visible
remote db: publication is visible

1 cluster 2 databases(development setup all on one machine):
global db: subscription is visible
global db: publication is NOT visible
remote db: subscription is visible
remote db: publication is visible

Because the subscription is visible to both remote and global databases in the
second scenario, we need to check for a publication first, as that will ONLY
be visible for a remote database.