### PR TITLE
Refactor create cloud subnet queue from providers

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -96,5 +96,21 @@ module ManageIQ::Providers
       name.gsub!(" #{self::PROVIDER_NAME}", "")
       includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
     end
+
+    def create_cloud_subnet_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Cloud Subnet for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_cloud_subnet',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
   end
 end


### PR DESCRIPTION
- `create_cloud_subnet_queue` method lives in the provider code but it is unnecessary and can be moved to core

Depends on:

* [ ] [Openstack](https://github.com/ManageIQ/manageiq-providers-openstack/pull/721)
* [ ] [Ovirt](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/565)
* [ ] [Nuage](https://github.com/ManageIQ/manageiq-providers-nuage/pull/251)
* [ ] [IBM](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/235)

