### PR TITLE
Add volume mount for root CA certificate

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -47,6 +47,27 @@ class ContainerOrchestrator
             }
           ]
         end
+      end.tap do |deployment|
+        if ENV["SSL_SECRET_NAME"].present?
+          deployment[:spec][:template][:spec][:containers][0][:volumeMounts] ||= []
+          deployment[:spec][:template][:spec][:containers][0][:volumeMounts] << {
+            :mountPath => "/etc/pki/ca-trust/source/anchors",
+            :name      => "internal-root-certificate",
+            :readOnly  => true,
+          }
+
+          deployment[:spec][:template][:spec][:volumes] ||= []
+          deployment[:spec][:template][:spec][:volumes] << {
+            :name   => "internal-root-certificate",
+            :secret => {
+              :secretName => ENV["SSL_SECRET_NAME"],
+              :items      => [
+                :key  => "root_crt",
+                :path => "root.crt",
+              ],
+            }
+          }
+        end
       end
     end
 

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -138,6 +138,28 @@ RSpec.describe ContainerOrchestrator do
         }
       )
     end
+
+    it "mounts the root CA certificate" do
+      stub_const("ENV", ENV.to_h.merge("SSL_SECRET_NAME" => "some-secret-name"))
+
+      deployment_definition = subject.send(:deployment_definition, "test")
+
+      expect(deployment_definition.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts, 0)).to eq(
+        :mountPath => "/etc/pki/ca-trust/source/anchors",
+        :name      => "internal-root-certificate",
+        :readOnly  => true
+      )
+      expect(deployment_definition.fetch_path(:spec, :template, :spec, :volumes, 0)).to eq(
+        :name   => "internal-root-certificate",
+        :secret => {
+          :secretName => "some-secret-name",
+          :items      => [
+            :key  => "root_crt",
+            :path => "root.crt",
+          ],
+        }
+      )
+    end
   end
 
   context "with stub connections" do


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq-pods/issues/724
This will allow the pods to trust self-signed certificates that are signed by the CA in the secret provided.

Related to https://github.com/ManageIQ/manageiq-pods/pull/739