### PR TITLE
Fix group level and names for miq event

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -22,8 +22,9 @@ class EmsEvent < EventStream
 
   def self.group_names_and_levels
     result = {:description => description}
+    result[:group_names] = {DEFAULT_GROUP_NAME => DEFAULT_GROUP_NAME.to_s.capitalize}
+
     event_groups.each_with_object(result) do |(group_name, group_details), hash|
-      hash[:group_names] ||= {}
       hash[:group_names][group_name] = group_details[:name]
 
       group_details.each_key do |level|

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -21,10 +21,7 @@ class EmsEvent < EventStream
   end
 
   def self.group_names_and_levels
-    result = {:description => description}
-    result[:group_names] = {DEFAULT_GROUP_NAME => DEFAULT_GROUP_NAME.to_s.capitalize}
-
-    event_groups.each_with_object(result) do |(group_name, group_details), hash|
+    event_groups.each_with_object(default_group_names_and_levels) do |(group_name, group_details), hash|
       hash[:group_names][group_name] = group_details[:name]
 
       group_details.each_key do |level|

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -10,8 +10,14 @@ class EmsEvent < EventStream
     'Rename_Task',
   ]
 
+  CLASS_GROUP_LEVELS = %i[critical warning].freeze
+
   def self.description
     _("Management Events")
+  end
+
+  def self.class_group_levels
+    CLASS_GROUP_LEVELS
   end
 
   def self.group_names_and_levels

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -35,8 +35,8 @@ class EventStream < ApplicationRecord
 
   after_commit :emit_notifications, :on => :create
 
+  DEFAULT_GROUP_NAME  = :other
   DEFAULT_GROUP_LEVEL = :detail
-  DEFAULT_GROUP = :other
 
   def self.description
     raise NotImplementedError, "Description must be implemented in a subclass"
@@ -87,14 +87,14 @@ class EventStream < ApplicationRecord
         .tap { |level_found| level = level_found || level }
     end&.first
 
-    group ||= DEFAULT_GROUP
+    group ||= DEFAULT_GROUP_NAME
     return group, level
   end
 
   def self.group_name(group)
     return if group.nil?
     group = event_groups[group.to_sym]
-    group.nil? ? 'Other' : group[:name]
+    group.nil? ? DEFAULT_GROUP_NAME.to_s.capitalize : group[:name]
   end
 
   # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -120,6 +120,14 @@ class EventStream < ApplicationRecord
     EventStream.subclasses.select { |e| e.respond_to?(:group_names_and_levels) }
   end
 
+  def self.default_group_names_and_levels
+    {
+      :description  => description,
+      :group_names  => {DEFAULT_GROUP_NAME => DEFAULT_GROUP_NAME.to_s.capitalize},
+      :group_levels => {}
+    }.freeze
+  end
+
   def self.timeline_options
     timeline_classes.map { |c| [c.name.to_sym, c.group_names_and_levels] }.to_h
   end

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -36,7 +36,8 @@ class MiqEvent < EventStream
 
   def self.group_names_and_levels
     hash = {:description => description}
-    hash[:group_names] = MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys
+    hash[:group_names] = {DEFAULT_GROUP_NAME => DEFAULT_GROUP_NAME.to_s.capitalize}
+    hash[:group_names].merge!(MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys)
 
     group_levels.each do |level|
       hash[:group_levels] ||= {}

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -35,12 +35,9 @@ class MiqEvent < EventStream
   end
 
   def self.group_names_and_levels
-    hash = {:description => description}
-    hash[:group_names] = {DEFAULT_GROUP_NAME => DEFAULT_GROUP_NAME.to_s.capitalize}
+    hash = default_group_names_and_levels
     hash[:group_names].merge!(MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys)
-
     group_levels.each do |level|
-      hash[:group_levels] ||= {}
       hash[:group_levels][level] ||= level.to_s.capitalize
     end
     hash

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -20,6 +20,16 @@ class MiqEvent < EventStream
                                         ContainerReplicator, ContainerGroup, ContainerProject,
                                         ContainerNode, ContainerImage, PhysicalServer].freeze
 
+  CLASS_GROUP_LEVELS = [MiqPolicy::CONDITION_SUCCESS, MiqPolicy::CONDITION_FAILURE].collect { |level| level.downcase.to_sym }
+
+  def self.description
+    _("Management Events")
+  end
+
+  def self.class_group_levels
+    CLASS_GROUP_LEVELS
+  end
+
   def self.description
     _("Policy Events")
   end
@@ -27,7 +37,11 @@ class MiqEvent < EventStream
   def self.group_names_and_levels
     hash = {:description => description}
     hash[:group_names] = MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys
-    hash[:group_levels] = [MiqPolicy::CONDITION_SUCCESS, MiqPolicy::CONDITION_FAILURE].index_by { |c| c.downcase.to_sym }
+
+    group_levels.each do |level|
+      hash[:group_levels] ||= {}
+      hash[:group_levels][level] ||= level.to_s.capitalize
+    end
     hash
   end
 

--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -37,12 +37,16 @@ RSpec.describe EventStream do
       expect(options[:EmsEvent].keys.sort).to eq %i[description group_levels group_names]
       expect(options[:EmsEvent][:description]).to eq(EmsEvent.description)
       expect(options[:EmsEvent][:group_levels].keys.sort).to eq %i[critical detail warning]
-      expect(options[:EmsEvent][:group_names].keys).to include(*%i[addition configuration console deletion devices])
+      expect(options[:EmsEvent][:group_levels].values.sort).to eq %w[Critical Detail Warning]
+      expect(options[:EmsEvent][:group_names].keys).to include(*%i[addition configuration console deletion devices other])
+      expect(options[:EmsEvent][:group_names].values).to include(*%w[Network Status Other])
 
       expect(options[:MiqEvent].keys.sort).to eq %i[description group_levels group_names]
       expect(options[:MiqEvent][:description]).to eq(MiqEvent.description)
       expect(options[:MiqEvent][:group_levels].keys.sort).to eq %i[detail failure success]
-      expect(options[:MiqEvent][:group_names].keys).to include(*%i[auth_validation authentication compliance container_operations ems_operations evm_operations])
+      expect(options[:MiqEvent][:group_levels].values.sort).to eq %w[Detail Failure Success]
+      expect(options[:MiqEvent][:group_names].keys).to include(*%i[auth_validation authentication compliance container_operations ems_operations evm_operations other])
+      expect(options[:MiqEvent][:group_names].values).to include(*%w[Other Compliance])
     end
   end
 end

--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe EventStream do
   describe ".event_groups" do
     EventStream.event_groups.each do |group_name, group_data|
-      EventStream::GROUP_LEVELS.each do |level|
+      (EmsEvent.group_levels + MiqEvent.group_levels).each do |level|
         group_data[level]&.each do |typ|
           it ":#{group_name}/:#{level}/#{typ} is string or regex", :providers_common => true do
             expect(typ.kind_of?(Regexp) || typ.kind_of?(String)).to eq(true)
@@ -41,7 +41,7 @@ RSpec.describe EventStream do
 
       expect(options[:MiqEvent].keys.sort).to eq %i[description group_levels group_names]
       expect(options[:MiqEvent][:description]).to eq(MiqEvent.description)
-      expect(options[:MiqEvent][:group_levels].keys.sort).to eq %i[failure success]
+      expect(options[:MiqEvent][:group_levels].keys.sort).to eq %i[detail failure success]
       expect(options[:MiqEvent][:group_names].keys).to include(*%i[auth_validation authentication compliance container_operations ems_operations evm_operations])
     end
   end


### PR DESCRIPTION
I was noticing that https://github.com/ManageIQ/manageiq-api/pull/1099 OPTIONS for event_streams was missing "other" and "detail" after https://github.com/ManageIQ/manageiq/pull/21552 was merged.

Part of https://github.com/ManageIQ/manageiq-api/issues/1090

I realized this is because we had defaults for "other" and "detail" buried in code and didn't have defaults in the base class with overrides in the subclasses.  This PR fixes some of this.

Here's an example of the JSON diff for OPTIONS on event_streams before and after this PR:

```diff
joerafaniello@Joes-MBP-2 manageiq % diff -u before.txt after.txt
--- before.txt	2021-11-19 15:17:47.000000000 -0500
+++ after.txt	2021-11-19 15:10:50.000000000 -0500
@@ -86,6 +86,7 @@
             "EmsEvent": {
                 "description": "Management Events",
                 "group_names": {
+                    "other": "Other",
                     "addition": "Creation/Addition",
                     "configuration": "Configuration/Reconfiguration",
                     "console": "Console Activity",
@@ -113,6 +114,7 @@
             "MiqEvent": {
                 "description": "Policy Events",
                 "group_names": {
+                    "other": "Other",
                     "ems_operations": "Provider Operation",
                     "host_operations": "Host Operation",
                     "compliance": "Compliance",
@@ -132,7 +134,8 @@
                 },
                 "group_levels": {
                     "success": "Success",
-                    "failure": "Failure"
+                    "failure": "Failure",
+                    "detail": "Detail"
                 }
             }
         }

```