### PR TITLE
[WIP] Move current_pods/deployments to instance attributes

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -1,11 +1,11 @@
 class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
-  class_attribute :current_pods
-  self.current_pods = Concurrent::Hash.new
+  attr_accessor :current_pods, :current_deployments, :deployments_monitor_thread, :pods_monitor_thread
 
-  class_attribute :current_deployments
-  self.current_deployments = Concurrent::Hash.new
-
-  attr_accessor :deployments_monitor_thread, :pods_monitor_thread
+  def initialize(*)
+    super
+    @current_pods        = Concurrent::Hash.new
+    @current_deployments = Concurrent::Hash.new
+  end
 
   def sync_monitor
     sync_from_system

--- a/spec/models/miq_server/worker_management/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/kubernetes_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe MiqServer::WorkerManagement::Kubernetes do
     expect(server.worker_manager.current_pods).to_not be_nil
   end
 
-  it ".current_pods initialized" do
-    expect(server.worker_manager.class.current_pods).to_not be_nil
-  end
-
-  it ".current_pods and #current_pods share the same hash" do
-    expect(server.worker_manager.class.current_pods.object_id).to eql(server.worker_manager.current_pods.object_id)
-    server.worker_manager.current_pods[:a] = :b
-    expect(server.worker_manager.class.current_pods[:a]).to eql(:b)
-  end
-
   context "#ensure_kube_monitors_started" do
     it "calls start_kube_monitor if nil monitor thread" do
       expect(server.worker_manager).to receive(:start_kube_monitor).once.with(:deployments)


### PR DESCRIPTION
These were previously class_attributes but now that WorkerManagement is a class these can be initialized when that class is instantiated