### PR TITLE
Added Missing Identifiers to miq_product_features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6814,6 +6814,14 @@
         :description: Display Individual Event Streams
         :feature_type: view
         :identifier: event_streams_show
+  - :name: Delete
+    :description: Delete Custom Button
+    :feature_type: view
+    :identifier: custom_button_delete
+  - :name: Set Delete
+    :description: Delete Custom Button Set
+    :feature_type: view
+    :identifier: custom_button_set_delete
   - :name: Custom Button Events
     :description: Everything under Custom Button Events
     :hidden: true


### PR DESCRIPTION
Added missing identifiers to prevent error in ui when trying to select a button/button group in Automation->Automate->Generic Objects

<img src="https://user-images.githubusercontent.com/64800041/126653829-af356bed-0e32-4cd2-b296-b24bda850cd8.png" width="500">