### PR TITLE
Remove empty and unused cancel_cleanup method

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -624,13 +624,8 @@ class MiqRequest < ApplicationRecord
   private
 
   def do_cancel
-    update(:cancelation_status => CANCEL_STATUS_PROCESSING)
-    cancel_cleanup
     update(:cancelation_status => CANCEL_STATUS_FINISHED, :request_state => "finished", :status => "Error", :message => "Request is canceled by user.")
     _log.info("Request #{description} is canceled by user.")
-  end
-
-  def cancel_cleanup
   end
 
   def clean_up_keys_for_request_task


### PR DESCRIPTION
It's empty and no subclasses implement it.

A search on the manageiq org shows no references to it other than the code
changed in this commit.

It was added in
https://github.com/ManageIQ/manageiq/pull/17825/commits/5f10870c906898e85bff0383a474119f77bff244
but apparantly was never  used.

We can add it back and setting the intermediate state of "canceling" if needed
in the future.  Right now, it's confusing.