### PR TITLE
all child classes define supported_auth_types.

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -522,8 +522,12 @@ class ExtManagementSystem < ApplicationRecord
     supports?(:add_volume_mapping)
   end
 
+  def supported_auth_types
+    %w[default]
+  end
+
   def supports_authentication?(authtype)
-    authtype.to_s == "default"
+    supported_auth_types.include?(authtype.to_s)
   end
 
   # UI method for determining which icon to show for a particular EMS


### PR DESCRIPTION
copying the implementation from a bunch of child classes

we can delete the child implementations of `supports_authentication`
when the need arises
