### PR TITLE
ManageIQ::Password raises exception on plaintext

### DIFF
--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -70,8 +70,7 @@ RSpec.describe FixAuth::AuthModel do
       end
 
       it "should not encrypt plaintext columns" do
-        subject.fix_passwords(plain, options)
-        expect(plain).to_not be_password_changed
+        expect { subject.fix_passwords(plain, options) }.to raise_error(ManageIQ::Password::PasswordError, "cannot decrypt plaintext string")
       end
 
       it "should raise exception for bad encryption" do


### PR DESCRIPTION
Fix the fix_auth auth_model_spec after manageiq-password v1.1.0

Fixes https://app.travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/547146397#L1050-L1062
```
Failures:

  1) FixAuth::AuthModel#authentications #recrypt should not encrypt plaintext columns
     Failure/Error: subject.fix_passwords(plain, options)

     ManageIQ::Password::PasswordError:
       cannot decrypt plaintext string

     # ./tools/fix_auth/auth_model.rb:48:in `recrypt_password'
     # ./tools/fix_auth/auth_model.rb:37:in `recrypt'
     # ./tools/fix_auth/auth_model.rb:62:in `block in fix_passwords'
     # ./tools/fix_auth/auth_model.rb:60:in `each'
     # ./tools/fix_auth/auth_model.rb:60:in `fix_passwords'
     # ./spec/tools/fix_auth/auth_model_spec.rb:73:in `block (4 levels) in <top (required)>'
```