### PR TITLE
purge tasks less frequently

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -74,9 +74,6 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
         end
       end
     end
-
-    # Purge tasks older than 4 hours
-    MiqTask.delete_older(4.hours.ago.utc, "name LIKE 'Performance rollup for %'") if rollups
   end
 
   def perf_capture_queue_targets_hist(targets, interval, start_time: nil, end_time: nil)

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -18,6 +18,7 @@ module Metric::Purging
   def self.purge_rollup_timer
     purge_hourly_timer
     purge_daily_timer
+    purge_rollup_task_timer
   end
 
   def self.purge_daily_timer(ts = nil)
@@ -33,6 +34,10 @@ module Metric::Purging
   def self.purge_realtime_timer(ts = nil)
     ts ||= purge_date(:keep_realtime_performances)
     purge_timer(ts, "realtime")
+  end
+
+  def self.purge_rollup_task_timer
+    MiqTask.delete_older(4.hours.ago.beginning_of_hour.utc, "name LIKE 'Performance rollup for %'")
   end
 
   def self.purge_timer(ts, interval)


### PR DESCRIPTION
## Overview

For vmware, we rollup ems clusters metrics with a task.
These tasks are typically cleaned up by our process but may
linger if metrics times out.
These tasks are only valid for 4 hours since data is only stored for 4 hours.

## Before

We were getting too many purge tasks entries on the queue

request to purge these tasks every metrics run. which is every 3 minutes

## After

request to purge these tasks every metrics purge. every half hour or so
Also, change the arguments to round the start time, so duplicates can be disposed.

Fixes: https://github.com/ManageIQ/manageiq/issues/21223