### PR TITLE
Add supports :check_compliance to ComplianceMixin

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -1,6 +1,7 @@
 class ContainerImage < ApplicationRecord
   acts_as_miq_taggable
 
+  include SupportsFeatureMixin
   include ComplianceMixin
   include MiqPolicyMixin
   include ScanningMixin
@@ -9,7 +10,6 @@ class ContainerImage < ApplicationRecord
   include ArchivedMixin
   include NewWithTypeStiMixin
   include CustomActionsMixin
-  include SupportsFeatureMixin
   include Metric::CiMixin
 
   include_concern 'Purging'

--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -9,6 +9,8 @@ module ComplianceMixin
              :inverse_of => :resource,
              :class_name => "Compliance"
 
+    supports :check_compliance
+
     virtual_delegate :last_compliance_status,
                      :to        => "last_compliance.compliant",
                      :type      => :boolean,


### PR DESCRIPTION
Currently callers do unnatural things like [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/131239b88664932f9bcd1f5e427a063555917cc3/app/controllers/application_controller/ci_processing.rb#L634).  

With this in place, callers can more naturally test via `supports?(:check_compliance)`