### PR TITLE
Remove autoload paths for code that was extracted to other repositories

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -103,9 +103,6 @@ module Vmdb
     #
     config.autoload_paths << Rails.root.join("app", "models", "aliases").to_s
     config.autoload_paths << Rails.root.join("app", "models", "mixins").to_s
-    config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models").to_s
-    config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models", "mixins").to_s
-    config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
     config.autoload_paths << Rails.root.join("lib").to_s
     config.autoload_paths << Rails.root.join("lib", "services").to_s
 


### PR DESCRIPTION
lib/miq_automation_engine was removed in 3aae2cace6bc67b5d2c7cd68b8f87eedf10c9be5
app/controllers was removed in faf5550c9340a68764850dc0a75f68b6c49ec52d


✂️ 🔥 ✂️ 🔥 ✂️ 🔥 

🍰  🍪 👏 🙇 😍 🎉