### PR TITLE
Add more comprehensive brakeman coverage across all plugins

### DIFF
--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,2 +1,4 @@
 ---
 :table_width: 400
+:safe_methods:
+- :report_build_html_table # Defined in lib/vmdb/global_methods.rb

--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -4,12 +4,14 @@ namespace :test do
 
     desc "Run Brakeman"
     task :brakeman do
+      require "vmdb/plugins"
       require "brakeman"
 
       # See all possible options here:
-      #   http://www.rubydoc.info/gems/brakeman/Brakeman#run-class_method
+      #   https://brakemanscanner.org/docs/brakeman_as_a_library/#using-options
       tracker = Brakeman.run(
-        :app_path     => ".",
+        :app_path     => Rails.root.to_s,
+        :engine_paths => Vmdb::Plugins.paths.values,
         :quiet        => false,
         :print_report => true
       )

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -68,6 +68,8 @@ module Vmdb
     end
 
     # Wrap a report html table body with html table tags and headers for the columns
+    #
+    # NOTE: This method is ignored by brakeman in the config/brakeman.yml
     def report_build_html_table(report, table_body, breakable = true)
       html = ''
       html << "<table class=\"table table-striped table-bordered #{breakable ? '' : 'non-breakable'}\">"
@@ -87,6 +89,7 @@ module Vmdb
       end
       html << '<tbody>'
       html << table_body << '</tbody></table>'
+      html.html_safe
     end
   end
 end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -39,6 +39,10 @@ module Vmdb
       end
     end
 
+    def paths
+      details.transform_values { |v| v[:path] }
+    end
+
     def versions
       details.transform_values { |v| v[:version] }
     end


### PR DESCRIPTION
Additionally,
- Add JSON output format to security scans
- Allow plugins to be able to run the security scans from the plugin itself.

@bdunne Please review.  cc @jrafanie, @lrhamann