### PR TITLE
Remove supports :migrate from base Vm class

### DIFF
--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -4,12 +4,7 @@ module VmOrTemplate::Operations::Relocation
   included do
     supports_not :live_migrate
     supports_not :warm_migrate
-    supports :migrate do
-      reason   = _("Migrate not supported because VM is blank")    if blank?
-      reason ||= _("Migrate not supported because VM is orphaned") if orphaned?
-      reason ||= _("Migrate not supported because VM is archived") if archived?
-      unsupported_reason_add(:migrate, reason) if reason
-    end
+    supports_not :migrate
   end
 
   def raw_live_migrate(_options = nil)


### PR DESCRIPTION
Having `supports :migrate` in the base VmOrTemplate class means that every vm which isn't blank, orphaned, or archived will say they support migrate even if they don't.