### PR TITLE
[WIP] ANSIBLE_LOCAL_TEMP/ANSIBLE_REMOTE_TEMP vars

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -205,7 +205,7 @@ module Ansible
         end
         command_line_hash.merge!(cred_command_line)
 
-        env_vars_hash   = env_vars.merge(cred_env_vars).merge(python_env)
+        env_vars_hash   = env_vars.merge(cred_env_vars).merge(ansible_runner_env)
         extra_vars_hash = extra_vars.merge(cred_extra_vars)
 
         create_hosts_file(base_dir, hosts)
@@ -303,14 +303,19 @@ module Ansible
         Ansible::Content.new(playbook_dir).fetch_galaxy_roles
       end
 
-      def python_env
+      def ansible_runner_env
+        env = {}
+
         if python3_modules_path.present?
-          { "PYTHONPATH" => python3_modules_path }
+          env["PYTHONPATH"] = python3_modules_path
         elsif python2_modules_path.present?
-          { "PYTHONPATH" => python2_modules_path }
-        else
-          {}
+          env["PYTHONPATH"] = python2_modules_path
         end
+
+        env["ANSIBLE_LOCAL_TEMP"] = "/tmp/.ansible_local_tmp"
+        env["ANSIBLE_REMOTE_TEMP"] = "/tmp/.ansible_remote_tmp"
+
+        env
       end
 
       def credentials_info(credentials, base_dir)


### PR DESCRIPTION
Fixes an issue on podified where `~/.ansible/tmp` is not writable since `~/` is actually `/` for our linux user.  Error output looks something like this:

```
Unhandled error:
 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 90, in makedirs_safe
    os.makedirs(b_rpath, mode)
  File "/usr/lib64/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib64/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: b'/.ansible'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 572, in update_config_data
    value, origin = self.get_config_value_and_origin(config, configfile)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 516, in get_config_value_and_origin
    value = ensure_type(value, defs[config].get('type'), origin=origin)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 122, in ensure_type
    makedirs_safe(value, 0o700)
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 95, in makedirs_safe
    raise AnsibleError("Unable to create local directories(%s): %s" % (to_native(rpath), to_native(e)))
ansible.errors.AnsibleError: Unable to create local directories(/.ansible/tmp): [Errno 13] Permission denied: b'/.ansible'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 90, in makedirs_safe
    os.makedirs(b_rpath, mode)
  File "/usr/lib64/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib64/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: b'/.ansible'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 572, in update_config_data
    value, origin = self.get_config_value_and_origin(config, configfile)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 516, in get_config_value_and_origin
    value = ensure_type(value, defs[config].get('type'), origin=origin)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 122, in ensure_type
    makedirs_safe(value, 0o700)
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 95, in makedirs_safe
    raise AnsibleError("Unable to create local directories(%s): %s" % (to_native(rpath), to_native(e)))
ansible.errors.AnsibleError: Unable to create local directories(/.ansible/tmp): [Errno 13] Permission denied: b'/.ansible'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 62, in <module>
    import ansible.constants as C
  File "/usr/lib/python3.6/site-packages/ansible/constants.py", line 175, in <module>
    config = ConfigManager()
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 291, in __init__
    self.update_config_data()
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 584, in update_config_data
    raise AnsibleError("Invalid settings supplied for %s: %s\n" % (config, to_native(e)), orig_exc=e)
ansible.errors.AnsibleError: Invalid settings supplied for DEFAULT_LOCAL_TMP: Unable to create local directories(/.ansible/tmp): [Errno 13] Permission denied: b'/.ansible'```

```

Switching to `/tmp/.ansible_local_tmp` and `/tmp/.ansible_remote_tmp` should allow this most playbooks that had issues writing to those respective `tmp` dirs to now do it.


Links
-----

* Comments on the original commit (without a branch):  https://github.com/ManageIQ/manageiq/commit/ac6f4d8d3ac0d431264724dc75a32e90b6407f2e#commitcomment-52455378
* Ansible config link:  https://github.com/ansible/ansible/blob/ad203a7dbdbcab9af0b89a577433af860b542e01/examples/ansible.cfg#L4-L8