### PR TITLE
[WIP] Convert supports_port? to SupportsFeatureMixin

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -187,6 +187,7 @@ class ExtManagementSystem < ApplicationRecord
   supports_not :label_mapping
   supports_not :metrics
   supports_not :object_storage
+  supports_not :port
   supports_not :provisioning
   supports_not :publish
   supports_not :reconfigure_disks
@@ -526,10 +527,6 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_add_volume_mapping
     supports_add_volume_mapping?
-  end
-
-  def supports_port?
-    false
   end
 
   def supports_api_version?


### PR DESCRIPTION
Refactored to `supports?(:port)`, but I do not like the way it reads.  Suggest we change it to one of the following

- `supports?(:configurable_port)`
- `supports?(:editable_port)`
- `supports?(:non_default_port)`

Goes with
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7906
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/450
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/743
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/572
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/755