### PR TITLE
[WIP] Default to miq_messaging for event_handler

### DIFF
--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -79,10 +79,10 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def get_message
-    if dequeue_method_via_drb? && @worker_monitor_drb
-      get_message_via_drb
-    elsif dequeue_method_via_miq_messaging?
+    if dequeue_method_via_miq_messaging?
       get_message_via_miq_messaging
+    elsif dequeue_method_via_drb? && @worker_monitor_drb
+      get_message_via_drb
     else
       get_message_via_sql
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1105,6 +1105,7 @@
           :queue_timeout: 120.minutes
           :dequeue_method: sql
       :event_handler:
+        :dequeue_method: miq_messaging
         :nice_delta: 7
       :generic_worker:
         :count: 2


### PR DESCRIPTION
Default to miq_messaging/kafka for event_hander dequeue_method

TODO:
- [ ] Fallback to drb if kafka isn't set up
- [ ] Enqueue events with miq_queue if event_handler isn't set up to dequeue with miq_messaging
- [ ] Move messaging_type out of Settings.prototype (will require a data migration)

https://github.com/ManageIQ/manageiq/issues/20027