### PR TITLE
Move profile= to live near the profile method

### DIFF
--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -57,6 +57,10 @@ class TimeProfile < ApplicationRecord
     super || (self.profile = {})
   end
 
+  def profile=(value)
+    super(value&.symbolize_keys)
+  end
+
   def tz
     profile[:tz]
   end
@@ -68,10 +72,6 @@ class TimeProfile < ApplicationRecord
 
   def tz_or_default(default_tz = DEFAULT_TZ)
     tz || default_tz
-  end
-
-  def profile=(value)
-    super(value&.symbolize_keys)
   end
 
   def days


### PR DESCRIPTION
Noticed this after merging #21311 , but the new profile= method was far from the profile method, and so may not be seen when casually reading the code.