### PR TITLE
[WIP] Add a top-level manageiq.service to replace evmserverd

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -5,38 +5,38 @@ class EvmApplication
 
   def self.start
     if server_state == :no_db
-      puts "EVM has no Database connection"
+      puts "ManageIQ has no Database connection"
       File.open(Rails.root.join("tmp", "pids", "evm.pid"), "w") { |f| f.write("no_db") }
       exit
     end
 
     if pid = MiqServer.running?
-      puts "EVM is already running (PID=#{pid})"
+      puts "ManageIQ is already running (PID=#{pid})"
       exit
     end
 
-    puts "Starting EVM..."
-    _log.info("EVM Startup initiated")
+    puts "Starting ManageIQ..."
+    _log.info("ManageIQ Startup initiated")
 
     MiqServer.kill_all_workers
     command_line = "#{Gem.ruby} #{Rails.root.join(*%w(lib workers bin evm_server.rb)).expand_path}"
 
     env_options = {}
     env_options["EVMSERVER"] = "true" if MiqEnvironment::Command.is_appliance?
-    puts "Running EVM in background..."
+    puts "Running ManageIQ in background..."
     pid = Kernel.spawn(env_options, command_line, :pgroup => true, [:out, :err] => [Rails.root.join("log/evm.log"), "a"])
     Process.detach(pid)
   end
 
   def self.stop
-    puts "Stopping EVM gracefully..."
-    _log.info("EVM Shutdown initiated")
+    puts "Stopping ManageIQ gracefully..."
+    _log.info("ManageIQ Shutdown initiated")
     MiqServer.stop(true)
   end
 
   def self.kill
-    puts "Killing EVM..."
-    _log.info("EVM Kill initiated")
+    puts "Killing ManageIQ..."
+    _log.info("ManageIQ Kill initiated")
     MiqServer.kill
   end
 
@@ -47,7 +47,7 @@ class EvmApplication
   end
 
   def self.status(include_remotes = false)
-    puts "Checking EVM status..."
+    puts "Checking ManageIQ status..."
 
     server = MiqServer.my_server(true)
     servers =
@@ -58,7 +58,7 @@ class EvmApplication
       end
 
     if servers.empty?
-      puts "Local EVM Server not Found"
+      puts "Local ManageIQ Server not Found"
     else
       output_status(servers_status(servers), "* marks a master appliance")
       puts "\n"

--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -3,9 +3,8 @@ RSpec.describe MiqWorker::SystemdCommon do
     before { MiqWorkerType.seed }
 
     it "every worker has a matching systemd target and service file", :providers_common => true do
-      expected_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
-
-      expected_units.delete("manageiq.target")
+      all_systemd_unit_files = Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")
+      expected_units         = all_systemd_unit_files.map(&:basename).map(&:to_s) - %w[manageiq.service manageiq.target]
 
       found_units = MiqWorkerType.worker_class_names.flat_map do |klass_name|
         klass = klass_name.constantize

--- a/systemd/manageiq.service
+++ b/systemd/manageiq.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=ManageIQ
+After=syslog.target memcached.service
+Wants=memcached.service
+PartOf=manageiq.target
+
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/bin/sh -c "/bin/evmserver.sh start"
+ExecStop=/bin/sh -c "/bin/evmserver.sh stop"
+Group=manageiq
+UMask=0002
+Type=forking
+Restart=on-failure
+KillMode=process
+Slice=manageiq.slice
+
+[Install]
+WantedBy=multi-user.target
+Alias=evmserverd.service


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/21397

Replace the evmserverd.service with manageiq.service which matches the
names of the other worker services.  This also aliases the service to
evmserverd so existing scripts/etc... should continue to work.

Alternative to and code stolen from https://github.com/ManageIQ/manageiq/pull/21301