### PR TITLE
[EmbeddedAnsible::ConfigurationScriptSource] virtual_attribute :verify_ssl

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
   FRIENDLY_NAME = "Embedded Ansible Project".freeze
 
+  virtual_attribute :verify_ssl, :integer
+
   validates :name,       :presence => true # TODO: unique within region?
   validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }
   validates :scm_branch, :presence => true

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -77,7 +77,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
   private def ensure_git_repository
     transaction do
-      # puts attrs_for_sync_git_repository.inspect
       repo = GitRepository.create!(attrs_for_sync_git_repository)
       if new_record?
         self.git_repository_id = repo.id


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/21284

Adds `verify_ssl` as a `virtual_attribute` so it can be queried properly by the API.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/21284


Steps for Testing/QA
--------------------

Will add some tests in the API to verify that this continues works over there, but for now, with a `ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource` running:

```console
$ curl "/api/configuration_script_sources/1?attributes=name,description,scm_url,authentication_id,scm_branch,verify_ssl"
```

Should return the `verify_ssl` properly with the rest of the UI.  This is the same query that is currently used by the Angular UI.