### PR TITLE
Fix rubocop issues in plugin generated code

### DIFF
--- a/lib/generators/manageiq/plugin/templates/%plugin_name%.gemspec
+++ b/lib/generators/manageiq/plugin/templates/%plugin_name%.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require '<%= plugin_path %>/version'
 

--- a/lib/generators/manageiq/plugin/templates/bin/rails
+++ b/lib/generators/manageiq/plugin/templates/bin/rails
@@ -2,12 +2,12 @@
 # This command will automatically be run when you run "rails" with Rails gems
 # installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/<%= plugin_path %>/engine', __FILE__)
-APP_PATH    = File.expand_path('../../spec/manageiq/config/application', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/<%= plugin_path %>/engine', __dir__)
+APP_PATH    = File.expand_path('../spec/manageiq/config/application', __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 require 'rails/all'

--- a/lib/generators/manageiq/plugin/templates/spec/spec_helper.rb
+++ b/lib/generators/manageiq/plugin/templates/spec/spec_helper.rb
@@ -3,7 +3,7 @@ if ENV['CI']
   SimpleCov.start
 end
 
-Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
-Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/shared/**/*.rb")].sort.each { |f| require f }
+Dir[File.join(__dir__, "support/**/*.rb")].sort.each { |f| require f }
 
 require "<%= plugin_name %>"


### PR DESCRIPTION
Some of the code in the generated plugin code fails newer rubocop rules