### PR TITLE
Switch to bionic on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+dist: bionic
 rvm:
 - 2.6.6
 - 2.7.2
@@ -19,7 +20,6 @@ matrix:
   - sudo: required
     group: edge
     virt: lxd
-    dist: bionic
     arch: arm64-graviton2
     rvm: 2.6.6
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ env:
 matrix:
   fast_finish: true
   jobs:
-  - sudo: required
-    group: edge
+  - group: edge
     virt: lxd
     arch: arm64-graviton2
     rvm: 2.6.6


### PR DESCRIPTION
Due to LetsEncrypt certificate validation errors with the xenial image.

https://techcrunch.com/2021/09/21/lets-encrypt-root-expiry/
https://community.letsencrypt.org/t/help-thread-for-dst-root-ca-x3-expiration-september-2021/149190/36