### PR TITLE
Add MiqWorkerType.worker_classes

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -40,7 +40,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def sync_workers
-    MiqWorkerType.worker_class_names.map(&:constantize).each_with_object({}) do |klass, result|
+    MiqWorkerType.worker_classes.each_with_object({}) do |klass, result|
       result[klass.name] = klass.sync_workers
       result[klass.name][:adds].each { |pid| worker_add(pid) unless pid.nil? }
     rescue => error
@@ -153,8 +153,8 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def do_system_limit_exceeded
-    MiqWorkerType.worker_class_names_in_kill_order.each do |class_name|
-      workers = class_name.constantize.find_current.to_a
+    MiqWorkerType.worker_classes_in_kill_order.each do |worker_class|
+      workers = worker_class.find_current.to_a
       next if workers.empty?
 
       w = workers.sort_by { |w| [w.memory_usage || -1, w.id] }.last

--- a/app/models/miq_server/worker_management/monitor/settings.rb
+++ b/app/models/miq_server/worker_management/monitor/settings.rb
@@ -8,9 +8,8 @@ module MiqServer::WorkerManagement::Monitor::Settings
 
   def sync_child_worker_settings
     @child_worker_settings = {}
-    MiqWorkerType.worker_class_names.each do |class_name|
-      c = class_name.constantize
-      @child_worker_settings[c.settings_name] = c.worker_settings
+    MiqWorkerType.worker_classes.each do |worker_class|
+      @child_worker_settings[worker_class.settings_name] = worker_class.worker_settings
     end
     @child_worker_settings
   end

--- a/app/models/miq_server/worker_management/monitor/systemd.rb
+++ b/app/models/miq_server/worker_management/monitor/systemd.rb
@@ -48,7 +48,7 @@ module MiqServer::WorkerManagement::Monitor::Systemd
 
   def systemd_miq_service_base_names
     @systemd_miq_service_base_names ||= begin
-      MiqWorkerType.worker_class_names.map(&:constantize).map(&:service_base_name)
+      MiqWorkerType.worker_classes.map(&:service_base_name)
     end
   end
 

--- a/app/models/miq_worker_type.rb
+++ b/app/models/miq_worker_type.rb
@@ -28,8 +28,16 @@ class MiqWorkerType < ApplicationRecord
     pluck(:worker_type)
   end
 
+  def self.worker_classes
+    worker_class_names.map(&:constantize)
+  end
+
   def self.worker_class_names_in_kill_order
     in_kill_order.pluck(:worker_type)
+  end
+
+  def self.worker_classes_in_kill_order
+    worker_class_names_in_kill_order.map(&:constantize)
   end
 
   private_class_method def self.classes_for_seed

--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe MiqWorker::SystemdCommon do
 
       expected_units.delete("manageiq.target")
 
-      found_units = MiqWorkerType.worker_class_names.flat_map do |klass_name|
-        klass = klass_name.constantize
-        service_base_name = klass.service_base_name
+      found_units = MiqWorkerType.worker_classes.flat_map do |worker_class|
+        service_base_name = worker_class.service_base_name
 
         service_file = "#{service_base_name}@.service"
         target_file  = "#{service_base_name}.target"


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq/pull/21470 moving `.map(&:constantize)` into `MiqWorkerManagement`