### PR TITLE
Log database connectability when loading the rails app

### DIFF
--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -26,5 +26,11 @@ module ActiveRecord
       result = connection.vacuum_analyze_table(table_name)
       _log.info("Completed Vacuuming of table #{table_name} with result #{result.result_status}")
     end
+
+    def self.connectable?
+      connection && connected?
+    rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad
+      false
+    end
   end
 end

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -1,7 +1,8 @@
 module Vmdb
   module Initializer
     def self.init
-      _log.info("- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}")
+      _log.info("Initializing Application: Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}")
+      ActiveRecord::Base.connectable? ? log_db_connectable : log_db_not_connectable
 
       # UiWorker called in Development Mode
       #   * command line(rails server)
@@ -15,6 +16,21 @@ module Vmdb
       # Rails console needs session store configured
       if defined?(Rails::Console)
         MiqUiWorker.preload_for_console
+      end
+    end
+
+    def self.log_db_connectable
+      _log.info("Successfully connected to the database.")
+    end
+
+    def self.log_db_not_connectable
+      msg = "Cannot connect to the database!"
+      _log.error(msg)
+      if $stderr.tty?
+        yellow_warn_bookends = ["\e[33m** ", "\e[0m"]
+        warn(yellow_warn_bookends.join(msg))
+      else
+        warn(msg)
       end
     end
   end

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -72,13 +72,7 @@ module Vmdb
       end
 
       def resource_queryable?
-        database_connectivity? && ::SettingsChange.table_exists?
-      end
-
-      def database_connectivity?
-        ActiveRecord::Base.connection && ActiveRecord::Base.connected?
-      rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad
-        false
+        ActiveRecord::Base.connectable? && ::SettingsChange.table_exists?
       end
     end
   end


### PR DESCRIPTION
Write a long line, warns in yellow with an attached tty or prints to stderr.

Part of https://github.com/ManageIQ/manageiq-pods/issues/740


Here's how it looks when bad:

![image](https://user-images.githubusercontent.com/19339/131033779-688e2823-0db2-424d-991d-338fef3ea09a.png)


```
[----] I, [2021-08-26T16:45:00.994786 #90557:3fd9ad43404c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for azure.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:00.994949 #90557:3fd9ad43404c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for vim.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:01.180883 #90557:3fd9ad43404c]  INFO -- evm: MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore
[----] I, [2021-08-26T16:45:02.360558 #90557:3fd9ad43404c]  INFO -- evm: MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 90557, ENV['EVMSERVER']:
[----] E, [2021-08-26T16:45:02.362795 #90557:3fd9ad43404c] ERROR -- evm: MIQ(Vmdb::Initializer.log_db_not_connectable) Cannot connect to the database!
[----] I, [2021-08-26T16:45:20.915836 #90579:3feb72032044]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for azure.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:20.916012 #90579:3feb72032044]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for vim.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:21.144726 #90579:3feb72032044]  INFO -- evm: MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore
[----] I, [2021-08-26T16:45:22.267246 #90579:3feb72032044]  INFO -- evm: MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 90579, ENV['EVMSERVER']:
[----] E, [2021-08-26T16:45:22.283460 #90579:3feb72032044] ERROR -- evm: MIQ(Vmdb::Initializer.log_db_not_connectable) Cannot connect to the database!
[----] I, [2021-08-26T16:45:35.498800 #90596:3ff95ac3204c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for azure.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:35.498969 #90596:3ff95ac3204c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for vim.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:35.688237 #90596:3ff95ac3204c]  INFO -- evm: MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore
[----] I, [2021-08-26T16:45:36.851872 #90596:3ff95ac3204c]  INFO -- evm: MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 90596, ENV['EVMSERVER']:
[----] E, [2021-08-26T16:45:36.853924 #90596:3ff95ac3204c] ERROR -- evm: MIQ(Vmdb::Initializer.log_db_not_connectable) Cannot connect to the database!
[----] I, [2021-08-26T16:45:51.871473 #90633:3feda7c3402c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for azure.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:51.871976 #90633:3feda7c3402c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for vim.log has been changed to [WARN]
[----] I, [2021-08-26T16:45:52.084235 #90633:3feda7c3402c]  INFO -- evm: MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore
[----] I, [2021-08-26T16:45:53.265276 #90633:3feda7c3402c]  INFO -- evm: MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 90633, ENV['EVMSERVER']:
[----] E, [2021-08-26T16:45:53.283804 #90633:3feda7c3402c] ERROR -- evm: MIQ(Vmdb::Initializer.log_db_not_connectable) Cannot connect to the database!
```

When good:

```
[----] I, [2021-08-26T16:48:21.150774 #90746:3fd05983205c]  INFO -- evm: MIQ(Vmdb::Loggers.apply_config) Log level for vim.log has been changed to [WARN]
[----] I, [2021-08-26T16:48:21.222145 #90746:3fd05983205c]  INFO -- evm: MIQ(ManageIQ::Session.configure_session_store) Using session_store: ActionDispatch::Session::MemCacheStore
[----] I, [2021-08-26T16:48:22.485012 #90746:3fd05983205c]  INFO -- evm: MIQ(Vmdb::Initializer.init) Initializing Application: Program Name: bin/rails, PID: 90746, ENV['EVMSERVER']:
[----] I, [2021-08-26T16:48:22.485090 #90746:3fd05983205c]  INFO -- evm: MIQ(Vmdb::Initializer.log_db_connectable) Successfully connected to the database.
```