### PR TITLE
[TokenManager] Fail token_valid? on empty/missing

### DIFF
--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -4,6 +4,9 @@ require 'securerandom'
 # Supporting class for Managing Tokens, i.e. Authentication Tokens for REST API, etc.
 #
 class TokenManager
+  EmptyTokenError    = Class.new(ArgumentError)
+  MissingTokenError  = Class.new(ArgumentError)
+
   RESTRICTED_OPTIONS = [:expires_on]
   DEFAULT_NS         = "default"
 
@@ -44,6 +47,9 @@ class TokenManager
   end
 
   def token_valid?(token)
+    raise MissingTokenError if token.nil?
+    raise EmptyTokenError   if token.length == 0
+
     !token_store.read(token).nil?
   end
 

--- a/spec/lib/token_manager_spec.rb
+++ b/spec/lib/token_manager_spec.rb
@@ -21,4 +21,34 @@ RSpec.describe TokenManager do
       expect(token_manager.token_ttl).to eq(120)
     end
   end
+
+  describe "#token_valid?" do
+    let(:token_store) { double("FakeTokenStore") }
+
+    it "raises MissingTokenError if token is nil" do
+      expect { subject.token_valid?(nil) }.to raise_error(described_class::MissingTokenError)
+    end
+
+    it "raises EmptyTokenError if token is empty" do
+      expect { subject.token_valid?("") }.to raise_error(described_class::EmptyTokenError)
+    end
+
+    it "returns true if the token exists" do
+      token = "token"
+
+      expect(subject).to     receive(:token_store).and_return(token_store)
+      expect(token_store).to receive(:read).with(token).and_return("foo")
+
+      expect(subject.token_valid?(token)).to eq(true)
+    end
+
+    it "returns false if the token does not exist" do
+      token = "not_a_token"
+
+      expect(subject).to     receive(:token_store).and_return(token_store)
+      expect(token_store).to receive(:read).with(token).and_return(nil)
+
+      expect(subject.token_valid?(token)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-api/pull/1089