### PR TITLE
Drop rake tasks used for starting/stopping miq_server

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -19,27 +19,6 @@ namespace :evm do
     end
   end
 
-  desc "Start the ManageIQ EVM Application"
-  task :start => :environment do
-    EvmApplication.start
-  end
-
-  desc "Restart the ManageIQ EVM Application"
-  task :restart => :environment do
-    EvmApplication.stop
-    EvmApplication.start
-  end
-
-  desc "Stop the ManageIQ EVM Application"
-  task :stop => :environment do
-    EvmApplication.stop
-  end
-
-  desc "Kill the ManageIQ EVM Application"
-  task :kill => :environment do
-    EvmApplication.kill
-  end
-
   desc "Report Status of the ManageIQ EVM Application"
   task :status => :environment do
     EvmApplication.status

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -3,30 +3,6 @@ require 'pid_file'
 class EvmApplication
   include Vmdb::Logging
 
-  def self.start
-    puts "Running EVM in background..."
-
-    command_line = "#{Gem.ruby} #{Rails.root.join(*%w(lib workers bin evm_server.rb)).expand_path}"
-
-    env_options = {}
-    env_options["EVMSERVER"] = "true" if MiqEnvironment::Command.is_appliance?
-
-    pid = Kernel.spawn(env_options, command_line, :pgroup => true, [:out, :err] => [Rails.root.join("log/evm.log"), "a"])
-    Process.detach(pid)
-  end
-
-  def self.stop
-    puts "Stopping EVM gracefully..."
-    _log.info("EVM Shutdown initiated")
-    MiqServer.stop(true)
-  end
-
-  def self.kill
-    puts "Killing EVM..."
-    _log.info("EVM Kill initiated")
-    MiqServer.kill
-  end
-
   def self.server_state
     MiqServer.my_server.status
   rescue => error


### PR DESCRIPTION
Both Podified and Systemd start evmserver with `ruby /var/www/miq/vmdb/lib/workers/bin/evm_server.rb` so the rake tasks used to start/stop are no longer needed for "production" applications.
Developers also can run `ruby lib/workers/bin/evm_server.rb` locally if they want to run the full server, or run individual workers by using `run_single_worker.rb`