### PR TITLE
Fix supports_attribute without a colname

### DIFF
--- a/app/models/ext_management_system/supports_attribute.rb
+++ b/app/models/ext_management_system/supports_attribute.rb
@@ -32,7 +32,9 @@ module ExtManagementSystem::SupportsAttribute
           class_by_ems(child_model)&.supports?(feature) || false
         end
       else
-        define_method(colname || "supports_#{feature}") do
+        colname ||= "supports_#{feature}"
+
+        define_method(colname) do
           supports?(feature)
         end
       end


### PR DESCRIPTION
If you use `supports_attribute` without a colname, just with `:feature => feature_name` defining the virtual_attribute fails ecause `colname` is `nil`

```
GET /api/providers?expand=resources&filter[]=supports_cloud_volume_create=true
{
  "error": {
    "kind": "bad_request",
    "message": "Must filter on valid attributes for resource",
    "klass": "Api::BadRequestError"
  }
}
```

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7960