### PR TITLE
Cache systemd services and processes in worker_management

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -7,12 +7,6 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
   attr_accessor :deployments_monitor_thread, :pods_monitor_thread
 
-  def sync_monitor
-    sync_from_system
-
-    super
-  end
-
   def sync_from_system
     # All miq_server instances have to reside on the same Kubernetes cluster, so
     # we only have to sync the list of pods and deployments once

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -15,6 +15,9 @@ module MiqServer::WorkerManagement::Monitor
     # Reload my_server so we can detect role and possibly other changes faster
     my_server.reload
 
+    # Cache a list of the native objects backing the miq_workers (e.g.: pods, services, or processes)
+    sync_from_system
+
     sync_monitor
 
     # Sync the workers after sync'ing the child worker settings

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -1,4 +1,10 @@
 class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
+  attr_accessor :miq_processes
+
+  def sync_from_system
+    self.miq_processes = miq_workers.pluck(:pid).map { |pid| MiqProcess.processInfo(pid) }
+  end
+
   def monitor_workers
     super
 

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -1,6 +1,4 @@
 class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
-  attr_accessor :miq_processes
-
   def sync_from_system
     require "sys/proctable"
     self.miq_processes = Sys::ProcTable.ps.select { |proc| proc.ppid == my_server.pid }
@@ -64,4 +62,8 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
 
     true
   end
+
+  private
+
+  attr_accessor :miq_processes
 end

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -2,7 +2,8 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
   attr_accessor :miq_processes
 
   def sync_from_system
-    self.miq_processes = miq_workers.pluck(:pid).map { |pid| MiqProcess.processInfo(pid) }
+    require "sys/proctable"
+    self.miq_processes = Sys::ProcTable.ps.select { |proc| proc.ppid == ::Process.pid }
   end
 
   def monitor_workers

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -3,7 +3,7 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
 
   def sync_from_system
     require "sys/proctable"
-    self.miq_processes = Sys::ProcTable.ps.select { |proc| proc.ppid == ::Process.pid }
+    self.miq_processes = Sys::ProcTable.ps.select { |proc| proc.ppid == my_server.pid }
   end
 
   def monitor_workers

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -1,13 +1,5 @@
 class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   attr_accessor :miq_services
-  attr_reader :systemd_manager
-
-  def initialize(*)
-    super
-
-    require "dbus/systemd"
-    @systemd_manager = DBus::Systemd::Manager.new
-  end
 
   def sync_from_system
     self.miq_services = systemd_services.select { |unit| manageiq_service?(unit) }
@@ -28,6 +20,13 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   end
 
   private
+
+  def systemd_manager
+    @systemd_manager ||= begin
+      require "dbus/systemd"
+      DBus::Systemd::Manager.new
+    end
+  end
 
   def systemd_stop_services(service_names)
     service_names.each do |service_name|

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -65,7 +65,7 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   end
 
   def failed_miq_service_namees
-    failed_miq_services.map { |service| service[:name] }
+    failed_miq_services.pluck(:name)
   end
 
   def systemd_services

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -1,4 +1,18 @@
 class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
+  attr_accessor :miq_services
+  attr_reader :systemd_manager
+
+  def initialize(*)
+    super
+
+    require "dbus/systemd"
+    @systemd_manager = DBus::Systemd::Manager.new
+  end
+
+  def sync_from_system
+    self.miq_services = systemd_services.select { |unit| manageiq_service?(unit) }
+  end
+
   def cleanup_failed_workers
     super
 
@@ -6,29 +20,14 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   end
 
   def cleanup_failed_systemd_services
-    failed_service_names = systemd_failed_miq_services.map { |service| service[:name] }
-    return if failed_service_names.empty?
+    service_names = failed_miq_service_namees
+    return if service_names.empty?
 
-    _log.info("Disabling failed unit files: [#{failed_service_names.join(", ")}]")
-    systemd_stop_services(failed_service_names)
-  end
-
-  def systemd_failed_miq_services
-    miq_services(systemd_failed_services)
-  end
-
-  def systemd_all_miq_services
-    miq_services(systemd_services)
+    _log.info("Disabling failed unit files: [#{service_names.join(", ")}]")
+    systemd_stop_services(service_names)
   end
 
   private
-
-  def systemd_manager
-    @systemd_manager ||= begin
-      require "dbus/systemd"
-      DBus::Systemd::Manager.new
-    end
-  end
 
   def systemd_stop_services(service_names)
     service_names.each do |service_name|
@@ -46,14 +45,12 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     Pathname.new("/lib/systemd/system")
   end
 
-  def miq_services(services)
-    services.select { |unit| systemd_miq_service_base_names.include?(systemd_service_base_name(unit)) }
+  def manageiq_service?(unit)
+    manageiq_service_base_names.include?(systemd_service_base_name(unit))
   end
 
-  def systemd_miq_service_base_names
-    @systemd_miq_service_base_names ||= begin
-      MiqWorkerType.worker_classes.map(&:service_base_name)
-    end
+  def manageiq_service_base_names
+    @manageiq_service_base_names ||= MiqWorkerType.worker_classes.map(&:service_base_name)
   end
 
   def systemd_service_name(unit)
@@ -64,8 +61,12 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     systemd_service_name(unit).split("@").first
   end
 
-  def systemd_failed_services
-    systemd_services.select { |service| service[:active_state] == "failed" }
+  def failed_miq_services
+    miq_services.select { |service| service[:active_state] == "failed" }
+  end
+
+  def failed_miq_service_namees
+    failed_miq_services.map { |service| service[:name] }
   end
 
   def systemd_services

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -1,6 +1,4 @@
 class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
-  attr_accessor :miq_services
-
   def sync_from_system
     self.miq_services = systemd_services.select { |unit| manageiq_service?(unit) }
   end
@@ -20,6 +18,8 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   end
 
   private
+
+  attr_accessor :miq_services
 
   def systemd_manager
     @systemd_manager ||= begin

--- a/spec/models/miq_server/worker_management/process_spec.rb
+++ b/spec/models/miq_server/worker_management/process_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MiqServer::WorkerManagement::Process do
 
       it "filters out non-workers" do
         server.worker_manager.sync_from_system
-        expect(server.worker_manager.miq_processes).to be_empty
+        expect(server.worker_manager.send(:miq_processes)).to be_empty
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe MiqServer::WorkerManagement::Process do
 
       it "filters out non-workers" do
         server.worker_manager.sync_from_system
-        expect(server.worker_manager.miq_processes.count).to eq(1)
+        expect(server.worker_manager.send(:miq_processes).count).to eq(1)
       end
     end
   end

--- a/spec/models/miq_server/worker_management/process_spec.rb
+++ b/spec/models/miq_server/worker_management/process_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe MiqServer::WorkerManagement::Process do
+  let(:server) { EvmSpecHelper.local_miq_server(:pid => 2) }
+
+  before do
+    MiqWorkerType.seed
+    allow(MiqServer::WorkerManagement).to receive(:podified?).and_return(false)
+    allow(MiqServer::WorkerManagement).to receive(:systemd?).and_return(false)
+  end
+
+  describe "#sync_from_system" do
+    before do
+      require "sys/proctable"
+      allow(Sys::ProcTable).to receive(:ps).and_return(processes)
+    end
+
+    context "with no workers" do
+      let(:processes) do
+        [
+          Struct::ProcTableStruct.new.tap do |proc|
+            proc.cmdline = "postgres: 13/main: root vmdb_development [local] idle"
+            proc.pid     = 1234
+            proc.ppid    = 1
+          end
+        ]
+      end
+
+      it "filters out non-workers" do
+        server.worker_manager.sync_from_system
+        expect(server.worker_manager.miq_processes).to be_empty
+      end
+    end
+
+    context "with a worker" do
+      let(:processes) do
+        [
+          Struct::ProcTableStruct.new.tap do |proc|
+            proc.cmdline = "postgres: 13/main: root vmdb_development [local] idle"
+            proc.pid     = 1234
+            proc.ppid    = 1
+          end,
+          Struct::ProcTableStruct.new.tap do |proc|
+            proc.cmdline = "MIQ: Vmware::InfraManager::RefreshWorker id: 39, queue: ems_2"
+            proc.pid     = 5678
+            proc.ppid    = server.pid
+          end
+        ]
+      end
+
+      it "filters out non-workers" do
+        server.worker_manager.sync_from_system
+        expect(server.worker_manager.miq_processes.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
       [
         {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
         {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service",      :active_state => "active"},
-        {:name => "ssh.service",                                          :active_state => "active"}
+        {:name => "ssh.service",                                                   :active_state => "active"}
       ]
     end
 

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
   end
 
   context "#cleanup_failed_systemd_services" do
+    before { server.worker_manager.sync_from_system }
+
     context "with no failed services" do
       let(:units) { [{:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
 
@@ -35,7 +37,9 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     end
   end
 
-  context "#systemd_all_miq_services" do
+  context "#sync_from_system" do
+    before { server.worker_manager.sync_from_system }
+
     let(:units) do
       [
         {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
@@ -45,11 +49,13 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     end
 
     it "filters out non-miq services" do
-      expect(server.worker_manager.systemd_all_miq_services.count).to eq(2)
+      expect(server.worker_manager.miq_services.count).to eq(2)
     end
   end
 
-  context "#systemd_failed_miq_services" do
+  context "#failed_miq_services (private)" do
+    before { server.worker_manager.sync_from_system }
+
     let(:units) do
       [
         {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :active_state => "failed"},
@@ -58,13 +64,13 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     end
 
     it "filters out only failed services" do
-      expect(server.worker_manager.systemd_failed_miq_services.count).to eq(1)
+      expect(server.worker_manager.send(:failed_miq_services).count).to eq(1)
     end
   end
 
-  context "#systemd_miq_service_base_names (private)" do
+  context "#manageiq_service_base_names (private)" do
     it "returns the minimal_class_name" do
-      expect(server.worker_manager.send(:systemd_miq_service_base_names)).to include("manageiq-generic", "manageiq-ui")
+      expect(server.worker_manager.send(:manageiq_service_base_names)).to include("manageiq-generic", "manageiq-ui")
     end
   end
 

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     end
 
     it "filters out non-miq services" do
-      expect(server.worker_manager.miq_services.count).to eq(2)
+      expect(server.worker_manager.send(:miq_services).count).to eq(2)
     end
   end
 


### PR DESCRIPTION
We currently sync current_pods and current_deployments in the kubernetes subclass of WorkerManagement.  We can benefit from having a current list of systemd services and processes as well.