### PR TITLE
Prepend with_block, which was renamed from with_lock in Dalli 2.7.7

### DIFF
--- a/lib/extensions/rack_session_dalli_patch.rb
+++ b/lib/extensions/rack_session_dalli_patch.rb
@@ -4,7 +4,7 @@ require "rack/session/dalli"
 module RackSessionDalliPatch
   def delete_sessions(session_ids)
     session_ids.each do |session_id|
-      delete_session(ManageIQ::Session.fake_request, session_id, :drop => true)
+      destroy_session(ManageIQ::Session.fake_request, session_id, :drop => true)
     end
   end
 
@@ -12,15 +12,27 @@ module RackSessionDalliPatch
   # cause a load to occur. Consequently, we need to manage things
   # carefully to prevent a deadlock between the Rails Interlock and
   # Dalli's own exclusive lock.
-  def with_lock(*args)
+  def with_block(*args)
     ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-      super(*args) do
+      super do |dc|
         ActiveSupport::Dependencies.interlock.running do
-          yield
+          yield dc
         end
       end
     end
   end
 end
 
+# In commit: https://github.com/petergoldstein/dalli/commit/9f9c508afab263a2451f2209c4396daf98d33a1b
+# with_lock was renamed to with_block with a slightly different interface.
+# All versions since 2.7.7 have with_block now.
+# Additionally, we'll detect and warn if the method we depend on in our prepended module doesn't exist before we try to prepend it.
+%w[with_block destroy_session].each do |method|
+  begin
+    Rack::Session::Dalli.instance_method(method)
+  rescue NameError => err
+    warn "Dalli is missing the method our prepended code depends on: #{err}."
+    warn "Did the dalli version change?  Was the method removed or renamed upstream? See: #{__FILE__}"
+  end
+end
 Rack::Session::Dalli.prepend(RackSessionDalliPatch)

--- a/lib/extensions/rack_session_dalli_patch.rb
+++ b/lib/extensions/rack_session_dalli_patch.rb
@@ -4,7 +4,7 @@ require "rack/session/dalli"
 module RackSessionDalliPatch
   def delete_sessions(session_ids)
     session_ids.each do |session_id|
-      destroy_session(ManageIQ::Session.fake_request, session_id, :drop => true)
+      destroy_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
     end
   end
 

--- a/lib/manageiq/session.rb
+++ b/lib/manageiq/session.rb
@@ -68,7 +68,7 @@ module ManageIQ
     # Create a new one each time instead of memoizing to avoid data getting
     # attached to the request hash (env).
     def self.fake_request
-      FakeRequest.new({})
+      FakeRequest.new({'rack.multithread' => true})
     end
 
     # :nodoc:


### PR DESCRIPTION
In commit: https://github.com/petergoldstein/dalli/commit/9f9c508afab263a2451f2209c4396daf98d33a1b
with_lock was renamed to with_block with a slightly different interface.
All versions since 2.7.7 have with_block now.
 
Additionally, we'll now detect and warn if the methods we depend on in our
prepended code doesn't exist before we try to prepend it.

This resolves a very similar deadlock with dalli and the rails autoloader
just like we did back in 2016 when the original patch was implemented:
https://github.com/ManageIQ/manageiq/pull/7334

We recently allowed dalli 2.7.8+, which caused these deadlocks to happen again:
https://github.com/ManageIQ/manageiq/pull/21265

As an example of the rename/removal detection, if we had this warning system before this PR, it would look like this whenever loading rails:

```
joerafaniello@Joes-MBP-2 manageiq % bin/rails c
Dalli is missing the method our prepended code depends on: undefined method `with_lock' for class `Rack::Session::Dalli'.
Did the dalli version change?  Was the method removed or renamed upstream? See: /Users/joerafaniello/Code/manageiq/lib/extensions/rack_session_dalli_patch.rb
** ManageIQ master, codename: Morphy
```