### PR TITLE
Add a mixin for object.queue_refresh and object.refresh

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -6,6 +6,7 @@ class CloudVolume < ApplicationRecord
   include SupportsFeatureMixin
   include CloudTenancyMixin
   include CustomActionsMixin
+  include EmsRefreshMixin
 
   include_concern 'Operations'
 

--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -3,6 +3,7 @@ class HostInitiator < ApplicationRecord
   include ProviderObjectMixin
   include SupportsFeatureMixin
   include CustomActionsMixin
+  include EmsRefreshMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :physical_storage, :inverse_of => :host_initiators
@@ -14,7 +15,6 @@ class HostInitiator < ApplicationRecord
 
   virtual_total :v_total_addresses, :san_addresses
 
-  supports :refresh_ems
   supports_not :create
   acts_as_miq_taggable
 
@@ -25,20 +25,6 @@ class HostInitiator < ApplicationRecord
 
   def self.class_by_ems(ext_management_system)
     ext_management_system&.class_by_ems(:HostInitiator)
-  end
-
-  def refresh_ems
-    unless ext_management_system
-      raise _("No Provider defined")
-    end
-    unless ext_management_system.has_credentials?
-      raise _("No Provider credentials defined")
-    end
-    unless ext_management_system.authentication_status_ok?
-      raise _("Provider failed last authentication check")
-    end
-
-    EmsRefresh.queue_refresh(ext_management_system)
   end
 
   def self.create_host_initiator_queue(userid, ext_management_system, options = {})

--- a/app/models/host_initiator_group.rb
+++ b/app/models/host_initiator_group.rb
@@ -3,6 +3,7 @@ class HostInitiatorGroup < ApplicationRecord
   include ProviderObjectMixin
   include SupportsFeatureMixin
   include CustomActionsMixin
+  include EmsRefreshMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :physical_storage, :inverse_of => :host_initiator_groups
@@ -14,7 +15,6 @@ class HostInitiatorGroup < ApplicationRecord
 
   virtual_total :v_total_addresses, :san_addresses
 
-  supports :refresh_ems
   supports_not :create
   acts_as_miq_taggable
 
@@ -25,20 +25,6 @@ class HostInitiatorGroup < ApplicationRecord
 
   def self.class_by_ems(ext_management_system)
     ext_management_system&.class_by_ems(:HostInitiatorGroup)
-  end
-
-  def refresh_ems
-    unless ext_management_system
-      raise _("No Provider defined")
-    end
-    unless ext_management_system.has_credentials?
-      raise _("No Provider credentials defined")
-    end
-    unless ext_management_system.authentication_status_ok?
-      raise _("Provider failed last authentication check")
-    end
-
-    EmsRefresh.queue_refresh(ext_management_system)
   end
 
   def self.create_host_initiator_group_queue(userid, ext_management_system, options = {})

--- a/app/models/mixins/ems_refresh_mixin.rb
+++ b/app/models/mixins/ems_refresh_mixin.rb
@@ -1,0 +1,64 @@
+module EmsRefreshMixin
+  extend ActiveSupport::Concern
+
+  included do
+    supports :ems_refresh
+  end
+
+  class_methods do
+    def queue_refresh(ems_id_or_ids, ems_ref = nil)
+      refresh_internal(ems_id_or_ids, ems_ref, :queue => true)
+    end
+    alias_method :refresh_ems, :queue_refresh
+
+    def refresh(ems_id_or_ids, ems_ref = nil)
+      refresh_internal(ems_id_or_ids, ems_ref, :queue => false)
+    end
+
+    private
+
+    def refresh_internal(ems_id_or_object_ids, ems_ref, queue:)
+      targets =
+        if ems_ref.nil?
+          Array(ems_id_or_object_ids).map { |id| [base_class, id] }
+        else
+          ems = ExtManagementSystem.find_by(:id => ems_id_or_object_ids)
+
+          raise _("No Provider defined") if ems.nil?
+          raise _("No Provider credentials defined") unless ems.has_credentials?
+          raise _("Provider failed last authentication check") unless ems.authentication_status_ok?
+
+          refresh_target(ems, ems_ref)
+        end
+
+      refresh_meth = queue ? :queue_refresh : :refresh
+
+      EmsRefresh.public_send(refresh_meth, targets)
+    end
+
+    def refresh_target(ems, ems_ref)
+      if ems.allow_targeted_refresh?
+        InventoryRefresh::Target.new(
+          :manager     => ems,
+          :association => refresh_association,
+          :manager_ref => {:ems_ref => ems_ref}
+        )
+      else
+        ems
+      end
+    end
+
+    def refresh_association
+      base_class.name.tableize.to_sym
+    end
+  end
+
+  def queue_refresh
+    self.class.queue_refresh(ext_management_system&.id, ems_ref)
+  end
+  alias refresh_ems queue_refresh
+
+  def refresh
+    self.class.refresh(ext_management_system&.id, ems_ref)
+  end
+end

--- a/app/models/physical_rack.rb
+++ b/app/models/physical_rack.rb
@@ -1,5 +1,6 @@
 class PhysicalRack < ApplicationRecord
   include SupportsFeatureMixin
+  include EmsRefreshMixin
 
   acts_as_miq_taggable
 
@@ -9,24 +10,8 @@ class PhysicalRack < ApplicationRecord
   has_many :physical_servers, :dependent => :nullify, :inverse_of => :physical_rack
   has_many :physical_storages, :dependent => :nullify, :inverse_of => :physical_rack
 
-  supports :refresh_ems
-
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
-  end
-
-  def refresh_ems
-    unless ext_management_system
-      raise _("No Provider defined")
-    end
-    unless ext_management_system.has_credentials?
-      raise _("No Provider credentials defined")
-    end
-    unless ext_management_system.authentication_status_ok?
-      raise _("Provider failed last authentication check")
-    end
-
-    EmsRefresh.queue_refresh(ext_management_system)
   end
 end

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -4,6 +4,7 @@ class PhysicalStorage < ApplicationRecord
   include ProviderObjectMixin
   include SupportsFeatureMixin
   include CustomActionsMixin
+  include EmsRefreshMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :physical_rack
@@ -32,7 +33,6 @@ class PhysicalStorage < ApplicationRecord
 
   has_many :wwpn_candidates, :dependent => :destroy
 
-  supports :refresh_ems
   supports_not :create
   supports_not :delete
   acts_as_miq_taggable
@@ -40,20 +40,6 @@ class PhysicalStorage < ApplicationRecord
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
-  end
-
-  def refresh_ems
-    unless ext_management_system
-      raise _("No Provider defined")
-    end
-    unless ext_management_system.has_credentials?
-      raise _("No Provider credentials defined")
-    end
-    unless ext_management_system.authentication_status_ok?
-      raise _("Provider failed last authentication check")
-    end
-
-    EmsRefresh.queue_refresh(ext_management_system)
   end
 
   def raw_delete_physical_storage

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -1,6 +1,7 @@
 class PhysicalSwitch < Switch
   include SupportsFeatureMixin
   include EventMixin
+  include EmsRefreshMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_switches,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"
@@ -19,25 +20,9 @@ class PhysicalSwitch < Switch
 
   alias_attribute :physical_servers, :connected_physical_servers
 
-  supports :refresh_ems
-
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
-  end
-
-  def refresh_ems
-    unless ext_management_system
-      raise _("No Provider defined")
-    end
-    unless ext_management_system.has_credentials?
-      raise _("No Provider credentials defined")
-    end
-    unless ext_management_system.authentication_status_ok?
-      raise _("Provider failed last authentication check")
-    end
-
-    EmsRefresh.queue_refresh(ext_management_system)
   end
 
   def event_where_clause(assoc = :ems_events)


### PR DESCRIPTION
Unify how sub-ext_management_system models handle class and instance level EmsRefresh requests.

Most support `object.refresh_ems` and `Class.refresh_ems(ids)` which queues a refresh, some automatically build an `InventoryRefresh::Target` if the ems supports targeted refresh, but none of these are consistent with each other.

The new mixin allows for:
```ruby
Klass.queue_refresh(ems_id, ems_ref)
Klass.queue_refresh([id1, id2, ...])
Klass.queue_refresh(id1)
Klass.refresh_ems(ems_id, ems_ref)
Klass.refresh_ems([id1, id2, ...])
Klass.refresh_ems(id1)
Klass.refresh(ems_id, ems_ref)
Klass.refresh([id1, id2, ...])
Klass.refresh(id1)
object.queue_refresh
object.refresh
```
