### PR TITLE
Add SKIP_UI_UPDATE option to bin/setup and bin/update

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,25 +6,17 @@ if ARGV.any?
 Usage: bin/setup
 
 Environment Variable Options:
-    SKIP_DATABASE_SETUP  Skip the creation, migration, and seeding of the
-                         database.
+    SKIP_DATABASE_SETUP  Skip the creation, migration, and seeding of the database.
+    SKIP_UI_UPDATE       Skip the update of UI assets.
     SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
                          true in production mode since the tasks do not exist.
 EOS
   exit 1
 end
 
-def skip_ui_update?
-  ENV["CI"]
-end
-
-def skip_database_setup?
-  ENV["SKIP_DATABASE_SETUP"] || ENV["CI"]
-end
-
-def skip_test_reset?
-  ENV["SKIP_TEST_RESET"]
-end
+ENV["SKIP_DATABASE_SETUP"] = "true" if ENV["CI"]
+ENV["SKIP_UI_UPDATE"] = "true" if ENV["CI"]
+ENV["SKIP_TEST_RESET"] = "true" if ENV['RAILS_ENV'] == 'production'
 
 Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.ensure_config_files
@@ -33,15 +25,15 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.install_bundler
   ManageIQ::Environment.bundle_update
 
-  ui_thread = ManageIQ::Environment.update_ui_thread unless skip_ui_update?
+  ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]
 
-  unless skip_database_setup?
+  unless ENV["SKIP_DATABASE_SETUP"]
     ManageIQ::Environment.create_database
     ManageIQ::Environment.migrate_database
     ManageIQ::Environment.seed_database
   end
 
-  ManageIQ::Environment.setup_test_environment unless skip_test_reset?
+  ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
 
   ui_thread&.join
 

--- a/bin/update
+++ b/bin/update
@@ -7,14 +7,15 @@ Usage: bin/update
 
 Environment Variable Options:
     SKIP_DATABASE_SETUP  Skip the migration and seeding of the database.
+    SKIP_UI_UPDATE       Skip the update of UI assets.
+    SKIP_AUTOMATE_RESET  Skip the reset of the automate domain.
     SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
                          true in production mode since the tasks do not exist.
-    SKIP_AUTOMATE_RESET  Skip the reset of the automate domain.
 EOS
   exit 1
 end
 
-ENV["SKIP_TEST_RESET"] = 'true' if ENV['RAILS_ENV'] == 'production'
+ENV["SKIP_TEST_RESET"] = "true" if ENV["RAILS_ENV"] == "production"
 
 Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.ensure_config_files
@@ -23,15 +24,17 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.install_bundler
   ManageIQ::Environment.bundle_update
 
-  ManageIQ::Environment.while_updating_ui do
-    unless ENV["SKIP_DATABASE_SETUP"]
-      ManageIQ::Environment.migrate_database
-      ManageIQ::Environment.seed_database
-    end
+  ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]
 
-    ManageIQ::Environment.setup_test_environment
-    ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
+  unless ENV["SKIP_DATABASE_SETUP"]
+    ManageIQ::Environment.migrate_database
+    ManageIQ::Environment.seed_database
   end
+
+  ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
+  ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
+
+  ui_thread&.join
 
   # Make sure update_ui is done before compiling assets
   ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -23,7 +23,7 @@ module ManageIQ
 
       create_database_user if ENV["CI"]
 
-      setup_test_environment(:task_prefix => 'app:', :root => plugin_root)
+      setup_test_environment(:task_prefix => 'app:', :root => plugin_root) unless ENV["SKIP_TEST_RESET"]
 
       prepare_codeclimate_test_reporter(plugin_root) if ENV["CI"]
     end
@@ -56,13 +56,6 @@ module ManageIQ
       ui_thread
     end
 
-    def self.while_updating_ui
-      # Run update:ui in a thread and continue to do the non-js stuff
-      ui_thread = update_ui_thread
-      yield
-      ui_thread.join
-    end
-
     def self.install_bundler(root = APP_ROOT)
       system!("echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc") if ENV['CI']
       system!("gem install bundler -v '#{bundler_version}' --conservative")
@@ -92,8 +85,6 @@ module ManageIQ
     end
 
     def self.setup_test_environment(task_prefix: '', root: APP_ROOT)
-      return if ENV["SKIP_TEST_RESET"]
-
       puts "\n== Resetting tests =="
       run_rake_task("#{task_prefix}test:vmdb:setup", :root => root)
     end


### PR DESCRIPTION
Before this commit, the only way to skip ui updates is to set ENV["CI"],
however that also has other side effects like changing the BUNDLE_PATH.
Instead, we have a dedicated option that defaults to true in CI.

Additionally, this commit make setup and update more similar in
structure.

@bdunne Please review.  @agrare Please also review as this might affect plugins.