### PR TITLE
Remove usage of VMDBLogger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "log_decorator",                    "~>0.1",             :require => false
 gem "manageiq-api-client",              "~>0.3.4",           :require => false
-gem "manageiq-loggers",                 "~>0.7",             :require => false
+gem "manageiq-loggers",                 "~>1.0",             :require => false
 gem "manageiq-messaging",               "~>1.0", ">=1.0.3",  :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.1",             :require => false

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -71,12 +71,12 @@ module Vmdb
       check_automate_disk_version_against_db(fh)
 
       fh.info("VMDB settings:")
-      VMDBLogger.log_hashes(fh, ::Settings, :filter => Vmdb::Settings.secret_filter)
+      fh.log_hashes(::Settings, :filter => Vmdb::Settings.secret_filter)
       fh.info("VMDB settings END")
       fh.info("---")
 
       fh.info("DATABASE settings:")
-      VMDBLogger.log_hashes(fh, ActiveRecord::Base.connection_config)
+      fh.log_hashes(ActiveRecord::Base.connection_config)
       fh.info("DATABASE settings END")
       fh.info("---")
     end
@@ -87,10 +87,11 @@ module Vmdb
       # the file must not be named ".log" or it will be removed by logrotate, and it must contain the Server GUID (by which the appliance is known in the vmdb,
       # the build identifier of the appliance as it is being started,  the appliance hostname and the name of the appliance as configured from our configuration screen.
 
-      startup_fname = File.join(Rails.root, "log/last_startup.txt")
-      FileUtils.rm_f(startup_fname) if File.exist?(startup_fname)
+      startup_fname = Rails.root.join("log", "last_startup.txt")
+      startup_fname.delete if startup_fname.exist?
+
       begin
-        startup = VMDBLogger.new(startup_fname)
+        startup = ManageIQ::Loggers::Base.new(startup_fname)
         log_config(:logger => startup, :startup => true)
         startup.info("Server GUID: #{MiqServer.my_guid}")
         startup.info("Server Zone: #{MiqServer.my_zone}")

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -87,11 +87,11 @@ module Vmdb
       # the file must not be named ".log" or it will be removed by logrotate, and it must contain the Server GUID (by which the appliance is known in the vmdb,
       # the build identifier of the appliance as it is being started,  the appliance hostname and the name of the appliance as configured from our configuration screen.
 
-      startup_fname = Rails.root.join("log", "last_startup.txt")
-      startup_fname.delete if startup_fname.exist?
+      last_startup_file = Rails.root.join("log", "last_startup.txt")
+      last_startup_file.delete if last_startup_file.exist?
 
       begin
-        startup = ManageIQ::Loggers::Base.new(startup_fname)
+        startup = ManageIQ::Loggers::Base.new(last_startup_file)
         log_config(:logger => startup, :startup => true)
         startup.info("Server GUID: #{MiqServer.my_guid}")
         startup.info("Server Zone: #{MiqServer.my_zone}")

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -121,5 +121,4 @@ module Vmdb
   end
 end
 
-require_relative "loggers/instrument"
 Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -1,7 +1,6 @@
 require 'manageiq'
 require 'manageiq-loggers'
 require 'miq_environment'
-require 'util/vmdb-logger'
 
 module Vmdb
   def self.logger
@@ -29,7 +28,7 @@ module Vmdb
       Vmdb::Plugins.each { |p| p.try(:apply_logger_config, config) }
     end
 
-    def self.create_logger(log_file, logger_class = VMDBLogger)
+    def self.create_logger(log_file, logger_class = ManageIQ::Loggers::Base)
       log_file = Pathname.new(log_file) if log_file.kind_of?(String)
       log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
       progname = log_file.try(:basename, ".*").to_s

--- a/lib/vmdb/loggers/audit_logger.rb
+++ b/lib/vmdb/loggers/audit_logger.rb
@@ -1,5 +1,5 @@
 module Vmdb::Loggers
-  class AuditLogger < VMDBLogger
+  class AuditLogger < ManageIQ::Loggers::Base
     def success(msg)
       msg = "<AuditSuccess> #{msg}"
       info(msg)

--- a/lib/vmdb/loggers/fog_logger.rb
+++ b/lib/vmdb/loggers/fog_logger.rb
@@ -1,5 +1,5 @@
 module Vmdb::Loggers
-  class FogLogger < VMDBLogger
+  class FogLogger < ManageIQ::Loggers::Base
     include Instrument
   end
 end

--- a/lib/vmdb/loggers/fog_logger.rb
+++ b/lib/vmdb/loggers/fog_logger.rb
@@ -1,3 +1,5 @@
+require_relative "./instrument"
+
 module Vmdb::Loggers
   class FogLogger < ManageIQ::Loggers::Base
     include Instrument

--- a/lib/vmdb/loggers/provider_sdk_logger.rb
+++ b/lib/vmdb/loggers/provider_sdk_logger.rb
@@ -1,11 +1,11 @@
 module Vmdb::Loggers
-  class ProviderSdkLogger < VMDBLogger
-    def initialize(*loggers, **kwargs)
+  class ProviderSdkLogger < ManageIQ::Loggers::Base
+    def initialize(*_, **_)
       super
 
       # pulled from Ruby's `Logger::Formatter`, which is what it defaults to when it is `nil`
       @datetime_format = "%Y-%m-%dT%H:%M:%S.%6N "
-      @formatter       = Vmdb::Loggers::ProviderSdkLogger::Formatter.new
+      @formatter = Formatter.new
     end
 
     def <<(msg)
@@ -14,7 +14,7 @@ module Vmdb::Loggers
       msg.size
     end
 
-    class Formatter < VMDBLogger::Formatter
+    class Formatter < ManageIQ::Loggers::Base::Formatter
       def call(severity, datetime, progname, msg)
         msg = msg.sub(/Bearer(.*?)\"/, 'Bearer [FILTERED] "')
         msg = msg.sub(/SharedKey(.*?)\"/, 'SharedKey [FILTERED] "')

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -73,9 +73,9 @@ module Vmdb
           next unless key.to_s.start_with?("level")
 
           level = value.to_s.upcase.to_sym
-          unless VMDBLogger::Severity.constants.include?(level)
+          unless Logger::Severity.constants.include?(level)
             valid = false
-            errors << [key, "#{key}, \"#{level}\", is invalid. Should be one of: #{VMDBLogger::Severity.constants.join(", ")}"]
+            errors << [key, "#{key}, \"#{level}\", is invalid. Should be one of: #{Logger::Severity.constants.join(", ")}"]
           end
         end
 

--- a/spec/lib/vmdb/appliance_spec.rb
+++ b/spec/lib/vmdb/appliance_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Vmdb::Appliance do
       before do
         stub_settings(fake_settings)
         allow(::Settings).to receive(:to_hash).and_return(fake_settings)
-        described_class.log_config(:logger => Logger.new(logger_io))
+        described_class.log_config(:logger => ManageIQ::Loggers::Base.new(logger_io))
       end
 
       it "filters out secrets" do

--- a/spec/lib/vmdb/loggers/fog_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/fog_logger_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Vmdb::Loggers::FogLogger do
   before do
     @log_stream = StringIO.new
     @log = described_class.new(@log_stream)
-    @log.level = VMDBLogger::DEBUG
+    @log.level = Logger::DEBUG
   end
 
   context ".instrument" do

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -178,27 +178,25 @@ RSpec.describe Vmdb::Loggers do
   end
 
   describe ".apply_config_value" do
-    before do
-      allow($log).to receive(:info)
-    end
-
     it "will update the main lower level logger instance" do
       log = described_class.create_logger(log_file_name)
-      described_class.apply_config_value({:foo => :info}, log, :foo)
 
-      expect(log.level).to eq(Logger::INFO)
+      described_class.apply_config_value({:level_foo => :error}, log, :level_foo)
+
+      expect(log.level).to eq(Logger::ERROR)
     end
 
     context "in a container environment" do
       around { |example| in_container_env(example) }
 
-      it "will always keep container logger as DEBUG" do
+      it "will honor the log level in the container logger" do
         log = described_class.create_logger(log_file_name)
         container_log = log.instance_variable_get(:@broadcast_logger)
-        described_class.apply_config_value({:foo => :info}, log, :foo)
 
-        expect(log.level).to           eq(Logger::INFO)
-        expect(container_log.level).to eq(Logger::INFO)
+        described_class.apply_config_value({:level_foo => :error}, log, :level_foo)
+
+        expect(log.level).to           eq(Logger::ERROR)
+        expect(container_log.level).to eq(Logger::ERROR)
       end
     end
   end

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -1,7 +1,7 @@
 require "stringio"
 
 RSpec.describe Vmdb::Loggers do
-  let(:log_file_name) { "foo.log" }
+  let(:log_file_name) { "#{SecureRandom.alphanumeric}.log" }
   let(:log_file_path) { Rails.root.join("log", log_file_name) }
 
   after do

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -4,8 +4,8 @@ $log.logdev = STDERR if ENV['LOG_TO_CONSOLE']
 
 # Set env var LOGLEVEL if you want custom log level during a local test
 # e.g. LOG_LEVEL=debug ruby spec/models/vm.rb
-env_level = VMDBLogger.const_get(ENV['LOG_LEVEL'].to_s.upcase) rescue nil if ENV['LOG_LEVEL']
-env_level ||= VMDBLogger::INFO
+env_level = Logger.const_get(ENV['LOG_LEVEL'].to_s.upcase) rescue nil if ENV['LOG_LEVEL']
+env_level ||= Logger::INFO
 $log.level = env_level
 Rails.logger.level = env_level
 

--- a/tools/ldap_ping.rb
+++ b/tools/ldap_ping.rb
@@ -1,23 +1,15 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 
-LOG_DIR = "./"
-logfile = File.join(LOG_DIR, "ldap_ping.log")
-$log = VMDBLogger.new(logfile)
-$log.level = VMDBLogger.const_get("INFO")
-
-def log(level, msg)
-  log_prefix = "LdapPing:"
-  puts "[#{Time.now.utc}] #{level.to_s.upcase}: #{msg}"
-  $log.send(level, "#{log_prefix} #{msg}")
-end
+$log = Vmdb::Loggers.create_logger("ldap_ping.log")
+$log.level = Logger::INFO
 
 #################################
-log(:info, "==================================")
-log(:info, "Starting")
+$log.info("==================================")
+$log.info("Starting")
 
 unless MiqLdap.using_ldap?
-  log(:info, "Not Configured to use LDAP")
+  $log.info("Not Configured to use LDAP")
   exit
 end
 
@@ -32,36 +24,36 @@ username     = ::Settings.authentication.bind_dn
 password     = ::Settings.authentication.bind_pwd
 bind_timeout = ::Settings.authentication.bind_timeout.to_i_with_method
 if ldap_hosts.to_s.strip.empty?
-  log(:info, "LDAP Host cannot be blank")
+  $log.info("LDAP Host cannot be blank")
   exit
 end
 
 ldap_addresses = []
 Array.wrap(ldap_hosts).each do |host|
   _canonical, _aliases, _type, *addresses = TCPSocket.gethostbyname(host)
-  log(:info, "Resolved host <#{host}> has these IP Address: #{addresses.inspect}")
+  $log.info("Resolved host <#{host}> has these IP Address: #{addresses.inspect}")
   ldap_addresses += addresses
 end
 
 ldap_addresses.each do |address|
   begin
-    log(:info, "----------------------------------")
-    log(:info, "Binding to LDAP: Host: <#{address}>, User: <#{username}>...")
+    $log.info("----------------------------------")
+    $log.info("Binding to LDAP: Host: <#{address}>, User: <#{username}>...")
     ldap     = MiqLdap.new(:host => address)
     raw_ldap = ldap.ldap
     raw_ldap.authenticate(username, password)
     Timeout.timeout(bind_timeout) do
       if raw_ldap.bind
-        log(:info, "Binding to LDAP: Host: <#{address}>, User: <#{username}>... successful")
+        $log.info("Binding to LDAP: Host: <#{address}>, User: <#{username}>... successful")
       else
-        log(:warn, "Binding to LDAP: Host: <#{address}>, User: <#{username}>... unsuccessful because <#{raw_ldap.get_operation_result.message}>")
+        $log.warn("Binding to LDAP: Host: <#{address}>, User: <#{username}>... unsuccessful because <#{raw_ldap.get_operation_result.message}>")
       end
     end
   rescue Exception => err
-    log(:warn, "Binding to LDAP: Host: <#{address}>, User: <#{username}>... failed because <#{err.message}>")
+    $log.warn("Binding to LDAP: Host: <#{address}>, User: <#{username}>... failed because <#{err.message}>")
   end
 end
 
-log(:info, "Done")
+$log.info("Done")
 
 exit 0

--- a/tools/purge_archived_vms.rb
+++ b/tools/purge_archived_vms.rb
@@ -6,8 +6,7 @@ ARCHIVE_CUTOFF = Time.now.utc - 1.month
 # If true, do not delete anything; only report:
 REPORT_ONLY = ActiveModel::Type::Boolean.new.cast(ENV.fetch("REPORT_ONLY", true))
 
-old_logger = $log
-$log = VMDBLogger.new(STDOUT)
+$log = Vmdb::Loggers.create_logger($stdout)
 $log.level = Logger::INFO
 
 query = Vm.where("updated_on < ? or updated_on IS NULL", ARCHIVE_CUTOFF)
@@ -37,6 +36,3 @@ end
 
 $log.info("Completed purging archived VMs. #{REPORT_ONLY ? 'Found' : 'Purged'} #{archived} archived VMs.")
 $log.info("To cleanup archived VMs re-run with REPORT_ONLY=false #{$PROGRAM_NAME}")
-
-$log.close
-$log = old_logger

--- a/tools/purge_ems_events.rb
+++ b/tools/purge_ems_events.rb
@@ -4,8 +4,7 @@ require File.expand_path('../config/environment', __dir__)
 KEEP_EVENTS  = 6.months
 PURGE_WINDOW = 1000
 
-old_logger = $log
-$log = VMDBLogger.new(STDOUT)
+$log = Vmdb::Loggers.create_logger($stdout)
 $log.level = Logger::INFO
 
 begin
@@ -13,6 +12,3 @@ begin
 rescue => err
   $log.log_backtrace(err)
 end
-
-$log.close
-$log = old_logger


### PR DESCRIPTION
This PR removes all usage of `VMDBLogger`, preferring `ManageIQ::Loggers::Base` via `Vmdb::Loggers.create_logger`

This PR also adds the ability to call `Vmdb::Loggers.create_logger` with a Pathname, String, or IO object, which is used in some of the tools.

After this PR `VmdbLogger` can be removed from manageiq-gems-pending: https://github.com/ManageIQ/manageiq-gems-pending/pull/529

Depends on 
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/7963
- [x] https://github.com/ManageIQ/manageiq/pull/21562
- [x] https://github.com/ManageIQ/manageiq/pull/21563
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/7965
 
???
Profit:  Remove `VMDBLogger.contents`
