### PR TITLE
[WIP] Purge miq requests every 6 months

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -1,6 +1,8 @@
 class MiqRequest < ApplicationRecord
   extend InterRegionApiMethodRelay
 
+  include_concern 'Purging'
+
   ACTIVE_STATES = %w(active queued)
   REQUEST_UNIQUE_KEYS = %w(id state status created_on updated_on type).freeze
 

--- a/app/models/miq_request/purging.rb
+++ b/app/models/miq_request/purging.rb
@@ -1,0 +1,27 @@
+class MiqRequest
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.miq_request.history.keep_miq_requests.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.miq_request.history.purge_window_size
+      end
+
+      def purge_scope(older_than)
+        MiqRequest.where(arel_table[:created_on].lt(older_than))
+      end
+
+      # this is MiqRequest#destroy hook (defined by relationships on MiqRequest)
+      def purge_associated_records(ids)
+        # sorry for the destroy. this needs to be recursive:
+        MiqRequestTask.where(:miq_request_id => ids).destroy_all
+        MiqApproval.where(:miq_request_id => ids).delete_all
+      end
+    end
+  end
+end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -109,6 +109,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "EventStream", :method_name => "purge_timer", :zone => nil)
   end
 
+  def miq_request_purge_timer
+    queue_work(:class_name => "MiqRequest", :method_name => "purge_timer", :zone => nil)
+  end
+
   def notification_purge_timer
     queue_work(:class_name => "Notification", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -254,6 +254,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:notification_purge_timer)
     end
 
+    # Schedule - Purging of MiqRequests
+    scheduler.schedule_every(
+      :miq_request_purge_timer,
+      worker_settings[:miq_request_purge_interval]
+    ) do
+      enqueue(:miq_request_purge_timer)
+    end
+
     # Schedule - Purging of tasks
     scheduler.schedule_every(
       :task_purge_timer,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -868,6 +868,10 @@
   :secret_filter: []
 :messaging:
   :type: miq_queue
+:miq_request:
+  :history:
+    :purge_window_size: 2000
+    :keep_miq_requests: 6.months
 :notifications:
   :history:
     :purge_window_size: 1000
@@ -1140,6 +1144,7 @@
       :evm_snapshot_interval: 1.hour
       :job_timeout_interval: 60.seconds
       :log_active_configuration_interval: 1.days
+      :miq_request_purge_interval: 1.week
       :nice_delta: 3
       :notifications_purge_interval: 1.day
       :orchestration_stack_retired_interval: 10.minutes

--- a/spec/models/miq_request/purging_spec.rb
+++ b/spec/models/miq_request/purging_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe MiqRequest do
+  let(:user) { FactoryBot.create(:user) }
+  context "::Purging" do
+    describe ".purge_by_date" do
+      before do
+        Timecop.freeze(7.months.ago) do
+          @old_request = FactoryBot.create(:vm_migrate_request, :requester => user)
+
+          FactoryBot.create(:miq_request_task, :miq_request => @old_request)
+          parent_task = FactoryBot.create(:miq_request_task, :miq_request => @old_request)
+          FactoryBot.create(:miq_request_task, :miq_request_task => parent_task)
+
+          FactoryBot.create(:miq_approval, :miq_request => @old_request)
+          FactoryBot.create(:miq_approval, :miq_request => @old_request)
+        end
+
+        Timecop.freeze(6.days.ago) do
+          @new_request = FactoryBot.create(:vm_migrate_request, :requester => user)
+          parent_task = FactoryBot.create(:miq_request_task, :miq_request => @new_request)
+          FactoryBot.create(:miq_request_task, :miq_request_task => parent_task)
+          FactoryBot.create(:miq_approval, :miq_request => @new_request)
+          FactoryBot.create(:miq_approval, :miq_request => @new_request)
+        end
+      end
+
+      it "purges old finished tasks" do
+        expect(described_class.all).to match_array([@old_request, @new_request])
+        expect(MiqRequestTask.count).to eq(5)
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.all).to match_array([@new_request])
+        expect(MiqRequestTask.count).to eq(2)
+      end
+    end
+
+    describe ".purge_timer" do
+      it "queues the correct purge method" do
+        EvmSpecHelper.local_miq_server
+        described_class.purge_timer
+        q = MiqQueue.first
+        expect(q).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have no process to clear out miq requests.

If we do not want to automatically delete these, I would feel more comfortable putting most of this PR in but removing the scheduler to automatically create them.

I am concerned about `MiqRequestTask.where().destroy_all`. I remember there was some trick with the tasks that do have child tasks, but can't remember the actual nuance. For this reason, I stuck with destroy. But we are going to bring a lot of records over the wire. `MiqApproval` is more straight forward and we can use `delete_all`
