### PR TITLE
[TokenStore] Use ActiveSupport::Cache::MemCacheStore

### DIFF
--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -38,8 +38,8 @@ class TokenStore
           store.extend KeyValueHelpers
         end
       when "cache"
-        require 'active_support/cache/dalli_store'
-        ActiveSupport::Cache::DalliStore.new(MiqMemcached.server_address, options).tap do |store|
+        require 'active_support/cache/mem_cache_store'
+        ActiveSupport::Cache::MemCacheStore.new(MiqMemcached.server_address, options).tap do |store|
           store.extend KeyValueHelpers
         end
       else


### PR DESCRIPTION
This is the Rails default now, and using the one from Dalli results in a
deprecation warning:

```
DEPRECATION: :dalli_store will be removed in Dalli 3.0.
Please use Rails' official :mem_cache_store instead.
https://guides.rubyonrails.org/caching_with_rails.html
```

Links
-----

* TBD (Will do a `cross-repo` with this one to make sure the API and UI still work...)