### PR TITLE
[ruby3] KWArgs Roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,12 +206,12 @@ class User < ApplicationRecord
   end
   alias_method :miq_group_description, :ldap_group
 
-  def role_allows?(options = {})
-    Rbac.role_allows?(options.merge(:user => self))
+  def role_allows?(**options)
+    Rbac.role_allows?(:user => self, **options)
   end
 
-  def role_allows_any?(options = {})
-    Rbac.role_allows?(options.merge(:user => self, :any => true))
+  def role_allows_any?(**options)
+    Rbac.role_allows?(:user => self, :any => true, **options)
   end
 
   def miq_user_role_name

--- a/lib/rbac.rb
+++ b/lib/rbac.rb
@@ -25,7 +25,7 @@ module Rbac
     valid_resources
   end
 
-  def self.role_allows?(*args)
-    Authorizer.role_allows?(*args)
+  def self.role_allows?(**options)
+    Authorizer.role_allows?(**options)
   end
 end

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -2,25 +2,19 @@ module Rbac
   class Authorizer
     include Vmdb::Logging
 
-    def self.role_allows?(*args)
-      new.role_allows?(*args)
+    def self.role_allows?(**options)
+      new.role_allows?(**options)
     end
 
-    def role_allows?(options = {})
-      user    = options[:user]
-
-      # 'identifier' comes from the back end (ex: User#role_allows?)
-      # 'feature' comes from the front end (ex: ApplicationHelper#role_allows?)
-      # As this API is a combination of the two, 'feature' is considered
-      # an alias of 'identifier' for legacy purposes.
-      identifier = options[:identifier] || options[:feature]
-
-      # The 'identifiers' option comes from the former User#role_allows_any? API
-      # It should be noted that there may be only ONE caller using 'identifiers'
-      # in Menu::Section, so this option may be changed shortly.
-      identifiers = options[:identifiers]
-
-      any     = options[:any]
+    # @options option any         - any of the identifiers can match (default: false)
+    # @options option identifier  - comes from the back end (ex: User#role_allows?)
+    # @options option feature     - same as identifier, comes from the front end (ex: ApplicationHelper#role_allows?)
+    # @options option identifiers - same as others
+    #                               This comes from the former User#role_allows_any? API
+    #                               there may be only ONE caller using 'identifiers'
+    #                               in Menu::Section, so this option may be changed shortly.
+    def role_allows?(user:, identifier: nil, feature: nil, identifiers: nil, any: false)
+      identifier ||= feature
 
       tenant_identifier = MiqProductFeature.current_tenant_identifier(identifier)
 
@@ -38,7 +32,7 @@ module Rbac
 
     private
 
-    def user_role_allows?(user, options = {})
+    def user_role_allows?(user, **options)
       return false if user.miq_user_role.nil?
       return true if user.miq_user_role.allows?(**options)
 
@@ -57,7 +51,7 @@ module Rbac
       end
     end
 
-    def user_role_allows_any?(user, options = {})
+    def user_role_allows_any?(user, **options)
       return false if user.miq_user_role.nil?
       user.miq_user_role.allows_any?(**options)
     end


### PR DESCRIPTION
we were using options in some areas and kwargs in others
ruby 3.0 said we had to choose one or the other

we are moving away from identifiers and towards identifier/feature.
tweaked this so we can `s/identifiers/identifier`


see also https://github.com/ManageIQ/manageiq-ui-classic/pull/7949

---

ASIDE: Roles has always confused me.

I always expect `role_allows_any?` to be a `for`/`any?` loop over the identifiers, but instead it works completely differently than `role_allows?` One seems to drill down and the other seems to roll up.

So I am not sure if these two statements are equivalent

```ruby
role_allows?(identifier: :x) || role_allows?(identifier: :y)
role_allows_any?(:identifiers => [:x, :y])
```


Also, The Rbac version of these calls seem to add some logic that are not present in the role form. Sometimes we call one but not the other and it is hard to know if the code wanted the nuances.

For this reason, I do not know if the goal of removing the `identifiers:` is actually desirable.
Also, it seems like `any => true` should just be implied. Either because `:identifiers` is present or `:identifier` contains an array. Not sure that we have the concept of requiring all roles to be defined.