### PR TITLE
Fix systemd unit dir location for cleanup

### DIFF
--- a/app/models/miq_server/worker_management/monitor/systemd.rb
+++ b/app/models/miq_server/worker_management/monitor/systemd.rb
@@ -39,7 +39,7 @@ module MiqServer::WorkerManagement::Monitor::Systemd
   end
 
   def systemd_unit_dir
-    Pathname.new("/etc/systemd/system")
+    Pathname.new("/lib/systemd/system")
   end
 
   def miq_services(services)


### PR DESCRIPTION
We moved where the systemd units get created from /etc/systemd/system to /lib/systemd/system (since this is where evmserverd.service is) but were still cleaning up old unit settings directories from /etc/