### PR TITLE
added new supported items to EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -162,6 +162,9 @@ class ExtManagementSystem < ApplicationRecord
 
   serialize :options
 
+  supports_not :add_host_initiator
+  supports_not :add_storage
+  supports_not :add_volume_mapping
   supports_not :admin_ui
   supports_not :assume_role
   supports_not :block_storage
@@ -325,6 +328,9 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_create_host_aggregate, :type => :boolean
   virtual_column :supports_create_network_router, :type => :boolean
   virtual_column :supports_storage_services, :type => :boolean
+  virtual_column :supports_add_storage, :type => :boolean
+  virtual_column :supports_add_host_initiator, :type => :boolean
+  virtual_column :supports_add_volume_mapping, :type => :boolean
 
   virtual_sum :total_vcpus,        :hosts, :total_vcpus
   virtual_sum :total_memory,       :hosts, :ram_size
@@ -508,6 +514,18 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   # UI methods for determining availability of fields
+  def supports_add_storage
+    supports_add_storage?
+  end
+
+  def supports_add_host_initiator
+    supports_add_host_initiator?
+  end
+
+  def supports_add_volume_mapping
+    supports_add_volume_mapping?
+  end
+
   def supports_port?
     false
   end


### PR DESCRIPTION
This set of PRs is meant to limit some operations so that they can only be performed on EMSs that support them.
The operations in question all have to do with block-storage managers.
- Add a new storage-system to the EMS
- Add a new host-initiator to the EMS
- Add a new volume-mapping
Currently the only manger that supports these operations is the manageiq-providers-autosde. But there's nothing to stop users from trying to perform these operations on other block-storage managers, such as Cinder.

So we add features to represent these operations, and we filter by them in the UI-forms for the operations. 

Related PRs
https://github.com/ManageIQ/manageiq/pull/21387
https://github.com/ManageIQ/manageiq-ui-classic/pull/7837
https://github.com/ManageIQ/manageiq-providers-autosde/pull/77



The screenshot below shows one of the forms that would be affected.

![image](https://user-images.githubusercontent.com/68283004/130060008-724172f3-40a4-45c5-b2db-076c875760c7.png)


