### PR TITLE
Remove locales for removed authentication columns

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -601,7 +601,6 @@ en:
       last_started_at: Last Started At
       last_state: Last State
       last_sync_on: Last Sync Time
-      last_update_check: Last Update Check
       last_update_status: Last Update Status Code
       last_update_status_str: Last Update Status
       last_valid_on: Last Valid On
@@ -928,8 +927,6 @@ en:
       retirement_state: Retirement State
       retirement_warn: Retirement Warn
       retires_on: Retires On
-      rh_registered: Rh Registered
-      rh_subscribed: Rh Subscribed
       root_disk_size: Root Disk Size
       routes_count: Routes Count
       rsc_type: Rsc Type
@@ -1049,9 +1046,6 @@ en:
       uid_ems: Uid Ems
       uncommitted: Uncommitted
       unique_set_size: Unique Set Size
-      updates_available: Updates Available
-      upgrade_message: Upgrade Message
-      upgrade_status: Upgrade Status
       uri_or_queue_name: Uri Or Queue Name
       uri: Uri
       url: URL

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -509,11 +509,9 @@ en:
       future: Future
       gce_pd_name: Gce Pd Name
       generic_subtype: Generic Subtype
-      github_organizations: Github Organizations
       git_repository: Git Repository
       git_revision: Git Revision
       glusterfs_endpoint_name: Glusterfs Endpoint Name
-      google_hosted_domain: Google Hosted Domain
       group: Group
       group_level: Group Level
       group_name: Group Name
@@ -544,7 +542,6 @@ en:
       hostnames: Host Names
       hosts: Hosts
       href_slug: Href Slug
-      htpassd_users: Htpassd Users
       hyperthreading: Hyperthreading
       hypervisor_hostname: Hypervisor Hostname
       identity_infra: Identity Infra
@@ -610,13 +607,7 @@ en:
       last_valid_on: Last Valid On
       lastlogoff: Last Logoff
       lastlogon: Last Logon
-      ldap_bind_dn: LDAP Bind Dn
-      ldap_email: LDAP Email
       ldap_group: LDAP Group
-      ldap_insecure: LDAP Insecure
-      ldap_name: LDAP Name
-      ldap_preferred_user_name: LDAP Preferred User Name
-      ldap_url: LDAP Url
       lease_expires: Lease Expires
       lease_obtained: Lease Obtained
       lifecycle_state: Lifecycle State
@@ -820,12 +811,6 @@ en:
       cpu_sockets: Number of CPUs
       object_labels: Object Labels
       objects: Objects
-      open_id_authorization_endpoint: Open Id Authorization Endpoint
-      open_id_extra_authorize_parameters: Open Id Extra Authorize Parameters
-      open_id_extra_scopes: Open Id Extra Scopes
-      open_id_sub_claim: Open Id Sub Claim
-      open_id_token_endpoint: Open Id Token Endpoint
-      open_id_user_info: Open Id User Info
       operating_system_flavor_name: Operating System Flavor Name
       operational_status: Operational Status Code
       operational_status_str: Operational Status
@@ -924,11 +909,6 @@ en:
       replicas: Replicas
       replicators_count: Replicators Count
       request_cpu_cores: Request CPU Cores
-      request_header_email_headers: Request Header Email Headers
-      request_header_headers: Request Header Headers
-      request_header_login_url: Request Header Login Url
-      request_header_name_headers: Request Header Name Headers
-      request_header_preferred_username_headers: Request Header Preferred Username Headers
       request_memory_bytes: Request Memory Bytes
       request_state: Request State
       request_type_display: Request Type Display
@@ -950,8 +930,6 @@ en:
       retires_on: Retires On
       rh_registered: Rh Registered
       rh_subscribed: Rh Subscribed
-      rhsm_server: Rhsm Server
-      rhsm_sku: Rhsm Sku
       root_disk_size: Root Disk Size
       routes_count: Routes Count
       rsc_type: Rsc Type

--- a/spec/database/data/id_column_whitelist.yml
+++ b/spec/database/data/id_column_whitelist.yml
@@ -1,7 +1,4 @@
 ---
-authentications:
-- ldap_id
-- rhsm_pool_id
 cloud_networks:
 - provider_segmentation_id
 container_volumes:


### PR DESCRIPTION
The code that uses a number of our authentications columns has been removed.
We cleaned them up but this is one last pass to remove the locales (and the columns)
associated with the removed functionality.

see also:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/599
- [x] https://github.com/ManageIQ/manageiq-schema/pull/588