### PR TITLE
Fix merge nil values

### DIFF
--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -26,7 +26,7 @@ module Vmdb
 
     def self.init
       ::Config.overwrite_arrays = true
-      ::Config.merge_nil_values = false
+      ::Config.merge_nil_values = true
       reset_settings_constant(for_resource(:my_server))
     end
 


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/835

Allows for users to save nil values on server advanced settings.

@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy 
@miq-bot add_reviewer @bdunne

