### PR TITLE
Supports manager create

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -41,11 +41,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.supported_types_for_create
-    permitted_subclasses.select(&:supported_for_create?)
-  end
-
-  def self.supported_for_create?
-    !reflections.include?("parent_manager")
+    subclasses_supporting(:create)
   end
 
   def self.label_mapping_prefixes
@@ -157,8 +153,6 @@ class ExtManagementSystem < ApplicationRecord
   supports_not :cloud_volume_create
   supports_not :console
   supports_not :discovery
-  supports_not :ems_network_new
-  supports_not :ems_storage_new
   supports_not :label_mapping
   supports_not :metrics
   supports_not :object_storage

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -8,10 +8,6 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
 
   supports :catalog
 
-  def self.supported_for_create?
-    false
-  end
-
   def self.catalog_types
     {"generic_ansible_playbook" => N_("Ansible Playbook")}
   end

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -9,7 +9,6 @@ module ManageIQ::Providers
       define_method(:singular_route_key) { "ems_network" }
     end
 
-    supports_not :ems_network_new
     supports_not :cloud_tenant_mapping
     supports_not :create_floating_ip
     supports_not :create_network_router

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -7,7 +7,6 @@ module ManageIQ::Providers
     supports_not :cloud_object_store_container_create
     supports_not :cloud_volume
     supports_not :cloud_volume_create
-    supports_not :ems_storage_new
     supports_not :object_storage
     supports_not :smartstate_analysis
     supports_not :storage_services


### PR DESCRIPTION
Depends: 

- [x] https://github.com/ManageIQ/manageiq/pull/21553

### Goal

Moving from a custom method `supported_for_create?` to `supports :create`
Moving from parent classes defining `:create` to the actual classes themselves defining it.

Also converted network managers and storage across to follow the same pattern.

only real question marks I had was physical infra provider. I did that. figure it would be easier to find one extra one that I added rather than missing one.

I also noticed ui classic had 2 mixins that would be nice to remove. But there are quite a few other classes that follow this code path and it seemed safer to leave that code be. Not sure how many of these classes do declare `supports :update`

### Other required PRs

- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/7985
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/731
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/270
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/120
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/110
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/486
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/71
- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/94
- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/206
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/306
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/33
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/71
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/454
- [x] ~~https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/192~~
- [x] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/343
- [x] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/50
- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/257
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/217
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/757
- [ ] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/37
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/587
- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/149
- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/197
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/767
