### PR TITLE
Set the proper class_attribute default

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -60,11 +60,9 @@ class MiqPolicy < ApplicationRecord
 
   virtual_column :display_name, :type => :string
 
-  @@associations_to_get_policies = [:parent_enterprise, :ext_management_system, :parent_datacenter, :ems_cluster, :parent_resource_pool, :host]
-
   attr_accessor :reserved
 
-  class_attribute :associations_to_get_policies
+  class_attribute :associations_to_get_policies, :default => [:parent_enterprise, :ext_management_system, :parent_datacenter, :ems_cluster, :parent_resource_pool, :host]
 
   @@built_in_policies = nil
 
@@ -452,7 +450,7 @@ class MiqPolicy < ApplicationRecord
 
     # get profiles and policies from associations
     assoc_policies =
-      @@associations_to_get_policies.collect do |assoc|
+      associations_to_get_policies.collect do |assoc|
         next unless target.respond_to?(assoc)
 
         obj = target.send(assoc)

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe MiqPolicy do
+  it "associations_to_get_policies have defaults" do
+    expect(described_class.associations_to_get_policies).to include(:ext_management_system)
+  end
+
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:miq_policy)
     expect { m.valid? }.not_to make_database_queries


### PR DESCRIPTION
Set the proper class_attribute default

Commit 080e97baf85 changed this from a cattr_accessor to a class_attribute
but failed to set the class_attribute default and assumed it was still using the
`@@-variable`.  Instead, we need to set the value using the class_attribute
default.