### PR TITLE
[WIP] revert backward americans (Dates)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,12 +86,6 @@ gem "mime-types",                       "~>3.0",             :require => false, 
 gem "handsoap",                         "=0.2.5.5",          :require => false, :source => "https://rubygems.manageiq.org" # for manageiq-gems-pending only
 gem "ruport",                           "=1.7.0.3",                             :source => "https://rubygems.manageiq.org"
 
-# In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
-# american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.
-# See miq_expression_spec Date/Time Support examples.
-# https://github.com/jeremyevans/ruby-american_date
-gem "american_date"
-
 # Make sure to tag your new bundler group with the manageiq_default group in addition to your specific bundler group name.
 # This default is used to automatically require all of our gems in processes that don't specify which bundler groups they want.
 #


### PR DESCRIPTION
Rails 1.8.6 -> 1.9.3 changed the parsing format of dates
to go from us centric (m/d/y) to eurpoean (d/m/y)

This was introduced in #f4123c06bf2

A lot of our parsing code has been cleaned up and
we're ready to remove this fix

(or at least ready to see if it can be done)