### PR TITLE
In containers, don't post process linking and copying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
 
 ## Copy/link the appliance files again so that we get ssl
 RUN source /etc/default/evm && \
-    $APPLIANCE_SOURCE_DIRECTORY/setup && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf
 
 ## Overwrite entrypoint from pods repo


### PR DESCRIPTION
rpms already place the files in the correct spot.
Don't then redo what the rpms does and copy/link them again.

Fixes https://github.com/ManageIQ/manageiq-appliance/issues/330

**Help:** I'm not sure the best way to test these container builds

**Aside:** I'm trying to remove this copying and linking. So we would need to change this eventually.