### PR TITLE
Remove unused VmOrTemplate#validate_scan

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -5,7 +5,6 @@ module VmOrTemplate::Operations
   include_concern 'Power'
   include_concern 'Relocation'
   include_concern 'Snapshot'
-  include_concern 'SmartState'
 
   alias_method :ruby_clone, :clone
 

--- a/app/models/vm_or_template/operations/smart_state.rb
+++ b/app/models/vm_or_template/operations/smart_state.rb
@@ -1,9 +1,0 @@
-class VmOrTemplate
-  module Operations
-    module SmartState
-      def validate_scan
-        {:available => true, :message => nil}
-      end
-    end
-  end
-end


### PR DESCRIPTION
This was last used (incorrectly) by the API to check if a VM supports smartstate.  This has been fixed in ManageIQ/manageiq-api#1050

This method wasn't overridden by any providers to indicate that smartstate wasn't supported: https://github.com/search?q=org%3AManageIQ+validate_scan&type=code

Depends on:
- [x] https://github.com/ManageIQ/manageiq-api/pull/1050