### PR TITLE
user widgets no longer update group widget order

### DIFF
--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -326,11 +326,15 @@ RSpec.describe MiqGroup do
     let(:group) { FactoryBot.create(:miq_group) }
 
     it "uses dashboard_order if present" do
+      # clear settings out of the group so we don't get surprised in the test
+      group.settings = nil
+
       ws1 = FactoryBot.create(:miq_widget_set, :name => 'A1', :owner => group)
       FactoryBot.create(:miq_widget_set, :name => 'C3', :owner => group)
       ws3 = FactoryBot.create(:miq_widget_set, :name => 'B2', :owner => group)
-
-      group.update(:settings => {:dashboard_order => [ws3.id.to_s, ws1.id.to_s]})
+      group.add_to_dashboard_order(ws3.id)
+      group.add_to_dashboard_order(ws1.id)
+      group.save
 
       expect(group.ordered_widget_sets).to eq([ws3, ws1])
     end


### PR DESCRIPTION
Before:

When user widgets changed, it updated the group widget ordering.
And widgets were returned from the group that were really part of the user.

After:

Groups are only updated if a widget set belongs to a group

Addresses:
- adding or removing a dashboard widget throws an error due to a nil workspace.
- refreshing a dashboard widget throws an error due to a nil workspace