### PR TITLE
Moving to a more appropriate file

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -12,7 +12,6 @@ class EmsCluster < ApplicationRecord
   has_many    :vms_and_templates, :dependent => :nullify
   has_many    :miq_templates, :inverse_of => :ems_cluster
   has_many    :vms, :inverse_of => :ems_cluster
-  alias       all_vms vms
 
   has_many    :metrics,                :as => :resource  # Destroy will be handled by purger
   has_many    :metric_rollups,         :as => :resource  # Destroy will be handled by purger

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -9,6 +9,7 @@ module AggregationMixin
     virtual_sum :aggregate_vm_cpus,         :vm_hardwares,   :cpu_sockets
     virtual_sum :aggregate_vm_memory,       :vm_hardwares,   :memory_mb
 
+    alias_method :all_vms,                :vms
     alias_method :all_vms_and_templates,  :vms_and_templates
     alias_method :all_vm_or_template_ids, :vm_or_template_ids
   end


### PR DESCRIPTION
See PR [#21522](https://github.com/ManageIQ/manageiq/pull/21522). This change does the same thing but moves the aliasing to a more appropriate file. 