### PR TITLE
Raise if model has sti but using base class

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -22,6 +22,10 @@ class ApplicationRecord < ActiveRecord::Base
     include MiqDecorator::Instance
   end
 
+  def self.sti?
+    columns_hash.key?(inheritance_column.to_s)
+  end
+
   def self.display_name(number = 1)
     n_(model_name.singular.titleize, model_name.plural.titleize, number)
   end

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers
     # @see test in /spec/models/manager_refresh/inventory_collection/builder_spec.rb
     class Builder
       class MissingModelClassError < StandardError; end
+
       class NotSubclassedError < StandardError; end
 
       require_nested :AutomationManager
@@ -244,8 +245,12 @@ module ManageIQ::Providers
         @options[:without_model_class] = skip
       end
 
-      def skip_sti(skip = true)
-        @options[:without_sti] = skip
+      def skip_sti
+        @options[:without_sti] = true
+      end
+
+      def with_sti
+        @options[:without_sti] = false
       end
 
       # Inventory object attributes are derived from setters

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -35,14 +35,10 @@ module ManageIQ::Providers
       #        (optional) method with this name also used for concrete inventory collection specific properties
       # @param persister_class [Class] used for "guessing" model_class
       # @param options [Hash]
-      def self.prepare_data(name, persister_class, options = {})
-        options = default_options.merge(options)
-        builder = new(name, persister_class, options)
-        builder.construct_data
-
-        yield(builder) if block_given?
-
-        builder
+      def self.prepare_data(name, persister_class, options = {}, &block)
+        new(name, persister_class, default_options.merge(options)).tap do |builder|
+          builder.construct_data(&block)
+        end
       end
 
       attr_accessor :name, :parent, :persister_class, :properties, :inventory_object_attributes,
@@ -88,6 +84,7 @@ module ManageIQ::Providers
         add_properties(@shared_properties, :if_missing)
 
         send(@name.to_sym) if @name.respond_to?(:to_sym) && respond_to?(@name.to_sym)
+        yield(self) if block_given?
 
         if @properties[:model_class].nil? && !(@options[:without_model_class])
           add_properties(:model_class => auto_model_class)

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -231,7 +231,12 @@ module ManageIQ::Providers
         return provider_class if provider_class.to_s == class_name
 
         klass = "::#{name.to_s.classify}".safe_constantize
-        raise NotSubclassedError, "#{name} should be subclassed under #{manager_class}" if klass && klass.sti? && !@options[:without_sti]
+        return if klass.nil?
+
+        if klass.sti? && !without_sti?
+          raise NotSubclassedError,
+                "expected #{name} to be found subclassed as #{class_name}, but instead found #{klass.name}"
+        end
 
         klass
       end
@@ -279,6 +284,12 @@ module ManageIQ::Providers
             value
           end
         end
+      end
+
+      private
+
+      def without_sti?
+        !!@options[:without_sti]
       end
     end
   end

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -233,7 +233,7 @@ module ManageIQ::Providers
         klass = "::#{name.to_s.classify}".safe_constantize
         return if klass.nil?
 
-        if klass.sti? && !without_sti?
+        if klass.sti? && with_sti?
           raise NotSubclassedError,
                 "expected #{name} to be found subclassed as #{class_name}, but instead found #{klass.name}"
         end
@@ -288,8 +288,8 @@ module ManageIQ::Providers
 
       private
 
-      def without_sti?
-        !!@options[:without_sti]
+      def with_sti?
+        !@options[:without_sti]
       end
     end
   end

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -233,13 +233,9 @@ module ManageIQ::Providers
         return provider_class if provider_class.to_s == class_name
 
         klass = "::#{name.to_s.classify}".constantize
-        raise NotSubclassedError, "#{name} should be subclassed under #{manager_class}" if sti?(klass) && !@options[:without_sti]
+        raise NotSubclassedError, "#{name} should be subclassed under #{manager_class}" if klass.sti? && !@options[:without_sti]
 
         klass
-      end
-
-      def sti?(klass)
-        klass.columns_hash.key?(klass.inheritance_column.to_s)
       end
 
       # Enables/disables auto_model_class and exception check

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -230,8 +230,8 @@ module ManageIQ::Providers
         # class in the hierarchy even though it isn't at the same hierarchy depth we are expecting.
         return provider_class if provider_class.to_s == class_name
 
-        klass = "::#{name.to_s.classify}".constantize
-        raise NotSubclassedError, "#{name} should be subclassed under #{manager_class}" if klass.sti? && !@options[:without_sti]
+        klass = "::#{name.to_s.classify}".safe_constantize
+        raise NotSubclassedError, "#{name} should be subclassed under #{manager_class}" if klass && klass.sti? && !@options[:without_sti]
 
         klass
       end

--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -213,6 +213,7 @@ module ManageIQ::Providers
         end
 
         def persistent_volumes
+          skip_sti
           add_default_values(:parent => ->(persister) { persister.manager })
         end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -113,6 +113,7 @@ module ManageIQ::Providers
         end
 
         def container_volumes
+          skip_sti
           add_properties(
             :manager_ref                  => %i[parent name],
             :parent_inventory_collections => %i[container_groups]

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -85,6 +85,8 @@ module ManageIQ::Providers
         end
 
         def ems_folders
+          skip_sti
+
           add_properties(
             :manager_ref          => %i[uid_ems],
             :attributes_blacklist => %i[parent]

--- a/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
@@ -24,6 +24,7 @@ module ManageIQ::Providers
         end
 
         def customization_scripts
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end

--- a/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
@@ -3,11 +3,13 @@ module ManageIQ::Providers
     class Builder
       class ProvisioningManager < ::ManageIQ::Providers::Inventory::Persister::Builder
         def customization_script_media
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 
         def customization_script_ptables
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
@@ -18,41 +20,49 @@ module ManageIQ::Providers
         end
 
         def configuration_locations
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:provisioning_manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_organizations
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:provisioning_manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_tags
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_architectures
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_compute_profiles
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_domains
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_environments
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 
         def configuration_realms
+          skip_sti
           add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -38,6 +38,8 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     end
 
     def ext_management_system
+      skip_model_class
+
       add_properties(
         :manager_ref       => %i[guid],
         :custom_save_block => lambda do |ems, inventory_collection|

--- a/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
@@ -43,6 +43,7 @@ module ManageIQ::Providers
         end
 
         def san_addresses
+          skip_sti
           add_common_default_values
         end
 

--- a/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- association ---
 
   it 'assigns association automatically to InventoryCollection' do
-    ic = cloud.prepare_data(:vms, persister_class).to_inventory_collection
+    ic = cloud.prepare_data(:vms, persister_class, :without_sti => true).to_inventory_collection
 
     expect(ic.association).to eq :vms
   end
@@ -34,13 +34,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "derives existing model_class without persister's class" do
-    data = cloud.prepare_data(:vms, persister_class).to_hash
+    data = cloud.prepare_data(:vms, persister_class, :without_sti => true).to_hash
 
     expect(data[:model_class]).to eq ::Vm
   end
 
   it "replaces derived model_class if model_class defined manually" do
-    data = cloud.prepare_data(:vms, persister_class) do |builder|
+    data = cloud.prepare_data(:vms, persister_class, :without_sti => true) do |builder|
       builder.add_properties(:model_class => ::MiqTemplate)
     end.to_hash
 
@@ -62,7 +62,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- adv. settings (TODO: link to gui)---
 
   it 'assigns Advanced settings' do
-    builder = cloud.prepare_data(:tmp, persister_class, :adv_settings => adv_settings)
+    builder = cloud.prepare_data(:tmp, persister_class, :without_model_class => true, :adv_settings => adv_settings)
     data = builder.to_hash
 
     expect(data[:strategy]).to eq :local_db_find_missing_references
@@ -70,7 +70,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't overwrite defined properties by Advanced settings" do
-    data = cloud.prepare_data(:vms, persister_class, :adv_settings => adv_settings) do |builder|
+    data = cloud.prepare_data(:vms, persister_class, :without_sti => true, :adv_settings => adv_settings) do |builder|
       builder.add_properties(:strategy => :custom)
     end.to_hash
 
@@ -81,13 +81,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- shared properties ---
 
   it 'applies shared properties' do
-    data = cloud.prepare_data(:tmp, persister_class, :shared_properties => {:uuid => 1}).to_hash
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true, :shared_properties => {:uuid => 1}).to_hash
 
     expect(data[:uuid]).to eq 1
   end
 
   it "doesn't overwrite defined properties by shared properties" do
-    data = cloud.prepare_data(:tmp, persister_class, :shared_properties => {:uuid => 1}) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true, :shared_properties => {:uuid => 1}) do |builder|
       builder.add_properties(:uuid => 2)
     end.to_hash
 
@@ -97,7 +97,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- properties ---
 
   it 'adds properties with add_properties repeatedly' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_properties(:first => 1, :second => 2)
       builder.add_properties(:third => 3)
     end.to_hash
@@ -108,7 +108,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'overrides properties in :overwrite mode' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_properties(:param => 1)
       builder.add_properties({:param => 2}, :overwrite)
     end.to_hash
@@ -117,7 +117,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't override properties in :if_missing mode" do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_properties(:param => 1)
       builder.add_properties({:param => 2}, :if_missing)
     end.to_hash
@@ -126,7 +126,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'adds property by method_missing' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_some_tmp_param(:some_value)
     end.to_hash
 
@@ -136,7 +136,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- default values ---
 
   it 'adds default_values repeatedly' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_default_values(:ems_id => 10)
       builder.add_default_values(:ems_id => 20)
       builder.add_default_values(:tmp_id => 30)
@@ -147,7 +147,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'transforms lambdas in default_values' do
-    bldr = cloud.prepare_data(:tmp, persister_class) do |builder|
+    bldr = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_default_values(:ems_id => ->(persister) { persister.manager.id })
     end
     bldr.evaluate_lambdas!(@persister)
@@ -160,19 +160,19 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- inventory object attributes ---
 
   it 'derives inventory object attributes automatically' do
-    data = cloud.prepare_data(:vms, persister_class).to_hash
+    data = cloud.prepare_data(:vms, persister_class, :without_sti => true).to_hash
 
     expect(data[:inventory_object_attributes]).not_to be_empty
   end
 
   it "doesn't derive inventory_object_attributes automatically when disabled" do
-    data = cloud.prepare_data(:vms, persister_class, :auto_inventory_attributes => false).to_hash
+    data = cloud.prepare_data(:vms, persister_class, :without_sti => true, :auto_inventory_attributes => false).to_hash
 
     expect(data[:inventory_object_attributes]).to be_empty
   end
 
   it 'can add inventory_object_attributes manually' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
     end.to_hash
 
@@ -180,7 +180,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'can remove inventory_object_attributes' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
       builder.remove_inventory_attributes(%i(attr2))
     end.to_hash
@@ -189,7 +189,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'can clear all inventory_object_attributes' do
-    data = cloud.prepare_data(:vms, persister_class) do |builder|
+    data = cloud.prepare_data(:vms, persister_class, :without_sti => true) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
       builder.clear_inventory_attributes!
     end.to_hash

--- a/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
     expect(data[:model_class]).to be_nil
   end
 
+  it "throws exception if model_class should be namespaced but isn't" do
+    expect { cloud.prepare_data(:vms, persister_class) }.to raise_error(
+      ::ManageIQ::Providers::Inventory::Persister::Builder::NotSubclassedError
+    )
+  end
+
   it 'throws exception if model_class not specified' do
     builder = cloud.prepare_data(:non_existing_ic, persister_class)
 

--- a/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
@@ -401,17 +401,18 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
   context "check validity of defined index" do
     it "checks primary index attributes exist" do
       expect do
-        persister.add_collection(persister.send(:cloud),
-                                 :vms,
-                                 :manager_ref => %i(ems_ref ems_gref))
+        persister.add_collection(persister.send(:cloud), :vms, {:manager_ref => %i[ems_ref ems_gref]}, {:without_sti => true})
       end.to raise_error("Invalid definition of index :manager_ref, there is no attribute :ems_gref on model Vm")
     end
 
     it "checks secondary index attributes exist" do
       expect do
-        persister.add_collection(persister.send(:cloud),
-                                 :vms,
-                                 :secondary_refs => {:by_uid_ems_and_name => %i(uid_emsa name)})
+        persister.add_collection(
+          persister.send(:cloud),
+          :vms,
+          {:secondary_refs => {:by_uid_ems_and_name => %i[uid_emsa name]}},
+          {:without_sti => true}
+        )
       end.to raise_error("Invalid definition of index :by_uid_ems_and_name, there is no attribute :uid_emsa on model Vm")
     end
 
@@ -426,14 +427,14 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
 
     it "checks relation is on model class" do
       expect do
-        persister.add_collection(persister.send(:cloud), :vms) do |builder|
+        persister.add_collection(persister.send(:cloud), :vms, {}, {:without_sti => true}) do |builder|
           builder.add_properties(:secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)})
         end
       end.to raise_error("Invalid definition of index :by_availability_zone_and_name, there is no attribute :availability_zone on model Vm")
     end
 
     it "checks we allow any index attributes when we use custom_saving block" do
-      persister.add_collection(persister.send(:cloud), :vms) do |builder|
+      persister.add_collection(persister.send(:cloud), :vms, {}, {:without_sti => true}) do |builder|
         builder.add_properties(
           :custom_save_block => ->(ems, _ic) { ems },
           :manager_ref       => %i(a b c)

--- a/spec/models/manageiq/providers/inventory/persister/test_persister.rb
+++ b/spec/models/manageiq/providers/inventory/persister/test_persister.rb
@@ -5,7 +5,7 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
     %i(vms
        miq_templates).each do |name|
 
-      add_collection(cloud, name) do |builder|
+      add_collection(cloud, name, {}, {:without_sti => true}) do |builder|
         builder.add_properties(
           :secondary_refs => {:by_name => [:name], :by_uid_ems_and_name => %i(uid_ems name)}
         )
@@ -25,7 +25,7 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
        orchestration_stacks_outputs
        orchestration_stacks_parameters).each do |name|
 
-      add_collection(cloud, name)
+      add_collection(cloud, name, {}, {:without_sti => true})
     end
 
     add_orchestration_stacks_resources
@@ -37,7 +37,7 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
        security_groups
        load_balancers).each do |name|
 
-      add_collection(network, name) do |builder|
+      add_collection(network, name, {}, {:without_sti => true}) do |builder|
         builder.add_properties(:parent => manager.network_manager)
       end
     end
@@ -57,7 +57,7 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
        load_balancer_health_checks
        load_balancer_health_check_members).each do |name|
 
-      add_collection(network, name) do |builder|
+      add_collection(network, name, {}, {:without_sti => true}) do |builder|
         builder.add_properties(:parent => manager.network_manager)
       end
     end
@@ -92,14 +92,14 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
 
   # Cloud InventoryCollection
   def add_flavors
-    add_collection(cloud, :flavors) do |builder|
+    add_collection(cloud, :flavors, {}, {:without_sti => true}) do |builder|
       builder.add_properties(:strategy => :local_db_find_references)
     end
   end
 
   # Network InventoryCollection
   def add_network_ports
-    add_collection(network, :network_ports) do |builder|
+    add_collection(network, :network_ports, {}, {:without_sti => true}) do |builder|
       builder.add_properties(
         :manager_uuids  => references(:vms) + references(:network_ports) + references(:load_balancers),
         :parent         => manager.network_manager,
@@ -110,7 +110,7 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
 
   # Network InventoryCollection
   def add_floating_ips
-    add_collection(network, :floating_ips) do |builder|
+    add_collection(network, :floating_ips, {}, {:without_sti => true}) do |builder|
       builder.add_properties(
         :manager_uuids => references(:floating_ips) + references(:load_balancers),
         :parent        => manager.network_manager

--- a/spec/support/ems_refresh_helper/test_persister.rb
+++ b/spec/support/ems_refresh_helper/test_persister.rb
@@ -3,8 +3,8 @@ module Spec
     module EmsRefreshHelper
       class TestPersister < ManageIQ::Providers::Inventory::Persister
         def initialize_inventory_collections
-          add_collection(infra, :vms)
-          add_collection(infra, :hosts)
+          add_collection(infra, :vms, {}, :without_sti => true)
+          add_collection(infra, :hosts, {}, :without_sti => true)
         end
       end
     end


### PR DESCRIPTION
For models which use STI it is important that the model_class is namespaced under the provider, for example the `:hosts` inventory collection has to have `:model_class => ManageIQ::Providers::Vmware::InfraManager::Host` not just `Host`.

The inventory persister class automatically detects this by doing safe_constantize so that provider subclases don't have to explicitly declare the model_class all the time.

This autodetection can be an issue if the provider author has forgotten to declare a subclass for the model or has forgotten for example a require_nested.  The failure mode in this case is silently creating records with the base-class as opposed to namespaced under the provider.

If we detect that a model has sti (e.g. it has a type string column) but we aren't using it then raise an exception 

Provider PRs (must be merged first):
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/734
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/271
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/126
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/487
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/72
- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/207
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/2
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/316
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/28
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/72
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/193
- [x] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/55
- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/259
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/766
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/38 
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/776
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/317

Cross-Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/570

Follow-ups:
* https://github.com/ManageIQ/manageiq-schema/pull/621
* https://github.com/ManageIQ/manageiq-schema/pull/622
* https://github.com/ManageIQ/manageiq-schema/pull/623
* https://github.com/ManageIQ/manageiq-schema/pull/624
* https://github.com/ManageIQ/manageiq-schema/pull/625
* https://github.com/ManageIQ/manageiq-schema/pull/626
* https://github.com/ManageIQ/manageiq-schema/pull/627
* https://github.com/ManageIQ/manageiq-schema/pull/628
* https://github.com/ManageIQ/manageiq-schema/pull/629
* https://github.com/ManageIQ/manageiq-schema/pull/630