### PR TITLE
Fixed delete subnet queued method name

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -63,7 +63,7 @@ class CloudSubnet < ApplicationRecord
 
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'raw_delete_cloud_subnet',
+      :method_name => 'delete_cloud_subnet',
       :instance_id => id,
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,


### PR DESCRIPTION
- Fixed delete subnet queued method name to match expected behaviour with providers

Reference: 
* [Refactor delete subnet queue](https://github.com/ManageIQ/manageiq-providers-nuage/pull/249#discussion_r659944130)

