### PR TITLE
Add volume mounts for httpd configuration

### DIFF
--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -42,5 +42,10 @@ class MiqUiWorker < MiqWorker
 
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "ui-httpd-configs", :mountPath => "/etc/httpd/conf.d"}
     definition[:spec][:template][:spec][:volumes] << {:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 420}}
+
+    if ENV["UI_SSL_SECRET_NAME"].present?
+      definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "ui-httpd-ssl", :mountPath => "/etc/pki/tls"}
+      definition[:spec][:template][:spec][:volumes] << {:name => "ui-httpd-ssl", :secret => {:secretName => ENV["UI_SSL_SECRET_NAME"], :items => [{:key => "ui_crt", :path => "certs/server.crt"}, {:key => "ui_key", :path => "private/server.key"}], :defaultMode => 400}}
+    end
   end
 end

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -37,5 +37,10 @@ class MiqWebServiceWorker < MiqWorker
 
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "api-httpd-config", :mountPath => "/etc/httpd/conf.d"}
     definition[:spec][:template][:spec][:volumes] << {:name => "api-httpd-config", :configMap => {:name => "api-httpd-configs", :defaultMode => 420}}
+
+    if ENV["API_SSL_SECRET_NAME"].present?
+      definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "api-httpd-ssl", :mountPath => "/etc/pki/tls"}
+      definition[:spec][:template][:spec][:volumes] << {:name => "api-httpd-ssl", :secret => {:secretName => ENV["API_SSL_SECRET_NAME"], :items => [{:key => "api_crt", :path => "certs/server.crt"}, {:key => "api_key", :path => "private/server.key"}], :defaultMode => 400}}
+    end
   end
 end


### PR DESCRIPTION
These volume mounts are required for the httpd server certificate and key on the UI and API pods