### PR TITLE
Introduce Ems#class_for_ems

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -1081,6 +1081,22 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
+  # Takes a child class (e.g.: "NetworkRouter") and returns the EMS specific version of it
+  #
+  # @param [String|Symbol] class_name name of the child class
+  # @param [Boolean] inherit - return the base class if the child does not have a specific one (default: false - return nil if no child)
+  # @returns The EMS specific version of the class requested
+  def class_for_ems(class_name, inherit = false)
+    self.class.class_for_ems(class_name, inherit)
+  end
+
+  def self.class_for_ems(class_name, inherit = false)
+    class_name = class_name.name if class_name.kind_of?(Class)
+    const_get(class_name, inherit)
+  rescue NameError
+    nil
+  end
+
   # @return [Boolean] true if a datastore exists for this type of ems
   def self.datastore?
     IsoDatastore.where(:ems_id => all).exists?

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -662,6 +662,44 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
+  describe "#class_for_ems" do
+    it 'returns a concrete target subclass for a concrete EMS' do
+      ems = FactoryBot.create(:ems_openstack)
+
+      expect(ems.class.class_for_ems("Vm", true)).to eq(ems.class::Vm)
+      expect(ems.class_for_ems("Vm", true)).to eq(ems.class::Vm)
+      expect(ems.class_for_ems("Vm")).to eq(ems.class::Vm)
+      expect(ems.class_for_ems(:Vm)).to eq(ems.class::Vm)
+      expect(ems.class_for_ems(::Vm)).to eq(ems.class::Vm)
+    end
+
+    # this is documenting what NOT to do
+    # it is showing that the results are sporadic
+    it 'expects generic target subclass (not a concrete one)' do
+      ems = FactoryBot.create(:ems_openstack)
+      expect(ems.class_for_ems(ems.class::Vm, true)).to eq(ems.class::Vm)
+      expect(ems.class_for_ems(ems.class::Vm)).to be nil
+    end
+
+    it 'returns nil for unknown class' do
+      ems = FactoryBot.create(:ext_management_system)
+      expect(ems.class_for_ems("RandomSymbol", true)).to be nil
+      expect(ems.class_for_ems(:RandomSymbol)).to be nil
+    end
+
+    it 'returns a concrete target subclass for a concrete EMS subclass' do
+      ems = FactoryBot.create(:ems_openstack_network)
+      expect(ems.class_for_ems("NetworkRouter", true)).to eq(ems.class::NetworkRouter)
+      expect(ems.class_for_ems("NetworkRouter")).to eq(ems.class::NetworkRouter)
+    end
+
+    it 'returns the base target class when the EMS does not have a subclass' do
+      ems = FactoryBot.create(:ems_infra)
+      expect(ems.class_for_ems("NetworkRouter", true)).to eq(::NetworkRouter)
+      expect(ems.class_for_ems("NetworkRouter")).to eq(nil)
+    end
+  end
+
   context "changing zone" do
     before do
       MiqRegion.seed


### PR DESCRIPTION
This is a factory method equivalent to ems.class::Vm and Vm.class_for_ems(ems)

It felt unnatural to call the `Model.class_for_ems(ems)` version and we wanted more flexibility than calling `ems.class::Model`
