### PR TITLE
update faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -285,7 +285,7 @@ unless ENV["APPLIANCE"]
 
     # TODO: faker is used for url generation in git repository factory and the lenovo
     # provider, via a xclarity_client dependency
-    gem "faker",                        "~>1.8",             :require => false
+    gem "faker",                        ">1.8",             :require => false
     gem "timecop",                      "~>0.9",             :require => false
     gem "vcr",                          "~>5.0",             :require => false
     gem "webmock",                      "~>3.7",             :require => false


### PR DESCRIPTION
upgrade this development dependency

- we are using 1.8 (2017) and 2.x (2019-2021) is recent
- It is only a dev gem
- not sure if this removes the warning, but at least it will be recent so we can fix the rpm build warning

```
*** WARNING: ./opt/manageiq/manageiq-gemset/gems/faker-1.8.7/lib/faker/time.rb is executable but has no shebang, removing executable bit
```

