### PR TITLE
Fix container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_REF=latest
-FROM manageiq/manageiq-ui-worker:${IMAGE_REF}
+FROM docker.io/manageiq/manageiq-ui-worker:${IMAGE_REF}
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq
 
 ENV DATABASE_URL=postgresql://root@localhost/vmdb_production?encoding=utf8&pool=5&wait_timeout=5

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
 ## Copy/link the appliance files again so that we get ssl
 RUN source /etc/default/evm && \
     $APPLIANCE_SOURCE_DIRECTORY/setup && \
-    mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf
 
 ## Overwrite entrypoint from pods repo


### PR DESCRIPTION
This file doesn't exist and causes the build to fail
It is removed [here](https://github.com/ManageIQ/manageiq-pods/blame/df663933ff91b5bf59da7efeae601f31e47fac80/images/manageiq-webserver-worker/Dockerfile#L18)

Error:
```
mv: cannot stat '/etc/httpd/conf.d/ssl.conf': No such file or directory
Error: error building at STEP "RUN source /etc/default/evm &&     $APPLIANCE_SOURCE_DIRECTORY/setup &&     mv /etc/httpd/conf.d/ssl.conf{,.orig} &&     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf": error while running runtime: exit status 1
```
