### PR TITLE
Simplify evm:start rake task

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -4,26 +4,13 @@ class EvmApplication
   include Vmdb::Logging
 
   def self.start
-    if server_state == :no_db
-      puts "EVM has no Database connection"
-      File.open(Rails.root.join("tmp", "pids", "evm.pid"), "w") { |f| f.write("no_db") }
-      exit
-    end
+    puts "Running EVM in background..."
 
-    if pid = MiqServer.running?
-      puts "EVM is already running (PID=#{pid})"
-      exit
-    end
-
-    puts "Starting EVM..."
-    _log.info("EVM Startup initiated")
-
-    MiqServer.kill_all_workers
     command_line = "#{Gem.ruby} #{Rails.root.join(*%w(lib workers bin evm_server.rb)).expand_path}"
 
     env_options = {}
     env_options["EVMSERVER"] = "true" if MiqEnvironment::Command.is_appliance?
-    puts "Running EVM in background..."
+
     pid = Kernel.spawn(env_options, command_line, :pgroup => true, [:out, :err] => [Rails.root.join("log/evm.log"), "a"])
     Process.detach(pid)
   end

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -19,6 +19,8 @@ class EvmServer
       exit
     end
 
+    MiqServer.kill_all_workers
+
     PidFile.create(MiqServer.pidfile)
     set_process_title
     validate_database


### PR DESCRIPTION
Now that the evmserverd.service ExecStart calls lib/workers/bin/evm_server.rb directly we don't need the extra logic in EvmApplication.start as this is solely a way to run evmserver in development.

Follow-up to https://github.com/ManageIQ/manageiq-appliance/pull/328