### PR TITLE
Utility to load provider info and write securely to stdin

### DIFF
--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -28,6 +28,13 @@ provider_opts = {
 
 # Create a temp file and immediately unlink it to create a
 # secure hidden file to be used for the child process' stdin.
+#
+# Typically this is done using a pipe but because we are exec'ing
+# the child worker not forking it we aren't able to have the child
+# worker read from one side of the pipe while the parent is writing
+# to the other side.  This means that the amount of data that can be
+# written is limited to the buffer size of the pipe and if you write
+# more than that it will hang.
 stdin_tmp = Tempfile.new
 File.unlink(stdin_tmp.path)
 
@@ -38,4 +45,7 @@ $stdin.reopen(stdin_tmp)
 
 puts "Starting PID: #{Process.pid} with #{args}..."
 
+# Using exec here rather than fork+exec so that we can continue to use the
+# standard systemd service Type=notify and not have to use Type=forking which
+# can limit other systemd options available to the service.
 Kernel.exec(args)

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -6,14 +6,16 @@ ems_id = ENV["EMS_ID"]
 
 ems      = ExtManagementSystem.find(ems_id)
 all_emss = [ems] + ems.child_managers
+ems_opts = all_emss.map do |e|
+  e.attributes.merge(
+    "endpoints"       => e.endpoints,
+    "authentications" => e.authentications
+  )
+end
 
 provider_opts = {
-  :ems => all_emss.map do |e|
-    e.attributes.merge(
-      "endpoints"       => e.endpoints,
-      "authentications" => e.authentications
-    )
-  end
+  :ems       => ems_opts,
+  :messaging => MiqQueue.messaging_client_options
 }
 
 # Send the connection information to the child process via STDIN by creating a

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require File.expand_path("../../../config/environment", __dir__)
+
+ems_id = ENV["EMS_ID"]
+
+ems = ExtManagementSystem.find(ems_id)
+
+provider_opts = {
+  :ems_id            => ems_id,
+  :ems_name          => ems.name,
+  :connection_config => ems.connection_configurations
+}
+
+stdin_rd, stdin_wr = IO.pipe
+stdin_wr.write(provider_opts.to_json)
+stdin_wr.close
+
+$stdin.reopen(stdin_rd)
+
+Kernel.exec(ARGV.join(" "))

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -15,7 +15,8 @@ end
 
 provider_opts = {
   :ems       => ems_opts,
-  :messaging => MiqQueue.messaging_client_options
+  :messaging => MiqQueue.messaging_client_options,
+  :settings  => Settings.to_h
 }
 
 # Create a temp file and immediately unlink it to create a

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -5,13 +5,21 @@ $stdout.sync = true
 require 'shellwords'
 args = ARGV.shelljoin
 
-puts "** Booting PID: #{Process.pid} with #{args}..."
+ems_id = ENV["EMS_ID"]
+abort("ERR: EMS_ID environment variable required") if ems_id.nil?
+
+worker_type = ENV["WORKER_TYPE"]
+abort("ERR: WORKER_TYPE environment variable required") if worker_type.nil?
+
+$stdout.puts "** Booting #{worker_type} with PID: #{Process.pid} and args: #{args}..."
 
 require File.expand_path("../../../config/environment", __dir__)
 
-ems_id = ENV["EMS_ID"]
+abort("ERR: WORKER_TYPE not found") unless MiqWorkerType.find_by(:worker_type => worker_type)
 
-ems      = ExtManagementSystem.find(ems_id)
+ems = ExtManagementSystem.find_by(:id => ems_id)
+abort("ERR: EMS not found for ID [#{ems_id}]") if ems.nil?
+
 all_emss = [ems] + ems.child_managers
 ems_opts = all_emss.map do |e|
   e.attributes.merge(
@@ -43,7 +51,7 @@ stdin_tmp.rewind
 
 $stdin.reopen(stdin_tmp)
 
-puts "Starting PID: #{Process.pid} with #{args}..."
+$stdout.puts "Starting #{worker_type} with PID: #{Process.pid} and args: #{args}..."
 
 # Using exec here rather than fork+exec so that we can continue to use the
 # standard systemd service Type=notify and not have to use Type=forking which

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -31,7 +31,7 @@ end
 provider_opts = {
   :ems       => ems_opts,
   :messaging => MiqQueue.messaging_client_options,
-  :settings  => Settings.to_h
+  :settings  => Settings.to_hash
 }
 
 # Create a temp file and immediately unlink it to create a

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -12,6 +12,10 @@ provider_opts = {
   :connection_config => ems.connection_configurations
 }
 
+# Send the connection information to the child process via STDIN by creating a
+# pipe, writing the config to our end of the pipe, and replacing STDIN with the
+# read end of the pipe.  This allows the child to simply read from STDIN to get
+# the credentials and other config in a secure way.
 stdin_rd, stdin_wr = IO.pipe
 stdin_wr.write(provider_opts.to_json)
 stdin_wr.close

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -1,5 +1,12 @@
 #!/usr/bin/env ruby
 
+$stdout.sync = true
+
+require 'shellwords'
+args = ARGV.shelljoin
+
+puts "** Booting PID: #{Process.pid} with #{args}..."
+
 require File.expand_path("../../../config/environment", __dir__)
 
 ems_id = ENV["EMS_ID"]
@@ -29,4 +36,6 @@ stdin_tmp.rewind
 
 $stdin.reopen(stdin_tmp)
 
-Kernel.exec(ARGV.shelljoin)
+puts "Starting PID: #{Process.pid} with #{args}..."
+
+Kernel.exec(args)

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -18,14 +18,14 @@ provider_opts = {
   :messaging => MiqQueue.messaging_client_options
 }
 
-# Send the connection information to the child process via STDIN by creating a
-# pipe, writing the config to our end of the pipe, and replacing STDIN with the
-# read end of the pipe.  This allows the child to simply read from STDIN to get
-# the credentials and other config in a secure way.
-stdin_rd, stdin_wr = IO.pipe
-stdin_wr.write(provider_opts.to_json)
-stdin_wr.close
+# Create a temp file and immediately unlink it to create a
+# secure hidden file to be used for the child process' stdin.
+stdin_tmp = Tempfile.new
+File.unlink(stdin_tmp.path)
 
-$stdin.reopen(stdin_rd)
+stdin_tmp.write(provider_opts.to_json)
+stdin_tmp.rewind
+
+$stdin.reopen(stdin_tmp)
 
 Kernel.exec(ARGV.shelljoin)

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -4,12 +4,16 @@ require File.expand_path("../../../config/environment", __dir__)
 
 ems_id = ENV["EMS_ID"]
 
-ems = ExtManagementSystem.find(ems_id)
+ems      = ExtManagementSystem.find(ems_id)
+all_emss = [ems] + ems.child_managers
 
 provider_opts = {
-  :ems_id            => ems_id,
-  :ems_name          => ems.name,
-  :connection_config => ems.connection_configurations
+  :ems => all_emss.map do |e|
+    e.attributes.merge(
+      "endpoints"       => e.endpoints,
+      "authentications" => e.authentications
+    )
+  end
 }
 
 # Send the connection information to the child process via STDIN by creating a

--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -18,4 +18,4 @@ stdin_wr.close
 
 $stdin.reopen(stdin_rd)
 
-Kernel.exec(ARGV.join(" "))
+Kernel.exec(ARGV.shelljoin)


### PR DESCRIPTION
This utility allows for non-rails workers to be run while still loading connection information from the database and passing it securely via a pipe to the child process.

This process can read JSON from stdin which is simple to do in any language.

Also rather than fork+exec this simply calls exec so that it runs seamlessly via systemd without requiring a `Type=forking`

Example run:
```
EMS_ID=14 WORKER_TYPE=ManageIQ::Providers::Azure::CloudManager::RefreshWorker lib/workers/bin/provider_worker jq
** ManageIQ master, codename: Oparin
{
  "ems": [
    {
      "id": 14,
      "name": "microstack",
      "created_on": "2022-06-28T18:51:19.595Z",
      "updated_on": "2022-06-28T18:51:19.595Z",
      "guid": "5c8ac76f-3f6b-444e-9b1d-3150d17d2e91",
      "zone_id": 2,
      "type": "ManageIQ::Providers::Openstack::CloudManager",
      "api_version": "v3",
      "uid_ems": "default",
      "host_default_vnc_port_start": null,
      "host_default_vnc_port_end": null,
      "provider_region": null,
      "last_refresh_error": null,
      "last_refresh_date": null,
      "provider_id": null,
      "realm": null,
      "tenant_id": 1,
      "project": null,
      "parent_ems_id": null,
      "subscription": null,
      "last_metrics_error": null,
      "last_metrics_update_date": null,
      "last_metrics_success_date": null,
      "tenant_mapping_enabled": null,
      "enabled": true,
      "options": null,
      "zone_before_pause_id": null,
      "last_inventory_date": null,
      "capabilities": {},
      "last_refresh_success_date": null,
      "endpoints": [
        {
          "id": 8,
          "role": "default",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": 13000,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:51:20.134Z",
          "updated_at": "2022-06-28T18:51:20.134Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": "ssl-with-validation",
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        },
        {
          "id": 10,
          "role": "ceilometer",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": null,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:52:42.067Z",
          "updated_at": "2022-06-28T18:52:42.067Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": null,
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        }
      ],
      "authentications": [
        {
          "id": 5,
          "name": "ManageIQ::Providers::Openstack::CloudManager microstack",
          "authtype": "default",
          "userid": "admin",
          "password": "*******",
          "resource_id": 14,
          "resource_type": "ExtManagementSystem",
          "created_on": "2022-06-28T18:51:20.137Z",
          "updated_on": "2022-06-28T18:51:24.865Z",
          "last_valid_on": null,
          "last_invalid_on": "2022-06-28T18:51:24.860Z",
          "credentials_changed_on": "2022-06-28T18:51:20.137Z",
          "status": "Error",
          "status_details": "Socket error: No route to host - connect(2) for 10.2.2.20:13000",
          "auth_key": null,
          "fingerprint": null,
          "service_account": null,
          "public_key": null,
          "manager_ref": null,
          "options": null,
          "evm_owner_id": null,
          "miq_group_id": 2,
          "tenant_id": 1,
          "become_username": null,
          "become_password": null,
          "auth_key_password": null,
          "ems_ref": null,
          "become_method": null
        }
      ]
    },
    {
      "id": 15,
      "name": null,
      "created_on": "2022-06-28T18:51:20.149Z",
      "updated_on": "2022-06-28T18:51:20.149Z",
      "guid": "69793e1b-f3ad-464b-a395-c37aa292d457",
      "zone_id": 2,
      "type": "ManageIQ::Providers::Openstack::NetworkManager",
      "api_version": null,
      "uid_ems": null,
      "host_default_vnc_port_start": null,
      "host_default_vnc_port_end": null,
      "provider_region": null,
      "last_refresh_error": null,
      "last_refresh_date": null,
      "provider_id": null,
      "realm": null,
      "tenant_id": 1,
      "project": null,
      "parent_ems_id": 14,
      "subscription": null,
      "last_metrics_error": null,
      "last_metrics_update_date": null,
      "last_metrics_success_date": null,
      "tenant_mapping_enabled": null,
      "enabled": true,
      "options": null,
      "zone_before_pause_id": null,
      "last_inventory_date": null,
      "capabilities": {},
      "last_refresh_success_date": null,
      "endpoints": [
        {
          "id": 8,
          "role": "default",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": 13000,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:51:20.134Z",
          "updated_at": "2022-06-28T18:51:20.134Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": "ssl-with-validation",
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        },
        {
          "id": 10,
          "role": "ceilometer",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": null,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:52:42.067Z",
          "updated_at": "2022-06-28T18:52:42.067Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": null,
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        }
      ],
      "authentications": [
        {
          "id": 5,
          "name": "ManageIQ::Providers::Openstack::CloudManager microstack",
          "authtype": "default",
          "userid": "admin",
          "password": "*******",
          "resource_id": 14,
          "resource_type": "ExtManagementSystem",
          "created_on": "2022-06-28T18:51:20.137Z",
          "updated_on": "2022-06-28T18:51:24.865Z",
          "last_valid_on": null,
          "last_invalid_on": "2022-06-28T18:51:24.860Z",
          "credentials_changed_on": "2022-06-28T18:51:20.137Z",
          "status": "Error",
          "status_details": "Socket error: No route to host - connect(2) for 10.2.2.20:13000",
          "auth_key": null,
          "fingerprint": null,
          "service_account": null,
          "public_key": null,
          "manager_ref": null,
          "options": null,
          "evm_owner_id": null,
          "miq_group_id": 2,
          "tenant_id": 1,
          "become_username": null,
          "become_password": null,
          "auth_key_password": null,
          "ems_ref": null,
          "become_method": null
        }
      ]
    },
    {
      "id": 16,
      "name": null,
      "created_on": "2022-06-28T18:51:20.159Z",
      "updated_on": "2022-06-28T18:51:20.159Z",
      "guid": "e55ca5b5-e782-4e18-868f-7c733b6adb82",
      "zone_id": 2,
      "type": "ManageIQ::Providers::Openstack::StorageManager::CinderManager",
      "api_version": null,
      "uid_ems": null,
      "host_default_vnc_port_start": null,
      "host_default_vnc_port_end": null,
      "provider_region": null,
      "last_refresh_error": null,
      "last_refresh_date": null,
      "provider_id": null,
      "realm": null,
      "tenant_id": 1,
      "project": null,
      "parent_ems_id": 14,
      "subscription": null,
      "last_metrics_error": null,
      "last_metrics_update_date": null,
      "last_metrics_success_date": null,
      "tenant_mapping_enabled": null,
      "enabled": true,
      "options": null,
      "zone_before_pause_id": null,
      "last_inventory_date": null,
      "capabilities": {},
      "last_refresh_success_date": null,
      "endpoints": [
        {
          "id": 8,
          "role": "default",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": 13000,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:51:20.134Z",
          "updated_at": "2022-06-28T18:51:20.134Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": "ssl-with-validation",
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        },
        {
          "id": 10,
          "role": "ceilometer",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": null,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:52:42.067Z",
          "updated_at": "2022-06-28T18:52:42.067Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": null,
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        }
      ],
      "authentications": [
        {
          "id": 5,
          "name": "ManageIQ::Providers::Openstack::CloudManager microstack",
          "authtype": "default",
          "userid": "admin",
          "password": "*******",
          "resource_id": 14,
          "resource_type": "ExtManagementSystem",
          "created_on": "2022-06-28T18:51:20.137Z",
          "updated_on": "2022-06-28T18:51:24.865Z",
          "last_valid_on": null,
          "last_invalid_on": "2022-06-28T18:51:24.860Z",
          "credentials_changed_on": "2022-06-28T18:51:20.137Z",
          "status": "Error",
          "status_details": "Socket error: No route to host - connect(2) for 10.2.2.20:13000",
          "auth_key": null,
          "fingerprint": null,
          "service_account": null,
          "public_key": null,
          "manager_ref": null,
          "options": null,
          "evm_owner_id": null,
          "miq_group_id": 2,
          "tenant_id": 1,
          "become_username": null,
          "become_password": null,
          "auth_key_password": null,
          "ems_ref": null,
          "become_method": null
        }
      ]
    },
    {
      "id": 17,
      "name": null,
      "created_on": "2022-06-28T18:51:20.168Z",
      "updated_on": "2022-06-28T18:51:20.168Z",
      "guid": "13523a42-d379-4e70-ae6f-5e758990d07b",
      "zone_id": 2,
      "type": "ManageIQ::Providers::Openstack::StorageManager::SwiftManager",
      "api_version": null,
      "uid_ems": null,
      "host_default_vnc_port_start": null,
      "host_default_vnc_port_end": null,
      "provider_region": null,
      "last_refresh_error": null,
      "last_refresh_date": null,
      "provider_id": null,
      "realm": null,
      "tenant_id": 1,
      "project": null,
      "parent_ems_id": 14,
      "subscription": null,
      "last_metrics_error": null,
      "last_metrics_update_date": null,
      "last_metrics_success_date": null,
      "tenant_mapping_enabled": null,
      "enabled": true,
      "options": null,
      "zone_before_pause_id": null,
      "last_inventory_date": null,
      "capabilities": {},
      "last_refresh_success_date": null,
      "endpoints": [
        {
          "id": 8,
          "role": "default",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": 13000,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:51:20.134Z",
          "updated_at": "2022-06-28T18:51:20.134Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": "ssl-with-validation",
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        },
        {
          "id": 10,
          "role": "ceilometer",
          "ipaddress": null,
          "hostname": "openstack.rb.nj.grare.com",
          "port": null,
          "resource_type": "ExtManagementSystem",
          "resource_id": 14,
          "created_at": "2022-06-28T18:52:42.067Z",
          "updated_at": "2022-06-28T18:52:42.067Z",
          "verify_ssl": 1,
          "url": null,
          "security_protocol": null,
          "api_version": null,
          "path": null,
          "certificate_authority": null,
          "options": {}
        }
      ],
      "authentications": [
        {
          "id": 5,
          "name": "ManageIQ::Providers::Openstack::CloudManager microstack",
          "authtype": "default",
          "userid": "admin",
          "password": "*******",
          "resource_id": 14,
          "resource_type": "ExtManagementSystem",
          "created_on": "2022-06-28T18:51:20.137Z",
          "updated_on": "2022-06-28T18:51:24.865Z",
          "last_valid_on": null,
          "last_invalid_on": "2022-06-28T18:51:24.860Z",
          "credentials_changed_on": "2022-06-28T18:51:20.137Z",
          "status": "Error",
          "status_details": "Socket error: No route to host - connect(2) for 10.2.2.20:13000",
          "auth_key": null,
          "fingerprint": null,
          "service_account": null,
          "public_key": null,
          "manager_ref": null,
          "options": null,
          "evm_owner_id": null,
          "miq_group_id": 2,
          "tenant_id": 1,
          "become_username": null,
          "become_password": null,
          "auth_key_password": null,
          "ems_ref": null,
          "become_method": null
        }
      ]
    }
  ],
  "messaging": {
    "port": 9092,
    "username": "admin",
    "password": "smartvm",
    "host": "localhost",
    "encoding": "json",
    "protocol": null
  },
  "settings": {
    "api": {
      "token_ttl": "10.minutes",
      "authentication_timeout": "30.seconds",
      "max_results_per_page": 1000
    },
    "log": {
      "level_api": "info",
      "level_automation": "info",
      "level_aws": "info",
      "level_ansible_tower": "info",
      "level_azure": "warn",
      "level_azure_stack": "info",
      "level_cisco_intersight": "info",
      "level_gce": "info",
      "level_ibm_cloud": "info",
      "level_ibm_power_hmc": "info",
      "level_lenovo": "info",
      "level_nsxt": "info",
      "level_nuage": "info",
      "level_fog": "info",
      "level_oracle": "info",
      "level_rhevm": "info",
      "level_scvmm": "info",
      ...
}

```