### PR TITLE
Add jpeg Extension to picture.rb

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -2,7 +2,7 @@ class Picture < ApplicationRecord
   validates :content, :presence => true
   validates :extension,
             :presence  => true,
-            :inclusion => { :in => %w(png jpg svg), :message => 'must be a png, jpg, or svg' }
+            :inclusion => {:in => %w[png jpeg jpg svg], :message => 'must be a png, jpg/jpeg, or svg'}
 
   virtual_has_one :image_href, :class_name => "String"
 

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe Picture do
     it 'is required' do
       subject.extension = nil
       expect(subject.valid?).to be_falsey
-      expect(subject.errors.messages).to eq(:extension => ["can't be blank", "must be a png, jpg, or svg"])
+      expect(subject.errors.messages).to eq(:extension => ["can't be blank", "must be a png, jpg/jpeg, or svg"])
     end
 
-    it "accepts only png, jpg, or svg" do
+    it "accepts only specific file extensions" do
       subject.extension = "foo"
 
       expect(subject.valid?).to be_falsey
-      expect(subject.errors.messages).to eq(:extension =>['must be a png, jpg, or svg'])
+      expect(subject.errors.messages).to eq(:extension => ["must be a png, jpg/jpeg, or svg"])
 
       subject.extension = "png"
       expect(subject.valid?).to be_truthy


### PR DESCRIPTION
Added .jpeg extension to list of allowed image extensions in picture.rb
Needs to be merged before: https://github.com/ManageIQ/manageiq-ui-classic/pull/7694