### PR TITLE
Remove references to PostgresAdmin

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -1,5 +1,3 @@
-require 'util/postgres_admin'
-
 module MiqServer::LogManagement
   extend ActiveSupport::Concern
 
@@ -72,7 +70,7 @@ module MiqServer::LogManagement
   end
 
   def pg_data_dir
-    PostgresAdmin.data_directory
+    Pathname.new(ENV.fetch("APPLIANCE_PG_DATA"))
   end
 
   def pg_log_patterns

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -73,18 +73,18 @@ namespace :evm do
   namespace :db do
     desc 'Start the local ManageIQ EVM Database (VMDB)'
     task :start do
-      LinuxAdmin::Service.new(PostgresAdmin.service_name).start
+      LinuxAdmin::Service.new(ENV.fetch("APPLIANCE_PG_SERVICE")).start
     end
 
     desc 'Stop the local ManageIQ EVM Database (VMDB)'
     task :stop do
-      LinuxAdmin::Service.new(PostgresAdmin.service_name).stop
+      LinuxAdmin::Service.new(ENV.fetch("APPLIANCE_PG_SERVICE")).stop
     end
 
     # Start the EVM Database silently - not to be a visible rake task
     task :silent_start do
       begin
-        LinuxAdmin::Service.new(PostgresAdmin.service_name).start
+        LinuxAdmin::Service.new(ENV.fetch("APPLIANCE_PG_SERVICE")).start
       rescue AwesomeSpawn::CommandResultError
         # ignore issues (ala silent)
       end
@@ -93,7 +93,7 @@ namespace :evm do
     # Stop the EVM Database silently - not to be a visible rake task
     task :silent_stop do
       begin
-        LinuxAdmin::Service.new(PostgresAdmin.service_name).stop
+        LinuxAdmin::Service.new(ENV.fetch("APPLIANCE_PG_SERVICE")).stop
       rescue AwesomeSpawn::CommandResultError
         # ignore issues (ala silent)
       end


### PR DESCRIPTION
@jrafanie Please review.

Goal here is to kill PostgresAdmin, so I'm just replacing the references to it as opposed to figuring out if these things should live in core or not at all.

After this PR all references will be removed and we can proceed with https://github.com/ManageIQ/manageiq-gems-pending/pull/516