### PR TITLE
Fix Automate Git import if branch is symbolic ref

### DIFF
--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -83,7 +83,8 @@ class GitWorktree
   def branch_info(name)
     branch = find_branch(name)
     raise GitWorktreeException::BranchMissing, name unless branch
-    {:time => branch.target.time, :message => branch.target.message, :commit_sha => branch.target.oid}
+    ref = branch.resolve
+    {:time => ref.target.time, :message => ref.target.message, :commit_sha => ref.target.oid}
   end
 
   def tags

--- a/spec/fixtures/git_repos/branch_and_tag.git/refs/heads/symbolic
+++ b/spec/fixtures/git_repos/branch_and_tag.git/refs/heads/symbolic
@@ -1,0 +1,1 @@
+ref: refs/heads/branch2

--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -266,11 +266,11 @@ RSpec.describe GitWorktree do
 
     describe "#branches" do
       it "all branches" do
-        expect(test_repo.branches).to match_array(%w(master branch1 branch2))
+        expect(test_repo.branches).to match_array(%w(master branch1 branch2 symbolic))
       end
 
       it "local branches only" do
-        expect(test_repo.branches(:local)).to match_array(%w(master branch1 branch2))
+        expect(test_repo.branches(:local)).to match_array(%w(master branch1 branch2 symbolic))
       end
 
       it "remote branches only" do
@@ -289,6 +289,9 @@ RSpec.describe GitWorktree do
     describe "#branch_info" do
       it "get branch info" do
         expect(test_repo.branch_info('branch2').keys).to match_array([:time, :message, :commit_sha])
+      end
+      it "get branch info symbolic ref" do
+        expect(test_repo.branch_info('symbolic').keys).to match_array([:time, :message, :commit_sha])
       end
     end
 


### PR DESCRIPTION
Branches can be symbolic refs, which need to be resolved to direct refs,
so that target is a commit.

Previously, some imports failed with error:

```
undefined method `time' for #<Rugged::Reference:0x...>
```

The problem appeared in release lasker-1.  Release kasparov-2 works as
expected.

Signed-off-by: Steffen Prohaska <prohaska@zib.de>
