### PR TITLE
Drop the v2v UI controllers plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -250,10 +250,6 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "jquery-rjs",                     "=0.1.1.2",          :source => "https://rubygems.manageiq.org"
 end
 
-group :v2v, :ui_dependencies do
-  manageiq_plugin "manageiq-v2v"
-end
-
 group :web_server, :manageiq_default do
   gem "puma",                           "~>4.2"
   gem "responders",                     "~>3.0"

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -39,14 +39,6 @@ RSpec.describe Vmdb::Plugins do
       expect(asset_path.path).to eq ManageIQ::UI::Classic::Engine.root
       expect(asset_path.namespace).to eq "manageiq-ui-classic"
     end
-
-    it "with engines with inflections" do
-      asset_paths = described_class.asset_paths
-
-      asset_path = asset_paths.detect { |ap| ap.name == "ManageIQ::V2V::Engine" }
-      expect(asset_path.path).to eq ManageIQ::V2V::Engine.root
-      expect(asset_path.namespace).to eq "manageiq-v2v"
-    end
   end
 
   it ".provider_plugins" do


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/21379

We'll drop the  model code in a followup PR.

Marking WIP until we discuss the order of merging things.

Related to https://github.com/ManageIQ/manageiq-rpm_build/pull/213