### PR TITLE
Define VIOS as an 'unix_aix' operating system

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -30,7 +30,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_solaris",   %w(solaris)],
     ["linux_oracle",    %w(oracle)],
     ["linux_generic",   %w(linux)],
-    ["unix_aix",        %w(aix)],
+    ["unix_aix",        %w(aix vios)],
     ["ibm_i",           %w(ibmi)]
   ]
 


### PR DESCRIPTION
As part of the work around the new Power HMC provider, define the "VIOS" operating system as "unix_aix" so that the UI displays VIOS VMs with the AIX logo. There is no logo available for Virtual I/O Servers, but they are actually built on top of an AIX base.