### PR TITLE
Add timeline_options to expose event_streams OPTIONS to the API

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -10,6 +10,25 @@ class EmsEvent < EventStream
     'Rename_Task',
   ]
 
+  def self.description
+    _("Management Events")
+  end
+
+  def self.group_names_and_levels
+    result = {:description => description}
+    event_groups.each_with_object(result) do |(group_name, group_details), hash|
+      hash[:group_names] ||= {}
+      hash[:group_names][group_name] = group_details[:name]
+
+      group_details.each_key do |level|
+        next if level == :name
+
+        hash[:group_levels] ||= {}
+        hash[:group_levels][level] ||= level.to_s.capitalize
+      end
+    end
+  end
+
   def handle_event
     EmsEventHelper.new(self).handle
   rescue => err

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -20,6 +20,17 @@ class MiqEvent < EventStream
                                         ContainerReplicator, ContainerGroup, ContainerProject,
                                         ContainerNode, ContainerImage, PhysicalServer].freeze
 
+  def self.description
+    _("Policy Events")
+  end
+
+  def self.group_names_and_levels
+    hash = {:description => description}
+    hash[:group_names] = MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys
+    hash[:group_levels] = [MiqPolicy::CONDITION_SUCCESS, MiqPolicy::CONDITION_FAILURE].index_by { |c| c.downcase.to_sym }
+    hash
+  end
+
   def self.raise_evm_event(target, raw_event, inputs = {}, options = {})
     # Target may have been deleted if it's a worker
     # Target, in that case will be the worker's server.

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -11,6 +11,9 @@ class MiqPolicy < ApplicationRecord
                                  PhysicalServer
                                  Vm).freeze
 
+  CONDITION_SUCCESS = N_("Success")
+  CONDITION_FAILURE = N_("Failure")
+
   def self.policy_towhat_applies_to_classes
     TOWHAT_APPLIES_TO_CLASSES.index_with { |key| ui_lookup(:model => key) }
   end

--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -21,4 +21,28 @@ RSpec.describe EventStream do
       end
     end
   end
+
+  context "description" do
+    it "raises NotImplementedError, for subclasses to implement" do
+      expect { described_class.description }.to raise_error(NotImplementedError)
+    end
+  end
+
+  context "timeline_options" do
+    it "has correct structure" do
+      MiqEventDefinitionSet.seed
+      options = described_class.timeline_options
+      expect(options.keys.sort).to eq %i[EmsEvent MiqEvent]
+
+      expect(options[:EmsEvent].keys.sort).to eq %i[description group_levels group_names]
+      expect(options[:EmsEvent][:description]).to eq(EmsEvent.description)
+      expect(options[:EmsEvent][:group_levels].keys.sort).to eq %i[critical detail warning]
+      expect(options[:EmsEvent][:group_names].keys).to include(*%i[addition configuration console deletion devices])
+
+      expect(options[:MiqEvent].keys.sort).to eq %i[description group_levels group_names]
+      expect(options[:MiqEvent][:description]).to eq(MiqEvent.description)
+      expect(options[:MiqEvent][:group_levels].keys.sort).to eq %i[failure success]
+      expect(options[:MiqEvent][:group_names].keys).to include(*%i[auth_validation authentication compliance container_operations ems_operations evm_operations])
+    end
+  end
 end


### PR DESCRIPTION
For issue: https://github.com/ManageIQ/manageiq-api/issues/1090

Note, currently there are several methods in EventStream whose implementation is
for EmsEvent and should move there.  We'll look at that when we need to
expose/test filtering on MiqEvent levels (success/failure) for the API.