### PR TITLE
convert supported_for_catalog to supports?(:catalog)

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -49,15 +49,11 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.supported_types_for_catalog
-    supported_subclasses.select(&:supported_for_catalog?)
+    subclasses_supports?(:catalog)
   end
 
   def self.supported_for_create?
     !reflections.include?("parent_manager")
-  end
-
-  def self.supported_for_catalog?
-    catalog_types.present?
   end
 
   def self.label_mapping_classes
@@ -162,6 +158,7 @@ class ExtManagementSystem < ApplicationRecord
 
   serialize :options
 
+  supports_not :catalog
   supports_not :add_host_initiator
   supports_not :add_storage
   supports_not :add_volume_mapping

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -6,6 +6,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
   require_nested :ConfiguredSystem
   require_nested :OrchestrationStack
 
+  supports :catalog
+
   def self.supported_for_create?
     false
   end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -102,7 +102,7 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def self.catalog_item_types
-    ems_classes = Rbac.filtered(ExtManagementSystem.all).collect(&:class).uniq.select(&:supported_for_catalog?)
+    ems_classes = Rbac.filtered(ExtManagementSystem.all).collect(&:class).uniq.select { |ems| ems.supports?(:catalog) }
     ci_types = Set.new(ems_classes.flat_map(&:catalog_types).reduce({}, :merge).keys)
 
     ci_types.add('generic_orchestration') if Rbac.filtered(OrchestrationTemplate).exists?


### PR DESCRIPTION
remove the custom supports_method and convert over to standard supports(:action)

part of https://github.com/ManageIQ/manageiq/pull/21505

```diff
- responds_to?(:catalog_type)
+ supports?(:catalog)
```

I had expected there to be more references to this but there were only the 2. So converting these across and the various providers that define them.

converting it over to a standard supports, so we also need to change a few references:

- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/725
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/268
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/477
- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/203
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/214
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/748
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/575
- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/193
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/758
