### PR TITLE
Extend timeout for destroying an EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -685,7 +685,7 @@ class ExtManagementSystem < ApplicationRecord
       :message => msg
     )
 
-    orchestrate_destroy_queue(task.id, queue_options)
+    orchestrate_destroy_queue(task.id, queue_options.reverse_merge(:msg_timeout => 3_600))
 
     task.id
   end


### PR DESCRIPTION
Destroying a large EMS can take a significant amount of time, extend the msg_timeout from the default 10 minutes to 1 hour.

This is a "quick fix" to handle 90% of the cases, there is still the possibility that this can take significantly longer especially if there are tens-of-thousands to hundreds-of-thousands of child records.  We've seen this operation take days and so more work to be able to handle extremely large providers needs to be done in a follow-up"

https://github.com/ManageIQ/manageiq/issues/21575