### PR TITLE
Add a memcached_ping tool

### DIFF
--- a/tools/memcached_ping.rb
+++ b/tools/memcached_ping.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'dalli'
+require 'benchmark'
+
+server_host    = ENV.fetch("MEMCACHED_SERVICE_HOST", "localhost")
+server_port    = ENV.fetch("MEMCACHED_SERVICE_PORT", "11211")
+server_address = "#{server_host}:#{server_port}"
+
+begin
+  client = Dalli::Client.new(server_address)
+  avg = 10.times.map { Benchmark.realtime { client.get("test") } }.inject(:+) / 10.0
+
+  puts "Average: #{avg.round(8)} seconds"
+rescue => err
+  puts "Failed: #{err}"
+end


### PR DESCRIPTION
Add a utility for measuring the average time it takes to fetch a non-existent key

```
$ ./tools/memcached_ping.rb 
Average: 0.00032861 seconds
```

With memcached stopped

```
$ ./tools/memcached_ping.rb 
W, [2021-08-19T12:14:41.651579 #229145]  WARN -- : localhost:11211 failed (count: 0) Errno::ECONNREFUSED: Connection refused - connect(2) for "localhost" port 11211
Failed: No server available
```

https://github.com/ManageIQ/manageiq-pods/issues/740