### PR TITLE
Add logical replication setup rake task

### DIFF
--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -45,12 +45,12 @@ module TaskHelpers
         end
 
         def setup_remote(region)
-          setup_one_region(region)
-          setup_remote_region(region)
+          create_region(region)
+          configure_remote_region(region)
         end
 
         def setup_global(region)
-          setup_one_region(region)
+          create_region(region)
           setup_global_region(region)
         end
 
@@ -90,12 +90,12 @@ module TaskHelpers
           run_command("psql -U #{PG_USER} #{database(region)} -c 'select * from pg_subscription;'")
         end
 
-        def setup_remote_region(region)
+        def configure_remote_region(region)
           run_command("#{command_environment(region)} bin/rails r 'MiqRegion.replication_type= :remote'")
           run_command("psql -U #{PG_USER} #{database(region)} -c 'select * from pg_publication;'")
         end
 
-        def setup_one_region(region)
+        def create_region(region)
           run_command("#{command_environment(region)} DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake evm:db:region")
           run_command("#{command_environment(region)} bin/rails r 'EvmDatabase.seed_primordial'")
         ensure

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -2,110 +2,115 @@ require 'awesome_spawn'
 
 module TaskHelpers
   module Development
-    module Replication
+    class Replication
       REMOTES = [1, 2]
       GLOBAL  = 99
       GUID_FILE   = Rails.root.join("GUID")
       BACKUP_GUID = Rails.root.join("GUID.backup")
 
-      def self.backup
-        if File.exist?(guid_file)
-          FileUtils.rm_f(backup_guid)
-          FileUtils.mv(guid_file, backup_guid)
+      class << self
+        def backup
+          if File.exist?(guid_file)
+            FileUtils.rm_f(backup_guid)
+            FileUtils.mv(guid_file, backup_guid)
+          end
         end
-      end
 
-      def self.restore
-        if File.exist?(backup_guid)
+        def restore
+          if File.exist?(backup_guid)
+            FileUtils.rm_f(guid_file)
+            FileUtils.mv(backup_guid, guid_file)
+          end
+        end
+
+        def setup
+          REMOTES.each {|r| setup_remote(r) }
+          setup_global(GLOBAL)
+        end
+
+        def teardown
+          REMOTES.each do |r|
+            teardown_global_subscription_for_region(r)
+            teardown_remote_publication(r)
+          end
+        end
+
+        def setup_remote(region)
+          setup_one_region(region)
+          setup_remote_region(region)
+        end
+
+        def setup_global(region)
+          setup_one_region(region)
+          setup_global_region(region)
+        end
+
+
+        def database(region)
+          "development_replication_#{region}"
+        end
+
+        def database_url(region)
+          "postgres://root:smartvm@localhost:5432/#{database(region)}"
+        end
+
+        def guid_file
+          GUID_FILE
+        end
+
+        def backup_guid
+          BACKUP_GUID
+        end
+
+        def setup_global_region_script
+          host = '127.0.0.1'
+          port = '5432'
+          user = 'root'
+          password = 'smartvm'
+
+          subs = []
+          REMOTES.each do |r|
+            subs << PglogicalSubscription.new(:host => host, :port => port, :user => user, :dbname => database(r), :password => password)
+          end
+          MiqPglogical.save_global_region(subs, [])
+        end
+
+        private
+
+        def setup_global_region(region)
+          cmd = "RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' bin/rails r 'TaskHelpers::Development::Replication.setup_global_region_script'"
+          puts "Setting up global including subscriptions #{cmd.inspect}..."
+          puts AwesomeSpawn.run!(cmd).output
+        end
+
+        def setup_remote_region(region)
+          cmd = "RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' bin/rails r 'MiqRegion.replication_type= :remote; puts MiqRegion.replication_type'"
+          puts "Setting up publication #{cmd.inspect}..."
+          puts AwesomeSpawn.run!(cmd).output
+
+          psql_cmd = "psql -U root #{database(region)} -c 'select * from pg_publication;'"
+          puts AwesomeSpawn.run!(psql_cmd).output
+        end
+
+        def setup_one_region(region)
+          cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake evm:db:region"
+          puts "Running #{cmd.inspect}..."
+          puts AwesomeSpawn.run!(cmd).output
+
+          cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake db:seed"
+          puts "Running #{cmd.inspect}..."
+          puts AwesomeSpawn.run!(cmd).output
+        ensure
           FileUtils.rm_f(guid_file)
-          FileUtils.mv(backup_guid, guid_file)
         end
-      end
 
-      def self.setup
-        REMOTES.each {|r| setup_remote(r) }
-        setup_global(GLOBAL)
-      end
-
-      def self.setup_remote(region)
-        setup_one_region(region)
-        setup_remote_region(region)
-      end
-
-      def self.setup_global(region)
-        setup_one_region(region)
-        setup_global_region(region)
-      end
-
-      def self.setup_global_region(region)
-        cmd = "RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' bin/rails r 'TaskHelpers::Development::Replication.setup_global_region_script'"
-        puts "Setting up global including subscriptions #{cmd.inspect}..."
-        puts AwesomeSpawn.run!(cmd).output
-      end
-
-      def self.setup_global_region_script
-        host = '127.0.0.1'
-        port = '5432'
-        user = 'root'
-        password = 'smartvm'
-
-        subs = []
-        REMOTES.each do |r|
-          subs << PglogicalSubscription.new(:host => host, :port => port, :user => user, :dbname => database(r), :password => password)
+        def teardown_global_subscription_for_region(region)
+          puts `psql -U root #{database(GLOBAL)} -c "drop subscription region_#{region}_subscription;"`
         end
-        MiqPglogical.save_global_region(subs, [])
-      end
 
-      def self.setup_remote_region(region)
-        cmd = "RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' bin/rails r 'MiqRegion.replication_type= :remote; puts MiqRegion.replication_type'"
-        puts "Setting up publication #{cmd.inspect}..."
-        puts AwesomeSpawn.run!(cmd).output
-
-        psql_cmd = "psql -U root #{database(region)} -c 'select * from pg_publication;'"
-        puts AwesomeSpawn.run!(psql_cmd).output
-      end
-
-      def self.setup_one_region(region)
-        cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake evm:db:region"
-        puts "Running #{cmd.inspect}..."
-        puts AwesomeSpawn.run!(cmd).output
-
-        cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake db:seed"
-        puts "Running #{cmd.inspect}..."
-        puts AwesomeSpawn.run!(cmd).output
-      ensure
-        FileUtils.rm_f(guid_file)
-      end
-
-      def self.teardown
-        REMOTES.each do |r|
-          teardown_global_subscription_for_region(r)
-          teardown_remote_publication(r)
+        def teardown_remote_publication(region)
+          puts `psql -U root #{database(region)} -c "drop publication miq;"`
         end
-      end
-
-      def self.teardown_global_subscription_for_region(region)
-        puts `psql -U root #{database(GLOBAL)} -c "drop subscription region_#{region}_subscription;"`
-      end
-
-      def self.teardown_remote_publication(region)
-        puts `psql -U root #{database(region)} -c "drop publication miq;"`
-      end
-
-      def self.database(region)
-        "development_replication_#{region}"
-      end
-
-      def self.database_url(region)
-        "postgres://root:smartvm@localhost:5432/#{database(region)}"
-      end
-
-      def self.guid_file
-        GUID_FILE
-      end
-
-      def self.backup_guid
-        BACKUP_GUID
       end
     end
   end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -3,6 +3,11 @@ require 'awesome_spawn'
 module TaskHelpers
   module Development
     module Replication
+      REMOTES = [1, 2]
+      GLOBAL  = 99
+      GUID_FILE   = Rails.root.join("GUID")
+      BACKUP_GUID = Rails.root.join("GUID.backup")
+
       def self.backup
         if File.exist?(guid_file)
           FileUtils.rm_f(backup_guid)
@@ -18,9 +23,8 @@ module TaskHelpers
       end
 
       def self.setup
-        setup_remote(1)
-        setup_remote(2)
-        setup_global(99)
+        REMOTES.each {|r| setup_remote(r) }
+        setup_global(GLOBAL)
       end
 
       def self.setup_remote(region)
@@ -58,11 +62,11 @@ module TaskHelpers
       end
 
       def self.guid_file
-        Rails.root.join("GUID")
+        GUID_FILE
       end
 
       def self.backup_guid
-        Rails.root.join("GUID.backup")
+        BACKUP_GUID
       end
     end
   end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -53,7 +53,7 @@ module TaskHelpers
 
         def setup_global(region)
           create_region(region)
-          setup_global_region(region)
+          configure_global_region(region)
         end
 
         def database(region)
@@ -73,7 +73,7 @@ module TaskHelpers
           BACKUP_GUID
         end
 
-        def setup_global_region_script
+        def configure_global_region_script
           subs = []
           REMOTES.each do |r|
             subs << PglogicalSubscription.new(:host => PG_HOST, :port => PG_PORT, :user => PG_USER, :dbname => database(r), :password => PG_PASS)
@@ -87,8 +87,8 @@ module TaskHelpers
           {"REGION" => region.to_s, "RAILS_ENV" => "development", "DATABASE_URL" => database_url(region)}
         end
 
-        def setup_global_region(region)
-          run_command("bin/rails r 'TaskHelpers::Development::Replication.setup_global_region_script'", env: command_environment(region))
+        def configure_global_region(region)
+          run_command("bin/rails r 'TaskHelpers::Development::Replication.configure_global_region_script'", env: command_environment(region))
           run_command("psql -U #{PG_USER} #{database(region)} -c 'select * from pg_subscription;'")
         end
 

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -18,9 +18,17 @@ module TaskHelpers
       end
 
       def self.setup
-        [1, 2, 99].each do |region|
-          setup_one_region(region)
-        end
+        setup_remotes
+        setup_global
+      end
+
+      def self.setup_remotes
+        setup_one_region(1)
+        setup_one_region(2)
+      end
+
+      def self.setup_global
+        setup_one_region(99)
       end
 
       def self.setup_one_region(region)

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -53,6 +53,21 @@ module TaskHelpers
         FileUtils.rm_f(guid_file)
       end
 
+      def self.teardown
+        REMOTES.each do |r|
+          teardown_global_subscription_for_region(r)
+          teardown_remote_publication(r)
+        end
+      end
+
+      def self.teardown_global_subscription_for_region(region)
+        puts `psql -U root #{database(GLOBAL)} -c "drop subscription region_#{region}_subscription;"`
+      end
+
+      def self.teardown_remote_publication(region)
+        puts `psql -U root #{database(region)} -c "drop publication miq;"`
+      end
+
       def self.database(region)
         "development_replication_#{region}"
       end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -3,16 +3,16 @@ require 'awesome_spawn'
 module TaskHelpers
   module Development
     class Replication
-      REMOTES = [1, 2]
+      REMOTES = [1, 2].freeze
       GLOBAL  = 99
       GUID_FILE   = Rails.root.join("GUID")
       BACKUP_GUID = Rails.root.join("GUID.backup")
 
-      PG_USER   = "root"
-      PG_PASS   = "smartvm"
-      PG_HOST   = "localhost"
-      PG_PORT   = "5432"
-      DB_PREFIX = "development_replication"
+      PG_USER   = "root".freeze
+      PG_PASS   = "smartvm".freeze
+      PG_HOST   = "localhost".freeze
+      PG_PORT   = "5432".freeze
+      DB_PREFIX = "development_replication".freeze
 
       class << self
         def backup
@@ -30,7 +30,7 @@ module TaskHelpers
         end
 
         def setup
-          REMOTES.each {|r| setup_remote(r) }
+          REMOTES.each { |r| setup_remote(r) }
           setup_global(GLOBAL)
 
           # TODO: We have the technology to watch for this and report when it's all good or bad
@@ -74,9 +74,8 @@ module TaskHelpers
         end
 
         def configure_global_region_script
-          subs = []
-          REMOTES.each do |r|
-            subs << PglogicalSubscription.new(:host => PG_HOST, :port => PG_PORT, :user => PG_USER, :dbname => database(r), :password => PG_PASS)
+          subs = REMOTES.collect do |r|
+            PglogicalSubscription.new(:host => PG_HOST, :port => PG_PORT, :user => PG_USER, :dbname => database(r), :password => PG_PASS)
           end
           MiqPglogical.save_global_region(subs, [])
         end
@@ -93,7 +92,7 @@ module TaskHelpers
         end
 
         def configure_remote_region(region)
-          run_command("bin/rails r 'MiqRegion.replication_type= :remote'", env: command_environment(region))
+          run_command("bin/rails r 'MiqRegion.replication_type = :remote'", env: command_environment(region))
           run_command("psql -U #{PG_USER} #{database(region)} -c 'select * from pg_publication;'")
         end
 
@@ -110,7 +109,8 @@ module TaskHelpers
           puts AwesomeSpawn.run!(command, env: env).output
         rescue AwesomeSpawn::CommandResultError => err
           raise if raise_on_error
-          puts "Error skipped: #{err.to_s}"
+
+          puts "Error skipped: #{err}"
         ensure
           puts "-" * 50
         end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -97,17 +97,20 @@ module TaskHelpers
           FileUtils.rm_f(guid_file)
         end
 
-        def run_command(command)
+        def run_command(command, raise_on_error: true)
           puts "Running #{command.inspect}..."
           puts AwesomeSpawn.run!(command).output
+        rescue AwesomeSpawn::CommandResultError => err
+          raise if raise_on_error
+          puts "Error skipped: #{err.to_s}"
         end
 
         def teardown_global_subscription_for_region(region)
-          run_command("psql -U root #{database(GLOBAL)} -c 'drop subscription region_#{region}_subscription;'")
+          run_command("psql -U root #{database(GLOBAL)} -c 'drop subscription region_#{region}_subscription;'", raise_on_error: false)
         end
 
         def teardown_remote_publication(region)
-          run_command("psql -U root #{database(region)} -c 'drop publication miq;'")
+          run_command("psql -U root #{database(region)} -c 'drop publication miq;'", raise_on_error: false)
         end
       end
     end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -35,6 +35,8 @@ module TaskHelpers
 
           # TODO: We have the technology to watch for this and report when it's all good or bad
           puts "Local replication is setup... try checking for users in all regions: psql -U root development_replication_99 -c \"select id from users;\""
+        ensure
+          restore
         end
 
         def teardown

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -46,7 +46,11 @@ module TaskHelpers
       end
 
       def self.setup_one_region(region)
-        cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rails evm:db:region db:seed"
+        cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake evm:db:region"
+        puts "Running #{cmd.inspect}..."
+        puts AwesomeSpawn.run!(cmd).output
+
+        cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake db:seed"
         puts "Running #{cmd.inspect}..."
         puts AwesomeSpawn.run!(cmd).output
       ensure

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -34,6 +34,26 @@ module TaskHelpers
 
       def self.setup_global(region)
         setup_one_region(region)
+        setup_global_region(region)
+      end
+
+      def self.setup_global_region(region)
+        cmd = "RAILS_ENV='development' DATABASE_URL='#{database_url(region)}' bin/rails r 'TaskHelpers::Development::Replication.setup_global_region_script'"
+        puts "Setting up global including subscriptions #{cmd.inspect}..."
+        puts AwesomeSpawn.run!(cmd).output
+      end
+
+      def self.setup_global_region_script
+        host = '127.0.0.1'
+        port = '5432'
+        user = 'root'
+        password = 'smartvm'
+
+        subs = []
+        REMOTES.each do |r|
+          subs << PglogicalSubscription.new(:host => host, :port => port, :user => user, :dbname => database(r), :password => password)
+        end
+        MiqPglogical.save_global_region(subs, [])
       end
 
       def self.setup_remote_region(region)

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -100,11 +100,14 @@ module TaskHelpers
         end
 
         def run_command(command, raise_on_error: true)
-          puts "Running #{command.inspect}..."
+          puts "+" * 50
+          puts "Running: #{command.inspect}..."
           puts AwesomeSpawn.run!(command).output
         rescue AwesomeSpawn::CommandResultError => err
           raise if raise_on_error
           puts "Error skipped: #{err.to_s}"
+        ensure
+          puts "-" * 50
         end
 
         def teardown_global_subscription_for_region(region)

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -54,11 +54,11 @@ module TaskHelpers
           setup_global_region(region)
         end
 
-
         def database(region)
           "#{DB_PREFIX}_#{region}"
         end
 
+        # Example: DATABASE_URL='postgres://root:smartvm@localhost:5432/development_replication_99'
         def database_url(region)
           "postgres://#{PG_USER}:#{PG_PASS}@#{PG_HOST}:#{PG_PORT}/#{database(region)}"
         end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -32,6 +32,9 @@ module TaskHelpers
         def setup
           REMOTES.each {|r| setup_remote(r) }
           setup_global(GLOBAL)
+
+          # TODO: We have the technology to watch for this and report when it's all good or bad
+          puts "Local replication is setup... try checking for users in all regions: psql -U root development_replication_99 -c \"select id from users;\""
         end
 
         def teardown

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -1,0 +1,44 @@
+require 'awesome_spawn'
+
+module TaskHelpers
+  module Development
+    module Replication
+      def self.backup
+        if File.exist?(guid_file)
+          FileUtils.rm_f(backup_guid)
+          FileUtils.mv(guid_file, backup_guid)
+        end
+      end
+
+      def self.restore
+        if File.exist?(backup_guid)
+          FileUtils.rm_f(guid_file)
+          FileUtils.mv(backup_guid, guid_file)
+        end
+      end
+
+      def self.setup
+        [1, 2, 99].each do |region|
+          setup_one_region(region)
+        end
+      end
+
+      def self.setup_one_region(region)
+        database_url = "postgres://root:smartvm@localhost:5432/development_replication_#{region}"
+        cmd = "REGION='#{region}' RAILS_ENV='development' DATABASE_URL='#{database_url}' DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rails evm:db:region db:seed"
+        puts "Running #{cmd.inspect}..."
+        puts AwesomeSpawn.run!(cmd).output
+      ensure
+        FileUtils.rm_f(guid_file)
+      end
+
+      def self.guid_file
+        Rails.root.join("GUID")
+      end
+
+      def self.backup_guid
+        Rails.root.join("GUID.backup")
+      end
+    end
+  end
+end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module TaskHelpers
   module Development
     class Replication
@@ -60,7 +62,7 @@ module TaskHelpers
 
         # Example: DATABASE_URL='postgres://root:smartvm@localhost:5432/development_replication_99'
         def database_url(region)
-          "postgres://#{PG_USER}:#{PG_PASS}@#{PG_HOST}:#{PG_PORT}/#{database(region)}"
+          URI::Generic.build(:scheme => "postgres", :host => PG_HOST, :userinfo => "#{PG_USER}:#{PG_PASS}", :port => PG_PORT, :path => "/#{database(region)}").to_s
         end
 
         def guid_file

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -92,7 +92,7 @@ module TaskHelpers
 
         def setup_one_region(region)
           run_command("#{command_environment(region)} DISABLE_DATABASE_ENVIRONMENT_CHECK='true' bin/rake evm:db:region")
-          run_command("#{command_environment(region)} bin/rake db:seed")
+          run_command("#{command_environment(region)} bin/rails r 'EvmDatabase.seed_primordial'")
         ensure
           FileUtils.rm_f(guid_file)
         end

--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -84,10 +84,11 @@ module TaskHelpers
 
         def setup_global_region(region)
           run_command("#{command_environment(region)} bin/rails r 'TaskHelpers::Development::Replication.setup_global_region_script'")
+          run_command("psql -U #{PG_USER} #{database(region)} -c 'select * from pg_subscription;'")
         end
 
         def setup_remote_region(region)
-          run_command("#{command_environment(region)} bin/rails r 'MiqRegion.replication_type= :remote; puts MiqRegion.replication_type'")
+          run_command("#{command_environment(region)} bin/rails r 'MiqRegion.replication_type= :remote'")
           run_command("psql -U #{PG_USER} #{database(region)} -c 'select * from pg_publication;'")
         end
 

--- a/lib/tasks/development_replication.rake
+++ b/lib/tasks/development_replication.rake
@@ -6,5 +6,9 @@ namespace :development do
       TaskHelpers::Development::Replication.setup
       TaskHelpers::Development::Replication.restore
     end
+
+    task :teardown => :environment do
+      TaskHelpers::Development::Replication.teardown
+    end
   end
 end

--- a/lib/tasks/development_replication.rake
+++ b/lib/tasks/development_replication.rake
@@ -4,7 +4,6 @@ namespace :development do
     task :setup => :environment do
       TaskHelpers::Development::Replication.backup
       TaskHelpers::Development::Replication.setup
-      TaskHelpers::Development::Replication.restore
     end
 
     task :teardown => :environment do

--- a/lib/tasks/development_replication.rake
+++ b/lib/tasks/development_replication.rake
@@ -1,0 +1,10 @@
+namespace :development do
+  namespace :replication do
+    desc "Manually setup logical replication locally"
+    task :setup => :environment do
+      TaskHelpers::Development::Replication.backup
+      TaskHelpers::Development::Replication.setup
+      TaskHelpers::Development::Replication.restore
+    end
+  end
+end


### PR DESCRIPTION
The summary of these rake tasks follow:

`rake development:replication:setup`

This task will setup 2 remote regions (1, 2) and a global region (99) and will configure them to replicate from the remotes to the global.  This last part means the two remotes (1, 2) each have a `publication` and the global, 99, has a `subscription` to these remotes. 

All 3 databases are seeded primordially, which means that after `setup` completes, replication will begin and  the region 99 database will have the admin user from region 1, 2, and 99 after a few minutes.

`rake development:replication:teardown`

This will stop replication but not blow away the databases.  This will drop the subscriptions on the global and the publications on the remotes.

Part of https://github.com/ManageIQ/manageiq/issues/21299

## Example output:

### Normal setup with 2 regions and 1 global:
![image](https://user-images.githubusercontent.com/19339/126706586-9147b075-a39b-409e-90ea-f05358f782d6.png)

### Normal teardown of the publications and subscriptions:

![image](https://user-images.githubusercontent.com/19339/126706653-8eef7d63-f50e-4504-8729-babc56886b4c.png)


### Non-fatal warning if you try to remove non-existing publication/subscriptions

![image](https://user-images.githubusercontent.com/19339/126706747-dc12fc8f-8035-42e0-8883-f25faf4592bf.png)

### Fatal error if you try to setup an environment that already is configured with publications and subscriptions:

![image](https://user-images.githubusercontent.com/19339/126698976-b73a7018-457a-44aa-a09b-95c4a75de6e8.png)

