### PR TITLE
Restore log/.gitkeep

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -42,9 +42,6 @@ module ManageIQ
         puts "Copying #{file} from template..."
         FileUtils.cp(APP_ROOT.join(source), file)
       end
-
-      logdir = APP_ROOT.join("log")
-      Dir.mkdir(logdir) unless Dir.exist?(logdir)
     end
 
     def self.update_ui_thread


### PR DESCRIPTION
Partial revert of ab4fa873 and 432531f6. Now that appliances are RPM-based,
the original git-based rationale for removing this no longer applies.

Replacement PR for #21327 

@bdunne @kbrock Please review.