### PR TITLE
Remove progname override from audit log

### DIFF
--- a/lib/vmdb/loggers/audit_logger.rb
+++ b/lib/vmdb/loggers/audit_logger.rb
@@ -1,13 +1,15 @@
 module Vmdb::Loggers
   class AuditLogger < VMDBLogger
     def success(msg)
-      info("Success") { msg }
-      $log.info("<AuditSuccess> #{msg}") if $log
+      msg = "<AuditSuccess> #{msg}"
+      info(msg)
+      $log.info(msg) if $log
     end
 
     def failure(msg)
-      warn("Failure") { msg }
-      $log.warn("<AuditFailure> #{msg}") if $log
+      msg = "<AuditFailure> #{msg}"
+      warn(msg)
+      $log.warn(msg) if $log
     end
   end
 end


### PR DESCRIPTION
Follow up to #21285 , I noticed that the audit log overwrites the progname, so this removes that overwriting.

@bdunne Please review.