### PR TITLE
Support local logical replication - Create the slot on the remote and the subscription on the global

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,7 +208,7 @@ group :automate, :seed, :manageiq_default do
 end
 
 group :replication, :manageiq_default do
-  gem "pg-logical_replication",         "~>1.0",             :require => false
+  gem "pg-logical_replication",         "~>1.1",             :require => false
 end
 
 group :rest_api, :manageiq_default do

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -144,13 +144,6 @@ class MiqRegion < ApplicationRecord
   end
 
   def self.replication_type
-    # From: https://www.postgresql.org/docs/10/catalog-pg-subscription.html
-    # "Unlike most system catalogs, pg_subscription is shared across all databases of a cluster:
-    # There is only one copy of pg_subscription per cluster, not one per database."
-    #
-    # If replication is enabled between databases in the same cluster, such as in development, we
-    # need to check if the current database has a publication first as global_replication_type?
-    # will be true in each database of the cluster.
     if remote_replication_type?
       :remote
     elsif global_replication_type?

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -253,9 +253,8 @@ class PglogicalSubscription < ActsAsArModel
     # 2) In the global subscriber, create the subscription without a slot but reference the slot name in the prior step.
     # From: https://www.postgresql.org/docs/10/sql-createsubscription.html
     with_remote_connection(5.seconds) do |conn|
-      # TODO: Move this down into logical replication code, perhaps: https://github.com/ManageIQ/pg-logical_replication/blob/master/lib/pg/logical_replication/client.rb
-      # Note, it needs to be aware we're running this against the remote raw_connection and not the configured rails one.
-      conn.exec_query("select pg_create_logical_replication_slot($1, 'pgoutput')", "SQL", [[nil, subscription]])
+      client = PG::LogicalReplication::Client.new(conn.raw_connection)
+      client.create_logical_replication_slot(subscription)
     end
 
     self.class.with_connection_error_handling do


### PR DESCRIPTION
TODO:

- [x]  [Add create_replication_slot to pglogical client](https://github.com/ManageIQ/pg-logical_replication/pull/8)
- [x] Test with New pg-logical_replication release
- [x] Verify this works on traditional 2+ appliance setups
- [x] Verify this works on dev setup outside of my machine
- [x] Slow existing pglogical replication tests, depends on [another PR](https://github.com/ManageIQ/manageiq/pull/21318) to make the tests much faster

CREATE SUBSCRIPTION normally works great on the global and properly creates the
pg_replication_slot on the remotes.  Except...

Creating the slot and subscription enabled in the same command will hang when replicating
between databases in the same cluster. Instead, we'll do the following:

1) On the remote, create a logical replication slot with pgoutput plugin name.
2) On the global, create the subscription without a slot but reference the
previously created slot name.
From: https://www.postgresql.org/docs/10/sql-createsubscription.html