### PR TITLE
Fix EmsEvent#manager_refresh full-refresh target

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -5,7 +5,7 @@ class EmsEvent
     def manager_refresh(sync: false)
       refresh_targets = manager_refresh_targets
 
-      return if refresh_targets.empty?
+      return if refresh_targets.blank?
 
       EmsRefresh.queue_refresh(refresh_targets, nil, :create_task => sync)
     end


### PR DESCRIPTION
If an ems does not support targeted refresh then the ems object is returned.  In this case the check for `#empty?` was causing failures:
```
NoMethodError (undefined method `empty?' for #<ManageIQ::Providers::Redhat::InfraManager:0x0000558842fee5c8>)
Did you mean?  emstype?
```