### PR TITLE
Eliminate hardware N+1 needed for cpu/mem/disk information

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -348,7 +348,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     rails_logger('allowed_templates', 1)
     log_allowed_template_list(allowed_templates_list)
 
-    MiqPreloader.preload(allowed_templates_list, [:operating_system])
+    MiqPreloader.preload(allowed_templates_list, [:hardware, :operating_system])
     @_ems_allowed_templates_cache = {}
     @allowed_templates_cache = allowed_templates_list.collect do |template|
       create_hash_struct_from_vm_or_template(template, options)


### PR DESCRIPTION
I was noticing an N+1 on hardwares for each vm in a provisioning workflow.

Since we need hardwares for the cpu/mem/disk information, we can eliminate those
extra queries by preloading the required table.

I saw this by going to Compute -> Cloud -> Providers.  Selecting my google provider.  Clicking the instances in the summary screen.  Then, selecting  Lifecycle -> Provision instances, the list of templates to provision from are displayed, including information found in the hardwares table:
![image](https://user-images.githubusercontent.com/19339/134708660-7d571b46-3cf1-4185-b485-df99e52a0290.png)



**Before**

![image](https://user-images.githubusercontent.com/19339/134708064-4236db60-5142-4938-b2b8-c8ab852250d0.png)

**After**
![image](https://user-images.githubusercontent.com/19339/134708116-dadbb18b-569d-46cb-9201-d68190c9805b.png)

