### PR TITLE
Cleanup constantize of worker_class_names

### DIFF
--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -90,19 +90,6 @@ RSpec.describe MiqServer::WorkerManagement::Monitor do
     context "#sync_workers" do
       let(:server) { EvmSpecHelper.local_miq_server }
 
-      it "ensures only expected worker classes are constantized" do
-        # Autoload abstract base class for the event catcher
-        ManageIQ::Providers::BaseManager::EventCatcher
-
-        # We'll try to constantize a non-existing EventCatcher class in an existing namespace,
-        # which incorrectly resolves to the base manager event catcher.
-        allow(MiqWorkerType).to receive(:worker_class_names).and_return(%w[ManageIQ::Providers::Foreman::ProvisioningManager::EventCatcher MiqGenericWorker])
-
-        expect(ManageIQ::Providers::BaseManager::EventCatcher).not_to receive(:sync_workers)
-        expect(MiqGenericWorker).to receive(:sync_workers).and_return(:adds => [111])
-        expect(server.sync_workers).to eq("MiqGenericWorker"=>{:adds=>[111]})
-      end
-
       it "rescues exceptions and moves on" do
         allow(MiqWorkerType).to receive(:worker_class_names).and_return(%w(MiqGenericWorker MiqPriorityWorker))
         allow(MiqGenericWorker).to receive(:sync_workers).and_raise

--- a/spec/models/miq_worker_type_spec.rb
+++ b/spec/models/miq_worker_type_spec.rb
@@ -26,4 +26,15 @@ RSpec.describe MiqWorkerType do
       expect(described_class.find_by(:worker_type => old_worker_name)).to be_nil
     end
   end
+
+  describe ".worker_class_names" do
+    before { described_class.seed }
+
+    it "contains properly subclassed workers", :providers_common => true do
+      described_class.worker_class_names.each do |class_name|
+        klass = class_name.constantize
+        raise NameError, "Constant problem: expected: #{class_name}, constantized: #{klass.name}" unless klass.name == class_name
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now that we only pull worker class names from the seeded database this seems like it shouldn't be an issue anymore but would like @jrafanie's opinion