### PR TITLE
Fix more kwargs issues: git worktree and authorizer

### DIFF
--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -320,7 +320,7 @@ class GitWorktree
 
   def fetch
     with_remote_options do |remote_options|
-      @repo.fetch(@remote_name, remote_options)
+      @repo.fetch(@remote_name, **remote_options)
     end
   end
 

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -40,7 +40,7 @@ module Rbac
 
     def user_role_allows?(user, options = {})
       return false if user.miq_user_role.nil?
-      return true if user.miq_user_role.allows?(options)
+      return true if user.miq_user_role.allows?(**options)
 
       ident = options[:identifier]
       parent = MiqProductFeature.feature_parent(ident)


### PR DESCRIPTION
```
lib/git_worktree.rb:323: warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call

lib/rbac/authorizer.rb:43: warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
```

sorry I introduced these fixes in more than one PR. I am just putting in the fixes when I see the warnings show up.