### PR TITLE
move EMS.supports :create_security_group to SecurityGroup.supports :create

### DIFF
--- a/app/models/ext_management_system/supports_attribute.rb
+++ b/app/models/ext_management_system/supports_attribute.rb
@@ -1,0 +1,43 @@
+module ExtManagementSystem::SupportsAttribute
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # define an attribute that is used by the ui to detect that a feature is supported
+    # These are often defined with an actual supports feature,
+    # but it is often not necessary and we are trying avoid
+    #
+    # This is mostly used instead of supports but is very related to the supports end goal
+    #
+    # examples:
+    #
+    #   a) supports_attribute :supports_create_security_group, child_model: SecurityGroup, feature: create
+    #
+    #   def supports_create_security_group
+    #     ext_management_system.class::ChildModel.supports?(feature)
+    #   end
+    #
+    #   NOTE: we could derive this name, but it is too hard to search
+    #
+    #   b) supports_attribute feature: :add_volume_mapping
+    #
+    #   def supports_add_volume_mapping
+    #     supports?(:add_volume_mapping)
+    #   end
+    #
+    def supports_attribute(colname = nil, feature: :create, child_model: nil)
+      feature = feature.to_sym
+
+      if child_model
+        define_method(colname) do
+          class_by_ems(child_model)&.supports?(feature) || false
+        end
+      else
+        define_method(colname || "supports_#{feature}") do
+          supports?(feature)
+        end
+      end
+
+      virtual_attribute colname, :boolean
+    end
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -922,4 +922,21 @@ RSpec.describe ExtManagementSystem do
       expect(ems_container.queue_name_for_ems_operations).to eql('generic')
     end
   end
+
+  describe '#supports_create_security_group' do
+    it "defaults to false" do
+      ems = ExtManagementSystem.new
+      expect(ems.supports_create_security_group).to be(false)
+    end
+
+    it "defaults to false" do
+      ems = ExtManagementSystem.new
+      expect(ems.supports_block_storage).to be(false)
+    end
+
+    it "detects security group for provider" do
+      ems = FactoryBot.build(:ems_openstack_network)
+      expect(ems.supports_create_security_group).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
### Overview

The front end wants to know which providers can create a `SecurityGroup`. 
We defined `virtual_attribute :supports_security_group, :boolean` to provide this information.

The answer to this question is stored in the provider specific `SecurityGroup` with `supports :create`.

Flavor also follows this exact pattern. Dozens follow the pattern loosely and more are requested.

### Before

- We created a supports clause on the provider with the same information.
- We created a virtual attribute to reflect this same value.
- We created a method with this answer, delegating to the provider specific `SecurityGroup`

note: I was not able to find any `supports? :create_security_group` in the code. So this supports clause only necessary for populating the value of the virtual attribute.
grep will show that there are the methods `create_security_group{,_queue}`, but they are not related to a `supports?` query.

### After

- We use a helper method that define the supports virtual attribute that gets the value from a supports clause in a related child class. 

This method can be used for all the similar `supports_` delegate virtual attributes but I want to go through them individually to see if the `supports` is still needed in the ems in addition to the virtual attribute.