### PR TITLE
Revive the plugin inflection test as a skipped test

### DIFF
--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Vmdb::Plugins do
       expect(asset_path.path).to eq ManageIQ::UI::Classic::Engine.root
       expect(asset_path.namespace).to eq "manageiq-ui-classic"
     end
+
+    it "with engines with inflections", :skip => "Waiting on replacement plugin specifying inflections like v2v did" do
+      asset_paths = described_class.asset_paths
+
+      asset_path = asset_paths.detect { |ap| ap.name == "ManageIQ::V2V::Engine" }
+      expect(asset_path.path).to eq ManageIQ::V2V::Engine.root
+      expect(asset_path.namespace).to eq "manageiq-v2v"
+    end
   end
 
   it ".provider_plugins" do


### PR DESCRIPTION
It all works but we don't have a plugin that has inflections now that v2v is
gone.  The test is good but we can't run it without a generic plugin that does
this.

Followup to https://github.com/ManageIQ/manageiq/pull/21515