### PR TITLE
Logical replication cleanup (use 1.2 with simpler interface)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,7 +208,7 @@ group :automate, :seed, :manageiq_default do
 end
 
 group :replication, :manageiq_default do
-  gem "pg-logical_replication",         "~>1.1",             :require => false
+  gem "pg-logical_replication",         "~>1.2",             :require => false
 end
 
 group :rest_api, :manageiq_default do

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -257,7 +257,7 @@ class PglogicalSubscription < ActsAsArModel
     end
 
     self.class.with_connection_error_handling do
-      pglogical.create_subscription(subscription, conn_info_hash, [MiqPglogical::PUBLICATION_NAME], {'enabled' => true, 'create_slot' => false, 'slot_name' => subscription}).check
+      pglogical.create_subscription(subscription, conn_info_hash, [MiqPglogical::PUBLICATION_NAME], create_slot: false).check
     end
     self
   end

--- a/lib/tasks/evm_dbsync.rake
+++ b/lib/tasks/evm_dbsync.rake
@@ -20,7 +20,6 @@ namespace :evm do
     desc "Resync excluded tables"
     task :resync_excludes => :environment do
       require 'application_record' unless defined?(ApplicationRecord)
-      require 'miq_pglogical'
       pgl = MiqPglogical.new
       pgl.refresh_excludes if pgl.provider?
       PglogicalSubscription.all.each(&:sync_tables)

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe PglogicalSubscription do
         :user     => "root",
         :password => "1234"
       }
-      expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn, ['miq'], {"create_slot" => false, "enabled" => true, "slot_name" => "region_2_subscription"}).and_return(double(:check => nil))
+      expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn, ['miq'], create_slot: false).and_return(double(:check => nil))
 
       sub = described_class.new(:host => "test-2.example.com", :user => "root", :password => "1234")
 
@@ -318,14 +318,14 @@ RSpec.describe PglogicalSubscription do
         :user     => "root",
         :password => "1234"
       }
-      expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn2, ['miq'], {"create_slot" => false, "enabled" => true, "slot_name" => "region_2_subscription"}).and_return(double(:check => nil))
+      expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn2, ['miq'], create_slot: false).and_return(double(:check => nil))
 
       dsn3 = {
         :host     => "test-3.example.com",
         :user     => "miq",
         :password => "1234"
       }
-      expect(pglogical).to receive(:create_subscription).with("region_3_subscription", dsn3, ['miq'], {"create_slot" => false, "enabled" => true, "slot_name" => "region_3_subscription"}).and_return(double(:check => nil))
+      expect(pglogical).to receive(:create_subscription).with("region_3_subscription", dsn3, ['miq'], create_slot: false).and_return(double(:check => nil))
 
       to_save = []
       to_save << described_class.new(dsn2)
@@ -350,7 +350,7 @@ RSpec.describe PglogicalSubscription do
         :user     => "miq",
         :password => "1234"
       }
-      expect(pglogical).to receive(:create_subscription).ordered.with("region_3_subscription", dsn3, ['miq'], {"create_slot" => false, "enabled" => true, "slot_name" => "region_3_subscription"}).and_return(double(:check => nil))
+      expect(pglogical).to receive(:create_subscription).ordered.with("region_3_subscription", dsn3, ['miq'], create_slot: false).and_return(double(:check => nil))
       expect(pglogical).to receive(:create_subscription).ordered.and_raise("Error two")
 
       to_save = []


### PR DESCRIPTION
* Use 1.2 logical replication for simpler interface for create_subscription
* Fix already initialized constant warnings due to pg_logical being autoloaded in one location and required in another.