### PR TITLE
Exclude deprecated templates from provisioning

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -314,7 +314,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
 
     rails_logger('allowed_templates', 0)
-    vms = VmOrTemplate.in_my_region.all
+
+    # Select only the non-deprecated templates as some providers retain templates even if not currently in use
+    templates = MiqTemplate.non_deprecated.in_my_region
     condition = allowed_template_condition
 
     unless options[:tag_filters].blank?
@@ -335,14 +337,14 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
       unless tag_conditions.blank?
         _log.info("Filtering VM templates with the following tag_filters: <#{tag_conditions.inspect}>")
-        vms = MiqTemplate.in_my_region.where(condition).find_tags_by_grouping(tag_conditions, :ns => "/managed")
+        templates = templates.where(condition).find_tags_by_grouping(tag_conditions, :ns => "/managed")
       end
     end
 
-    # Only select the columns we need on non-deprecated templates
-    vms = vms.where(:deprecated => [nil, false]).select(:id, :type, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
+    # Only select the columns we need
+    templates = templates.select(:id, :type, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
 
-    allowed_templates_list = source_vm_rbac_filter(vms, condition, VM_OR_TEMPLATE_EXTRA_COLS).to_a
+    allowed_templates_list = source_vm_rbac_filter(templates, condition, VM_OR_TEMPLATE_EXTRA_COLS).to_a
     @allowed_templates_filter = filter_id
     @allowed_templates_tag_filters = @values[:vm_tags]
     rails_logger('allowed_templates', 1)
@@ -359,9 +361,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def allowed_template_condition
-    return ["vms.template = ? AND vms.ems_id IS NOT NULL", true] unless self.class.respond_to?(:provider_model)
+    return ["vms.ems_id IS NOT NULL"] unless self.class.respond_to?(:provider_model)
 
-    ["vms.template = ? AND vms.ems_id in (?)", true, self.class.provider_model.pluck(:id)]
+    ["vms.ems_id in (?)", self.class.provider_model.pluck(:id)]
   end
 
   def source_vm_rbac_filter(vms, condition = nil, *extra_cols)

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -339,8 +339,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       end
     end
 
-    # Only select the colums we need
-    vms = vms.select(:id, :type, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
+    # Only select the columns we need on non-deprecated templates
+    vms = vms.where(:deprecated => [nil, false]).select(:id, :type, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
 
     allowed_templates_list = source_vm_rbac_filter(vms, condition, VM_OR_TEMPLATE_EXTRA_COLS).to_a
     @allowed_templates_filter = filter_id

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe MiqProvisionVirtWorkflow do
 
   context "#allowed_template_condition" do
     it "without a provider model defined" do
-      expect(workflow.allowed_template_condition).to eq(["vms.template = ? AND vms.ems_id IS NOT NULL", true])
+      expect(workflow.allowed_template_condition).to eq(["vms.ems_id IS NOT NULL"])
     end
 
     it "with a provider model defined" do
@@ -234,7 +234,7 @@ RSpec.describe MiqProvisionVirtWorkflow do
       workflow = FactoryBot.create(:miq_provision_virt_workflow_vmware)
 
       expect(workflow.class).to receive(:provider_model).once.and_return(ems.class)
-      expect(workflow.allowed_template_condition).to eq(["vms.template = ? AND vms.ems_id in (?)", true, [ems.id]])
+      expect(workflow.allowed_template_condition).to eq(["vms.ems_id in (?)", [ems.id]])
     end
   end
 
@@ -401,6 +401,11 @@ RSpec.describe MiqProvisionVirtWorkflow do
     it "includes templates where deprecated is not specified" do
       FactoryBot.create(:template_vmware, :ext_management_system => local_vmware, :deprecated => nil)
       expect(workflow.allowed_templates.count).to eq(1)
+    end
+
+    it "excludes templates without an ems" do
+      FactoryBot.create(:template_vmware, :ext_management_system => nil, :deprecated => false)
+      expect(workflow.allowed_templates.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
From @agrare: "GCE doesn't delete templates and only marks them as not active".  

Because of this, some provisioning instances for GCE providers were causing the workflow to include deprecated templates.  This bloated the UI and the session and caused great confusion.

We can exclude these deprecated templates because they're inactive in GCE.