### PR TITLE
[Vmdb::Settings] Add password_filter

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -860,6 +860,7 @@
   :level_fog: info
   :level_policy: info
   :level_remote_console: info
+  :secret_filter: []
 :notifications:
   :history:
     :purge_window_size: 1000

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -71,7 +71,7 @@ module Vmdb
       check_automate_disk_version_against_db(fh)
 
       fh.info("VMDB settings:")
-      VMDBLogger.log_hashes(fh, ::Settings, :filter => Vmdb::Settings::PASSWORD_FIELDS)
+      VMDBLogger.log_hashes(fh, ::Settings, :filter => Vmdb::Settings.secret_filter)
       fh.info("VMDB settings END")
       fh.info("---")
 

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -101,6 +101,10 @@ module Vmdb
       build_template.load!
     end
 
+    def self.secret_filter
+      (Array(::Settings.log.secret_filter) + PASSWORD_FIELDS.to_a).uniq
+    end
+
     # This is a near copy of Config.load_and_set_settings, but we can't use that
     # method as it also calls Config.load_files, which enforces specific file
     # sources and doesn't allow you insert new sources into the middle of the

--- a/spec/lib/vmdb/appliance_spec.rb
+++ b/spec/lib/vmdb/appliance_spec.rb
@@ -1,6 +1,51 @@
 require 'stringio'
 
 RSpec.describe Vmdb::Appliance do
+  describe "log_config" do
+    context "logging settings" do
+      let(:logger_io)     { StringIO.new }
+      let(:secret_filter) { [] }
+      let(:fake_settings) do
+        {
+          :authentication => {
+            :username  => "foobar",
+            :password  => "12345",  # "That's the same combination I have on my luggage!"
+            :api_token => "abc123"
+          },
+          :database => {
+            :maintenance => {
+              :reindex_schedule => "1 * * * *",
+              :reindex_tables   => %w[Metric MiqQueue]
+            }
+          },
+          :log => {
+            :secret_filter => secret_filter
+          }
+        }
+      end
+
+      before do
+        stub_settings(fake_settings)
+        allow(::Settings).to receive(:to_hash).and_return(fake_settings)
+        described_class.log_config(:logger => Logger.new(logger_io))
+      end
+
+      it "filters out secrets" do
+        expect(logger_io.string).to include("password: [FILTERED]")
+        expect(logger_io.string).to include("api_token: abc123")
+      end
+
+      context "with a user configured secret_filter" do
+        let(:secret_filter) { ["api_token"] }
+
+        it "will use user configured secret_filter" do
+          expect(logger_io.string).to include("password: [FILTERED]")
+          expect(logger_io.string).to include("api_token: [FILTERED]")
+        end
+      end
+    end
+  end
+
   describe ".installed_rpms (private)" do
     it "writes the correct string" do
       file = StringIO.new


### PR DESCRIPTION
Adds user configurable `.password_filter` so that users can define their own fields to be filtered via things like

```ruby
VMDBLogger.log_hashes($log, hash, :filter => Vmdb::Settings.password_filter)
```

These can be configured in the Settings.log.filter, so users can add whatever fields make sense for them and their environment.


Links
-----

* Partially Addresses https://github.com/ManageIQ/manageiq/issues/21392
* Related PR:  https://github.com/ManageIQ/manageiq-automation_engine/pull/481