### PR TITLE
Remove writing of memcached config from evmserver

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -23,21 +23,6 @@ module MiqServer::EnvironmentManagement
 
       [ipaddr, hostname, mac_address]
     end
-
-    def start_memcached
-      # TODO: Need to periodically check the memcached instance to see if it's up, and bounce it and notify the UiWorkers to re-connect
-      return unless ::Settings.server.session_store.to_s == 'cache'
-      return unless MiqEnvironment::Command.supports_memcached?
-
-      require Rails.root.join("lib/miq_memcached").to_s unless Object.const_defined?(:MiqMemcached)
-
-      _svr, port = MiqMemcached.server_address.to_s.split(":")
-      opts = ::Settings.session.memcache_server_opts.to_s
-
-      MiqMemcached::Control.restart!(:port => port, :options => opts) if MiqMemcached::Config.new(:port => port, :options => opts).changed?
-
-      _log.info("Status: #{MiqMemcached::Control.status[1]}")
-    end
   end
 
   def disk_usage_threshold

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -988,7 +988,6 @@
 :session:
   :interval: 60
   :memcache_server: 127.0.0.1:11211
-  :memcache_server_opts: "-l 127.0.0.1 -I 1M"
   :show_login_info: true
   :timeout: 3600
   :log_threshold: 100.kilobytes

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -106,8 +106,6 @@ class EvmServer
 
     EvmDatabase.seed_rest
 
-    MiqServer.start_memcached
-
     MiqEvent.raise_evm_event(@current_server, "evm_server_start")
 
     _log.info("Server starting...")


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq/pull/21343

Do we need to write out memcached config from the main app?  What memcached options do we want to expose as knobs and can they be turned from appliance_console?

Currently this code is only used on appliance deployments as podified has a separate memcached pod.

TODO:
- [ ] Add appliance console menu for modifying memcached settings (?)
- [ ] Data migration to remove `memcache_server_opts` server opts (https://github.com/ManageIQ/manageiq-schema/pull/601)