### PR TITLE
[WIP] Normalize event_where_clause to return relations for EventStream subclasses

### DIFF
--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -36,7 +36,11 @@ class AvailabilityZone < ApplicationRecord
     ems ? ems.my_zone : MiqServer.my_zone
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.availability_zone_id = ?", id]
+  def event_where_clause_ems_events
+    EmsEvent.where(:availability_zone_id => id)
+  end
+
+  def event_where_clause_miq_events
+    MiqEvent.where(:availability_zone_id => id)
   end
 end

--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -35,12 +35,4 @@ class AvailabilityZone < ApplicationRecord
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
   end
-
-  def event_where_clause_ems_events
-    EmsEvent.where(:availability_zone_id => id)
-  end
-
-  def event_where_clause_miq_events
-    MiqEvent.where(:availability_zone_id => id)
-  end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -27,16 +27,17 @@ class Container < ApplicationRecord
 
   acts_as_miq_taggable
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      # TODO: improve relationship using the id
-      ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ? AND container_name = ?",
-       container_project.try(:name), ext_management_system.try(:id), name]
-    when :policy_events
-      # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ext_management_system.try(:id)]
-    end
+  def event_where_clause_ems_events
+    # TODO: improve relationship using the id
+    EmsEvent
+      .where(:container_name => name)
+      .where(:container_namespace => container_project.try(:name))
+      .where(:ems_id => ext_management_system.try(:id))
+  end
+
+  def event_where_clause_miq_events
+    # TODO: implement policy events and its relationship
+    MiqEvent.where(:ems_id => ext_management_system.try(:id))
   end
 
   PERF_ROLLUP_CHILDREN = []

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -66,16 +66,17 @@ class ContainerGroup < ApplicationRecord
   include EventMixin
   include Metric::CiMixin
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      # TODO: improve relationship using the id
-      ["container_namespace = ? AND container_group_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
-       container_project.try(:name), name, ems_id]
-    when :policy_events
-      # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
-    end
+  def event_where_clause_ems_events
+    # TODO: improve relationship using the id
+    EmsEvent
+      .where(:container_namespace => container_project.try(:name))
+      .where(:container_group_name => name)
+      .where(:ems_id => ems_id)
+  end
+
+  def event_where_clause_miq_events
+    # TODO: implement policy events and its relationship
+    MiqEvent.where(:ems_id => ems_id)
   end
 
   PERF_ROLLUP_CHILDREN = []

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -60,15 +60,16 @@ class ContainerNode < ApplicationRecord
   include Metric::CiMixin
   include CustomAttributeMixin
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      # TODO: improve relationship using the id
-      ["container_node_name = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
-    when :policy_events
-      # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
-    end
+  def event_where_clause_ems_events
+    # TODO: improve relationship using the id
+    EmsEvent
+      .where(:container_node_name => name)
+      .where(:ems_id => ems_id)
+  end
+
+  def event_where_clause_miq_events
+    # TODO: implement policy events and its relationship
+    MiqEvent.where(:ems_id => ems_id)
   end
 
   # TODO: children will be container groups

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -55,15 +55,16 @@ class ContainerProject < ApplicationRecord
     ContainerGroup.where(:container_project_id => id).or(ContainerGroup.where(:old_container_project_id => id))
   end
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      # TODO: improve relationship using the id
-      ["container_namespace = ? AND #{events_table_name(assoc)}.ems_id = ?", name, ems_id]
-    when :policy_events
-      # TODO: implement policy events and its relationship
-      ["ems_id = ?", ems_id]
-    end
+  def event_where_clause_ems_events
+    # TODO: improve relationship using the id
+    EmsEvent
+      .where(:container_namespace => name)
+      .where(:ems_id => ems_id)
+  end
+
+  def event_where_clause_miq_events
+    # TODO: implement policy events and its relationship
+    MiqEvent.where(:ems_id => ems_id)
   end
 
   def perf_rollup_parents(_interval_name = nil)

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -25,16 +25,16 @@ class ContainerReplicator < ApplicationRecord
 
   PERF_ROLLUP_CHILDREN = [:container_groups]
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      # TODO: improve relationship using the id
-      ["container_namespace = ? AND container_replicator_name = ? AND #{events_table_name(assoc)}.ems_id = ?",
-       container_project.name, name, ems_id]
-    when :policy_events
-      # TODO: implement policy events and its relationship
-      ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
-    end
+  def event_where_clause_ems_events
+    EmsEvent
+      .where(:container_namespace => container_project.name)
+      .where(:container_replicator_name => name)
+      .where(:ems_id => ems_id)
+  end
+
+  def event_where_clause_miq_events
+    # TODO: implement policy events and its relationship
+    MiqEvent.where(:ems_id => ems_id)
   end
 
   def perf_rollup_parents(_interval_name = nil)

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -183,14 +183,10 @@ class EmsCluster < ApplicationRecord
   end
 
   def event_where_clause_ems_events
-    EmsEvent.where(:ems_cluster_id => id)
+    super
       .or(EmsEvent.where(:host_id => host_ids))
       .or(EmsEvent.where(:vm_or_template_id => vm_or_template_ids))
       .or(EmsEvent.where(:dest_vm_or_template_id => vm_or_template_ids))
-  end
-
-  def event_where_clause_miq_events
-    MiqEvent.where(:ems_cluster_id => id)
   end
 
   def ems_events

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -804,14 +804,6 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  def event_where_clause_ems_events
-    EmsEvent.where("event_streams.ems_id" => id)
-  end
-
-  def event_where_clause_miq_events
-    MiqEvent.where("event_streams.ems_id" => id)
-  end
-
   def vm_count_by_state(state)
     vms.inject(0) { |t, vm| vm.power_state == state ? t + 1 : t }
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -804,8 +804,12 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.ems_id = ?", id]
+  def event_where_clause_ems_events
+    EmsEvent.where("event_streams.ems_id" => id)
+  end
+
+  def event_where_clause_miq_events
+    MiqEvent.where("event_streams.ems_id" => id)
   end
 
   def vm_count_by_state(state)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1503,12 +1503,7 @@ class Host < ApplicationRecord
   end
 
   def event_where_clause_ems_events
-    EmsEvent.where(:host_id => id)
-      .or(EmsEvent.where(:dest_host_id => id))
-  end
-
-  def event_where_clause_miq_events
-    MiqEvent.where(:host_id => id)
+    super.or(EmsEvent.where(:dest_host_id => id))
   end
 
   def has_vm_scan_affinity?

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1502,13 +1502,13 @@ class Host < ApplicationRecord
     services.order(:name).uniq.pluck(:name)
   end
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      ["host_id = ? OR dest_host_id = ?", id, id]
-    when :policy_events
-      ["host_id = ?", id]
-    end
+  def event_where_clause_ems_events
+    EmsEvent.where(:host_id => id)
+      .or(EmsEvent.where(:dest_host_id => id))
+  end
+
+  def event_where_clause_miq_events
+    MiqEvent.where(:host_id => id)
   end
 
   def has_vm_scan_affinity?

--- a/app/models/mixins/event_mixin.rb
+++ b/app/models/mixins/event_mixin.rb
@@ -1,4 +1,11 @@
-# EventMixin expects that event_where_clause is defined in the model.
+# EventMixin expects that event_where_clause_ems_events is defined as most
+# classes have specific columns added to event_streams for their type.
+# Alternatively, a model can override event_where_clause for custom logic.
+#
+# event_where_clause_miq_events defaults to automatically lookup policy events via the
+# belongs_to target (target_type, target_id) association.
+# If this isn't how policy events are created for a class, that class would need to be override
+# this method with custom logic.
 module EventMixin
   extend ActiveSupport::Concern
 
@@ -34,6 +41,15 @@ module EventMixin
 
   def events_table_name(assoc)
     events_assoc_class(assoc).table_name
+  end
+
+  def event_where_clause(assoc = :ems_events)
+    case assoc.to_sym
+    when :ems_events, :event_streams
+      event_where_clause_ems_events
+    when :miq_events, :policy_events
+      event_where_clause_miq_events
+    end
   end
 
   private

--- a/app/models/physical_chassis.rb
+++ b/app/models/physical_chassis.rb
@@ -31,7 +31,11 @@ class PhysicalChassis < ApplicationRecord
     ems ? ems.my_zone : MiqServer.my_zone
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.physical_chassis_id = ?", id]
+  def event_where_clause_ems_events
+    EmsEvent.where(:physical_chassis_id => id)
+  end
+
+  def event_where_clause_miq_events
+    MiqEvent.where(:physical_chassis_id => id)
   end
 end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -79,8 +79,12 @@ class PhysicalServer < ApplicationRecord
     ems ? ems.my_zone : MiqServer.my_zone
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.physical_server_id = ?", id]
+  def event_where_clause_ems_events
+    EmsEvent.where(:physical_server_id => id)
+  end
+
+  def event_where_clause_miq_events
+    MiqEvent.where(:physical_server_id => id)
   end
 
   def v_availability

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -25,6 +25,12 @@ class PhysicalSwitch < Switch
     ems ? ems.my_zone : MiqServer.my_zone
   end
 
+  # Must define these methods because EventMixin#belongs_to_column_id uses base class
+  # to guess the column name, which results in: switch_id.
+  def event_where_clause_ems_events
+    EmsEvent.where(:physical_switch_id => id)
+  end
+
   def event_where_clause_miq_events
     MiqEvent.where(:physical_switch_id => id)
   end

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -25,8 +25,8 @@ class PhysicalSwitch < Switch
     ems ? ems.my_zone : MiqServer.my_zone
   end
 
-  def event_where_clause(assoc = :ems_events)
-    ["#{events_table_name(assoc)}.physical_switch_id = ?", id]
+  def event_where_clause_miq_events
+    MiqEvent.where(:physical_switch_id => id)
   end
 
   def self.display_name(number = 1)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1289,11 +1289,12 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def event_where_clause_ems_events
-    EmsEvent.where("event_streams.vm_or_template_id" => id).or(EmsEvent.where("event_streams.dest_vm_or_template_id" => id))
+    super.or(EmsEvent.where("event_streams.dest_vm_or_template_id" => id))
   end
 
   def event_where_clause_miq_events
-    MiqEvent.where(["vm_or_template_id= ? OR (target_id = ? AND target_type = ?) ", id, id, self.class.base_class.name])
+    super.or(MiqEvent.where(:target_id => id)
+                     .where(:target_type => self.class.base_class.name))
   end
 
   # Virtual columns for owning resource pool, folder and datacenter

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1288,13 +1288,12 @@ class VmOrTemplate < ApplicationRecord
     ent
   end
 
-  def event_where_clause(assoc = :ems_events)
-    case assoc.to_sym
-    when :ems_events, :event_streams
-      return ["vm_or_template_id = ? OR dest_vm_or_template_id = ? ", id, id]
-    when :policy_events
-      return ["target_id = ? and target_class = ? ", id, self.class.base_class.name]
-    end
+  def event_where_clause_ems_events
+    EmsEvent.where("event_streams.vm_or_template_id" => id).or(EmsEvent.where("event_streams.dest_vm_or_template_id" => id))
+  end
+
+  def event_where_clause_miq_events
+    MiqEvent.where(["vm_or_template_id= ? OR (target_id = ? AND target_type = ?) ", id, id, self.class.base_class.name])
   end
 
   # Virtual columns for owning resource pool, folder and datacenter

--- a/spec/factories/container_nodes.rb
+++ b/spec/factories/container_nodes.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :container_node do
+    sequence(:name) { |n| "container_node_#{seq_padded_for_sorting(n)}" }
     after(:create) do |x|
       x.computer_system = FactoryBot.create(:computer_system)
     end

--- a/spec/factories/event_stream.rb
+++ b/spec/factories/event_stream.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :event_stream
+  factory :ems_event,
+          :class  => "EmsEvent",
+          :parent => :event_stream
+  factory :miq_event,
+          :class  => "MiqEvent",
+          :parent => :event_stream
+end

--- a/spec/models/availability_zone_spec.rb
+++ b/spec/models/availability_zone_spec.rb
@@ -7,10 +7,4 @@ RSpec.describe AvailabilityZone do
     expect(described_class.available.length).to eq(2)
     described_class.available.each { |az| expect(az.class).not_to eq(ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull) }
   end
-
-  it ".event_where_clause" do
-    zone = FactoryBot.create(:availability_zone_amazon)
-    expect(zone.event_where_clause).not_to be nil
-    expect(EmsEvent.where(zone.event_where_clause).length).to eq(0)
-  end
 end

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -217,45 +217,4 @@ RSpec.describe EmsCluster do
       expect(subject.current_tenant).to eq(Tenant.root_tenant)
     end
   end
-
-  describe "#event_where_clause" do
-    let(:cluster) { FactoryBot.create(:ems_cluster) }
-    # just doing one to avoid db random ordering
-    let(:vms) { FactoryBot.create_list(:vm, 1, :ems_cluster => cluster)}
-    let(:hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => cluster)}
-    it "handles empty cluster" do
-      expect(cluster.event_where_clause).to eq(["ems_cluster_id = ?", cluster.id])
-    end
-
-    it "handles vms" do
-      vms # pre-load vms
-      result = cluster.event_where_clause
-      expected = [
-        "ems_cluster_id = ? OR vm_or_template_id IN (?) OR dest_vm_or_template_id IN (?)",
-        cluster.id, vms.map(&:id), vms.map(&:id)
-      ]
-      expect(result).to eq(expected)
-    end
-
-    it "handles hosts" do
-      hosts # pre-load vms
-      result = cluster.event_where_clause
-      expected = [
-        "ems_cluster_id = ? OR host_id IN (?) OR dest_host_id IN (?)",
-        cluster.id, hosts.map(&:id), hosts.map(&:id)
-      ]
-      expect(result).to eq(expected)
-    end
-
-    it "handles both" do
-      vms # pre-load vms, hosts
-      hosts
-      result = cluster.event_where_clause
-      expected = [
-        "ems_cluster_id = ? OR host_id IN (?) OR dest_host_id IN (?) OR vm_or_template_id IN (?) OR dest_vm_or_template_id IN (?)",
-        cluster.id, hosts.map(&:id), hosts.map(&:id), vms.map(&:id), vms.map(&:id)
-      ]
-      expect(result).to eq(expected)
-    end
-  end
 end

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe EventMixin do
       it "ems_events" do
         expected1 = FactoryBot.create(:ems_event, :availability_zone_id => object.id)
         FactoryBot.create(:ems_event, :availability_zone_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :availability_zone_id => object.id)
         FactoryBot.create(:miq_event, :availability_zone_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -111,14 +111,14 @@ RSpec.describe EventMixin do
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => project_name)
         allow(object).to receive(:container_project).and_return(double(:name => project_name))
         allow(object).to receive(:ext_management_system).and_return(double(:id => ems_id))
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
         FactoryBot.create(:miq_event, :ems_id => other_object.id)
         allow(object).to receive(:ext_management_system).and_return(double(:id => ems_id))
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -132,13 +132,13 @@ RSpec.describe EventMixin do
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_group_name => object.name)
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => project_name)
         allow(object).to receive(:container_project).and_return(double(:name => project_name))
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
         FactoryBot.create(:miq_event, :ems_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -150,13 +150,13 @@ RSpec.describe EventMixin do
         expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_node_name => object.name)
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_node_name => other_object.name)
         FactoryBot.create(:ems_event, :ems_id => other_object.id, :container_node_name => object.name)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
         FactoryBot.create(:miq_event, :ems_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -167,13 +167,13 @@ RSpec.describe EventMixin do
         expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => object.name)
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => other_object.name)
         FactoryBot.create(:ems_event, :ems_id => other_object.id, :container_namespace => object.name)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
         FactoryBot.create(:miq_event, :ems_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -187,13 +187,13 @@ RSpec.describe EventMixin do
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_replicator_name => object.name)
         FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => project_name)
         allow(object).to receive(:container_project).and_return(double(:name => project_name))
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
         FactoryBot.create(:miq_event, :ems_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -214,13 +214,13 @@ RSpec.describe EventMixin do
         # Pretend there's hosts and vms for this cluster
         allow(object).to receive(:host_ids).and_return([object.id])
         allow(object).to receive(:vm_or_template_ids).and_return([object.id])
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1, expected2, expected3, expected4])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1, expected2, expected3, expected4])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_cluster_id => object.id)
         FactoryBot.create(:miq_event, :ems_cluster_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -231,13 +231,13 @@ RSpec.describe EventMixin do
       it "ems_events" do
         expected1 = FactoryBot.create(:ems_event, :ems_id => object.id)
         FactoryBot.create(:ems_event, :ems_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :ems_id => object.id)
         FactoryBot.create(:miq_event, :ems_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -250,13 +250,13 @@ RSpec.describe EventMixin do
         expected2 = FactoryBot.create(:ems_event, :dest_host_id => object.id)
         FactoryBot.create(:ems_event, :host_id => other_object.id)
         FactoryBot.create(:ems_event, :dest_host_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1, expected2])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1, expected2])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :host_id => object.id)
         FactoryBot.create(:miq_event, :host_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -267,13 +267,13 @@ RSpec.describe EventMixin do
       it "ems_events" do
         expected1 = FactoryBot.create(:ems_event, :physical_chassis_id => object.id)
         FactoryBot.create(:ems_event, :physical_chassis_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :physical_chassis_id => object.id)
         FactoryBot.create(:miq_event, :physical_chassis_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -284,13 +284,13 @@ RSpec.describe EventMixin do
       it "ems_events" do
         expected1 = FactoryBot.create(:ems_event, :physical_server_id => object.id)
         FactoryBot.create(:ems_event, :physical_server_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :physical_server_id => object.id)
         FactoryBot.create(:miq_event, :physical_server_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -301,13 +301,13 @@ RSpec.describe EventMixin do
       it "ems_events" do
         expected1 = FactoryBot.create(:ems_event, :physical_switch_id => object.id)
         FactoryBot.create(:ems_event, :physical_switch_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :physical_switch_id => object.id)
         FactoryBot.create(:miq_event, :physical_switch_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 
@@ -320,13 +320,13 @@ RSpec.describe EventMixin do
         expected2 = FactoryBot.create(:ems_event, :dest_vm_or_template_id => object.id)
         FactoryBot.create(:ems_event, :vm_or_template_id => other_object.id)
         FactoryBot.create(:ems_event, :dest_vm_or_template_id => other_object.id)
-        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1, expected2])
+        expect(object.event_where_clause(:ems_events)).to match_array([expected1, expected2])
       end
 
       it "miq_events" do
         expected1 = FactoryBot.create(:miq_event, :target_id => object.id, :target_type => object.class.name)
         FactoryBot.create(:miq_event, :target_id => other_object.id, :target_type => other_object.class.name)
-        expect(object.class.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+        expect(object.event_where_clause(:miq_events)).to match_array([expected1])
       end
     end
 

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe EventMixin do
       end
     end
 
-    context "PhysicalChassis" do
+    context "PhysicalSwitch" do
       let(:object)       { FactoryBot.create(:physical_switch) }
       let(:other_object) { FactoryBot.create(:physical_switch) }
 

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -71,45 +71,269 @@ RSpec.describe EventMixin do
 
   context "event_where_clause" do
     let(:ems_id)       { 1234 }
-    let(:object_name)  { "object_name" }
     let(:project_name) { "container_project_name" }
     let(:known_missing_event_mixin_classes) { [MiqServer, Storage, ResourcePool, ContainerImage] }
+
+    # TODO: The classes: Storage, ContainerImage, ResourcePool:
+    #  * Do NOT have _id columns in event_streams
+    #  * Do NOT include EventMixin
+    #  * Are included in MiqEvent::SUPPORTED_POLICY_AND_ALERT_CLASSES
+    #
+    # TODO: The classes:  AvailabilityZone, Container, PhysicalChassis, PhysicalSwitch
+    #   * Do have id columns in event_streams
+    #   * Do include EventMixin
+    #   * Are NOT included in MiqEvent::SUPPORTED_POLICY_AND_ALERT_CLASSES
+    context "AvailabilityZone" do
+      let(:object)       { FactoryBot.create(:availability_zone) }
+      let(:other_object) { FactoryBot.create(:availability_zone) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :availability_zone_id => object.id)
+        FactoryBot.create(:ems_event, :availability_zone_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :availability_zone_id => object.id)
+        FactoryBot.create(:miq_event, :availability_zone_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "Container" do
+      let(:object)       { FactoryBot.create(:container, :ems_id => ems_id) }
+      let(:other_object) { FactoryBot.create(:container, :ems_id => ems_id) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_name => object.name, :container_namespace => project_name)
+        FactoryBot.create(:ems_event, :ems_id => other_object.id)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_name => object.name)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => project_name)
+        allow(object).to receive(:container_project).and_return(double(:name => project_name))
+        allow(object).to receive(:ext_management_system).and_return(double(:id => ems_id))
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
+        FactoryBot.create(:miq_event, :ems_id => other_object.id)
+        allow(object).to receive(:ext_management_system).and_return(double(:id => ems_id))
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "ContainerGroup" do
+      let(:object)       { FactoryBot.create(:container_group, :ems_id => ems_id) }
+      let(:other_object) { FactoryBot.create(:container_group, :ems_id => ems_id) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_group_name => object.name, :container_namespace => project_name)
+        FactoryBot.create(:ems_event, :ems_id => other_object.id)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_group_name => object.name)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => project_name)
+        allow(object).to receive(:container_project).and_return(double(:name => project_name))
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
+        FactoryBot.create(:miq_event, :ems_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "ContainerNode" do
+      let(:object)       { FactoryBot.create(:container_node, :ems_id => ems_id) }
+      let(:other_object) { FactoryBot.create(:container_node, :ems_id => ems_id) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_node_name => object.name)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_node_name => other_object.name)
+        FactoryBot.create(:ems_event, :ems_id => other_object.id, :container_node_name => object.name)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
+        FactoryBot.create(:miq_event, :ems_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "ContainerProject" do
+      let(:object)       { FactoryBot.create(:container_project, :ems_id => ems_id) }
+      let(:other_object) { FactoryBot.create(:container_project, :ems_id => ems_id) }
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => object.name)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => other_object.name)
+        FactoryBot.create(:ems_event, :ems_id => other_object.id, :container_namespace => object.name)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
+        FactoryBot.create(:miq_event, :ems_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "ContainerReplicator" do
+      let(:object)       { FactoryBot.create(:container_replicator, :ems_id => ems_id) }
+      let(:other_object) { FactoryBot.create(:container_replicator, :ems_id => ems_id) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_id => ems_id, :container_replicator_name => object.name, :container_namespace => project_name)
+        FactoryBot.create(:ems_event, :ems_id => other_object.id)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_replicator_name => object.name)
+        FactoryBot.create(:ems_event, :ems_id => ems_id, :container_namespace => project_name)
+        allow(object).to receive(:container_project).and_return(double(:name => project_name))
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_id => ems_id)
+        FactoryBot.create(:miq_event, :ems_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "EmsCluster" do
+      let(:object)       { FactoryBot.create(:ems_cluster) }
+      let(:other_object) { FactoryBot.create(:ems_cluster) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_cluster_id => object.id)
+        expected2 = FactoryBot.create(:ems_event, :host_id => object.id)
+        expected3 = FactoryBot.create(:ems_event, :vm_or_template_id => object.id)
+        expected4 = FactoryBot.create(:ems_event, :dest_vm_or_template_id => object.id)
+        FactoryBot.create(:ems_event, :ems_cluster_id => other_object.id)
+        FactoryBot.create(:ems_event, :host_id => other_object.id)
+        FactoryBot.create(:ems_event, :vm_or_template_id => other_object.id)
+        FactoryBot.create(:ems_event, :dest_vm_or_template_id => other_object.id)
+
+        # Pretend there's hosts and vms for this cluster
+        allow(object).to receive(:host_ids).and_return([object.id])
+        allow(object).to receive(:vm_or_template_ids).and_return([object.id])
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1, expected2, expected3, expected4])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_cluster_id => object.id)
+        FactoryBot.create(:miq_event, :ems_cluster_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "ExtManagementSystem" do
+      let(:object)       { FactoryBot.create(:ext_management_system) }
+      let(:other_object) { FactoryBot.create(:ext_management_system) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :ems_id => object.id)
+        FactoryBot.create(:ems_event, :ems_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :ems_id => object.id)
+        FactoryBot.create(:miq_event, :ems_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "Host" do
+      let(:object)       { FactoryBot.create(:host) }
+      let(:other_object) { FactoryBot.create(:host) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :host_id => object.id)
+        expected2 = FactoryBot.create(:ems_event, :dest_host_id => object.id)
+        FactoryBot.create(:ems_event, :host_id => other_object.id)
+        FactoryBot.create(:ems_event, :dest_host_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1, expected2])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :host_id => object.id)
+        FactoryBot.create(:miq_event, :host_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "PhysicalChassis" do
+      let(:object)       { FactoryBot.create(:physical_chassis) }
+      let(:other_object) { FactoryBot.create(:physical_chassis) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :physical_chassis_id => object.id)
+        FactoryBot.create(:ems_event, :physical_chassis_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :physical_chassis_id => object.id)
+        FactoryBot.create(:miq_event, :physical_chassis_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "PhysicalServer" do
+      let(:object)       { FactoryBot.create(:physical_server) }
+      let(:other_object) { FactoryBot.create(:physical_server) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :physical_server_id => object.id)
+        FactoryBot.create(:ems_event, :physical_server_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :physical_server_id => object.id)
+        FactoryBot.create(:miq_event, :physical_server_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "PhysicalChassis" do
+      let(:object)       { FactoryBot.create(:physical_switch) }
+      let(:other_object) { FactoryBot.create(:physical_switch) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :physical_switch_id => object.id)
+        FactoryBot.create(:ems_event, :physical_switch_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :physical_switch_id => object.id)
+        FactoryBot.create(:miq_event, :physical_switch_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
+
+    context "VmOrTemplate" do
+      let(:object)       { FactoryBot.create(:vm_or_template) }
+      let(:other_object) { FactoryBot.create(:vm_or_template) }
+
+      it "ems_events" do
+        expected1 = FactoryBot.create(:ems_event, :vm_or_template_id => object.id)
+        expected2 = FactoryBot.create(:ems_event, :dest_vm_or_template_id => object.id)
+        FactoryBot.create(:ems_event, :vm_or_template_id => other_object.id)
+        FactoryBot.create(:ems_event, :dest_vm_or_template_id => other_object.id)
+        expect(EventStream.where(object.event_where_clause(:ems_events))).to match_array([expected1, expected2])
+      end
+
+      it "miq_events" do
+        expected1 = FactoryBot.create(:miq_event, :target_id => object.id, :target_type => object.class.name)
+        FactoryBot.create(:miq_event, :target_id => other_object.id, :target_type => other_object.class.name)
+        expect(object.class.where(object.event_where_clause(:miq_events))).to match_array([expected1])
+      end
+    end
 
     MiqEvent::SUPPORTED_POLICY_AND_ALERT_CLASSES.each do |klass|
       it "#{klass} includes EventMixin and is correct" do
         pending("Missing EventMixin means timeline support is likely broken") if known_missing_event_mixin_classes.include?(klass)
         expect(klass).to include(EventMixin)
-
-        object = FactoryBot.create(klass.name.tableize.singularize.to_sym)
-        expected_event_where_clause_for_ems_events = {
-          EmsCluster          => ["ems_cluster_id = ?", object.id],
-          ExtManagementSystem => ["event_streams.ems_id = ?", object.id],
-          ContainerGroup      => ["container_namespace = ? AND container_group_name = ? AND event_streams.ems_id = ?", project_name, object_name, ems_id],
-          ContainerNode       => ["container_node_name = ? AND event_streams.ems_id = ?", object_name, ems_id],
-          ContainerProject    => ["container_namespace = ? AND event_streams.ems_id = ?", object_name, ems_id],
-          ContainerReplicator => ["container_namespace = ? AND container_replicator_name = ? AND event_streams.ems_id = ?", project_name, object_name, ems_id],
-          Host                => ["host_id = ? OR dest_host_id = ?", object.id, object.id],
-          PhysicalServer      => ["event_streams.physical_server_id = ?", object.id],
-          VmOrTemplate        => ["vm_or_template_id = ? OR dest_vm_or_template_id = ? ", object.id, object.id]
-        }
-
-        expected_event_where_clause_for_policy_events = {
-          EmsCluster          => ["ems_cluster_id = ?", object.id],
-          ExtManagementSystem => ["event_streams.ems_id = ?", object.id],
-          ContainerGroup      => ["event_streams.ems_id = ?", ems_id],
-          ContainerNode       => ["event_streams.ems_id = ?", ems_id],
-          ContainerProject    => ["event_streams.ems_id = ?", ems_id],
-          ContainerReplicator => ["event_streams.ems_id = ?", ems_id],
-          Host                => ["host_id = ?", object.id],
-          PhysicalServer      => ["event_streams.physical_server_id = ?", object.id],
-          VmOrTemplate        => ["target_id = ? and target_class = ? ", object.id, "VmOrTemplate"]
-        }
-
-        allow(object).to receive(:ems_id).and_return(ems_id)
-        allow(object).to receive(:name).and_return(object_name)
-        allow(object).to receive(:container_project).and_return(double(:name => project_name))
-        expect(object.event_where_clause(:ems_events)).to eq(expected_event_where_clause_for_ems_events[klass])
-        expect(object.event_where_clause(:policy_events)).to eq(expected_event_where_clause_for_policy_events[klass])
       end
     end
   end


### PR DESCRIPTION
Note:  This is WIP.  The goal is to be able to get EventStream results for a specific Vm, Template, Host, etc. or just the EmsEvents or just the MiqEvents.

TODO: 

- [ ] Figure out what to do with policy_events (did we really want to get PolicyEvent records or were we really interested in event_streams of the MiqEvent type?
- [ ] Some classes are implemented strangely:
  - [ ] Storage, ContainerImage, ResourcePool:
     * Do NOT have _id columns in event_streams
     * Do NOT include EventMixin
     * Are included in MiqEvent::SUPPORTED_POLICY_AND_ALERT_CLASSES
  - [ ] AvailabilityZone, Container, PhysicalChassis, PhysicalSwitch
    * Do have id columns in event_streams
    * Do include EventMixin
    * Are NOT included in MiqEvent::SUPPORTED_POLICY_AND_ALERT_CLASSES
- [x] Refactor the common cases where event_where_clause looks for class's _id column in event_streams.  For example:  PhysicalSwitch has a physical_switch_id column in EventStream so it's easy to default to do `EmsEvent.where(:physical_switch_id => id)` and `MiqEvent.where(:physical_switch_id => id)`
- [ ] Update callers to use the new interface for event_where_clause:  `["ems_id = ?", 1]` is now `EmsEvent.where(:ems_id => 1)`