### PR TITLE
Add branch release tasks

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -58,9 +58,108 @@ task :release do
   exit $?.exitstatus unless system("git commit -m 'Revert Gemfile tag reference update and put back branch reference'")
 
   puts
-  puts "The commit on #{branch} with the tag #{version} has been created"
+  puts "The commit on #{branch} with the tag #{version} has been created."
   puts "Run the following to push to the upstream remote:"
   puts
   puts "\tgit push upstream #{branch} #{version}"
   puts
+end
+
+namespace :release do
+  desc "Tasks to run on a new branch when a new branch is created"
+  task :new_branch do
+    require 'pathname'
+
+    branch = ENV["RELEASE_BRANCH"]
+    if branch.nil? || branch.empty?
+      STDERR.puts "ERROR: You must set the env var RELEASE_BRANCH to the proper value."
+      exit 1
+    end
+
+    current_branch = `git rev-parse --abbrev-ref HEAD`.chomp
+    if current_branch == "master"
+      STDERR.puts "ERROR: You cannot do new branch tasks from the master branch."
+      exit 1
+    end
+
+    root = Pathname.new(__dir__).join("../..")
+
+    # Modify Gemfile
+    gemfile = root.join("Gemfile")
+    content = gemfile.read
+    gemfile.write(content.gsub(/(:branch => ")[^"]+(")/, "\\1#{branch}\\2"))
+
+    # Modify Dockerfile
+    dockerfile = root.join("Dockerfile")
+    content = dockerfile.read
+    dockerfile.write(content.sub(/^(ARG IMAGE_REF=).+/, "\\1latest-#{branch}"))
+
+    # Modify docker-assets README
+    docker_readme = root.join("docker-assets", "README.md")
+    content = docker_readme.read
+    docker_readme.write(content.sub(%r{(manageiq-pods/tree/)[^/]+(/)}, "\\1#{branch}\\2"))
+
+    # Modify VERSION
+    version_file = root.join("VERSION")
+    version_file.write("#{branch}-pre")
+
+    # Commit
+    files_to_update = [gemfile, dockerfile, docker_readme, version_file]
+    exit $?.exitstatus unless system("git add #{files_to_update.join(" ")}")
+    exit $?.exitstatus unless system("git commit -m 'Changes for new branch #{branch}'")
+
+    puts
+    puts "The commit on #{current_branch} has been created."
+    puts "Run the following to push to the upstream remote:"
+    puts
+    puts "\tgit push upstream #{current_branch}"
+    puts
+  end
+
+  desc "Tasks to run on the master branch when a new branch is created"
+  task :new_branch_master do
+    require 'pathname'
+
+    branch = ENV["RELEASE_BRANCH"]
+    if branch.nil? || branch.empty?
+      STDERR.puts "ERROR: You must set the env var RELEASE_BRANCH to the proper value."
+      exit 1
+    end
+
+    next_branch = ENV["RELEASE_BRANCH_NEXT"]
+    if next_branch.nil? || next_branch.empty?
+      STDERR.puts "ERROR: You must set the env var RELEASE_BRANCH_NEXT to the proper value."
+      exit 1
+    end
+
+    current_branch = `git rev-parse --abbrev-ref HEAD`.chomp
+    if current_branch != "master"
+      STDERR.puts "ERROR: You cannot do master branch tasks from a non-master branch (#{current_branch})."
+      exit 1
+    end
+
+    root = Pathname.new(__dir__).join("../..")
+
+    # Modify CODENAME
+    vmdb_appliance = root.join("lib", "vmdb", "appliance.rb")
+    content = vmdb_appliance.read
+    vmdb_appliance.write(content.sub(/(CODENAME\n\s+")[^"]+(")/, "\\1#{next_branch.capitalize}\\2"))
+
+    # Modify Deprecation version
+    deprecation = root.join("lib", "vmdb", "deprecation.rb")
+    content = deprecation.read
+    deprecation.write(content.sub(/(ActiveSupport::Deprecation.new\(")[^"]+(")/, "\\1#{next_branch[0].capitalize.next}-release\\2"))
+
+    # Commit
+    files_to_update = [vmdb_appliance, deprecation]
+    exit $?.exitstatus unless system("git add #{files_to_update.join(" ")}")
+    exit $?.exitstatus unless system("git commit -m 'Changes after new branch #{branch}'")
+
+    puts
+    puts "The commit on #{current_branch} has been created."
+    puts "Run the following to push to the upstream remote:"
+    puts
+    puts "\tgit push upstream #{current_branch}"
+    puts
+  end
 end


### PR DESCRIPTION
@chessbyte Please review.

On a number of repos we need to run a task when a new branch is created.  The plan is to introduce two new rake tasks where needed: `release:new_branch` and `release:new_branch_master`.  If available, `release:new_branch` will be run on the new branch created by the release_branch.rb script (in manageiq-release).  If available, `release:new_branch_master` will be run on the master branch by the release_branch.rb script.