### PR TITLE
[KASPAROV] Handle brakeman failure by making method private

### DIFF
--- a/tools/radar/rollup_radar_mixin.rb
+++ b/tools/radar/rollup_radar_mixin.rb
@@ -29,7 +29,7 @@ module RollupRadarMixin
     end
   end
 
-  def date_trunc(by, attribute)
+  private def date_trunc(by, attribute)
     Arel::Nodes::NamedFunction.new(
       'DATE_TRUNC', [Arel.sql("'#{by}'"), attribute]
     )


### PR DESCRIPTION
On the kasparov branch, brakeman is failing saying this is a potential
SQL injection.

```
Confidence: Medium
Category: SQL Injection
Check: SQL
Message: Possible SQL injection
Code: Arel.sql("'#{by}'")
File: tools/radar/rollup_radar_mixin.rb
Line: 34
```

However, this method is technically a private method used within this
file, with a Ruby literal as the parameter.  As such, it is a false
positive.  Making the method private lets brakeman understand that,
removing the error.

Note that this code has been removed in lasker and master.

@jrafanie Please review.