### PR TITLE
Add providers_common Vmdb::Settings spec

### DIFF
--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -654,4 +654,8 @@ RSpec.describe Vmdb::Settings do
 
     expect(::Settings.api.token_ttl).to eq("2.minutes")
   end
+
+  it ".validate", :providers_common => true do
+    expect { described_class.validate }.not_to raise_exception
+  end
 end


### PR DESCRIPTION
Catch bad provider settings in the plugin

```
rake app:test:providers_common

Failures:

  1) Vmdb::Settings .validate
     Failure/Error: expect { described_class.validate }.not_to raise_exception

       expected no Exception, got #<RuntimeError: Missing config section event_catcher_ibm_cloud_iks> with backtrace:
         # /home/grare/adam/src/manageiq/manageiq/app/models/miq_worker.rb:200:in `block in fetch_worker_settings_from_options_hash'
         # /home/grare/adam/src/manageiq/manageiq/app/models/miq_worker.rb:198:in `each'
         # /home/grare/adam/src/manageiq/manageiq/app/models/miq_worker.rb:198:in `fetch_worker_settings_from_options_hash'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:208:in `validate_worker_request_limit'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:195:in `block in workers'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:194:in `each'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:194:in `workers'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:22:in `block in validate'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:17:in `each_key'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings/validator.rb:17:in `validate'
         # /home/grare/adam/src/manageiq/manageiq/lib/vmdb/settings.rb:52:in `validate'
         # ./spec/manageiq/spec/lib/vmdb/settings_spec.rb:659:in `block (3 levels) in <top (required)>'
         # ./spec/manageiq/spec/lib/vmdb/settings_spec.rb:659:in `block (2 levels) in <top (required)>'
         # /home/grare/adam/.gem/ruby-2.7/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ./spec/manageiq/spec/lib/vmdb/settings_spec.rb:659:in `block (2 levels) in <top (required)>'
     # /home/grare/adam/.gem/ruby-2.7/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 5.66 seconds (files took 12.48 seconds to load)
1059 examples, 1 failure

Failed examples:

rspec ./spec/manageiq/spec/lib/vmdb/settings_spec.rb:658 # Vmdb::Settings .validate
```