### PR TITLE
[ProviderSdkLogger] Fix kwargs warnings

### DIFF
--- a/lib/vmdb/loggers/provider_sdk_logger.rb
+++ b/lib/vmdb/loggers/provider_sdk_logger.rb
@@ -1,6 +1,6 @@
 module Vmdb::Loggers
   class ProviderSdkLogger < VMDBLogger
-    def initialize(*loggers)
+    def initialize(*loggers, **kwargs)
       super
 
       # pulled from Ruby's `Logger::Formatter`, which is what it defaults to when it is `nil`


### PR DESCRIPTION
**MERGE AFTER https://github.com/ManageIQ/manageiq-gems-pending/pull/527**

```console
$ bin/rails c
/Users/nicklamuro/code/redhat/manageiq/lib/vmdb/loggers/provider_sdk_logger.rb:4: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/nicklamuro/code/redhat/manageiq-gems-pending/lib/gems/pending/util/vmdb-logger.rb:10: warning: The called method `initialize' is defined here
** ManageIQ master, codename: Najdorf
Loading development environment (Rails 6.0.4.1)
irb(main):001:0>
```


Links
-----

* https://github.com/ManageIQ/manageiq-gems-pending/pull/527