### PR TITLE
Only restart memcached when config changed

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -26,12 +26,17 @@ module MiqServer::EnvironmentManagement
 
     def start_memcached
       # TODO: Need to periodically check the memcached instance to see if it's up, and bounce it and notify the UiWorkers to re-connect
-      return unless ::Settings.server.session_store.to_s == 'cache'
-      return unless MiqEnvironment::Command.supports_memcached?
-      require "#{Rails.root}/lib/miq_memcached" unless Object.const_defined?(:MiqMemcached)
+      return if !::Settings.server.session_store.to_s == 'cache' || !MiqEnvironment::Command.supports_memcached?
+
+      require Rails.root.join("lib/miq_memcached").to_s unless Object.const_defined?(:MiqMemcached)
+
       _svr, port = MiqMemcached.server_address.to_s.split(":")
       opts = ::Settings.session.memcache_server_opts.to_s
-      MiqMemcached::Control.restart!(:port => port, :options => opts)
+
+      if MiqMemcached::Config.new(opts).changed?(MiqMemcached::Control::CONF_FILE)
+        MiqMemcached::Control.restart!(:port => port, :options => opts)
+      end
+
       _log.info("Status: #{MiqMemcached::Control.status[1]}")
     end
   end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -26,16 +26,15 @@ module MiqServer::EnvironmentManagement
 
     def start_memcached
       # TODO: Need to periodically check the memcached instance to see if it's up, and bounce it and notify the UiWorkers to re-connect
-      return if !::Settings.server.session_store.to_s == 'cache' || !MiqEnvironment::Command.supports_memcached?
+      return unless ::Settings.server.session_store.to_s == 'cache'
+      return unless MiqEnvironment::Command.supports_memcached?
 
       require Rails.root.join("lib/miq_memcached").to_s unless Object.const_defined?(:MiqMemcached)
 
       _svr, port = MiqMemcached.server_address.to_s.split(":")
       opts = ::Settings.session.memcache_server_opts.to_s
 
-      if MiqMemcached::Config.new(opts).changed?(MiqMemcached::Control::CONF_FILE)
-        MiqMemcached::Control.restart!(:port => port, :options => opts)
-      end
+      MiqMemcached::Control.restart!(:port => port, :options => opts) if MiqMemcached::Config.new(:port => port, :options => opts).changed?
 
       _log.info("Status: #{MiqMemcached::Control.status[1]}")
     end

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -20,6 +20,8 @@ module MiqMemcached
   class ControlError < Error; end
 
   class Config
+    # TODO: Expose all of the constants and get them from the config
+    DEFAULT_CONF_FILE = '/etc/sysconfig/memcached'
     DEFAULT_PORT = 11211
     DEFAULT_USER = 'memcached'
     DEFAULT_MEMORY = 64
@@ -30,11 +32,11 @@ module MiqMemcached
       update(opts)
     end
 
-    def save(fname)
+    def save(fname = DEFAULT_CONF_FILE)
       File.open(fname, "w") { |f| f.write(@config) }
     end
 
-    def changed?(fname)
+    def changed?(fname = DEFAULT_CONF_FILE)
       current_config = File.read(fname)
       current_config == @config
     end
@@ -108,11 +110,8 @@ module MiqMemcached
     #                (default: 1mb, min: 1k, max: 128m)
     #  -S            Turn on Sasl authentication
 
-    # TODO: Expose all of the constants and get them from the config
-    CONF_FILE = '/etc/sysconfig/memcached'
-
     def self.start(opts = {})
-      MiqMemcached::Config.new(opts).save(CONF_FILE)
+      MiqMemcached::Config.new(opts).save
       LinuxAdmin::Service.new("memcached").start
       _log.info("started memcached with options: #{opts.inspect}")
       true

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -34,6 +34,11 @@ module MiqMemcached
       File.open(fname, "w") { |f| f.write(@config) }
     end
 
+    def changed?(fname)
+      current_config = File.read(fname)
+      current_config == @config
+    end
+
     def update(opts = {})
       port = opts[:port] || DEFAULT_PORT
       user = opts[:user] || DEFAULT_USER
@@ -41,13 +46,14 @@ module MiqMemcached
       maxconn = opts[:maxconn] || DEFAULT_MAXCONN
       options = opts[:options] || DEFAULT_OPTIONS
 
-      @config = <<-END_OF_CONFIG
-PORT="#{port}"
-USER="#{user}"
-MAXCONN="#{maxconn}"
-CACHESIZE="#{memory}"
-OPTIONS="#{options}"
-END_OF_CONFIG
+      @config = <<~END_OF_CONFIG
+        PORT="#{port}"
+        USER="#{user}"
+        MAXCONN="#{maxconn}"
+        CACHESIZE="#{memory}"
+        OPTIONS="#{options}"
+      END_OF_CONFIG
+
       @config
     end
   end


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq-appliance/pull/321 systemd will automatically start memcached for us whenever evmserverd starts up.

Currently `lib/workers/evm_server.rb` writes out config and restarts it everytime evmserverd starts up.  We only need to restart it if the config has changed