### PR TITLE
Re-adding all_vms method

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -12,6 +12,7 @@ class EmsCluster < ApplicationRecord
   has_many    :vms_and_templates, :dependent => :nullify
   has_many    :miq_templates, :inverse_of => :ems_cluster
   has_many    :vms, :inverse_of => :ems_cluster
+  alias       all_vms vms
 
   has_many    :metrics,                :as => :resource  # Destroy will be handled by purger
   has_many    :metric_rollups,         :as => :resource  # Destroy will be handled by purger


### PR DESCRIPTION
Clicking on the number of VMs from the 'All VMs' option will not load the corresponding page. Page will just show the spinner and not load. 

**backport:** also backport https://github.com/ManageIQ/manageiq/pull/21523

## BEFORE

![Screen Shot 2021-10-27 at 11 21 33 AM](https://user-images.githubusercontent.com/29209973/139096898-31ee6863-c159-4a24-83ee-ff33353109ad.png)

![Screen Shot 2021-10-27 at 11 25 09 AM](https://user-images.githubusercontent.com/29209973/139096907-0c57b666-1298-4073-a712-b45db17900b5.png)


## AFTER

![Screen Shot 2021-10-27 at 11 21 33 AM](https://user-images.githubusercontent.com/29209973/139096556-bc17369f-8f1a-4f9f-a0a5-1a298b294f99.png)

![Screen Shot 2021-10-27 at 11 21 40 AM](https://user-images.githubusercontent.com/29209973/139096567-ec274fe6-a113-4e20-8121-2d944e000f1c.png)

@miq-bot add-reviewer @NickLaMuro 
@miq-bot add-reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu  