### PR TITLE
Support specifying a different database password when setting up development replication

### DIFF
--- a/lib/task_helpers/development/replication.rb
+++ b/lib/task_helpers/development/replication.rb
@@ -47,7 +47,7 @@ module TaskHelpers
 
           regions = REMOTES + [GLOBAL]
           regions.each do |r|
-            run_command("dropdb -U #{PG_USER} #{database(r)}", raise_on_error: false)
+            run_command("dropdb -U '#{PG_USER}' -h #{PG_HOST} #{database(r)}", env: {"PGPASSWORD" => PG_PASS}, raise_on_error: false)
           end
         end
 


### PR DESCRIPTION
- Use psql with database url string to support a user's password
- Specify PGPASSWORD in the env for dropdb to support a user's password.