### PR TITLE
Sort "Recently Discovered VMs" by discovery date

### DIFF
--- a/product/reports/100_Configuration Management - Virtual Machines/070_Newest VMs.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/070_Newest VMs.yaml
@@ -24,7 +24,7 @@ headers:
 - Vendor Display
 - Location
 - Href Slug
-- Created on Time
+- Discovered on
 - Description
 conditions:
 order: Descending

--- a/product/reports/100_Configuration Management - Virtual Machines/070_Newest VMs.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/070_Newest VMs.yaml
@@ -9,7 +9,7 @@ cols:
 - vendor_display
 - location
 - href_slug
-- ems_created_on
+- created_on
 - description
 include: {}
 col_order:
@@ -17,7 +17,7 @@ col_order:
 - vendor_display
 - location
 - href_slug
-- ems_created_on
+- created_on
 - description
 headers:
 - Name
@@ -29,7 +29,7 @@ headers:
 conditions:
 order: Descending
 sortby:
-- ems_created_on
+- created_on
 - description
 group:
 graph:


### PR DESCRIPTION
The `ems_created_on` column is for the VM creation timestamp, and is not
included in all providers (and even worse `nil` is sorted to the top of
the list). The `created_on` column is for the discovery timestamp and
should be populated in every row.

fixes #21461
