### PR TITLE
Don't restart apache on evmserver startup

### DIFF
--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -106,7 +106,6 @@ class EvmServer
     EvmDatabase.seed_rest
 
     MiqServer.start_memcached
-    MiqApache::Control.restart if MiqEnvironment::Command.supports_apache?
 
     MiqEvent.raise_evm_event(@current_server, "evm_server_start")
 


### PR DESCRIPTION
Follow-up to #21325 I missed this one when removing the start/stop in role_management.