### PR TITLE
[WIP] Add a top-level manageiq.service to replace evmserverd

### DIFF
--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -3,9 +3,8 @@ RSpec.describe MiqWorker::SystemdCommon do
     before { MiqWorkerType.seed }
 
     it "every worker has a matching systemd target and service file", :providers_common => true do
-      expected_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
-
-      expected_units.delete("manageiq.target")
+      all_systemd_unit_files = Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")
+      expected_units         = all_systemd_unit_files.map(&:basename).map(&:to_s) - %w[manageiq.service manageiq.target]
 
       found_units = MiqWorkerType.worker_class_names.flat_map do |klass_name|
         klass = klass_name.constantize

--- a/systemd/manageiq.service
+++ b/systemd/manageiq.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ManageIQ
+After=syslog.target
+PartOf=manageiq.target
+
+[Service]
+ExecStart=/bin/sh -c "/bin/evmserver.sh start"
+ExecStop=/bin/sh -c "/bin/evmserver.sh stop"
+Type=forking
+Restart=on-failure
+KillMode=process
+Slice=manageiq.slice
+
+[Install]
+WantedBy=multi-user.target
+Alias=evmserverd.service


### PR DESCRIPTION
Replace the evmserverd.service with manageiq.service which matches the names of the other worker services.  This also aliases the service to evmserverd so existing scripts/etc... should continue to work.

Example of the alias:
```
[root@manageiq ~]# systemctl status evmserverd
● manageiq.service - ManageIQ
   Loaded: loaded (/usr/lib/systemd/system/manageiq.service; enabled; vendor pr>
   Active: active (running) since Fri 2021-06-25 14:01:06 EDT; 36min ago
```

TODO:
- [ ] Update appliance-build to not copy the evmserverd.service
- [ ] Test on a live appliance