### PR TITLE
Use default HOME

### DIFF
--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -123,7 +123,6 @@ class MiqWorker
     def unit_environment_variables
       # Override this in a child class to add env vars
       [
-        "HOME=/root"
       ]
     end
   end


### PR DESCRIPTION
## before

we were creating an override for the HOME value for each process created.

HOME=/root does not work for non-root users.

## After

It is easier to just set the variable in the systemd service
file or `/etc/defaults/*.properties` rather than create a custom override.

We are now able to setup an embedded ansible repository

## testing

Tested this for mangeiq-generic (running as user manageiq, and the `HOME=/home/manageiq` -- which is not valid, but a problem for another day since it is not raising errors)

thnx @NickLaMuro for the scripts to help me reproduce this one