### PR TITLE
[MORPHY] Move ResourceGroups under the CloudManager

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -29,6 +29,7 @@ module ManageIQ::Providers
     has_many :cloud_databases,               :foreign_key => :ems_id, :dependent => :destroy
     has_many :key_pairs,                     :class_name  => "AuthKeyPair", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
+    has_many :resource_groups,               :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
     has_one  :source_tenant, :as => :source, :class_name  => 'Tenant'
 
     has_many :vm_and_template_labels,        :through     => :vms_and_templates, :source => :labels

--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -2,6 +2,8 @@ class ResourceGroup < ApplicationRecord
   acts_as_miq_taggable
   alias_attribute :images, :templates
 
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+
   has_many :vm_or_templates
 
   # Rely on default scopes to get expected information


### PR DESCRIPTION
Merge pull request #21200 from agrare/move_resource_groups_under_manager
Move ResourceGroups under the CloudManager

(cherry picked from commit c3e51190374e0494a715ae51dd2c3990539dc354)

Morphy backport of https://github.com/ManageIQ/manageiq/pull/21200 without changing https://github.com/ManageIQ/manageiq/pull/21200/files#diff-32770faae1fe217e3f7a355b6093466eaedd62747a51d55ee9d08153964a1dddL96 so that Azure and AzureStack continue to function without a data migration