### PR TITLE
[MORPHY] Remove ManageIQ::Providers::CloudManager::CloudDatabase

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/cloud_database.rb
+++ b/app/models/manageiq/providers/cloud_manager/cloud_database.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::CloudManager::CloudDatabase < ::CloudDatabase
-end


### PR DESCRIPTION
This is leading to the providers' not finding any cloud databases due to STI not finding any child classes
```
@ems.cloud_databases.to_sql
"SELECT \"cloud_databases\".* FROM \"cloud_databases\" WHERE \"cloud_databases\".\"type\" = 'ManageIQ::Providers::CloudManager::CloudDatabase' AND \"cloud_databases\".\"ems_id\" = 56000000002055
```

Since the providers subclass `< ::CloudDatabase` not this intermediate class.

This was introduced in https://github.com/ManageIQ/manageiq/pull/21424/files#diff-57166b1eeaf686671105fe22547f82a06c55564211c7d06d58897c84f130919e and I'm honestly not sure how it got there since this file never existed on master as far as I can tell and I don't think I would have had it locally for any reason.  Either way it made it into a cherry-pick which was my fault for not noticing.