### PR TITLE
support mo files

### DIFF
--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -51,6 +51,7 @@ module Vmdb
 
     def self.register_locales
       Vmdb::Gettext::Domains.add_domain(Vmdb::Gettext::Domains::TEXT_DOMAIN, locale_path.to_s, :po) # Default ManageIQ domain
+      Vmdb::Gettext::Domains.add_domain(Vmdb::Gettext::Domains::TEXT_DOMAIN, locale_path.to_s, :mo)
       Vmdb::Gettext::Domains.initialize_chain_repo
 
       available_locales = find_available_locales


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq-rpm_build/pull/177

load `mo` or `po` files for locales.
This way we can support the more compact form or the one we use in development
