### PR TITLE
Lockdown dalli to 3.0.6 while we address breaking changes in 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "connection_pool",                                       :require => false # For Dalli
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false
-gem "dalli",                            "~>3.0",             :require => false
+gem "dalli",                            "~>3.0.6",           :require => false
 gem "default_value_for",                "~>3.3"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false


### PR DESCRIPTION
Fixes #21593

Dalli 3.1.0 was released and had the following changes from 3.0.6:
https://github.com/petergoldstein/dalli/compare/v3.0.6...v3.1.0

Among these these changes:
* destroy_session was renamed to delete_session
* with_block is now with_dalli_client

This is important because we have monkey patches on these private methods to
ensure we can safely load code in threads from within them.  When these patches
aren't applied, we can get deadlocks.

Additionally, request.session_options[:id] is now a Rack::Session::SessionId
object that can't be cast in find_by calls so we may need to make this change in
user:

```diff
-    sessions << Session.find_or_create_by(:session_id => session_id)
+    sessions << Session.find_or_create_by(:session_id => session_id.private_id)
```

Related to https://github.com/rails/activerecord-session_store/issues/154

Note, even with local changes to account for the renames and this change in the
session_id, some pages were still hung so we'll just lock down to 3.0.6 until we
can resolve them.