### PR TITLE
[Kasparov] update mimemagic

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -796,7 +796,9 @@ GEM
     memoist (0.16.2)
     memory_buffer (0.1.0)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.3)

--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -477,7 +477,6 @@ GEM
     bunny (2.1.0)
       amq-protocol (>= 2.0.0)
     byebug (11.1.3)
-    coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -494,7 +493,6 @@ GEM
     dalli (2.7.6)
     dbus-systemd (1.1.2)
       ruby-dbus (~> 0.14)
-    dead_end (1.1.7)
     declarative (0.0.20)
     declarative-option (0.1.0)
     deep_merge (1.2.1)
@@ -872,19 +870,6 @@ GEM
     prometheus-api-client (0.6.2)
       faraday (>= 0.9, < 2.0.0)
     promise.rb (0.7.4)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
-    pry-doc (1.1.0)
-      pry (~> 0.11)
-      yard (~> 0.9.11)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
-    pry-theme (1.3.1)
-      coderay (~> 1.1)
     psych (3.3.0)
     public_suffix (3.1.1)
     puma (4.3.7)
@@ -1113,7 +1098,6 @@ GEM
       httpclient (~> 2.8.3)
       json-schema (~> 2.8.0)
       uuid (~> 2.3.8)
-    yard (0.9.26)
 
 PLATFORMS
   ruby
@@ -1133,7 +1117,6 @@ DEPENDENCIES
   config (= 2.2.1)
   dalli (= 2.7.6)
   dbus-systemd (~> 1.1.0)
-  dead_end
   default_value_for (~> 3.3)
   docker-api (~> 1.33.6)
   elif (= 0.1.0)
@@ -1200,11 +1183,6 @@ DEPENDENCIES
   pg
   pg-dsn_parser (~> 0.1.0)
   pg-logical_replication (~> 1.0)
-  pry
-  pry-byebug
-  pry-doc
-  pry-rails
-  pry-theme
   psych (~> 3.1)
   puma (~> 4.2)
   qpid_proton (~> 0.30.0)


### PR DESCRIPTION
- Some dev dependencies were accidentally introduced, remove them
- Update mimemagic to fix `Your bundle is locked to mimemagic (0.3.5), but that version could not be found`