### PR TITLE
Rename supported_subclasses to permitted_subclasses

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -20,11 +20,11 @@ class ExtManagementSystem < ApplicationRecord
     concrete_subclasses.collect(&:ems_type)
   end
 
-  def self.supported_types
-    supported_subclasses.collect(&:ems_type)
+  def self.permitted_types
+    permitted_subclasses.collect(&:ems_type)
   end
 
-  def self.supported_subclasses
+  def self.permitted_subclasses
     concrete_subclasses.select(&:permitted?)
   end
 
@@ -33,12 +33,8 @@ class ExtManagementSystem < ApplicationRecord
   end
   delegate :permitted?, :to => :class
 
-  def self.supported_types_and_descriptions_hash
-    supported_subclasses.each_with_object({}) { |klass, hash| hash[klass.ems_type] = klass.description }
-  end
-
   def self.subclasses_supports?(feature)
-    supported_subclasses.select { |subclass| subclass.supports?(feature) }
+    permitted_subclasses.select { |subclass| subclass.supports?(feature) }
   end
 
   def self.api_allowed_attributes
@@ -46,7 +42,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.supported_types_for_create
-    supported_subclasses.select(&:supported_for_create?)
+    permitted_subclasses.select(&:supported_for_create?)
   end
 
   def self.supported_types_for_catalog
@@ -70,7 +66,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.provider_create_params
-    supported_types_for_create.each_with_object({}) do |ems_type, create_params|
+    permitted_types_for_create.each_with_object({}) do |ems_type, create_params|
       create_params[ems_type.name] = ems_type.params_for_create if ems_type.respond_to?(:params_for_create)
     end
   end
@@ -1051,7 +1047,7 @@ class ExtManagementSystem < ApplicationRecord
   private
 
   def validate_ems_type
-    errors.add(:base, "emstype #{self.class.name} is not supported for create") unless ExtManagementSystem.supported_types_and_descriptions_hash.key?(emstype)
+    errors.add(:base, "emstype #{self.class.name} is not permitted for create") unless ExtManagementSystem.permitted_types.include?(emstype)
   end
 
   def disable!(validate: true)

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -83,12 +83,6 @@ module ManageIQ::Providers
       n_('Network Manager', 'Network Managers', number)
     end
 
-    def self.supported_types_and_descriptions_hash
-      supported_subclasses.select { |k| k.supports?(:ems_network_new) }.each_with_object({}) do |klass, hash|
-        hash[klass.ems_type] = klass.description
-      end
-    end
-
     def name
       "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
     end

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -62,12 +62,5 @@ module ManageIQ::Providers
       define_method(:route_key) { "ems_storages" }
       define_method(:singular_route_key) { "ems_storage" }
     end
-
-    # Allow only adding supported types. Non-supported types for adding will not be visible in the Type field
-    def self.supported_types_and_descriptions_hash
-      supported_subclasses.select { |k| k.supports?(:ems_storage_new) }.each_with_object({}) do |klass, hash|
-        hash[klass.ems_type] = klass.description
-      end
-    end
   end
 end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -616,7 +616,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
   # @returns Hash<class, Integer> Hash of ems_class => refresh_interval
   def schedule_settings_for_ems_refresh
-    ExtManagementSystem.supported_subclasses.each.with_object({}) do |klass, hash|
+    ExtManagementSystem.permitted_subclasses.each.with_object({}) do |klass, hash|
       next unless klass.ems_type
       every = ::Settings.ems_refresh[klass.ems_type].try(:refresh_interval) || ::Settings.ems_refresh.refresh_interval
       every = every.respond_to?(:to_i_with_method) ? every.to_i_with_method : every.to_i

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -29,7 +29,7 @@ class Provider < ApplicationRecord
     leaf_subclasses | descendants.select { |d| d.try(:acts_as_sti_leaf_class?) }
   end
 
-  def self.supported_subclasses
+  def self.permitted_subclasses
     concrete_subclasses
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -79,65 +79,53 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
-  describe ".supported_subclasses" do
+  describe ".permitted_subclasses" do
     context "on the EmsCloud subclass" do
       it "only returns cloud types" do
-        cloud_supported_subclasses = EmsCloud.supported_subclasses
+        cloud_permitted_subclasses = EmsCloud.permitted_subclasses
 
-        expect(cloud_supported_subclasses).to     include(ManageIQ::Providers::Amazon::CloudManager)
-        expect(cloud_supported_subclasses).not_to include(ManageIQ::Providers::Vmware::InfraManager)
+        expect(cloud_permitted_subclasses).to     include(ManageIQ::Providers::Amazon::CloudManager)
+        expect(cloud_permitted_subclasses).not_to include(ManageIQ::Providers::Vmware::InfraManager)
       end
     end
 
     context "on the EmsInfra subclass" do
       it "only returns infra types" do
-        infra_supported_subclasses = EmsInfra.supported_subclasses
+        infra_permitted_subclasses = EmsInfra.permitted_subclasses
 
-        expect(infra_supported_subclasses).to     include(ManageIQ::Providers::Vmware::InfraManager)
-        expect(infra_supported_subclasses).not_to include(ManageIQ::Providers::Amazon::CloudManager)
+        expect(infra_permitted_subclasses).to     include(ManageIQ::Providers::Vmware::InfraManager)
+        expect(infra_permitted_subclasses).not_to include(ManageIQ::Providers::Amazon::CloudManager)
       end
     end
   end
 
-  describe ".supported_types" do
+  describe ".permitted_types" do
     it "with default permissions" do
-      expect(described_class.supported_types).to include("ec2", "vmwarews")
+      expect(described_class.permitted_types).to include("ec2", "vmwarews")
     end
 
     it "with removed permissions" do
       allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(true)
       allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(false)
-      expect(described_class.supported_types).not_to include("vmwarews")
+      expect(described_class.permitted_types).not_to include("vmwarews")
     end
 
     context "on the EmsCloud subclass" do
       it "only returns cloud types" do
-        cloud_supported_types = EmsCloud.supported_types
+        cloud_permitted_types = EmsCloud.permitted_types
 
-        expect(cloud_supported_types).to     include("ec2")
-        expect(cloud_supported_types).not_to include("vmwarews")
+        expect(cloud_permitted_types).to     include("ec2")
+        expect(cloud_permitted_types).not_to include("vmwarews")
       end
     end
 
     context "on the EmsInfra subclass" do
       it "only returns infra types" do
-        infra_supported_types = EmsInfra.supported_types
+        infra_permitted_types = EmsInfra.permitted_types
 
-        expect(infra_supported_types).to     include("vmwarews")
-        expect(infra_supported_types).not_to include("ec2")
+        expect(infra_permitted_types).to     include("vmwarews")
+        expect(infra_permitted_types).not_to include("ec2")
       end
-    end
-  end
-
-  describe ".supported_types_and_descriptions_hash" do
-    it "with default permissions" do
-      expect(described_class.supported_types_and_descriptions_hash).to include("vmwarews" => "VMware vCenter")
-    end
-
-    it "with removed permissions" do
-      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(true)
-      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(false)
-      expect(described_class.supported_types_and_descriptions_hash).to_not include("vmwarews")
     end
   end
 


### PR DESCRIPTION
The concept of "supports" is more centered around specific features
within a provider, however `supported_subclasses` is more centeted on
whether or not specific provider has been permitted or not via the
`Vmdb::PermissionsStores`. This overlap of the term "supported" is
confusing. This commit renames `supported_subclasses` to
`permitted_subclasses` to clarify that distinction.

Additionally it turns out that `supported_types_and_descriptions_hash`
is not used anywhere relevant, so this commit removes that method.

@agrare @kbrock Please review.

Must be merged with
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7959
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1100