### PR TITLE
Add PhysicalStorage and CloudVolume to supported target type array

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -84,7 +84,7 @@ module EmsRefresh
       target_class = target_class.to_s.constantize unless target_class.kind_of?(Class)
 
       if ManageIQ::Providers::Inventory.persister_class_for(target_class).blank? &&
-         [VmOrTemplate, Host, PhysicalServer, ExtManagementSystem, InventoryRefresh::Target].none? { |k| target_class <= k }
+         [VmOrTemplate, Host, PhysicalServer, PhysicalStorage, CloudVolume, ExtManagementSystem, InventoryRefresh::Target].none? { |k| target_class <= k }
         _log.warn("Unknown target type: [#{target_class}].")
         next
       end


### PR DESCRIPTION
Targeted refresh support was added to Autosde CloudVolume and PhysicalStorage  but in order for it to work properly we need to update get_target_objects() to acknoladge them.



links
---------
target refresh need additional fixes in order to work properly. the fixes are done in:
https://github.com/ManageIQ/manageiq/pull/21582
https://github.com/ManageIQ/manageiq-providers-autosde/pull/115
https://github.com/ManageIQ/manageiq-providers-autosde/pull/114