### PR TITLE
Fix session warning

### DIFF
--- a/lib/manageiq/session.rb
+++ b/lib/manageiq/session.rb
@@ -44,7 +44,7 @@ module ManageIQ
     # Configures the session store to be used by the Rails application
     # (Vmdb::Application) and logs what is being used.
     def self.configure_session_store(adapter)
-      Vmdb::Application.config.session_store(*adapter.session_store_config_args)
+      Vmdb::Application.config.session_store(adapter.type, **adapter.session_options)
       msg = "Using session_store: #{Vmdb::Application.config.session_store}"
       _log.info(msg)
       puts "** #{msg}" if !Rails.env.production? && adapter.type != :mem_cache_store

--- a/lib/manageiq/session/abstract_store_adapter.rb
+++ b/lib/manageiq/session/abstract_store_adapter.rb
@@ -11,10 +11,6 @@ module ManageIQ
 
         session_options
       end
-
-      def session_store_config_args
-        [type, session_options]
-      end
     end
   end
 end


### PR DESCRIPTION
fixes warning:

```
lib/manageiq/session.rb:47: warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
```

not sure if we want to split the helper to have 2 methods (args and keywords/options)
Or if we want to move the VMDB call into this class.

WIP: This is more of a conversation starter PR

