### PR TITLE
run basic services as manageiq user

### DIFF
--- a/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_event_catcher@.service
+++ b/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_event_catcher@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::EventCatcher --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_event_catcher.slice

--- a/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_metrics_collector@.service
+++ b/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_metrics_collector@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_metrics_collector.slice

--- a/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_refresh@.service
+++ b/lib/generators/manageiq/provider/templates/systemd/%plugin_name%_%manager_path%_refresh@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb <%= class_name %>::<%= manager_type %>::RefreshWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=<%= plugin_name %>_<%= manager_path %>_refresh.slice

--- a/systemd/manageiq-cockpit_ws@.service
+++ b/systemd/manageiq-cockpit_ws@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqCockpitWsWorker --heartbeat --guid=%i
+Group=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-cockpit_ws.slice

--- a/systemd/manageiq-ems_metrics_processor@.service
+++ b/systemd/manageiq-ems_metrics_processor@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-ems_metrics_processor.slice

--- a/systemd/manageiq-event_handler@.service
+++ b/systemd/manageiq-event_handler@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-event_handler.slice

--- a/systemd/manageiq-generic@.service
+++ b/systemd/manageiq-generic@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-generic.slice

--- a/systemd/manageiq-priority@.service
+++ b/systemd/manageiq-priority@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-priority.slice

--- a/systemd/manageiq-remote_console@.service
+++ b/systemd/manageiq-remote_console@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-remote_console.slice

--- a/systemd/manageiq-reporting@.service
+++ b/systemd/manageiq-reporting@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-reporting.slice

--- a/systemd/manageiq-schedule@.service
+++ b/systemd/manageiq-schedule@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-schedule.slice

--- a/systemd/manageiq-smart_proxy@.service
+++ b/systemd/manageiq-smart_proxy@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-smart_proxy.slice

--- a/systemd/manageiq-ui@.service
+++ b/systemd/manageiq-ui@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-ui.slice

--- a/systemd/manageiq-web_service@.service
+++ b/systemd/manageiq-web_service@.service
@@ -7,6 +7,8 @@ WorkingDirectory=/var/www/miq/vmdb
 Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i
+User=manageiq
+UMask=0002
 Restart=no
 Type=notify
 Slice=manageiq-web_service.slice


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq-rpm_build/pull/157

as long as the v2_key can be read, these services
are fine running without any special privileges

cockpit is running as root, but the others are running as the `manageiq` user