### PR TITLE
Handle ManageIQ::Password raising exception on plaintext

### DIFF
--- a/tools/fix_auth/auth_model.rb
+++ b/tools/fix_auth/auth_model.rb
@@ -36,9 +36,11 @@ module FixAuth
         else
           recrypt_password(old_value, options[:legacy_key])
         end
-      rescue
+      rescue => err
         if options[:invalid]
           hardcode(old_value, options[:invalid])
+        elsif err.kind_of?(ManageIQ::Password::PasswordError) && err.to_s == "cannot decrypt plaintext string"
+          old_value
         else
           raise
         end


### PR DESCRIPTION
Fixes the fix_auth auth_model_spec after manageiq-password v1.1.0

https://app.travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/547146397#L1050-L1062

Failures:

```
  1) FixAuth::AuthModel#authentications #recrypt should not encrypt plaintext columns
     Failure/Error: subject.fix_passwords(plain, options)

     ManageIQ::Password::PasswordError:
       cannot decrypt plaintext string

     # ./tools/fix_auth/auth_model.rb:48:in `recrypt_password'
     # ./tools/fix_auth/auth_model.rb:37:in `recrypt'
     # ./tools/fix_auth/auth_model.rb:62:in `block in fix_passwords'
     # ./tools/fix_auth/auth_model.rb:60:in `each'
     # ./tools/fix_auth/auth_model.rb:60:in `fix_passwords'
     # ./spec/tools/fix_auth/auth_model_spec.rb:73:in `block (4 levels) in <top (required)>'
```

Alternative to https://github.com/ManageIQ/manageiq/pull/21546 .  Also see the discussion here: https://github.com/ManageIQ/manageiq/pull/21178#pullrequestreview-637148954

@kbrock @agrare Please review.