### PR TITLE
Create log dir if it doesn't already exist

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -30,7 +30,10 @@ module Vmdb
     end
 
     def self.create_logger(log_file_name, logger_class = VMDBLogger)
-      log_file = ManageIQ.root.join("log", log_file_name)
+      log_dir = ManageIQ.root.join("log")
+      log_dir.mkpath unless log_dir.exist?
+
+      log_file = log_dir.join(log_file_name)
       progname = File.basename(log_file_name, ".*")
 
       logger_class.new(log_file, progname: progname).tap do |logger|


### PR DESCRIPTION
The log dir is intentionally not part of the repository since we want to
use a separate volume mount for that in the appliances.

However, during release tagging, which uses simple rake tasks, creation
of the logger fails because the directory doesn't exist. This commit
creates the log dir on demand if it doesn't already exist.

@bdunne Please review.