### PR TITLE
[skip_ci] Partially Revert "[skip_ci] Update dependencies"

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -712,7 +712,7 @@ GEM
     httpi (2.5.0)
       rack
       socksify
-    i18n (1.8.11)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ibm-cloud-sdk (0.1.11)
       httparty


### PR DESCRIPTION
This partially reverts commit cf4a476a404fa40bdae01d1322e590d6c19c5824.

Newer i18n conflicts with `manageiq-appliance_console`

```
Bundler could not find compatible versions for gem "i18n":
  In snapshot (Gemfile.lock):
    i18n (= 1.8.11)

  In Gemfile:
    manageiq-appliance_console (~> 6.0) was resolved to 6.1.1, which depends on
      i18n (~> 0.8)

    money (~> 6.13.5) was resolved to 6.13.8, which depends on
      i18n (>= 0.6.4, <= 2)

    rails-i18n (~> 6.x) was resolved to 6.0.0, which depends on
      i18n (>= 0.7, < 2)
```