### PR TITLE
[Ansible::Runner] Set ANSIBLE_STDOUT_CALLBACK

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -206,7 +206,7 @@ module Ansible
         end
         command_line_hash.merge!(cred_command_line)
 
-        env_vars_hash   = env_vars.merge(cred_env_vars).merge(python_env)
+        env_vars_hash   = env_vars.merge(cred_env_vars).merge(runner_env)
         extra_vars_hash = extra_vars.merge(cred_extra_vars)
 
         create_hosts_file(base_dir, hosts)
@@ -305,14 +305,11 @@ module Ansible
         Ansible::Content.new(playbook_dir).fetch_galaxy_roles
       end
 
-      def python_env
-        if python3_modules_path.present?
-          { "PYTHONPATH" => python3_modules_path }
-        elsif python2_modules_path.present?
-          { "PYTHONPATH" => python2_modules_path }
-        else
-          {}
-        end
+      def runner_env
+        {
+          "ANSIBLE_STDOUT_CALLBACK" => "json",
+          "PYTHONPATH"              => python_path
+        }.delete_nils
       end
 
       def credentials_info(credentials, base_dir)
@@ -385,6 +382,14 @@ module Ansible
         end
 
         res
+      end
+
+      def python_path
+        if python3_modules_path.present?
+          python3_modules_path
+        else
+          python2_modules_path
+        end
       end
 
       PYTHON2_MODULE_PATHS = %w[

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -98,7 +98,17 @@ RSpec.describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
     end
 
-    it "sets PYTHONPATH correctly with python3 awx modules only installed " do
+    it "sets ANSIBLE_STDOUT_CALLBACK to json" do
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+
+        expect(options[:env]["ANSIBLE_STDOUT_CALLBACK"]).to eq("json")
+      end.and_return(result)
+
+      described_class.run(env_vars, extra_vars, playbook)
+    end
+
+    it "sets PYTHONPATH correctly with python3 awx modules only installed" do
       allow(File).to receive(:exist?).with(python2_modules_path).and_return(false)
       allow(File).to receive(:exist?).with(python3_modules_path).and_return(false)
       allow(File).to receive(:exist?).with(py3_awx_modules_path).and_return(true)
@@ -112,7 +122,7 @@ RSpec.describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
     end
 
-    it "sets PYTHONPATH correctly with python2 modules installed " do
+    it "sets PYTHONPATH correctly with python2 modules installed" do
       allow(File).to receive(:exist?).with(python2_modules_path).and_return(true)
       allow(File).to receive(:exist?).with(python3_modules_path).and_return(false)
       allow(File).to receive(:exist?).with(py3_awx_modules_path).and_return(false)


### PR DESCRIPTION
This allows getting rid of this setting in a config value in the
appliance:

  https://github.com/ManageIQ/manageiq-appliance/blob/a6758392ea32b71307828f868db6407be0858a12/LINK/root/.ansible.cfg#L2

Which frees up the potential of removing that file all together.

cc @kbrock


Links
-----

* https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_STDOUT_CALLBACK
* As requested by Keenan here:  https://github.com/ManageIQ/manageiq-rpm_build/pull/159#issuecomment-898773230