### PR TITLE
[BinaryBlob::Purging] Use created_at column

### DIFF
--- a/app/models/binary_blob/purging.rb
+++ b/app/models/binary_blob/purging.rb
@@ -17,13 +17,7 @@ class BinaryBlob < ApplicationRecord
       end
 
       def purge_scope(older_than = nil)
-        where(:resource => nil).or(
-          where(
-            arel_table[:resource_type].eq("StateVarHash").and(
-              arel_table[:resource_id].gt(- older_than.to_i)
-            )
-          )
-        )
+        where(:resource_id => nil).where(arel_table[:created_at].lteq(older_than))
       end
 
       def purge_associated_records(ids)

--- a/app/models/binary_blob/purging.rb
+++ b/app/models/binary_blob/purging.rb
@@ -4,16 +4,26 @@ class BinaryBlob < ApplicationRecord
     include PurgingMixin
 
     module ClassMethods
-      def purge_timer
-        purge_queue(:scope)
+      def purge_mode_and_value
+        [:scope, purge_date]
+      end
+
+      def purge_date
+        ::Settings.binary_blob.keep_orphaned.to_i_with_method.ago.utc
       end
 
       def purge_window_size
         ::Settings.binary_blob.purge_window_size
       end
 
-      def purge_scope(_older_than = nil)
-        where(:resource => nil)
+      def purge_scope(older_than = nil)
+        where(:resource => nil).or(
+          where(
+            arel_table[:resource_type].eq("StateVarHash").and(
+              arel_table[:resource_id].gt(- older_than.to_i)
+            )
+          )
+        )
       end
 
       def purge_associated_records(ids)

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -96,6 +96,7 @@ module PurgingMixin
       _log.info("Purging #{table_name.humanize}...")
       total = purge_in_batches(purge_scope(older_than), window || purge_window_size, &block)
       _log.info("Purging #{table_name.humanize}...Complete - Deleted #{total} records")
+      total
     end
 
     def purge_by_orphaned(fk_name, window = purge_window_size)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,6 +20,7 @@
   :amazon_key:
   :amazon_secret:
 :binary_blob:
+  :keep_orphaned: 1.month
   :purge_window_size: 100
 :capacity:
   :profile:

--- a/spec/models/binary_blob/purging_spec.rb
+++ b/spec/models/binary_blob/purging_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe BinaryBlob do
         binary_blob2  = BinaryBlob.create(:resource => report_result)
 
         # StateVarHash blob that hasn't expired
-        binary_blob3 = BinaryBlob.create(:resource_id => - 1.week.ago.utc.to_i,   :resource_type => "StateVarHash")
+        binary_blob3 = BinaryBlob.create(:data => "---\n", :created_at => 1.week.ago.utc)
 
-        # StateVarHash blob that hasn expired
-        binary_blob4 = BinaryBlob.create(:resource_id => - 2.months.ago.utc.to_i, :resource_type => "StateVarHash")
+        # StateVarHash blob that has expired
+        binary_blob4 = BinaryBlob.create(:data => "---\n", :created_at => 2.months.ago.utc)
 
         expect(described_class.all).to match_array([binary_blob1, binary_blob2, binary_blob3, binary_blob4])
         count = described_class.purge_by_scope(purge_time)
-        expect(described_class.all).to match_array([binary_blob2, binary_blob3])
-        expect(count).to eq(2)
+        expect(described_class.all).to match_array([binary_blob1, binary_blob2, binary_blob3])
+        expect(count).to eq(1)
       end
     end
 

--- a/spec/models/binary_blob/purging_spec.rb
+++ b/spec/models/binary_blob/purging_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe BinaryBlob do
+  let(:purge_time) { 1.month.ago.round }
+
+  context "::Purging" do
+    describe ".purge_by_scope" do
+      it "purges all non-resource rows and expired StateVarHash ones" do
+        # BinaryBlob with no resource
+        binary_blob1 = BinaryBlob.create
+
+        # BinaryBlob with a resource
+        report_result = FactoryBot.create(:miq_report_result)
+        binary_blob2  = BinaryBlob.create(:resource => report_result)
+
+        # StateVarHash blob that hasn't expired
+        binary_blob3 = BinaryBlob.create(:resource_id => - 1.week.ago.utc.to_i,   :resource_type => "StateVarHash")
+
+        # StateVarHash blob that hasn expired
+        binary_blob4 = BinaryBlob.create(:resource_id => - 2.months.ago.utc.to_i, :resource_type => "StateVarHash")
+
+        expect(described_class.all).to match_array([binary_blob1, binary_blob2, binary_blob3, binary_blob4])
+        count = described_class.purge_by_scope(purge_time)
+        expect(described_class.all).to match_array([binary_blob2, binary_blob3])
+        expect(count).to eq(2)
+      end
+    end
+
+    describe ".purge_timer" do
+      it "queues the correct purge method" do
+        expect(described_class).to receive(:purge_date).and_return(purge_time)
+        EvmSpecHelper.local_miq_server
+        described_class.purge_timer
+
+        expect(MiqQueue.first).to have_attributes(
+          :class_name  => described_class.name,
+          :method_name => "purge_by_scope",
+          :args        => [purge_time]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/binary_blob/purging_spec.rb
+++ b/spec/models/binary_blob/purging_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe BinaryBlob do
         binary_blob2  = BinaryBlob.create(:resource => report_result)
 
         # StateVarHash blob that hasn't expired
-        binary_blob3 = BinaryBlob.create(:data => "---\n", :created_at => 1.week.ago.utc)
+        binary_blob3 = BinaryBlob.create(:binary => "---\n", :created_at => 1.week.ago.utc)
 
         # StateVarHash blob that has expired
-        binary_blob4 = BinaryBlob.create(:data => "---\n", :created_at => 2.months.ago.utc)
+        binary_blob4 = BinaryBlob.create(:binary => "---\n", :created_at => 2.months.ago.utc)
 
         expect(described_class.all).to match_array([binary_blob1, binary_blob2, binary_blob3, binary_blob4])
         count = described_class.purge_by_scope(purge_time)


### PR DESCRIPTION
**Depends on: https://github.com/ManageIQ/manageiq-schema/pull/605**

~~**Follow up to: https://github.com/ManageIQ/manageiq/pull/21390** (merge after)~~ includes https://github.com/ManageIQ/manageiq/pull/21390

Now that there are `:created_at` columns on `BinaryBlob` records:

  https://github.com/ManageIQ/manageiq-schema/pull/605

Use that instead of the hack previously implemented on `:resource_id`.


Links
-----

* **Depends on:**
  - [x] https://github.com/ManageIQ/manageiq-schema/pull/605
* Can be merged with or after https://github.com/ManageIQ/manageiq-automation_engine/pull/479
* ~~Follow up to https://github.com/ManageIQ/manageiq/pull/21390~~
  - Okay... I screwed up, and apparently if you have a PR closed, and then force push to it, it can't be re-opened...  I made some changes/fixups on this branch that I was pushing back to [#21390](https://github.com/ManageIQ/manageiq/pull/21390) but that happened... so now this will just included both... 😩 
* Related to fixing https://github.com/ManageIQ/manageiq/issues/21351