### PR TITLE
Mount secret to provide server.cer and key

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -18,6 +18,30 @@ class MiqWorker
         container[:imagePullPolicy] = "IfNotPresent"
       end
 
+      if instance_of?(MiqRemoteConsoleWorker)
+        container[:volumeMounts] << {
+          :name      => "vol-server-tls-secret",
+          :mountPath => "/var/www/miq/vmdb/certs/server.cer",
+          :readOnly  => true,
+          :subPath   => "tls.crt"
+        }
+
+        container[:volumeMounts] << {
+          :name      => "vol-server-tls-secret",
+          :mountPath => "/var/www/miq/vmdb/certs/server.cer.key",
+          :readOnly  => true,
+          :subPath   => "tls.key"
+        }
+
+        definition[:spec][:template][:spec][:volumes] << {
+          :name   => "vol-server-tls-secret",
+          :secret => {
+            :defaultMode => 420,
+            :secretName  => "server-tls-secret"
+          }
+        }
+      end
+
       container[:image] = container_image
       container[:env] << {:name => "WORKER_CLASS_NAME", :value => self.class.name}
       container[:env] << {:name => "BUNDLER_GROUPS", :value => self.class.bundler_groups.join(",")}


### PR DESCRIPTION
This PR could fix https://github.com/ManageIQ/manageiq-pods/issues/755

The issue is for running Manageiq on Kubernetes using Manageiq-pods and using the remote console functionality using webMKS to take over a console for VMWare.

This PR fixed one of the issue I encountered trying to get this functionality working.

Things that need fixing to get the console working:

- WebMKS had to be included into the UI-worker POD. ManageIQ-Pod currently has no functionality for that. We use a customised Dockerfile for this.
- There was an issue with the httpd config that was not forwarding traffic to the remote-console pod. See https://github.com/ManageIQ/manageiq-pods/pull/756
- The remote console pod needs an additional certificate. This PR mounts a secret to address this.

The creation of the certificate is still a manual step

```
# Generate server.cer and server.cer.key for the remote console
openssl req -x509 -newkey rsa -days 1095 -keyout server.cer.key -out server.cer -subj "/CN=server" -nodes -batch

# Store it as a kubernetes secret
oc create secret tls server-tls-secret --cert=server.cer --key=server.cer.key
```

If the cert is missing from the pod and try to create a remote console this error is thrown

```
{"@timestamp":"2021-09-27T14:43:44.098759 ","hostname":"1-remote-console-6b4cdb569d-nkk6k","pid":9,"tid":"2aadbdaed9f0","level":"err","message":"RemoteConsole proxy for VM 69 errored with No such file or directory @ rb_sysopen - certs/server.cer /var/www/miq/vmdb/lib/remote_console/client_adapter/ssl_socket.rb:23:in `initialize'\n/var/www/miq/vmdb/lib/remote_console/client_adapter/ssl_socket.rb:23:in `open'\n/var/www/miq/vmdb/lib/remote_console/client_adapter/ssl_socket.rb:23:in `setup_ssl'\n/var/www/miq/vmdb/lib/remote_console/client_adapter/ssl_socket.rb:7:in `initialize'\n/var/www/miq/vmdb/lib/remote_console/client_adapter/web_mks.rb:9:in `initialize'\n/var/www/miq/vmdb/lib/remote_console/client_adapter.rb:11:in `new'\n/var/www/miq/vmdb/lib/remote_console/client_adapter.rb:11:in `new'\n/var/www/miq/vmdb/lib/remote_console/rack_server.rb:89:in `init_proxy'\n/var/www/miq/vmdb/lib/remote_console/rack_server.rb:63:in `call'\n/opt/manageiq/manageiq-gemset/gems/puma-4.3.7/lib/puma/configuration.rb:228:in `call'\n/opt/manageiq/manageiq-gemset/gems/puma-4.3.7/lib/puma/server.rb:713:in `handle_request'\n/opt/manageiq/manageiq-gemset/gems/puma-4.3.7/lib/puma/server.rb:472:in `process_client'\n/opt/manageiq/manageiq-gemset/gems/puma-4.3.7/lib/puma/server.rb:328:in `block in run'\n/opt/manageiq/manageiq-gemset/gems/puma-4.3.7/lib/puma/thread_pool.rb:134:in `block in spawn_thread'"}
```

Links
----------------
* https://github.com/ManageIQ/manageiq-pods/issues/755
* https://github.com/ManageIQ/manageiq-pods/pull/756

