### PR TITLE
avoid faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -278,10 +278,6 @@ unless ENV["APPLIANCE"]
     gem "coveralls",                    "~>0.8.23",          :require => false
     gem "db-query-matchers",            "~>0.10.0"
     gem "factory_bot",                  "~>5.1",             :require => false
-
-    # TODO: faker is used for url generation in git repository factory and the lenovo
-    # provider, via a xclarity_client dependency
-    gem "faker",                        ">1.8",             :require => false
     gem "timecop",                      "~>0.9",             :require => false
     gem "vcr",                          "~>5.0",             :require => false
     gem "webmock",                      "~>3.7",             :require => false

--- a/spec/factories/git_repository.rb
+++ b/spec/factories/git_repository.rb
@@ -1,9 +1,6 @@
 FactoryBot.define do
   factory :git_repository do
     sequence(:name) { |n| "git_repo_#{seq_padded_for_sorting(n)}" }
-    url do
-      require 'faker'
-      "https://#{Faker::Internet.domain_name}/#{Faker::Internet.domain_word}/#{Faker::Internet.domain_word}.git"
-    end
+    sequence(:url)  { |n| "https://host#{seq_padded_for_sorting(n)}.com/word/repo#{n}.git" }
   end
 end


### PR DESCRIPTION
Faker is giving some ruby 3 warnings. In this case, it this instance, it is easier to use our standard string from the sequence.

This addresses a few failures with https://github.com/ManageIQ/manageiq/pull/21531


FYI/ I also put in https://github.com/lenovo/xclarity_client/pull/155 and https://github.com/ManageIQ/manageiq-providers-lenovo/pull/341 to remove faker completely, but none of these dependend upon each other
