### PR TITLE
use kwargs for call to allows_any

### DIFF
--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -59,7 +59,7 @@ module Rbac
 
     def user_role_allows_any?(user, options = {})
       return false if user.miq_user_role.nil?
-      user.miq_user_role.allows_any?(options)
+      user.miq_user_role.allows_any?(**options)
     end
   end
 end


### PR DESCRIPTION
newer version of ruby is complaining

```
authorizer.rb:62: warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
app/models/miq_user_role.rb:51: warning: The called method `allows_any?' is defined here
```