### PR TITLE
Fix Ansible amazon schema STS Token

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -29,9 +29,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential 
       :name       => 'security_token',
       :id         => 'security_token',
       :type       => 'password',
-      :maxLength  => 1024,
-      :isRequired => true,
-      :validate   => [{:type => 'required'}],
+      :maxLength  => 1024
     },
   ].freeze
 


### PR DESCRIPTION
Removed required for STS token.

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add-label bug