### PR TITLE
Add proper expectation stubs for slow MiqRegion.destroy_region

### DIFF
--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -286,4 +286,19 @@ RSpec.describe MiqRegion do
       expect(region.remote_ws_miq_server).to be_nil
     end
   end
+
+  context ".destroy_region" do
+    let!(:regionA)      { FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number + 1) }
+    let!(:regionB)      { FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number + 2) }
+    let!(:vm_regionA)   { FactoryBot.create(:vm_vmware, :id => ApplicationRecord.id_in_region(1, regionA.region)) }
+    let!(:vm_regionB)   { FactoryBot.create(:vm_vmware, :id => ApplicationRecord.id_in_region(1, regionB.region)) }
+    let!(:host_regionA) { FactoryBot.create(:host_vmware, :id => ApplicationRecord.id_in_region(1, regionA.region)) }
+    let!(:host_regionB) { FactoryBot.create(:host_vmware, :id => ApplicationRecord.id_in_region(1, regionB.region)) }
+
+    it "removes target region's rows" do
+      described_class.destroy_region(ApplicationRecord.connection, regionB.region, %w[hosts vms])
+      expect(Host.all.pluck(:id)).to match_array([vm_regionA.id])
+      expect(Vm.all.pluck(:id)).to match_array([vm_regionA.id])
+    end
+  end
 end


### PR DESCRIPTION
We need to do proper expectations to ensure it's called the right number of times
with the correct arguments in some situations but we should not actually call
this in test as it walks all replicated tables and removes data for the region.

Locally, tests go from 31 to 0.7 seconds.

Before:
% be rspec spec/models/pglogical_subscription_spec.rb | grep Finished
Finished in 31.15 seconds (files took 11.66 seconds to load)

After:
% be rspec spec/models/pglogical_subscription_spec.rb | grep Finished
Finished in 0.7697 seconds (files took 11.78 seconds to load)

EDIT:
I added a very simple test of the `destroy_region` functionality since we're largely mocking the implementation in the logical replication tests for speed and because the underlying implementation isn't important at that layer.