### PR TITLE
Remove usage of VMDBLogger#filename

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -92,7 +92,7 @@ module Vmdb
       new_level_name = (config[key] || "INFO").to_s.upcase
       new_level      = VMDBLogger.const_get(new_level_name)
       if old_level != new_level
-        $log.info("MIQ(#{name}.apply_config) Log level for #{File.basename(logger.filename)} has been changed to [#{new_level_name}]")
+        $log.info("MIQ(#{name}.apply_config) Log level for #{logger.progname} has been changed to [#{new_level_name}]")
         logger.level = new_level
       end
     end


### PR DESCRIPTION
progname is an existing public method that we now leverage, so we don't
need filename.

Part of https://github.com/ManageIQ/manageiq/pull/21558