### PR TITLE
Refactor delete subnet queue from providers

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -55,6 +55,24 @@ class CloudSubnet < ApplicationRecord
     ext_management_system && ext_management_system.class::CloudSubnet
   end
 
+  def delete_cloud_subnet_queue(userid)
+    task_opts = {
+      :action => "deleting Cloud Subnet for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'raw_delete_cloud_subnet',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
   def delete_cloud_subnet
     raw_delete_cloud_subnet
   end


### PR DESCRIPTION
- Added `delete_cloud_subnet_queue` to core and duplicate methods in the following providers were removed: 
```
manageiq-providers-ibm_cloud/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
manageiq-providers-ibm_cloud/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
manageiq-providers-nuage/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb
manageiq-providers-openstack/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
```

Depends on:

* [ ] [VPC delete cloud subnets functionality](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/232)
* [ ] [Openstack - Refactor delete subnet queue](https://github.com/ManageIQ/manageiq-providers-openstack/pull/718)
* [ ] [Nuage - Refactor delete subnet queue](https://github.com/ManageIQ/manageiq-providers-nuage/pull/249)

