### PR TITLE
added two additional changes, one for pin policy and second  for the IBMi Power License in Advanced Settings

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -228,15 +228,17 @@ class VmOrTemplate < ApplicationRecord
 
   # Add virtual columns/methods for specific things derived from advanced_settings
   REQUIRED_ADVANCED_SETTINGS = {
-    'vmi.present'         => [:paravirtualization,   :boolean],
-    'vmsafe.enable'       => [:vmsafe_enable,        :boolean],
-    'vmsafe.agentAddress' => [:vmsafe_agent_address, :string],
-    'vmsafe.agentPort'    => [:vmsafe_agent_port,    :integer],
-    'vmsafe.failOpen'     => [:vmsafe_fail_open,     :boolean],
-    'vmsafe.immutableVM'  => [:vmsafe_immutable_vm,  :boolean],
-    'vmsafe.timeoutMS'    => [:vmsafe_timeout_ms,    :integer],
-    'entitled_processors' => [:entitled_processors,  :float],
-    'processor_type'      => [:processor_share_type, :string],
+    'vmi.present'          => [:paravirtualization,   :boolean],
+    'vmsafe.enable'        => [:vmsafe_enable,        :boolean],
+    'vmsafe.agentAddress'  => [:vmsafe_agent_address, :string],
+    'vmsafe.agentPort'     => [:vmsafe_agent_port,    :integer],
+    'vmsafe.failOpen'      => [:vmsafe_fail_open,     :boolean],
+    'vmsafe.immutableVM'   => [:vmsafe_immutable_vm,  :boolean],
+    'vmsafe.timeoutMS'     => [:vmsafe_timeout_ms,    :integer],
+    'entitled_processors'  => [:entitled_processors,  :float],
+    'processor_type'       => [:processor_share_type, :string],
+    'pin_policy'           => [:processor_pin_policy, :string],
+    'software_licenses'    => [:software_licenses,    :string],
   }
   REQUIRED_ADVANCED_SETTINGS.each do |k, (m, t)|
     define_method(m) do


### PR DESCRIPTION
There are PowerVS specific advanced settings that are required for reporting. These have been added in the REQUIRED_ADVANCED_SETTINGS.
