### PR TITLE
Set the pod HOME env variable to a writable location

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -107,6 +107,7 @@ class ContainerOrchestrator
     def default_environment
       [
         {:name => "GUID",                    :value => MiqServer.my_guid},
+        {:name => "HOME",                    :value => Rails.root.join("tmp").to_s},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},


### PR DESCRIPTION
Our code or libraries could try to use `~` or `$HOME` and expect to be able to
create directories or files here and fail.  Previously, `$HOME` would default to `/`, which is
not writable for our user.

This now looks very similar to the heartbeat file location:

```
irb(main):001:0> pp ContainerOrchestrator.new.send(:default_environment)[1]
{:name=>"HOME", :value=>"/Users/joerafaniello/Code/manageiq/tmp"}
=> {:name=>"HOME", :value=>"/Users/joerafaniello/Code/manageiq/tmp"}

irb(main):002:0> pp ContainerOrchestrator.new.send(:default_environment)[4]
{:name=>"WORKER_HEARTBEAT_FILE",
 :value=>"/Users/joerafaniello/Code/manageiq/tmp/worker.hb"}
=> {:name=>"WORKER_HEARTBEAT_FILE", :value=>"/Users/joerafaniello/Code/manageiq/tmp/worker.hb"}
```

Note, on pods/appliances, this location is `/var/www/miq/vmdb/tmp`