### PR TITLE
Remove unused supports_*? methods from EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -528,22 +528,6 @@ class ExtManagementSystem < ApplicationRecord
     supports_add_volume_mapping?
   end
 
-  def supports_port?
-    false
-  end
-
-  def supports_api_version?
-    false
-  end
-
-  def supports_security_protocol?
-    false
-  end
-
-  def supports_provider_id?
-    false
-  end
-
   def supports_authentication?(authtype)
     authtype.to_s == "default"
   end


### PR DESCRIPTION
These `supports_{port,api_version}?`methods used to be used by the UI but are no longer used.

Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/7908

TODO:
- [x] Cross-repo tests

Follow-ups:
* https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/451
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/744
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/573
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/756