### PR TITLE
[WIP] Make supports default to false

### DIFF
--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -16,9 +16,6 @@ class CloudObjectStoreContainer < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete, :reason => N_("Delete operation is not supported.")
-  supports_not :cloud_object_store_container_clear
-
   # Create a cloud object store container as a queued task and return the task
   # id. The queue name and the queue zone are derived from the provided EMS
   # instance. The EMS instance and a userid are mandatory. Any +options+ are

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -15,8 +15,6 @@ class CloudObjectStoreObject < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete, :reason => N_("Delete operation is not supported.")
-
   def disconnect_inv
     # This is for bypassing a weird Rails behaviour. If we do a ems.cloud_object_store_objects.delete(objects) and a
     # relation in the ems is missing a :dependent => :destroy on :cloud_object_store_objects relation, it does not

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -25,15 +25,7 @@ class CloudVolume < ApplicationRecord
   has_many   :volume_mappings, :dependent => :destroy
   has_many   :host_initiators, :through => :volume_mappings
 
-  supports_not :backup_create
-  supports_not :backup_restore
-  supports_not :create
-  supports_not :snapshot_create
-  supports_not :update
-
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
-
-  supports_not :safe_delete
   virtual_column :supports_safe_delete, :type => :boolean
 
   def supports_safe_delete

--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -1,11 +1,6 @@
 module CloudVolume::Operations
   extend ActiveSupport::Concern
 
-  included do
-    supports_not :attach_volume
-    supports_not :detach_volume
-  end
-
   # Attach a cloud volume as a queued task and return the task id. The queue
   # name and the queue zone are derived from the server EMS, and both a userid
   # and server EMS ref are mandatory. The device is optional.

--- a/app/models/cloud_volume_backup.rb
+++ b/app/models/cloud_volume_backup.rb
@@ -11,8 +11,6 @@ class CloudVolumeBackup < ApplicationRecord
   belongs_to :cloud_volume
   has_one :cloud_tenant, :through => :cloud_volume
 
-  supports_not :backup_restore
-
   # Restore a cloud volume backup as a queued task and return the task id. The queue
   # name and the queue zone are derived from the EMS. The userid is mandatory, and
   # the volumeid and name are optional.

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -26,8 +26,6 @@ class ConfigurationProfile < ApplicationRecord
 
   delegate :my_zone, :provider, :zone, :to => :manager
 
-  supports_not :console
-
   virtual_has_one :configuration_architecture,  :class_name => 'ConfigurationArchitecture', :uses => :configuration_tags
   virtual_has_one :configuration_compute_profile, :class_name => 'ConfigurationProfile',    :uses => :configuration_tags
   virtual_has_one :configuration_domain,          :class_name => 'ConfigurationDomain',     :uses => :configuration_tags

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -41,8 +41,6 @@ class ConfiguredSystem < ApplicationRecord
   virtual_delegate :cpu_total_cores, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
   virtual_delegate :ram_size, :to => "hardware.memory_mb", :allow_nil => true, :default => 0, :type => :integer
 
-  supports_not :console
-
   virtual_column  :my_zone,                            :type => :string
   virtual_column  :configuration_architecture_name,    :type => :string
   virtual_column  :configuration_compute_profile_name, :type => :string

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -14,8 +14,6 @@ class ContainerTemplate < ApplicationRecord
   serialize :objects, Array
   serialize :object_labels, Hash
 
-  supports_not :instantiate
-
   acts_as_miq_taggable
 
   def instantiate(_params, _project_name)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -139,35 +139,7 @@ class ExtManagementSystem < ApplicationRecord
 
   serialize :options
 
-  supports_not :catalog
-  supports_not :add_host_initiator
-  supports_not :add_storage
-  supports_not :add_volume_mapping
-  supports_not :admin_ui
-  supports_not :assume_role
-  supports_not :block_storage
-  supports_not :change_password
-  supports_not :cloud_object_store_container_create
-  supports_not :cloud_subnet_create
-  supports_not :cloud_tenant_mapping
-  supports_not :cloud_volume_create
-  supports_not :create_iso_datastore
-  supports_not :console
-  supports_not :discovery
-  supports_not :label_mapping
-  supports_not :metrics
-  supports_not :object_storage
-  supports_not :provisioning
-  supports_not :publish
-  supports_not :reconfigure_disks
   supports     :refresh_ems
-  supports_not :regions
-  supports_not :smartstate_analysis
-  supports_not :storage_manager
-  supports_not :streaming_refresh
-  supports_not :swift_service
-  supports_not :vm_import
-  supports_not :volume_availability_zones
 
   def edit_with_params(params, endpoints, authentications)
     tap do |ems|

--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -15,8 +15,6 @@ class FloatingIp < ApplicationRecord
   belongs_to :network_router
   alias_attribute :name, :address
 
-  supports_not :delete_floating_ip
-
   def self.available
     where(:vm_id => nil, :network_port_id => nil)
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -179,7 +179,6 @@ class Host < ApplicationRecord
   after_save    :process_events
 
   supports     :destroy
-  supports_not :quick_stats
   supports     :reset do
     unsupported_reason_add(:reset, _("The Host is not configured for IPMI")) if ipmi_address.blank?
     unsupported_reason_add(:reset, _("The Host has no IPMI credentials")) if authentication_type(:ipmi).nil?
@@ -187,13 +186,6 @@ class Host < ApplicationRecord
       unsupported_reason_add(:reset, _("The Host has invalid IPMI credentials"))
     end
   end
-  supports_not :refresh_advanced_settings
-  supports_not :refresh_firewall_rules
-  supports_not :refresh_logs
-  supports_not :refresh_network_interfaces
-  supports_not :set_node_maintenance
-  supports_not :smartstate_analysis
-  supports_not :unset_node_maintenance
 
   def self.non_clustered
     where(:ems_cluster_id => nil)

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -17,12 +17,6 @@ class HostAggregate < ApplicationRecord
   has_many   :metric_rollups,         :as => :resource
   has_many   :vim_performance_states, :as => :resource
 
-  supports_not :add_host
-  supports_not :create
-  supports_not :delete
-  supports_not :remove_host
-  supports_not :update
-
   virtual_total :total_vms, :vms
 
   def self.create_aggregate_queue(userid, ext_management_system, options = {})

--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -15,7 +15,6 @@ class HostInitiator < ApplicationRecord
 
   virtual_total :v_total_addresses, :san_addresses
 
-  supports_not :create
   acts_as_miq_taggable
 
   def my_zone

--- a/app/models/host_initiator_group.rb
+++ b/app/models/host_initiator_group.rb
@@ -15,7 +15,6 @@ class HostInitiatorGroup < ApplicationRecord
 
   virtual_total :v_total_addresses, :san_addresses
 
-  supports_not :create
   acts_as_miq_taggable
 
   def my_zone

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -41,13 +41,6 @@ module ManageIQ::Providers
 
     virtual_has_many :volume_availability_zones, :class_name => "AvailabilityZone", :uses => :availability_zones
 
-    supports_not :auth_key_pair_create
-    supports_not :cinder_service
-    supports_not :cloud_tenants
-    supports_not :cloud_volume
-    supports_not :cloud_tenant_mapping
-    supports_not :create_flavor
-
     validates_presence_of :zone
 
     # TODO: remove and have each manager include this

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
-  supports_not :import_image
-
   default_value_for :cloud, true
 
   virtual_column :image?, :type => :boolean

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -42,10 +42,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
                  :type => :string_set,
                  :uses => {:load_balancer_pool_members => :load_balancer_health_check_states_with_reason}
 
-  supports_not :add_security_group
-  supports_not :associate_floating_ip
-  supports_not :disassociate_floating_ip
-
   def load_balancer_health_check_state
     return @health_check_state if @health_check_state
     return (@health_check_state = nil) if load_balancer_pool_members.blank?

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -9,10 +9,6 @@ module ManageIQ::Providers
       define_method(:singular_route_key) { "ems_network" }
     end
 
-    supports_not :cloud_tenant_mapping
-    supports_not :create_floating_ip
-    supports_not :create_network_router
-
     # cloud_subnets are defined on base class, because of virtual_total performance
     has_many :floating_ips,                       :foreign_key => :ems_id, :dependent => :destroy
     has_many :security_groups,                    :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -1,17 +1,6 @@
 module ManageIQ::Providers
   class StorageManager < ManageIQ::Providers::BaseManager
     include SupportsFeatureMixin
-    supports_not :block_storage
-    supports_not :cinder_volume_types
-    supports_not :cloud_object_store_container_clear
-    supports_not :cloud_object_store_container_create
-    supports_not :cloud_volume
-    supports_not :cloud_volume_create
-    supports_not :object_storage
-    supports_not :smartstate_analysis
-    supports_not :storage_services
-    supports_not :volume_multiattachment
-    supports_not :volume_resizing
 
     has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
     has_many :volume_availability_zones, :class_name => "AvailabilityZone", :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -3,8 +3,6 @@ class MiqTemplate < VmOrTemplate
 
   default_scope { where(:template => true) }
 
-  supports_not :kickstart_provisioning
-
   virtual_column :display_type,                         :type => :string
   virtual_column :display_operating_system,             :type => :string
   virtual_column :display_platform,                     :type => :string

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -3,16 +3,5 @@ module MiqTemplate::Operations
 
   included do
     supports     :clone
-    supports_not :collect_running_processes, :reason => _("Process Collection is not available for Images and VM Templates.")
-    supports_not :pause,                     :reason => _("Pause Operation is not available for Images and VM Templates.")
-    supports_not :provisioning,              :reason => _("Provisioning Operation is not available for Images and VM Templates.")
-    supports_not :reboot_guest,              :reason => _("Reboot Guest Operation is not available for Images and VM Templates.")
-    supports_not :reset,                     :reason => _("Reset Operation is not available for Images and VM Templates.")
-    supports_not :retire,                    :reason => _("Retire Operation is not available for Images and VM Templates.")
-    supports_not :shutdown_guest,            :reason => _("Shutdown Guest Operation is not available for Images and VM Templates.")
-    supports_not :standby_guest,             :reason => _("Standby Guest Operation is not available for Images and VM Templates.")
-    supports_not :start,                     :reason => _("Start Operation is not available for Images and VM Templates.")
-    supports_not :stop,                      :reason => _("Stop Operation is not available for Images and VM Templates.")
-    supports_not :suspend,                   :reason => _("Suspend Operation is not available for Images and VM Templates.")
   end
 end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -56,10 +56,6 @@ module SupportsFeatureMixin
   # Whenever this mixin is included we define all features as unsupported by default.
   # This way we can query for every feature
   included do
-    COMMON_FEATURES.each do |feature|
-      supports_not(feature)
-    end
-
     private_class_method :unsupported
     private_class_method :unsupported_reason_add
     private_class_method :define_supports_feature_methods
@@ -72,13 +68,13 @@ module SupportsFeatureMixin
   # query instance for the reason why the feature is unsupported
   def unsupported_reason(feature)
     feature = feature.to_sym
-    public_send("supports_#{feature}?") unless unsupported.key?(feature)
+    supports?(feature) unless unsupported.key?(feature)
     unsupported[feature]
   end
 
   # query the instance if the feature is supported or not
   def supports?(feature)
-    public_send("supports_#{feature}?")
+    try("supports_#{feature}?") || false
   end
 
   # query the instance if a feature is generally known
@@ -113,7 +109,7 @@ module SupportsFeatureMixin
 
     # query the class if the feature is supported or not
     def supports?(feature)
-      public_send("supports_#{feature}?")
+      try("supports_#{feature}?") || false
     end
 
     # all subclasses that are considered for supporting features
@@ -146,7 +142,7 @@ module SupportsFeatureMixin
     # query the class for the reason why something is unsupported
     def unsupported_reason(feature)
       feature = feature.to_sym
-      public_send("supports_#{feature}?") unless unsupported.key?(feature)
+      supports?(feature) unless unsupported.key?(feature)
       unsupported[feature]
     end
 

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -32,9 +32,6 @@ class NetworkRouter < ApplicationRecord
   virtual_column :main_route_table     , :type => :boolean # :array
   virtual_column :high_availability    , :type => :boolean
 
-  supports_not :add_interface
-  supports_not :remove_interface
-
   # Define all getters and setters for extra_attributes related virtual columns
   %i(external_gateway_info distributed routes propagating_vgws main_route_table high_availability).each do |action|
     define_method("#{action}=") do |value|

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -33,8 +33,6 @@ class PhysicalStorage < ApplicationRecord
 
   has_many :wwpn_candidates, :dependent => :destroy
 
-  supports_not :create
-  supports_not :delete
   acts_as_miq_taggable
 
   def my_zone

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -29,8 +29,6 @@ class SecurityGroup < ApplicationRecord
   virtual_total :total_security_policy_rules_as_source, :security_policy_rules_as_source, :uses => :security_policy_rules_as_source
   virtual_total :total_security_policy_rules_as_destination, :security_policy_rules_as_destination, :uses => :security_policy_rules_as_destination
 
-  supports_not :delete_security_group
-
   def self.non_cloud_network
     where(:cloud_network_id => nil)
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -84,8 +84,6 @@ class Storage < ApplicationRecord
     end
   end
 
-  supports_not :evacuate
-
   def to_s
     name
   end

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -46,14 +46,6 @@ module Vm::Operations
 
       unsupported_reason_add(:collect_running_processes, reason) if reason
     end
-
-    supports_not :evacuate
-    supports_not :reconfigure_disks
-    supports_not :reconfigure_disksize
-    supports_not :reconfigure_network_adapters
-    supports_not :reconfigure_cdroms
-    supports_not :remove_security_group
-    supports_not :resize
   end
 
   def ipv4_address

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -5,11 +5,6 @@ module Vm::Operations::Guest
     api_relay_method :shutdown_guest
     api_relay_method :reboot_guest
     api_relay_method :reset
-
-    supports_not :reboot_guest
-    supports_not :reset
-    supports_not :shutdown_guest
-    supports_not :standby_guest
   end
 
   def raw_shutdown_guest

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -23,10 +23,6 @@ module Vm::Operations::Power
       msg ||= _('The VM is not powered on') unless vm_powered_on?
       unsupported_reason_add(:stop, msg) if msg
     end
-
-    supports_not :pause
-    supports_not :shelve
-    supports_not :shelve_offload
   end
 
   def vm_powered_on?

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1624,7 +1624,6 @@ class VmOrTemplate < ApplicationRecord
     MiqTemplate.where(:id => ids).exists?
   end
 
-  supports_not :snapshots
   supports :destroy
 
   # Stop showing Reconfigure VM task unless the subclass allows

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -141,10 +141,6 @@ module VmOrTemplate::Operations
             end
       unsupported_reason_add(:control, msg) if msg
     end
-    supports_not :clone
-    supports_not :quick_stats
-    supports_not :rename
-    supports_not :terminate
   end
 
   def validate_vm_control_powered_on

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -1,14 +1,6 @@
 module VmOrTemplate::Operations::Relocation
   extend ActiveSupport::Concern
 
-  included do
-    supports_not :evacuate
-    supports_not :live_migrate
-    supports_not :migrate
-    supports_not :move_into_folder
-    supports_not :relocate
-  end
-
   def raw_live_migrate(_options = nil)
     raise NotImplementedError, _("raw_live_migrate must be implemented in a subclass")
   end

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -42,8 +42,6 @@ module VmOrTemplate::Operations::Snapshot
         unsupported_reason_add(:revert_to_snapshot, unsupported_reason(:remove_snapshot))
       end
     end
-
-    supports_not :snapshots
   end
 
   def raw_create_snapshot(_name, _desc = nil, _memory)

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -1,10 +1,6 @@
 module VmOrTemplate::Scanning
   extend ActiveSupport::Concern
 
-  included do
-    supports_not :smartstate_analysis
-  end
-
   # Call the VmScan Job and raise a "request" event
   def scan(userid = "system", options = {})
     # Check if there are any current scan jobs already waiting to run

--- a/app/models/volume_mapping.rb
+++ b/app/models/volume_mapping.rb
@@ -13,8 +13,6 @@ class VolumeMapping < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
 
-  supports_not :create
-  supports_not :delete
   acts_as_miq_taggable
 
   def my_zone

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -132,6 +132,24 @@ RSpec.describe SupportsFeatureMixin do
     end
   end
 
+  context "for an undeclared feature" do
+    it ".supports defaults to false" do
+      expect(Post.supports?(:unstated)).to be false
+    end
+
+    it "#supports? defaults to false" do
+      expect(Post.new.supports?(:unstated)).to be false
+    end
+
+    it "#unsupported_reason(:feature) defaults to no reason" do
+      expect(Post.new.unsupported_reason(:unstated)).to be nil
+    end
+
+    it ".unsupported_reason(:feature) defaults to no reason" do
+      expect(Post.unsupported_reason(:unstated)).to be nil
+    end
+  end
+
   context "definition in nested modules" do
     it "defines a class method on the model" do
       expect(Post.respond_to?(:supports_archive?)).to be true

--- a/spec/models/vm_or_template/operations/relocation_spec.rb
+++ b/spec/models/vm_or_template/operations/relocation_spec.rb
@@ -24,4 +24,10 @@ RSpec.describe VmOrTemplate::Operations::Relocation do
       )
     end
   end
+
+  context "supports" do
+    it "does not support migrate by default" do
+      expect(FactoryBot.build(:vm).supports?(:migrate)).to be false
+    end
+  end
 end


### PR DESCRIPTION
Blocked:

- [x] #21493

### Overview

It is a lot of work to declare the not supports, so we can default to unsupported.
When making the transition from our old system to our new system, we have been needing to declare quite a few `supports_not`. This PR is about removing the need fo that.

Pulled from @Fryguy in  https://github.com/ManageIQ/manageiq/pull/21473 /cc @chessbyte 


### Before

the default features like `:create` were defaulted to unsupported
All other features needed to be declared
Features that were not declared would throw an exception

### After

All features are defaulted to unsupported
Features that are not declared have `supported?(:unknown_feature) == false`

The `supports_feature?` methods are no longer declared for these. This will be a problem if we are using the longer form,  methods but will be fine if we are using the shorter (i.e.: `supports?(:feature)`) form.

### Implication

We can give it a reason, but the non reason seemed to make more sense here.
There were a few `supports_not(:feature)` that gave a reason why it was not supported but we want to just remove them and throw away the reason.

There is the possibility to default the response to some text if this works better in the user interface

With this change, there is less checking of the names of these features. So it is easier to not detect a typo since it no longer throws an error. It is similar to going from accessing a variable (where an error is thrown for an invalid variable) to accessing a value from a hash (where no error is thrown for accessing a missing key).

This change encourages us to transition from the long method to the short one. Which could be implemented using a class level hash lookup.
