### PR TITLE
Add debugging for Ansible::Runner

### DIFF
--- a/lib/ansible/runner/response.rb
+++ b/lib/ansible/runner/response.rb
@@ -3,7 +3,7 @@ module Ansible
     class Response
       include Vmdb::Logging
 
-      attr_reader :base_dir, :ident
+      attr_reader :base_dir, :debug, :ident
 
       # Response object designed for holding full response from ansible-runner
       #
@@ -12,13 +12,15 @@ module Ansible
       # @param stdout [String] Stdout from ansible-runner run
       # @param stderr [String] Stderr from ansible-runner run
       # @param ident [String] ansible-runner ident parameter
-      def initialize(base_dir:, return_code: nil, stdout: nil, stderr: nil, ident: "result")
+      # @param debug [Boolean] whether or not to delete base_dir after run (for debugging)
+      def initialize(base_dir:, return_code: nil, stdout: nil, stderr: nil, ident: "result", debug: false)
         @base_dir      = base_dir
         @ident         = ident
         @return_code   = return_code
         @stdout        = stdout
         @parsed_stdout = parse_stdout(stdout) if stdout
         @stderr        = stderr
+        @debug         = debug
       end
 
       # @return [Integer] Return code of the ansible-runner run, 0 == ok, others mean failure
@@ -41,6 +43,8 @@ module Ansible
         # Load all needed files, before we cleanup the dir
         return_code
         stdout
+
+        return if debug
 
         FileUtils.remove_entry(base_dir)
       end

--- a/lib/ansible/runner/response_async.rb
+++ b/lib/ansible/runner/response_async.rb
@@ -3,7 +3,7 @@ module Ansible
     class ResponseAsync
       include Vmdb::Logging
 
-      attr_reader :base_dir, :ident
+      attr_reader :base_dir, :debug, :ident
 
       # Response object designed for holding full response from ansible-runner
       #
@@ -12,9 +12,11 @@ module Ansible
       # @param ident [String] An identifier that will be used when generating the artifacts directory and can be used to
       #        uniquely identify a playbook run. We use unique base dir per run, so this identifier can be static for
       #        most cases.
-      def initialize(base_dir:, ident: "result")
+      # @param debug [Boolean] whether or not to delete base_dir after run (for debugging)
+      def initialize(base_dir:, ident: "result", debug: false)
         @base_dir = base_dir
         @ident    = ident
+        @debug    = debug
       end
 
       # @return [Boolean] true if the ansible job is still running, false when it's finished
@@ -33,7 +35,7 @@ module Ansible
         return if running?
         return @response if @response
 
-        @response = Ansible::Runner::Response.new(:base_dir => base_dir, :ident => ident)
+        @response = Ansible::Runner::Response.new(:base_dir => base_dir, :ident => ident, :debug => debug)
         @response.cleanup_filesystem!
 
         @response
@@ -45,6 +47,7 @@ module Ansible
       def dump
         {
           :base_dir => base_dir,
+          :debug    => debug,
           :ident    => ident
         }
       end

--- a/spec/lib/ansible/runner/response_spec.rb
+++ b/spec/lib/ansible/runner/response_spec.rb
@@ -95,4 +95,32 @@ RSpec.describe Ansible::Runner::Response do
       end
     end
   end
+
+  describe "cleanup_filesystem!" do
+    before do
+      expect(subject).to receive(:return_code)
+      expect(subject).to receive(:stdout)
+    end
+
+    # Required so top level `after` can call `.rm_rf` properly
+    after { allow(FileUtils).to receive(:remove_entry).and_call_original }
+
+    context "without debug" do
+      it "calls FileUtils.remove_entry" do
+        expect(FileUtils).to receive(:remove_entry).with(base_dir)
+
+        subject.cleanup_filesystem!
+      end
+    end
+
+    context "with debug" do
+      subject { described_class.new(:base_dir => base_dir, :ident => ident, :debug => true) }
+
+      it "does not call FileUtils.remove_entry" do
+        expect(FileUtils).to receive(:remove_entry).with(base_dir).never
+
+        subject.cleanup_filesystem!
+      end
+    end
+  end
 end

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :tags => tags)
     end
 
-    it "calls run with the correct verbosity" do
+    it "calls run with the correct verbosity (and triggers debug mode)" do
       expect(AwesomeSpawn).to receive(:run) do |command, options|
         expect(command).to eq("ansible-runner")
 
@@ -81,7 +81,8 @@ RSpec.describe Ansible::Runner do
         expect(args).to eq(:ident => "result", :playbook => "playbook", :project_dir => "/path/to/my", "-vvvvv" => nil)
       end.and_return(result)
 
-      described_class.run(env_vars, extra_vars, playbook, :verbosity => 6)
+      response = described_class.run(env_vars, extra_vars, playbook, :verbosity => 6)
+      expect(response.debug).to eq(true)
     end
 
     it "calls run with become options" do


### PR DESCRIPTION
Adds two changes to `Ansible::Runner`:

- When generating the `env/cmdline` flag, include more of the parameters
- Create a `debug` option that can be enabled by `verbosity = 5` or `ANSIBLE_KEEP_REMOTE_FILES=1`


Links
-----

* (Partially) addresses https://github.com/ManageIQ/manageiq/issues/20243
* [Ansible Docs on `ANSIBLE_KEEP_REMOTE_FILES`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-keep-remote-files)