### PR TITLE
[dialog_field_tag_control_spec.rb] Fix .split

### DIFF
--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe DialogFieldTagControl do
       it "automate_output_value with multiple values" do
         tags = [Classification.first, Classification.last]
         @df.value = tags.collect(&:id).join(",")
-        expect(@df.automate_output_value.split(",")).to match_array tags.collect { |tag| "#{tag.class.name}::#{tag.id}" }
+        expect(@df.automate_output_value.split("\x1F")).to match_array tags.collect { |tag| "#{tag.class.name}::#{tag.id}" }
       end
     end
   end


### PR DESCRIPTION
This was updated in:

  https://github.com/ManageIQ/manageiq-automation_engine/pull/484

So now we are splitting on `"\x1F"` and not `","`.


Links
-----

* Caused by:
  - https://github.com/ManageIQ/manageiq-automation_engine/pull/484