### PR TITLE
Add virtual_column for Flavor cpus/cpu_cores

### DIFF
--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -17,6 +17,9 @@ class Flavor < ApplicationRecord
   alias_attribute :cpus, :cpu_total_cores
   alias_attribute :cpu_cores, :cpu_cores_per_socket
 
+  virtual_column :cpus, :type => :integer
+  virtual_column :cpu_cores, :type => :integer
+
   def name_with_details
     details = if cpus == 1
                 if root_disk_size.nil?


### PR DESCRIPTION
Add a virtual_column for the two aliases (cpus, cpu_cores) for backwards compatibility.  Without the virtual_column the automatically built service models in automate doesn't pick up on the alias.

Fix for https://travis-ci.com/github/ManageIQ/manageiq-automation_engine/jobs/524298720#L2156 and https://travis-ci.com/github/ManageIQ/manageiq-content/jobs/524299345#L2188-L2192