### PR TITLE
Fix start_servers starting servers twice

### DIFF
--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -38,7 +38,8 @@ class EvmServer
   end
 
   def start_servers
-    refresh_servers_to_monitor
+    @servers_to_monitor = servers_from_db if servers_to_monitor.empty?
+
     as_each_server { start_server }
   end
 

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     started_on      { Time.now.utc }
     stopped_on      { "" }
     version         { '9.9.9.9' }
+
+    factory :miq_server_in_default_zone do
+      zone          { FactoryBot.build(:zone, :name => "default") }
+    end
   end
 end

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -102,6 +102,49 @@ describe EvmServer do
     end
   end
 
+  describe "#start_servers" do
+    context "when podified" do
+      before do
+        allow(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+      end
+
+      it "impersonates and starts just created servers in region" do
+        subject
+        2.times { FactoryBot.create(:miq_server_in_default_zone) }
+        expect(subject).to receive(:impersonate_server).twice
+        expect(subject).to receive(:start_server).twice
+        subject.start_servers
+      end
+
+      it "impersonates and starts previously created servers in region" do
+        2.times { FactoryBot.create(:miq_server_in_default_zone) }
+        expect(subject).to receive(:impersonate_server).twice
+        expect(subject).to receive(:start_server).twice
+        subject.start_servers
+      end
+    end
+
+    context "when appliances" do
+      it "impersonates and starts just created my_server" do
+        subject
+        EvmSpecHelper.local_miq_server
+        2.times { FactoryBot.create(:miq_server_in_default_zone) }
+        expect(subject).to receive(:impersonate_server).once
+        expect(subject).to receive(:start_server).once
+        subject.start_servers
+      end
+
+      it "impersonates and starts previously created my_server" do
+        EvmSpecHelper.local_miq_server
+        2.times { FactoryBot.create(:miq_server_in_default_zone) }
+
+        expect(subject).to receive(:impersonate_server).once
+        expect(subject).to receive(:start_server).once
+        subject.start_servers
+      end
+    end
+  end
+
   describe "#as_each_server (private)" do
     it "yields the local server when not podified" do
       server = EvmSpecHelper.local_miq_server

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -117,6 +117,7 @@ describe EvmServer do
       before do
         4.times { FactoryBot.create(:miq_server) }
         allow(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+        allow(Vmdb::Settings::Validator).to receive(:new).and_return(double(:valid? => true, :validate => [true, {}]))
       end
 
       it "sets the server variable to each server" do


### PR DESCRIPTION
Initialize an empty servers_to_monitor to avoid repeat starts 

refresh_servers_to_monitor is responsible for detecting added or
removed servers and reacting to them.  It does the following:
1) refresh the servers to monitor list: adding or removing servers from the list.
2) With this server list, start new servers and stop no longer monitored servers.

This logic is used in monitor_servers to ensure the list of monitored servers is
correct and starts or stops based on this list vs. the prior iteration's list.

For start_servers, there is no desired state list we care about, only the
current list of servers from the db, therefore we can avoid using refresh_servers_to_monitor
and update the list directly if it was previously empty.

This avoids having two methods that could start servers in the start_servers
method and possibly starting the same server twice.  This was happening when seeding
the default server AFTER the EvmServer object was initialized, which happens in the start method.

Note, this was causing weird issues when I tested appliance builds on lasker-1.  On initial deployment, the first start of evmserverd would completely start the workers, and then another attempt to start the server was done, causing strange errors.

For Example:

```
### First start:
[----] I, [2021-07-15T11:48:24.378074 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#impersonate_server) Impersonating server - id: 1, guid: fa82ab2b-8da3-42f1-a472-0b40022a0afb
[----] I, [2021-07-15T11:48:24.957076 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server IP Address: 192.168.1.20
[----] I, [2021-07-15T11:48:24.957234 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Hostname: new-host
[----] I, [2021-07-15T11:48:24.957323 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server MAC Address: 08:00:27:aa:40:4b
[----] I, [2021-07-15T11:48:24.957415 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server GUID: fa82ab2b-8da3-42f1-a472-0b40022a0afb
[----] I, [2021-07-15T11:48:24.957585 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Zone: default
[----] I, [2021-07-15T11:48:24.964305 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Role:
[----] I, [2021-07-15T11:48:24.964463 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Region number: 0, name: Region 0
[----] I, [2021-07-15T11:48:24.967655 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Database Latency: 0.30341280000243387 ms
[----] I, [2021-07-15T11:48:24.967763 #6591:2b19cec5d970]  INFO -- evm: *************************************************
[----] I, [2021-07-15T11:48:24.967825 #6591:2b19cec5d970]  INFO -- evm: * [VMDB] started on [2021-07-15 11:48:24 -0400] *
[----] I, [2021-07-15T11:48:24.967884 #6591:2b19cec5d970]  INFO -- evm: *************************************************
[----] I, [2021-07-15T11:48:24.967987 #6591:2b19cec5d970]  INFO -- evm: Release: Lasker
[----] I, [2021-07-15T11:48:24.968393 #6591:2b19cec5d970]  INFO -- evm: Version: lasker-1
[----] I, [2021-07-15T11:48:24.968699 #6591:2b19cec5d970]  INFO -- evm: Build:   20210713173155_7f825df
[----] I, [2021-07-15T11:48:24.968772 #6591:2b19cec5d970]  INFO -- evm: Codename: Lasker
...
### Second start
** Server starting...Complete
[----] I, [2021-07-15T11:49:36.300388 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server IP Address: 192.168.1.20
[----] I, [2021-07-15T11:49:36.300507 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Hostname: new-host
[----] I, [2021-07-15T11:49:36.300622 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server MAC Address: 08:00:27:aa:40:4b
[----] I, [2021-07-15T11:49:36.300723 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server GUID: fa82ab2b-8da3-42f1-a472-0b40022a0afb
[----] I, [2021-07-15T11:49:36.300832 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Zone: default
[----] I, [2021-07-15T11:49:36.301856 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Role: automate,database_operations,database_owner,ems_inventory,ems_operations,event,remote_console,reporting,scheduler,smartstate,user_interface,web_services
[----] I, [2021-07-15T11:49:36.301962 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Server Region number: 0, name: Region 0
[----] I, [2021-07-15T11:49:36.303915 #6591:2b19cec5d970]  INFO -- evm: MIQ(EvmServer#log_server_info) Database Latency: 0.1831172999999353 ms
[----] I, [2021-07-15T11:49:36.304009 #6591:2b19cec5d970]  INFO -- evm: *************************************************
[----] I, [2021-07-15T11:49:36.304065 #6591:2b19cec5d970]  INFO -- evm: * [VMDB] started on [2021-07-15 11:49:36 -0400] *
[----] I, [2021-07-15T11:49:36.304123 #6591:2b19cec5d970]  INFO -- evm: *************************************************
[----] I, [2021-07-15T11:49:36.304217 #6591:2b19cec5d970]  INFO -- evm: Release: Lasker
[----] I, [2021-07-15T11:49:36.304273 #6591:2b19cec5d970]  INFO -- evm: Version: lasker-1
[----] I, [2021-07-15T11:49:36.304326 #6591:2b19cec5d970]  INFO -- evm: Build:   20210713173155_7f825df
[----] I, [2021-07-15T11:49:36.304386 #6591:2b19cec5d970]  INFO -- evm: Codename: Lasker
...
### Some errors after the second start:
Jul 15 11:49:41 new-host manageiq[7097]: INFO -- evm: MIQ(MiqScheduleWorker#log_status) [Schedule Worker] Worker ID [9], PID [7097], GUID [dc78d9f9-af59-4196-8ad2-14803924fbe1], Last Heartbeat [2021-07-15 15:49:25 UTC], Process Info: Memory Usage [222642176], Memory Size [443441152], Proportional Set Size: [202388000], Unique Set Size: [201508000], Memory % [0.04], CPU Time [1008.0], CPU % [0.05], Priority [20]
Jul 15 11:49:41 new-host manageiq[7097]: ERROR -- evm: MIQ(MiqScheduleWorker::Runner) ID [9] PID [7097] GUID [dc78d9f9-af59-4196-8ad2-14803924fbe1] Error heartbeating because Dalli::RingError: No server available#012/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/ring.rb:45:in `server_for_key'\n/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/client.rb:361:in `perform'\n/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/client.rb:58:in `get'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:337:in `server_last_change'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:322:in `config_out_of_date?'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:296:in `heartbeat'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:266:in `block in do_work_loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:264:in `loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:264:in `do_work_loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:114:in `run'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:96:in `start'\nlib/workers/bin/run_single_worker.rb:128:in `<main>' Worker exiting.
Jul 15 11:49:41 new-host manageiq[7097]: INFO -- evm: Deleting worker record for MiqScheduleWorker, id 9
Jul 15 11:49:41 new-host systemd[1]: Started memcached daemon.
Jul 15 11:49:41 new-host manageiq[6591]: INFO -- evm: MIQ(MiqMemcached::Control.start) started memcached with options: {:port=>"11211", :options=>"-l 127.0.0.1 -I 1M"}
Jul 15 11:49:41 new-host systemd[1]: schedule@dc78d9f9-af59-4196-8ad2-14803924fbe1.service: Succeeded.
Jul 15 11:49:41 new-host manageiq[7126]: INFO -- evm: MIQ(MiqWebServiceWorker#log_status) [Web Services Worker] Worker ID [11], PID [7126], GUID [e4a7d16a-9990-46c4-97ac-cc57bcfc94cd], Last Heartbeat [2021-07-15 15:49:28 UTC], Process Info: Memory Usage [274550784], Memory Size [529330176], Proportional Set Size: [252969000], Unique Set Size: [252020000], Memory % [0.05], CPU Time [1295.0], CPU % [0.06], Priority [20]
Jul 15 11:49:41 new-host manageiq[7126]: ERROR -- evm: MIQ(MiqWebServiceWorker::Runner) ID [11] PID [7126] GUID [e4a7d16a-9990-46c4-97ac-cc57bcfc94cd] Error heartbeating because Dalli::RingError: No server available#012/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/ring.rb:45:in `server_for_key'\n/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/client.rb:361:in `perform'\n/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/client.rb:58:in `get'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:337:in `server_last_change'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:322:in `config_out_of_date?'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:296:in `heartbeat'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:266:in `block in do_work_loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:264:in `loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:264:in `do_work_loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:114:in `run'\n/var/www/miq/vmdb/app/models/mixins/miq_web_server_runner_mixin.rb:13:in `block in run' Worker exiting.
Jul 15 11:49:41 new-host manageiq[7110]: INFO -- evm: MIQ(MiqUiWorker#log_status) [User Interface Worker] Worker ID [10], PID [7110], GUID [fd3fe5e1-63e8-43c1-8fe5-a98d4f22bcf4], Last Heartbeat [2021-07-15 15:49:28 UTC], Process Info: Memory Usage [274427904], Memory Size [529190912], Proportional Set Size: [253034000], Unique Set Size: [252096000], Memory % [0.05], CPU Time [1312.0], CPU % [0.06], Priority [20]
Jul 15 11:49:41 new-host manageiq[7110]: ERROR -- evm: MIQ(MiqUiWorker::Runner) ID [10] PID [7110] GUID [fd3fe5e1-63e8-43c1-8fe5-a98d4f22bcf4] Error heartbeating because Dalli::RingError: No server available#012/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/ring.rb:45:in `server_for_key'\n/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/client.rb:361:in `perform'\n/opt/manageiq/manageiq-gemset/gems/dalli-2.7.6/lib/dalli/client.rb:58:in `get'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:337:in `server_last_change'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:322:in `config_out_of_date?'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:296:in `heartbeat'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:266:in `block in do_work_loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:264:in `loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:264:in `do_work_loop'\n/var/www/miq/vmdb/app/models/miq_worker/runner.rb:114:in `run'\n/var/www/miq/vmdb/app/models/mixins/miq_web_server_runner_mixin.rb:13:in `block in run' Worker exiting.
Jul 15 11:49:41 new-host manageiq[7126]: INFO -- evm: Deleting worker record for MiqWebServiceWorker, id 11
Jul 15 11:49:41 new-host manageiq[7110]: INFO -- evm: Deleting worker record for MiqUiWorker, id 10

```