### PR TITLE
[WIP] [POC] Remove multiple server support from the orchestrator process.

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -16,7 +16,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
   def sync_from_system
     # All miq_server instances have to reside on the same Kubernetes cluster, so
     # we only have to sync the list of pods and deployments once
-    ensure_kube_monitors_started if my_server.is_master?
+    ensure_kube_monitors_started if my_server_is_primary?
 
     # Before syncing the workers check for any orphaned worker rows that don't have
     # a current pod and delete them
@@ -94,6 +94,12 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
   private
 
+  # In podified there is only one "primary" miq_server whose zone is "default", the
+  # other miq_server instances are simply to allow for additional zones
+  def my_server_is_primary?
+    my_server.zone&.name == "default"
+  end
+
   def cpu_value_eql?(current, desired)
     # Convert to millicores if not already converted: "1" -> 1000; "1000m" -> 1000
     current = current.to_s[-1] == "m" ? current.to_f : current.to_f * 1000
@@ -138,7 +144,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
   end
 
   def delete_failed_deployments
-    return unless my_server.is_master?
+    return unless my_server_is_primary?
 
     failed_deployments.each do |failed|
       orchestrator.delete_deployment(failed)

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -87,7 +87,16 @@ class EvmServer
   private
 
   def servers_from_db
-    MiqEnvironment::Command.is_podified? ? MiqServer.in_my_region.to_a : [MiqServer.my_server(true)].compact
+    my_server = MiqServer.my_server(true)
+
+    if MiqEnvironment::Command.is_podified?
+      # Ensure that the "primary" miq_server is first in the list of servers.
+      # This ensures that any work that is only done on the primary is completed
+      # before processing the rest of the servers.
+      MiqServer.in_my_region.to_a.unshift(my_server).uniq.compact
+    else
+      [my_server].compact
+    end
   end
 
   def set_process_title

--- a/spec/models/miq_server/worker_management/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/kubernetes_spec.rb
@@ -1,7 +1,7 @@
 require 'recursive-open-struct'
 
 RSpec.describe MiqServer::WorkerManagement::Kubernetes do
-  let(:server)          { EvmSpecHelper.create_guid_miq_server_zone.second }
+  let(:server)          { EvmSpecHelper.local_miq_server(:is_master => true) }
   let(:orchestrator)    { double("ContainerOrchestrator") }
   let(:deployment_name) { '1-generic-79bb8b8bb5-8ggbg' }
   let(:pod_label)       { '1-generic' }

--- a/spec/models/miq_server/worker_management/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/kubernetes_spec.rb
@@ -1,7 +1,7 @@
 require 'recursive-open-struct'
 
 RSpec.describe MiqServer::WorkerManagement::Kubernetes do
-  let(:server)          { EvmSpecHelper.local_miq_server(:is_master => true) }
+  let(:server)          { FactoryBot.create(:miq_server_in_default_zone).tap { |s| EvmSpecHelper.stub_as_local_server(s) } }
   let(:orchestrator)    { double("ContainerOrchestrator") }
   let(:deployment_name) { '1-generic-79bb8b8bb5-8ggbg' }
   let(:pod_label)       { '1-generic' }


### PR DESCRIPTION
This PR is a PoC to show how we don't need as_each_server at the evm_server level.  It probably does not work as is.  This is a partial revert of https://github.com/ManageIQ/manageiq/pull/19734

The idea here is that the orchestrator should only be responsible for its own "server".  In appliances this is done automatically because we only watch one server anwyay, and we presume the rest of the server records are being watched by _their_ orchestrators.  In podified, this was changed to watch every "server", however all of the servers are fake records that are only in place to deal with the zone -> miq_server relationship which we need for zone support.  

Instead, what we can do is just watch the one "server" record we care about, and then change the way we monitor other servers in server_monitor.rb.  What's missing from this PR is that the server_monitor.rb code needs to change such that we can have a subclass for Kubernetes that effectively does nothing for the other "fake" servers (i.e. we don't care about heartbeats), but still allow for role management to support the zones concept of placement.  @agrare had a good idea for a `MiqServer::PlatformManagement`, which I think aligns with this.

Built on #21532, so only look at the latest commit: https://github.com/Fryguy/manageiq/compare/Fryguy:remove_as_each_server~...Fryguy:remove_as_each_server?expand=1

cc @agrare @jrafanie 