### PR TITLE
extract subclassess_supporting

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -44,24 +44,16 @@ class ExtManagementSystem < ApplicationRecord
     permitted_subclasses.select(&:supported_for_create?)
   end
 
-  def self.supported_types_for_catalog
-    subclasses_supporting(:catalog)
-  end
-
   def self.supported_for_create?
     !reflections.include?("parent_manager")
   end
 
-  def self.label_mapping_classes
-    subclasses_supporting(:label_mapping)
-  end
-
   def self.label_mapping_prefixes
-    label_mapping_classes.map(&:label_mapping_prefix).uniq
+    subclasses_supporting(:label_mapping).map(&:label_mapping_prefix).uniq
   end
 
   def self.entities_for_label_mapping
-    label_mapping_classes.reduce({}) { |all_mappings, klass| all_mappings.merge(klass.entities_for_label_mapping) }
+    subclasses_supporting(:label_mapping).reduce({}) { |all_mappings, klass| all_mappings.merge(klass.entities_for_label_mapping) }
   end
 
   def self.provider_create_params

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -33,9 +33,8 @@ class ExtManagementSystem < ApplicationRecord
   end
   delegate :permitted?, :to => :class
 
-  def self.subclasses_supports?(feature)
-    permitted_subclasses.select { |subclass| subclass.supports?(feature) }
-  end
+  # when looking at supported features, only look at the classes permitted to be used
+  singleton_class.send(:alias_method, :supported_subclasses, :permitted_subclasses)
 
   def self.api_allowed_attributes
     %w[]
@@ -46,7 +45,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.supported_types_for_catalog
-    subclasses_supports?(:catalog)
+    subclasses_supporting(:catalog)
   end
 
   def self.supported_for_create?
@@ -54,7 +53,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.label_mapping_classes
-    subclasses_supports?(:label_mapping)
+    subclasses_supporting(:label_mapping)
   end
 
   def self.label_mapping_prefixes

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -31,7 +31,7 @@ class MiqTemplate < VmOrTemplate
   end
 
   def self.eligible_for_provisioning
-    supporting(:provisioning).where.not(:ems_id => nil)
+    supporting(:provisioning).active
   end
 
   def self.without_volume_templates

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -31,8 +31,7 @@ class MiqTemplate < VmOrTemplate
   end
 
   def self.eligible_for_provisioning
-    types = descendants.select { |d| d.supports?(:provisioning) }.map(&:name)
-    where(:type => types).where.not(:ems_id => nil)
+    supporting(:provisioning).where.not(:ems_id => nil)
   end
 
   def self.without_volume_templates

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -130,6 +130,19 @@ module SupportsFeatureMixin
       subclasses_supporting(feature).map(&:module_parent)
     end
 
+    # scope to query all those classes that support a particular feature
+    def supporting(feature)
+      where(:type => subclasses_supporting(feature).map(&:name))
+    end
+
+    # Providers that support this feature
+    #
+    # example:
+    #   Host.providers_supporting(feature) # => [Ems]
+    def providers_supporting(feature)
+      ExtManagementSystem.where(:type => provider_classes_supporting(feature).map(&:name))
+    end
+
     # query the class for the reason why something is unsupported
     def unsupported_reason(feature)
       feature = feature.to_sym

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -116,6 +116,20 @@ module SupportsFeatureMixin
       public_send("supports_#{feature}?")
     end
 
+    # all subclasses that are considered for supporting features
+    def supported_subclasses
+      descendants
+    end
+
+    def subclasses_supporting(feature)
+      supported_subclasses.select { |subclass| subclass.supports?(feature) }
+    end
+
+    # Provider classes that support this feature
+    def provider_classes_supporting(feature)
+      subclasses_supporting(feature).map(&:module_parent)
+    end
+
     # query the class for the reason why something is unsupported
     def unsupported_reason(feature)
       feature = feature.to_sym

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -95,7 +95,7 @@ class ServiceTemplate < ApplicationRecord
         "generic_orchestration" => N_("Orchestration"),
       }
 
-      ExtManagementSystem.supported_types_for_catalog
+      ExtManagementSystem.subclasses_supporting(:catalog)
         .flat_map(&:catalog_types)
         .reduce(builtin_catalog_item_types, :merge)
     end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -197,7 +197,7 @@ class Zone < ApplicationRecord
 
   # @return [Array<ExtManagementSystem>] All emses that can collect Capacity and Utilization metrics
   def ems_metrics_collectable
-    supported_ems_types = ExtManagementSystem.subclasses_supports?(:metrics).map(&:name)
+    supported_ems_types = ExtManagementSystem.subclasses_supporting(:metrics).map(&:name)
     ext_management_systems.where(:type => supported_ems_types).select { |e| e.supports?(:metrics) }
   end
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -197,8 +197,7 @@ class Zone < ApplicationRecord
 
   # @return [Array<ExtManagementSystem>] All emses that can collect Capacity and Utilization metrics
   def ems_metrics_collectable
-    supported_ems_types = ExtManagementSystem.subclasses_supporting(:metrics).map(&:name)
-    ext_management_systems.where(:type => supported_ems_types).select { |e| e.supports?(:metrics) }
+    ext_management_systems.supporting(:metrics).select { |e| e.supports?(:metrics) }
   end
 
   def ems_networks


### PR DESCRIPTION
Provide a mechanism that allows a class (e.g.: `Vm`) to easily generate a `:types =>` clause that will only return instances that support a particular feature

This was very cool in ems, and looks like it could provide some nice features for other classes.

This is here to build upon https://github.com/ManageIQ/manageiq-ui-classic/pull/7954#discussion_r746862439