### PR TITLE
Split 'ibm' vendor into 'ibm_cloud' and 'ibm_power_vc'

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -35,20 +35,21 @@ class VmOrTemplate < ApplicationRecord
 
   VENDOR_TYPES = {
     # DB            Displayed
-    "azure"       => "Azure",
-    "azure_stack" => "AzureStack",
-    "vmware"      => "VMware",
-    "microsoft"   => "Microsoft",
-    "xen"         => "XenSource",
-    "parallels"   => "Parallels",
-    "amazon"      => "Amazon",
-    "redhat"      => "RedHat",
-    "openstack"   => "OpenStack",
-    "oracle"      => "Oracle",
-    "google"      => "Google",
-    "kubevirt"    => "KubeVirt",
-    "ibm"         => "IBM",
-    "unknown"     => "Unknown"
+    "azure"        => "Azure",
+    "azure_stack"  => "AzureStack",
+    "vmware"       => "VMware",
+    "microsoft"    => "Microsoft",
+    "xen"          => "XenSource",
+    "parallels"    => "Parallels",
+    "amazon"       => "Amazon",
+    "redhat"       => "RedHat",
+    "openstack"    => "OpenStack",
+    "oracle"       => "Oracle",
+    "google"       => "Google",
+    "kubevirt"     => "KubeVirt",
+    "ibm_cloud"    => "IBM Cloud",
+    "ibm_power_vc" => "IBM PowerVC",
+    "unknown"      => "Unknown"
   }
 
   POWER_OPS = %w(start stop suspend reset shutdown_guest standby_guest reboot_guest)


### PR DESCRIPTION
The 'ibm' vendor was being used to identify IBM Cloud providers (along
with an IBM Cloud icon). Splitting it into two types that each have
unique branding.

See https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/243

Schema data migration: https://github.com/ManageIQ/manageiq-schema/pull/587