### PR TITLE
add ibm_power_vm vendor type, mostly useful for HMC provider

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -49,6 +49,7 @@ class VmOrTemplate < ApplicationRecord
     "kubevirt"     => "KubeVirt",
     "ibm_cloud"    => "IBM Cloud",
     "ibm_power_vc" => "IBM PowerVC",
+    "ibm_power_vm" => "IBM PowerVM",
     "unknown"      => "Unknown"
   }
 


### PR DESCRIPTION
Need to identify PowerVM vms managed by HMC provider (mostly to display a specific icon).