### PR TITLE
[MORPHY] Remove x86 references introduced in #21555

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -889,7 +889,7 @@ GEM
     net-ssh (4.2.0)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.12.5)
       racc (~> 1.4)
     nori (2.6.0)
     oauth (0.5.8)
@@ -1168,7 +1168,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   activerecord-session_store (~> 2.0)


### PR DESCRIPTION
This is causing bundler issues on other architectures:

```bash
---> bundle lock --update --conservative --patch
/usr/share/gems/gems/psych-3.1.0/lib/psych.rb:237: warning: already initialized constant Psych::LIBYAML_VERSION
/usr/share/ruby/psych.rb:237: warning: previous definition of LIBYAML_VERSION was here
/usr/share/gems/gems/psych-3.1.0/lib/psych.rb:239: warning: already initialized constant Psych::NOT_GIVEN
/usr/share/ruby/psych.rb:239: warning: previous definition of NOT_GIVEN was here
Fetching https://github.com/ManageIQ/manageiq-v2v
Fetching https://github.com/ManageIQ/manageiq-ui-classic
Fetching https://github.com/ManageIQ/manageiq-decorators
Fetching https://github.com/ManageIQ/manageiq-consumption
Fetching https://github.com/ManageIQ/manageiq-content
Fetching https://github.com/ManageIQ/manageiq-graphql
Fetching https://github.com/ManageIQ/manageiq-api
Fetching https://github.com/ManageIQ/manageiq-automation_engine
Fetching https://github.com/ManageIQ/manageiq-providers-vmware
Fetching https://github.com/ManageIQ/manageiq-providers-scvmm
Fetching https://github.com/ManageIQ/manageiq-providers-ovirt
Fetching https://github.com/ManageIQ/manageiq-providers-openstack
Fetching https://github.com/ManageIQ/manageiq-providers-openshift
Fetching https://github.com/ManageIQ/manageiq-providers-redfish
Fetching https://github.com/ManageIQ/manageiq-providers-oracle_cloud
Fetching https://github.com/ManageIQ/manageiq-providers-nuage
Fetching https://github.com/ManageIQ/manageiq-providers-nsxt
Fetching https://github.com/ManageIQ/manageiq-providers-lenovo
Fetching https://github.com/ManageIQ/manageiq-providers-kubevirt
Fetching https://github.com/ManageIQ/manageiq-providers-kubernetes
Fetching https://github.com/ManageIQ/manageiq-providers-ibm_terraform
Fetching https://github.com/ManageIQ/manageiq-providers-ibm_power_vc
Fetching https://github.com/ManageIQ/manageiq-providers-ibm_cloud
Fetching https://github.com/ManageIQ/manageiq-providers-google
Fetching https://github.com/ManageIQ/manageiq-providers-foreman
Fetching https://github.com/ManageIQ/manageiq-providers-azure_stack
Fetching https://github.com/ManageIQ/manageiq-providers-azure
Fetching https://github.com/ManageIQ/manageiq-providers-autosde
Fetching https://github.com/ManageIQ/manageiq-providers-ansible_tower
Fetching https://github.com/ManageIQ/amazon_ssa_support.git
Fetching https://github.com/ManageIQ/manageiq-providers-amazon
Fetching https://github.com/ManageIQ/manageiq-schema
Fetching https://github.com/ManageIQ/manageiq-gems-pending.git
Fetching source index from https://rubygems.manageiq.org/
Fetching gem metadata from https://rubygems.org/......
Fetching source index from https://rubygems.org/
Resolving dependencies....................................................................................................................................................................................................................
Bundler could not find compatible versions for gem "handsoap":
  In snapshot (Gemfile.lock):
    handsoap (>= 0.2.5.5)

  In Gemfile:
    handsoap (= 0.2.5.5)

    manageiq-smartstate (~> 0.7.0) was resolved to 0.7.0, which depends on
      vmware_web_service (~> 2.0) was resolved to 2.1.1, which depends on
        handsoap (~> 0.2.5)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

Bundler could not find compatible versions for gem "linux_admin":
  In snapshot (Gemfile.lock):
    linux_admin (>= 2.0.2)

  In Gemfile:
    linux_admin (~> 2.0, >= 2.0.1)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

Bundler could not find compatible versions for gem "mini_portile2":
  In snapshot (Gemfile.lock):
    mini_portile2 (= 2.7.1)

  In Gemfile:
    handsoap (= 0.2.5.5) was resolved to 0.2.5.5, which depends on
      nokogiri (>= 1.2.3) was resolved to 1.12.5, which depends on
        mini_portile2 (~> 2.6.1)

    manageiq-messaging (~> 1.0) was resolved to 1.0.3, which depends on
      rdkafka (~> 0.8) was resolved to 0.10.0, which depends on
        mini_portile2 (~> 2.1)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

Bundler could not find compatible versions for gem "nokogiri":
  In snapshot (Gemfile.lock):
    nokogiri (= 1.12.5)

  In Gemfile:
    rails (~> 6.0.4, >= 6.0.4.1) was resolved to 6.0.4.1, which depends on
      actiontext (= 6.0.4.1) was resolved to 6.0.4.1, which depends on
        nokogiri (>= 1.8.5)

    handsoap (= 0.2.5.5) was resolved to 0.2.5.5, which depends on
      nokogiri (>= 1.2.3)

    linux_admin (~> 2.0, >= 2.0.1) was resolved to 2.0.2, which depends on
      nokogiri (>= 1.8.5, != 1.10.0, != 1.10.1, != 1.10.2, < 2)

    rails (~> 6.0.4, >= 6.0.4.1) was resolved to 6.0.4.1, which depends on
      actionpack (= 6.0.4.1) was resolved to 6.0.4.1, which depends on
rails-html-sanitizer (~> 1.0, >= 1.2.0) was resolved to 1.4.2, which
depends on
          loofah (~> 2.3) was resolved to 2.12.0, which depends on
            nokogiri (>= 1.5.9)

    rails (~> 6.0.4, >= 6.0.4.1) was resolved to 6.0.4.1, which depends on
      actionmailer (= 6.0.4.1) was resolved to 6.0.4.1, which depends on
        rails-dom-testing (~> 2.0) was resolved to 2.0.3, which depends on
          nokogiri (>= 1.6)

    wim_parser (~> 1.0) was resolved to 1.0.1, which depends on
      nokogiri (~> 1.10)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

Bundler could not find compatible versions for gem "wim_parser":
  In snapshot (Gemfile.lock):
    wim_parser (>= 1.0.1)

  In Gemfile:
    wim_parser (~> 1.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```