### PR TITLE
Cleanup from gracefully handling non-superuser pg user

### DIFF
--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -83,8 +83,7 @@ class MiqPglogical
     PglogicalSubscription.delete_all if current_type == :global
     configure_provider if desired_type == :remote
 
-    # Do nothing to add a global
-    desired_type
+    # When adding a global (desired_type == :global), we do nothing here
   end
 
   def replication_wal_retained

--- a/lib/miq_pglogical/connection_handling.rb
+++ b/lib/miq_pglogical/connection_handling.rb
@@ -10,7 +10,7 @@ class MiqPglogical
       def logical_replication_supported?
         return @logical_replication_supported if defined?(@logical_replication_supported)
 
-        is_superuser = ActiveRecord::Base.connection.select_value("SELECT usesuper FROM pg_user WHERE usename = CURRENT_USER;", "SQL")
+        is_superuser = ActiveRecord::Base.connection.select_value("SELECT usesuper FROM pg_user WHERE usename = CURRENT_USER")
         unless is_superuser
           warn_bookends = ["\e[33m", "\e[0m"]
           msg = "WARNING: Current user is NOT a superuser, logical replication will not function."

--- a/lib/miq_pglogical/connection_handling.rb
+++ b/lib/miq_pglogical/connection_handling.rb
@@ -15,7 +15,7 @@ class MiqPglogical
           warn_bookends = ["\e[33m", "\e[0m"]
           msg = "WARNING: Current user is NOT a superuser, logical replication will not function."
           if $stderr.tty?
-            warn(warn_bookends.join(msg).to_s)
+            warn(warn_bookends.join(msg))
           else
             warn msg
           end


### PR DESCRIPTION
- Setter already returns the set value
- Remove extra semicolon and useless second argument
- to_s is not needed since warn already casts as a string

Followup from https://github.com/ManageIQ/manageiq/pull/21372
