### PR TITLE
update gem sys-filesystem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem "rugged",                           "~>1.1",             :require => false
 gem "snmp",                             "~>1.2.0",           :require => false
 gem "sprockets",                        "~>3.7.2",           :require => false
 gem "sync",                             "~>0.5",             :require => false
-gem "sys-filesystem",                   "~>1.3.4"
+gem "sys-filesystem",                   "~>1.4.3"
 gem "terminal",                                              :require => false
 gem "wim_parser",                       "~>1.0",             :require => false
 


### PR DESCRIPTION
My computer is Mac m1
when I run /bin/setup, always error that

== Updating database ==
rails aborted!
rake aborted!
FFI::NotFoundError: Function 'getmntinfo64' not found in [libc.dylib]

fixes #21528

/cc @Numbero @fryguy