### PR TITLE
Cleanup unused evm:update_start/stop rake tasks

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -73,21 +73,6 @@ namespace :evm do
     EvmApplication.set_region_file(Rails.root.join("REGION"), configured_region)
   end
 
-  # update_start can be called in an environment where the database configuration is
-  # not set, so we need to give it a dummy config
-  desc "Start updating the appliance"
-  task :update_start do
-    EvmRakeHelper.with_dummy_database_url_configuration do
-      Rake::Task["environment"].invoke
-      EvmApplication.update_start
-    end
-  end
-
-  desc "Stop updating the appliance"
-  task :update_stop => :environment do
-    EvmApplication.update_stop
-  end
-
   desc "Determine the deployment scenario"
   task :deployment_status => :environment do
     status_to_code = {

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -159,25 +159,6 @@ class EvmApplication
     data.sort_by { |w| [w["Region"], w["Zone"], w["Server"], w["Type"], w["PID"]] }
   end
 
-  def self.update_start
-    require 'fileutils'
-    filename = MiqServer.pidfile
-    tempfile = "#{filename}.yum"
-    FileUtils.mkdir_p(File.dirname(filename))
-    File.write(filename, "no_db") if File.file?(tempfile)
-    FileUtils.rm_f(tempfile)
-  end
-
-  def self.update_stop
-    return if MiqServer.my_server.status != "started"
-
-    require 'fileutils'
-    tempfile = "#{MiqServer.pidfile}.yum"
-    FileUtils.mkdir_p(File.dirname(tempfile))
-    File.write(tempfile, " ")
-    stop
-  end
-
   def self.set_region_file(region_file, new_region)
     old_region = region_file.read.to_i if region_file.exist?
 

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -256,42 +256,6 @@ RSpec.describe EvmApplication do
     end
   end
 
-  context ".update_start" do
-    it "was running" do
-      expect(FileUtils).to receive(:mkdir_p).once
-      expect(File).to receive(:file?).once.and_return(true)
-      expect(File).to receive(:write).once
-      expect(FileUtils).to receive(:rm_f).once
-
-      described_class.update_start
-    end
-
-    it "was not running" do
-      expect(FileUtils).to receive(:mkdir_p).once
-      expect(FileUtils).to receive(:rm_f).once
-
-      described_class.update_start
-    end
-  end
-
-  context ".update_stop" do
-    it "was running" do
-      EvmSpecHelper.create_guid_miq_server_zone
-      expect(FileUtils).to receive(:mkdir_p)
-      expect(File).to receive(:write)
-      expect(EvmApplication).to receive(:stop)
-
-      described_class.update_stop
-    end
-
-    it "was not running" do
-      _, server, = EvmSpecHelper.create_guid_miq_server_zone
-      server.update_attribute(:status, "stopped")
-
-      described_class.update_stop
-    end
-  end
-
   describe ".set_region_file" do
     let(:region_file) { Pathname.new(Tempfile.new("REGION").path) }
 


### PR DESCRIPTION
These were used when updating the RPM packages to shutdown evmserver, update the rpms, ensure evm-watchdog didn't re-start the server, and then start it again when the package upgrade was complete.

We now simply systemctl try-restart evmserverd in the post scriptlet thus these are not needed any longer.

Depends:
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/185