### PR TITLE
Move common methods to core inventory collector

### DIFF
--- a/app/models/manageiq/providers/inventory/collector.rb
+++ b/app/models/manageiq/providers/inventory/collector.rb
@@ -25,10 +25,10 @@ class ManageIQ::Providers::Inventory::Collector
     target.manager_refs_by_association&.dig(collection, manager_ref)&.to_a&.compact || []
   end
 
-  def add_target!(association, manager_ref)
+  def add_target!(association, manager_ref, options = {})
     return if manager_ref.blank?
 
     manager_ref = {:ems_ref => manager_ref} unless manager_ref.kind_of?(Hash)
-    target.add_target(:association => association, :manager_ref => manager_ref)
+    target.add_target(:association => association, :manager_ref => manager_ref, :options => options)
   end
 end

--- a/app/models/manageiq/providers/inventory/collector.rb
+++ b/app/models/manageiq/providers/inventory/collector.rb
@@ -18,4 +18,17 @@ class ManageIQ::Providers::Inventory::Collector
   def options
     @options ||= Settings.ems_refresh[manager.class.ems_type]
   end
+
+  private
+
+  def references(collection, manager_ref: :ems_ref)
+    target.manager_refs_by_association&.dig(collection, manager_ref)&.to_a&.compact || []
+  end
+
+  def add_target!(association, manager_ref)
+    return if manager_ref.blank?
+
+    manager_ref = {:ems_ref => manager_ref} unless manager_ref.kind_of?(Hash)
+    target.add_target(:association => association, :manager_ref => manager_ref)
+  end
 end


### PR DESCRIPTION
All providers which support targeted refresh redefine these methods in
one way or another.

Dependents:
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/729
* https://github.com/ManageIQ/manageiq-providers-azure/pull/485
* https://github.com/ManageIQ/manageiq-providers-autosde/pull/118
* https://github.com/ManageIQ/manageiq-providers-nuage/pull/258
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/585
* https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/70
* https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/309
* https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/25
* https://github.com/ManageIQ/manageiq-providers-nsxt/pull/54
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/755

Doc changes:
* https://github.com/ManageIQ/guides/pull/477

NOTE ansible_tower also implements these but in a slightly different way.  They dynamically determine the manager_ref from the collection which I actually really like, but I don't like how they implement it specifically so I want to come back and refactor that