### PR TITLE
Add supports_not for storage_manager

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -188,6 +188,7 @@ class ExtManagementSystem < ApplicationRecord
   supports     :refresh_ems
   supports_not :regions
   supports_not :smartstate_analysis
+  supports_not :storage_manager
   supports_not :streaming_refresh
   supports_not :swift_service
   supports_not :vm_import


### PR DESCRIPTION
Initialize a negative for storage_manager. Used in IBM, Openstack and Amazon provider. Example: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/255

@miq-bot add_reviewer @agrare
@miq-bot add-label enhancement