### PR TITLE
Introduce stubbing for params_for_

### DIFF
--- a/spec/support/supports_helper.rb
+++ b/spec/support/supports_helper.rb
@@ -2,12 +2,20 @@ module Spec
   module Support
     module SupportsHelper
       # when testing requests, ensure the model supports a certain attribute
-      def stub_supports(model, feature = :update, supported: true)
+      # @param (Symbol) feature which supports feature is supported (e.g.: :create, :update, :delete)
+      # @param (Array|Nil) fields value to stub params_for_* (default: nil don't stub)
+      def stub_supports(model, feature = :update, supported: true, fields: nil)
         model = model.class unless model.kind_of?(Class)
 
         receive_supports = receive(:supports?).with(feature).and_return(supported)
         allow(model).to receive_supports
         allow_any_instance_of(model).to receive_supports
+
+        return if fields.nil?
+
+        receive_this_message = receive("params_for_#{feature}".to_sym).and_return("fields" => fields)
+        allow(model).to(receive_this_message)                 # only useful for create
+        allow_any_instance_of(model).to(receive_this_message) # only useful for update
       end
 
       def stub_supports_not(model, feature = :update, reason = nil)


### PR DESCRIPTION
BLOCKS:

- [x] https://github.com/ManageIQ/manageiq-api/pull/1079

the api uses `params_for_create` and `params_for_update`
for many of the `OPTIONS` around the `supports?` cases.

Since the `OPTIONS` are driven by the `supports?` feature, putting the params case into the same stub method
