### PR TITLE
Use routes_lazy_routes for faster dev/test boot time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -298,6 +298,7 @@ unless ENV["APPLIANCE"]
 
   group :development, :test do
     gem "parallel_tests"
+    gem "routes_lazy_routes"
     gem "rspec-rails",                  "~>4.0.1"
   end
 end


### PR DESCRIPTION
Locally, it goes from 4.2 seconds to 3.3.

It seems to correctly load the routes on demand where I had issues with #19836
```
irb(main):001:0> Rails.application.routes.routes.length
=> 0
irb(main):002:0> app.get("/")
=> 403
irb(main):003:0> Rails.application.routes.routes.length
=> 5015
```
