### PR TITLE
Dependent destroy child network_manager

### DIFF
--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -5,7 +5,8 @@ module HasNetworkManagerMixin
     has_one :network_manager,
             :foreign_key => :parent_ems_id,
             :class_name  => "ManageIQ::Providers::NetworkManager",
-            :autosave    => true
+            :autosave    => true,
+            :dependent   => :destroy
 
     delegate :floating_ips,
              :security_groups,


### PR DESCRIPTION
With the recent change to move all the extra worker stopping logic out of `ExtManagementSystem#destroy` we also don't do `child_managers.each(&:destroy)` automatically any longer.

This doesn't impact `#orchestrate_destroy` because that does loop through the child managers and call `#orchestrate_destroy`  on each first, but this will ensure child managers are removed if anyone manually destroys an EMS via `rails c`