### PR TITLE
Add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be requi
 gem "ancestry",                         "~>4.1.0",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
+gem "bootsnap",                         ">= 1.4.2",          :require => false
 gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,3 +6,5 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 # add the lib dir of the engine if we are running as a dummy app for an engine
 $LOAD_PATH.unshift(File.expand_path('../../../lib', __dir__)) if defined?(ENGINE_ROOT)
+
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Bootsnap is installed by default in Rails 6 applications.  It improves
boot time (on my Mac) from ~14s to ~6s (~57% faster).

@jrafanie @bdunne @agrare Please review.  If you could comment with your timings that would help.