### PR TITLE
[WIP] On worker destroy error out miq request and request tasks

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -609,7 +609,9 @@ class MiqQueue < ApplicationRecord
   private
 
   def activate_miq_task(args)
-    MiqTask.update_status(miq_task_id, MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "Task starting") if miq_task_id
+    return args unless miq_task_id
+
+    MiqTask.update_status(miq_task_id, MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "Task starting")
     params = args.first
     params[:miq_task_id] = miq_task_id if params.kind_of?(Hash)
     args

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -622,7 +622,7 @@ class MiqRequest < ApplicationRecord
   end
 
   def abort_with_message(message)
-    miq_request_tasks.each { |t| t.abort_with_message_queue(message) }
+    miq_request_tasks.each { |t| t.abort_with_message(message) }
 
     update(:request_state => "finished", :status => "Error", :message => message)
     _log.info("Request #{description} is aborted due to #{message}.")

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -621,6 +621,13 @@ class MiqRequest < ApplicationRecord
     cancelation_status == CANCEL_STATUS_FINISHED
   end
 
+  def abort_with_message(message)
+    miq_request_tasks.each { |t| t.abort_with_message_queue(message) }
+
+    update(:request_state => "finished", :status => "Error", :message => message)
+    _log.info("Request #{description} is aborted due to #{message}.")
+  end
+
   private
 
   def do_cancel

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -47,7 +47,7 @@ class MiqRequestTask < ApplicationRecord
 
   def update_and_notify_parent(upd_attr)
     upd_attr[:message] = upd_attr[:message][0, 255] if upd_attr.key?(:message)
-    update!(upd_attr)
+    update!(upd_attr.except(:miq_task_id))
 
     # If this request has a miq_request_task parent use that, otherwise the parent is the miq_request
     parent = miq_request_task || miq_request

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -234,7 +234,7 @@ class MiqRequestTask < ApplicationRecord
     cancelation_status == MiqRequestTask::CANCEL_STATUS_FINISHED
   end
 
-  def abort_with_message_queue(message)
+  def abort_with_message(message)
     MiqQueue.put(
       :class_name  => "MiqRequestTask",
       :instance_id => id,

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -234,6 +234,15 @@ class MiqRequestTask < ApplicationRecord
     cancelation_status == MiqRequestTask::CANCEL_STATUS_FINISHED
   end
 
+  def abort_with_message_queue(message)
+    MiqQueue.put(
+      :class_name  => "MiqRequestTask",
+      :instance_id => id,
+      :method_name => "update_and_notify_parent",
+      :args        => [:state => "finished", :status => "Error", :message => message]
+    )
+  end
+
   private
 
   def validate_request_type

--- a/spec/models/log_file_spec.rb
+++ b/spec/models/log_file_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe LogFile do
 
       it "delivering MiqServer._request_logs message should call _post_my_logs with correct args" do
         expected_options = {:timeout     => described_class::LOG_REQUEST_TIMEOUT,
-                            :taskid      => @task.id, :miq_task_id => nil,
+                            :taskid      => @task.id,
                             :callback    => {:instance_id => @task.id, :class_name => 'MiqTask',
                                              :method_name => :queue_callback_on_exceptions, :args => ['Finished']}}
         expect_any_instance_of(MiqServer).to receive(:_post_my_logs).with(expected_options)
@@ -91,7 +91,7 @@ RSpec.describe LogFile do
         end
 
         it "MiqServer#post_logs message should have correct args" do
-          expect(message.args).to         eq([{:taskid => @task.id, :miq_task_id => nil}])
+          expect(message.args).to         eq([{:taskid => @task.id}])
           expect(message.priority).to     eq(MiqQueue::HIGH_PRIORITY)
           expect(message.miq_callback).to eq(:instance_id => @task.id, :class_name => 'MiqTask', :method_name => :queue_callback_on_exceptions, :args => ['Finished'])
           expect(message.msg_timeout).to  eq(described_class::LOG_REQUEST_TIMEOUT)

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe MiqProvisionRequestTemplate do
       provision_request_template.create_tasks_for_service(service_task, parent_svc)
     end
 
-    it "request: abort_with_message_queue errors request and all tasks" do
+    it "request: abort_with_message errors request and all tasks" do
       request = service_task.miq_request
       request.abort_with_message("ABORT!")
 
@@ -87,8 +87,8 @@ RSpec.describe MiqProvisionRequestTemplate do
       end
     end
 
-    it "task: abort_with_message_queue errors task and update_and_notify_parent request" do
-      service_task.abort_with_message_queue("ABORT!")
+    it "task: abort_with_message errors task and update_and_notify_parent request" do
+      service_task.abort_with_message("ABORT!")
 
       queue_message = MiqQueue.find_by(:method_name => "update_and_notify_parent")
       status, message, result = queue_message.deliver

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -61,22 +61,43 @@ RSpec.describe MiqProvisionRequestTemplate do
                        })
   end
 
-  it "abort_with_message_queue errors task and update_and_notify_parent request" do
-    Zone.seed
+  context "abort_with_message for request and request task" do
+    before do
+      Zone.seed
 
-    allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Provision).to receive(:get_hostname).and_return('hostname')
-    allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(double(:root => 'miq'))
-    allow(MiqServer).to receive(:my_zone).and_return(Zone.default_zone.name)
-    provision_request_template.create_tasks_for_service(service_task, parent_svc)
+      allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Provision).to receive(:get_hostname).and_return('hostname')
+      allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(double(:root => 'miq'))
+      allow(MiqServer).to receive(:my_zone).and_return(Zone.default_zone.name)
+      provision_request_template.create_tasks_for_service(service_task, parent_svc)
+    end
 
-    service_task.abort_with_message_queue("ABORT!")
-    queue_message = MiqQueue.find_by(:method_name => "update_and_notify_parent")
-    status, message, result = queue_message.deliver
-    queue_message.delivered(status, message, result)
+    it "request: abort_with_message_queue errors request and all tasks" do
+      request = service_task.miq_request
+      request.abort_with_message("ABORT!")
 
-    expect(service_task.reload.state).to eql("finished")
-    expect(service_task.status).to eql("Error")
-    expect(service_task.miq_request.reload.status).to eql("Error")
+      MiqQueue.where(:method_name => "update_and_notify_parent").each do |queue_message|
+        status, message, result = queue_message.deliver
+        queue_message.delivered(status, message, result)
+      end
+
+      expect(request.reload.status).to eql("Error")
+      request.miq_request_tasks.each do |task|
+        expect(task.reload.state).to eql("finished")
+        expect(task.status).to eql("Error")
+      end
+    end
+
+    it "task: abort_with_message_queue errors task and update_and_notify_parent request" do
+      service_task.abort_with_message_queue("ABORT!")
+
+      queue_message = MiqQueue.find_by(:method_name => "update_and_notify_parent")
+      status, message, result = queue_message.deliver
+      queue_message.delivered(status, message, result)
+
+      expect(service_task.reload.state).to eql("finished")
+      expect(service_task.status).to eql("Error")
+      expect(service_task.miq_request.reload.status).to eql("Error")
+    end
   end
 
   describe '#create_tasks_for_service' do

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -940,6 +940,26 @@ RSpec.describe MiqQueue do
     end
   end
 
+  context "#activate_miq_task(private)" do
+    let(:miq_task) { FactoryBot.create(:miq_task) }
+    let(:message)  { MiqQueue.create!(:state => "ready", :zone => FactoryBot.create(:zone).name, :args => [{}]) }
+    it "with a task" do
+      message.update(:miq_task => miq_task)
+      result = message.reload.send(:activate_miq_task, message.args)
+
+      expect(result).to eql(message.args)
+      expect(miq_task.reload.state).to eql(MiqTask::STATE_ACTIVE)
+      expect(message.args).to eql([{:miq_task_id => miq_task.id}])
+    end
+
+    it "without a miq_task" do
+      result = message.send(:activate_miq_task, message.args)
+
+      expect(result).to eql(message.args)
+      expect(message.args).to eql([{}])
+    end
+  end
+
   context "validates that the zone exists in the current region" do
     it "with a matching region" do
       zone = FactoryBot.create(:zone)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -960,6 +960,63 @@ RSpec.describe MiqQueue do
     end
   end
 
+  context "#parse_tracking_label" do
+    it "nil tracking_label" do
+      message = MiqQueue.new(:tracking_label => nil)
+      expect(message.parse_tracking_label).to eql(nil)
+    end
+
+    it "incorrect format: no underscores" do
+      message = MiqQueue.new(:tracking_label => nil)
+      expect(message.parse_tracking_label).to eql(nil)
+    end
+
+    it "incorrect format: less than 3 parts" do
+      message = MiqQueue.new(:tracking_label => "r1_service_template_provision_task")
+      expect(message.parse_tracking_label).to eql(nil)
+    end
+
+    it "incorrect format: missing leading 'r'" do
+      message = MiqQueue.new(:tracking_label => "1_service_template_provision_task_1")
+      expect(message.parse_tracking_label).to eql(nil)
+    end
+
+    it "incorrect format: missing leading 'r' with number" do
+      message = MiqQueue.new(:tracking_label => "r_service_template_provision_task_1")
+      expect(message.parse_tracking_label).to eql(nil)
+    end
+
+    it "incorrect format: missing trailing number (request or task)" do
+      message = MiqQueue.new(:tracking_label => "r1_service_template_provision_task_")
+      expect(message.parse_tracking_label).to eql(nil)
+    end
+
+    it "service_template_provision_task" do
+      message = MiqQueue.new(:tracking_label => "r1_service_template_provision_task_10")
+      expect(message.parse_tracking_label).to eql([1, "ServiceTemplateProvisionTask", 10])
+    end
+
+    it "service_retire_task" do
+      message = MiqQueue.new(:tracking_label => "r2_service_retire_task_10")
+      expect(message.parse_tracking_label).to eql([2, "ServiceRetireTask", 10])
+    end
+
+    it "service_template_provision_request" do
+      message = MiqQueue.new(:tracking_label => "r2_service_template_provision_request_2")
+      expect(message.parse_tracking_label).to eql([2, "ServiceTemplateProvisionRequest", 2])
+    end
+
+    it "service_template_provision_task region 99" do
+      message = MiqQueue.new(:tracking_label => "r99000000000003_service_template_provision_task_99000000000004")
+      expect(message.parse_tracking_label).to eql([99000000000003, "ServiceTemplateProvisionTask", 99000000000004])
+    end
+
+    it "service_template_provision_request region 99" do
+      message = MiqQueue.new(:tracking_label => "r99000000000004_service_template_provision_request_99000000000004")
+      expect(message.parse_tracking_label).to eql([99000000000004, "ServiceTemplateProvisionRequest", 99000000000004])
+    end
+  end
+
   context "validates that the zone exists in the current region" do
     it "with a matching region" do
       zone = FactoryBot.create(:zone)


### PR DESCRIPTION
This is a much more complicated mechanism to error out long running tasks when a worker is destroyed, like https://github.com/ManageIQ/manageiq/pull/21443, but this time for MiqRequest and MiqRequestTask.

Part of https://github.com/ManageIQ/manageiq/issues/21175

The idea behind this came from looking at how one of the MiqRequestTask subclasses had a tool to [kill provisions in the queue](https://github.com/ManageIQ/manageiq/blob/914348af0b854ed936e418e7f98f17ef707a8795/tools/kill_provision.rb#L13).  

The simple overview is if a worker is killed, we need to cleanup based on what it was working on:
* MiqRequestTask(such as miq provision): we need to error out that task and notify the parent, which will error out the parent request object.  This leads to the request in errored state with at least 1 subtask in error.
* MiqRequest: we need to error out the request and all of it's tasks.

The complicated part is that there isn't a direct association from `miq_queue` messages to requests or request tasks.  We have a tracking label as the only thing to work with.  It looks like this:

```
"r99000000000003_service_template_provision_request_99000000000003"
"r99000000000003_service_template_provision_task_99000000000004"
```

I guess this format can be written in words like:
`rRequestID_RequestOrRequestTaskClassInUnderscoreFormat_RequestOrRequestTaskID`

Therefore, the first example is a `MiqRequest` subclass `ServiceTemplateProvisionRequest` with id `99000000000003`. 
The second example is a `MiqRequestTask` subclass `ServiceTemplateProvisionTask` with id `99000000000004` and parent request: `99000000000003`.

In both cases, the object class (request or request task) is in the middle in underscored format.

Given, we can parse the message `tracking_label`  into request vs. request tasks, we can properly error out the request or tasks.

TODO:

- [ ] Find a good location for the `parse_tracking_label` and where it should be called to abort the appropriate task/request.  It doesn't seem correct where it is.  Write tests for this.
- [ ] The first two commits (regarding `miq_task_id` on queue messages) are really bug fixes but lack the context of this PR to be split off yet as independent fixes.  Why queue deliver injects `miq_task_id` into any hash args passed on the queue message is beyond the scope of this PR.  I wasn't expecting this and it's weird that any code called through the queue with hash arguments would need to know this and handle it.
