### PR TITLE
Ignore specs in CodeQL runs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,4 @@ name: "Custom CodeQL Config"
 paths-ignore:
 - lib/generators/manageiq/plugin/templates
 - lib/generators/manageiq/provider/templates
+- spec


### PR DESCRIPTION
This will remove about 32 false positives in the CodeQL runs...namely "rb/hardcoded-credentials" in specs.