### PR TITLE
Add associations for cloud network firewall rules

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -25,6 +25,7 @@ class CloudNetwork < ApplicationRecord
   # TODO(lsmola) figure out what this means, like security groups used by VMs in the network? It's not being
   # refreshed, so we can probably delete this association
   has_many   :security_groups
+  has_many :firewall_rules, :as => :resource, :dependent => :destroy
 
   # Use for virtual columns, mainly for modeling array and hash types, we get from the API
   serialize :extra_attributes

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -21,6 +21,7 @@ module ManageIQ::Providers
     has_many :security_policy_rules,              :through => :security_policies
     has_many :firewall_rules,                     :through => :security_groups
     has_many :cloud_networks,                     :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_network_firewall_rules,       :through => :cloud_networks, :class_name => "FirewallRule", :source => :firewall_rules
     has_many :network_ports,                      :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_subnet_network_ports,         :through => :network_ports
     has_many :network_routers,                    :foreign_key => :ems_id, :dependent => :destroy


### PR DESCRIPTION
- cloud network firewall rules will be used for firewall rules that are dependent on cloud networks and not security groups (i.e. network ACLs)

Used in:
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/297