### PR TITLE
Fix storage_manager parent_inventory_collections

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
@@ -23,7 +23,6 @@ module ManageIQ::Providers
         end
 
         def host_initiators
-          add_properties(:parent_inventory_collections => [:physical_storages])
           add_common_default_values
         end
 
@@ -40,12 +39,10 @@ module ManageIQ::Providers
         end
 
         def san_addresses
-          add_properties(:parent_inventory_collections => %i[host_initiators])
           add_common_default_values
         end
 
         def storage_resources
-          add_properties(:parent_inventory_collections => %i[physical_storages])
           add_common_default_values
         end
 


### PR DESCRIPTION
These invalid parent_inventory_collections are causing failures during targeted refresh of an autosde provider

Required for:
* https://github.com/ManageIQ/manageiq-providers-autosde/pull/115