### PR TITLE
Declare httpd a requirement dependency of UI and API workers

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -36,21 +36,6 @@ module MiqServer::EnvironmentManagement
     end
   end
 
-  #
-  # Apache
-  #
-  def start_apache
-    return unless MiqEnvironment::Command.is_appliance?
-
-    MiqApache::Control.start
-  end
-
-  def stop_apache
-    return unless MiqEnvironment::Command.is_appliance?
-
-    MiqApache::Control.stop
-  end
-
   def disk_usage_threshold
     ::Settings.server.events.disk_usage_gt_percent
   end

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -1,8 +1,6 @@
 module MiqServer::RoleManagement
   extend ActiveSupport::Concern
 
-  ROLES_NEEDING_APACHE = %w[user_interface web_services remote_console cockpit_ws].freeze
-
   included do
     has_many :assigned_server_roles, :dependent => :destroy
     has_many :server_roles,   :through => :assigned_server_roles
@@ -40,12 +38,6 @@ module MiqServer::RoleManagement
 
   def sync_active_roles
     @active_role_names = active_role_names
-  end
-
-  def apache_needed?
-    # TODO: We need to splat the Array into multiple arguments for now
-    # https://github.com/ManageIQ/more_core_extensions/pull/18
-    active_role_names.include_any?(*ROLES_NEEDING_APACHE)
   end
 
   def set_active_role_flags

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -196,9 +196,6 @@ module MiqServer::WorkerManagement::Monitor
       sync_active_roles          if roles_changed
       set_active_role_flags      if roles_changed
 
-      stop_apache                if roles_changed && !apache_needed?
-      start_apache               if roles_changed &&  apache_needed?
-
       EvmDatabase.restart_failover_monitor_service if (roles_added | roles_deleted).include?("database_operations")
 
       reset_queue_messages       if roles_changed

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -8,34 +8,6 @@ RSpec.describe "Server Role Management" do
       @miq_server.deactivate_all_roles
     end
 
-    context "#apache_needed?" do
-      it "false with neither webservices or user_interface active" do
-        allow(@miq_server).to receive_messages(:active_role_names => ["reporting"])
-        expect(@miq_server.apache_needed?).to be_falsey
-      end
-
-      it "true with only cockpit_ws active" do
-        allow(@miq_server).to receive_messages(:active_role_names => ["cockpit_ws"])
-        expect(@miq_server.apache_needed?).to be_truthy
-      end
-
-      it "true with web_services active" do
-        allow(@miq_server).to receive_messages(:active_role_names => ["web_services"])
-        expect(@miq_server.apache_needed?).to be_truthy
-      end
-
-      it "true with both web_services and user_interface active" do
-        allow(@miq_server).to receive_messages(:active_role_names => ["web_services", "user_interface"])
-        expect(@miq_server.apache_needed?).to be_truthy
-      end
-
-      it "true with all three active" do
-        roles = %w("web_services user_interface cockpit_ws")
-        allow(@miq_server).to receive_messages(:active_role_names => roles)
-        expect(@miq_server.apache_needed?).to be_truthy
-      end
-    end
-
     context "role=" do
       it "normal case" do
         @miq_server.assign_role(ServerRole.find_by(:name => 'ems_operations'), 1)

--- a/systemd/manageiq-cockpit_ws@.service
+++ b/systemd/manageiq-cockpit_ws@.service
@@ -1,5 +1,6 @@
 [Unit]
 PartOf=manageiq-cockpit_ws.target
+Wants=httpd.service
 [Install]
 WantedBy=manageiq-cockpit_ws.target
 [Service]

--- a/systemd/manageiq-remote_console@.service
+++ b/systemd/manageiq-remote_console@.service
@@ -1,5 +1,6 @@
 [Unit]
 PartOf=manageiq-remote_console.target
+Wants=httpd.service
 [Install]
 WantedBy=manageiq-remote_console.target
 [Service]

--- a/systemd/manageiq-ui@.service
+++ b/systemd/manageiq-ui@.service
@@ -1,5 +1,6 @@
 [Unit]
 PartOf=manageiq-ui.target
+Wants=httpd.service
 [Install]
 WantedBy=manageiq-ui.target
 [Service]

--- a/systemd/manageiq-web_service@.service
+++ b/systemd/manageiq-web_service@.service
@@ -1,5 +1,6 @@
 [Unit]
 PartOf=manageiq-web_service.target
+Wants=httpd.service
 [Install]
 WantedBy=manageiq-web_service.target
 [Service]


### PR DESCRIPTION
Both of these workers expect Apache to be running, so declare a requirement dependency on httpd.service for them.

`Wants=` will start the units whenever the declaring unit is started but has enforces no explicity ordering like `After=` or `Before=` [[ref]](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=).
Since we just need Apache to start whenever the UI/API are running we don't need to enforce any ordering.