### PR TITLE
Warn that the db is not seeded if no servers in region

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -88,7 +88,7 @@ class EvmDatabase
     # While not technically accurate, as someone could just insert a record
     # directly, this is the simplest check at the moment to guess whether or not
     # a primordial seed has completed.
-    MiqDatabase.any? && MiqRegion.in_my_region.any?
+    MiqDatabase.any? && MiqRegion.in_my_region.any? && MiqServer.in_my_region.any?
   end
 
   # Returns whether or not a full seed has completed.

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe EvmDatabase do
   end
 
   def simulate_primordial_seed
-    described_class.seed(["MiqDatabase", "MiqRegion"])
+    described_class.seed(%w[MiqDatabase MiqRegion Zone MiqServer])
   end
 
   def simulate_full_seed
-    described_class.seed(["MiqDatabase", "MiqRegion", "MiqAction"])
+    described_class.seed(%w[MiqDatabase MiqRegion Zone MiqServer MiqAction])
   end
 
   describe ".seeded_primordially?" do


### PR DESCRIPTION
We try to call methods on the server row in bin/rails server and it's confusing
if you get this error:

```
lib/vmdb/initializer.rb:12:in `init’: undefined method starting_server_record' for nil:NilClass (NoMethodError)
```

This commit properly detects if MiqServer is seeded with a server in the region
and presents a more useful error if not:

```
app/models/mixins/miq_web_server_worker_mixin.rb:26:in `preload_for_worker_role': Expected database to be seeded via `rake db:seed`. (RuntimeError)
```