### PR TITLE
Add common provider regions logic to core

### DIFF
--- a/app/models/manageiq/providers/regions.rb
+++ b/app/models/manageiq/providers/regions.rb
@@ -1,0 +1,46 @@
+module ManageIQ::Providers
+  class Regions
+    class << self
+      def regions
+        from_file.merge(additional_regions).except(*disabled_regions)
+      end
+
+      def all
+        regions.values
+      end
+
+      def names
+        regions.keys
+      end
+
+      def find_by_name(name)
+        regions[name]
+      end
+
+      private
+
+      def from_file
+        # Memoize the regions file as this should not change at runtime
+        @from_file ||= YAML.load_file(regions_yml).transform_values(&:freeze).freeze
+      end
+
+      def additional_regions
+        Settings.dig(:ems, ems_type, :additional_regions).to_h.stringify_keys
+      end
+
+      def disabled_regions
+        Settings.dig(:ems, ems_type, :disabled_regions).to_a
+      end
+
+      def ems_type
+        vendor = module_parent.name.sub("ManageIQ::Providers::", "").sub("::", "_").downcase
+
+        "ems_#{vendor}".to_sym
+      end
+
+      def regions_yml
+        module_parent::Engine.root.join("config/regions.yml")
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/regions.rb
+++ b/app/models/manageiq/providers/regions.rb
@@ -13,10 +13,6 @@ module ManageIQ::Providers
         regions.keys
       end
 
-      def find_by_name(name)
-        regions[name]
-      end
-
       private
 
       def from_file


### PR DESCRIPTION
A number of providers implement very similar "load default regions from yaml file, allow additional regions from settings, disable regions from settings".

This can be simplified by moving the common logic to core and allowing providers to simply subclass this.

Follow-ups:
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/728
* https://github.com/ManageIQ/manageiq-providers-azure/pull/483

Future:
* Update other providers' `Regions` to inherit from this, thus adding support for runtime additional/disabled regions