### PR TITLE
Move ovirt_metrics gem declaration out of core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,7 +190,6 @@ end
 
 group :ovirt, :manageiq_default do
   manageiq_plugin "manageiq-providers-ovirt"
-  gem "ovirt_metrics",                  "~>3.0.1",           :require => false
 end
 
 group :scvmm, :manageiq_default do


### PR DESCRIPTION
This gem is only used in the manageiq-providers-ovirt provider repo and the declaration belongs in that plugin's gemspec

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/583