### PR TITLE
Don't update the sti_loader.yml in production

### DIFF
--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -178,9 +178,15 @@ class DescendantLoader
 
     def save_cache!
       return unless @cache_dirty
-      cache_path.parent.mkpath
-      cache_path.open('w') do |f|
-        YAML.dump(cache, f)
+
+      # Don't write sti_loader.yml in production, this shouldn't change from what is in the RPM
+      if Rails.env.production?
+        $stderr.puts "\nSTI cache is out of date in production, check that source files haven't been modified"
+      else
+        cache_path.parent.mkpath
+        cache_path.open('w') do |f|
+          YAML.dump(cache, f)
+        end
       end
     end
 

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -74,7 +74,7 @@ class DescendantLoader
       begin
         parsed = RipperRubyParser::Parser.new.parse(content, filename)
       rescue => e
-        $stderr.puts "\nError parsing classes in #{filename}:\n#{e.class.name}: #{e}\n\n"
+        warn "\nError parsing classes in #{filename}:\n#{e.class.name}: #{e}\n\n"
         raise
       end
 
@@ -181,7 +181,7 @@ class DescendantLoader
 
       # Don't write sti_loader.yml in production, this shouldn't change from what is in the RPM
       if Rails.env.production?
-        $stderr.puts "\nSTI cache is out of date in production, check that source files haven't been modified"
+        warn "\nSTI cache is out of date in production, check that source files haven't been modified"
       else
         cache_path.parent.mkpath
         cache_path.open('w') do |f|


### PR DESCRIPTION
The sti_loader.yml file shouldn't change from what is built in the RPM, this indicates that someone has manually edited the source files on an appliance or there is an issue with the pre-built sti_loader.


```
touch /var/www/miq/vmdb/app/models/account.rb
systemctl start evmserverd
systemctl stop evmserverd
```

```
Jul 06 13:21:52 localhost.localdomain ruby[102955]: STI cache is out of date in production, check that source files haven't been modified
```