### PR TITLE
Fix Google factory ems_google_with_authentication missing_credentials?

### DIFF
--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -6,6 +6,12 @@ FactoryBot.define do
     status      { "Valid" }
   end
 
+  factory :auth_token, :parent => :authentication do
+    authtype { "default" }
+    auth_key { "secret" }
+    type     { "AuthToken" }
+  end
+
   factory :authentication_status_error, :parent => :authentication do
     status      { "Error" }
     authtype    { "bearer" }

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -331,7 +331,9 @@ FactoryBot.define do
 
   factory :ems_google_with_authentication,
           :parent => :ems_google do
-    authtype { "default" }
+    after(:create) do |ems|
+      ems.authentications << FactoryBot.create(:auth_token)
+    end
   end
 
   factory :ems_google_network,


### PR DESCRIPTION
Now that `Google::CloudManager#missing_credentials?` isn't hard-coded to false `ems_google_with_authentication` has to set up the proper type of authentication (specifically it has to have an auth_key attribute)

Introduced by https://github.com/ManageIQ/manageiq-providers-google/pull/201