### PR TITLE
Creation of host initiator group

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -317,6 +317,7 @@ class ExtManagementSystem < ApplicationRecord
   supports_attribute :feature => :storage_services
   supports_attribute :feature => :add_storage
   supports_attribute :feature => :add_host_initiator
+  supports_attribute :supports_create_host_initiator_group, :child_model => "HostInitiatorGroup"
   supports_attribute :feature => :add_volume_mapping
 
   virtual_sum :total_vcpus,        :hosts, :total_vcpus


### PR DESCRIPTION
In this set of PRs we will allow users to create new host-initiator-groups on their storage systems through MIQ.

Part of https://github.com/ManageIQ/manageiq-providers-autosde/issues/108

![image](https://user-images.githubusercontent.com/68283004/143038710-7020280e-7251-4bdb-b268-3f02e4d45f23.png)

![image](https://user-images.githubusercontent.com/68283004/143039248-ee83b398-7ad2-4052-9c70-81bbdfabd1c8.png)
