### PR TITLE
Enhance check_compliance to handle has_compliance_policies

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -104,11 +104,6 @@ class ContainerImage < ApplicationRecord
     MiqEvent.raise_evm_event(self, 'containerimage_created', {})
   end
 
-  def has_compliance_policies?
-    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "containerimage_compliance_check")
-    !plist.blank?
-  end
-
   def openscap_failed_rules_summary
     openscap_rule_results.where(:result => "fail").group(:severity).count.symbolize_keys
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1693,11 +1693,6 @@ class Host < ApplicationRecord
   end
   Vmdb::Deprecation.deprecate_methods(self, :host_create_os_types)
 
-  def has_compliance_policies?
-    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "host_compliance_check")
-    !plist.blank?
-  end
-
   def writable_storages
     if host_storages.loaded? && host_storages.all? { |hs| hs.association(:storage).loaded? }
       host_storages.reject(&:read_only).map(&:storage)

--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -9,7 +9,9 @@ module ComplianceMixin
              :inverse_of => :resource,
              :class_name => "Compliance"
 
-    supports :check_compliance
+    supports :check_compliance do
+      unsupported_reason_add(:check_compliance, "No compliance policies assigned") unless has_compliance_policies?
+    end
 
     virtual_delegate :last_compliance_status,
                      :to        => "last_compliance.compliant",
@@ -36,7 +38,12 @@ module ComplianceMixin
 
   def compliance_policies
     target_class = self.class.base_model.name.downcase
+    target_class = "vm" if target_class.include?("template")
     _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "#{target_class}_compliance_check")
     plist
+  end
+
+  def has_compliance_policies?
+    compliance_policies.present?
   end
 end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -7,6 +7,7 @@ class PhysicalServer < ApplicationRecord
   include SupportsFeatureMixin
   include EventMixin
   include ProviderObjectMixin
+  include ComplianceMixin
 
   include_concern 'Operations'
 
@@ -46,11 +47,6 @@ class PhysicalServer < ApplicationRecord
     details % {
       :name => name,
     }
-  end
-
-  def has_compliance_policies?
-    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "physicalserver_compliance_check")
-    !plist.blank?
   end
 
   def label_for_vendor

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1277,12 +1277,6 @@ class VmOrTemplate < ApplicationRecord
     )
   end)
 
-
-  def has_compliance_policies?
-    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "vm_compliance_check")
-    !plist.blank?
-  end
-
   def classify_with_parent_folder_path_queue(add = true)
     MiqQueue.submit_job(
       :class_name  => self.class.name,

--- a/spec/models/container_image_spec.rb
+++ b/spec/models/container_image_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe ContainerImage do
   subject { FactoryBot.create(:container_image) }
 
   include_examples "MiqPolicyMixin"
+  include_examples "ComplianceMixin"
 
   it "#full_name" do
     image = ContainerImage.new(:name => "fedora")

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Host do
 
   include_examples "AggregationMixin"
   include_examples "MiqPolicyMixin"
+  include_examples "ComplianceMixin"
 
   it "groups and users joins" do
     user1  = FactoryBot.create(:account_user)

--- a/spec/models/miq_template_spec.rb
+++ b/spec/models/miq_template_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe MiqTemplate do
+  subject { FactoryBot.create(:template) }
+
+  include_examples "ComplianceMixin"
+
   it ".corresponding_model" do
     expect(described_class.corresponding_model).to eq(Vm)
     expect(ManageIQ::Providers::Vmware::InfraManager::Template.corresponding_model).to eq(ManageIQ::Providers::Vmware::InfraManager::Vm)

--- a/spec/models/physical_server_spec.rb
+++ b/spec/models/physical_server_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PhysicalServer do
   subject { FactoryBot.create(:physical_server, :with_asset_detail) }
 
   include_examples "MiqPolicyMixin"
+  include_examples "ComplianceMixin"
 
   describe '#compatible_firmware_binaries' do
     before { subject.asset_detail.update(**attrs) }

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe Vm do
+  subject { FactoryBot.create(:vm) }
+
   include_examples "OwnershipMixin"
+  include_examples "ComplianceMixin"
 
   it "#corresponding_model" do
     expect(Vm.corresponding_model).to eq(MiqTemplate)

--- a/spec/support/examples_group/shared_examples_for_compliance_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_compliance_mixin.rb
@@ -1,0 +1,30 @@
+shared_examples_for "ComplianceMixin" do
+  context "ComplianceMixin methods" do
+    let(:towhat) { subject.class.base_model.name.gsub(/.*template.*/i, "Vm") }
+    let(:action) { FactoryBot.create(:miq_action) }
+    let(:event)  { FactoryBot.create(:miq_event_definition, :name => "#{towhat.downcase}_compliance_check") }
+    let(:policy) do
+      FactoryBot.create(:miq_policy, :active => true, :towhat => towhat, :mode => 'compliance').tap do |p|
+        p.replace_actions_for_event(event, [[action, {:qualifier => :success}]])
+      end
+    end
+
+    describe "#has_compliance_policies?" do
+      it 'detects no policies' do
+        expect(subject.has_compliance_policies?).to be false
+      end
+
+      it 'detects policies' do
+        subject.add_policy(policy)
+        expect(subject.has_compliance_policies?).to be true
+      end
+    end
+
+    describe "#compliance_policies" do
+      it 'detects policies' do
+        subject.add_policy(policy)
+        expect(subject.compliance_policies).to eq([policy])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before

- Not all classes implemented `has_compliance_policies?`
- Not all classes implemented `compliance_policies`
- api had to use one or the other to check if a model had policies assigned and therefore supported compliance.

### After

- All classes implement both methods
- supports uses `has_compliance_policies?` to properly answer supports question
- hosts no longer implements has_compliance_policies since the default works fine
- api no longer is concerned with these details
