### PR TITLE
Handle ansible runner exceptions in the AnsibleRunnerWorkflow

### DIFF
--- a/app/models/manageiq/providers/ansible_runner_workflow.rb
+++ b/app/models/manageiq/providers/ansible_runner_workflow.rb
@@ -50,6 +50,8 @@ class ManageIQ::Providers::AnsibleRunnerWorkflow < Job
 
       route_signal(:poll_runner)
     end
+  rescue => err
+    route_signal(:abort, "Failed to run ansible #{execution_type}: #{err}", "error")
   end
 
   def poll_runner


### PR DESCRIPTION
There are scenarios where the `Ansible::Runner.run*` family of methods raise exceptions, if this occurs then the `#execute` method of the ansible runner workflow fails to signal abort leaving the job "stuck"

Fixes https://github.com/ManageIQ/manageiq/issues/21411