### PR TITLE
moving evmserverd to core

### DIFF
--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MiqWorker::SystemdCommon do
     it "every worker has a matching systemd target and service file", :providers_common => true do
       expected_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
 
-      expected_units.delete("manageiq.target")
+      expected_units -= %w[manageiq-db-ready.service evmserverd.service manageiq.target]
 
       found_units = MiqWorkerType.worker_classes.flat_map do |worker_class|
         service_base_name = worker_class.service_base_name

--- a/systemd/evmserverd.service
+++ b/systemd/evmserverd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=EVM server daemon
+After=memcached.service manageiq-db-ready.service
+Wants=memcached.service manageiq-db-ready.service
+
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+EnvironmentFile=/etc/default/manageiq*.properties
+Environment=EVMSERVER=true
+ExecStart=/usr/bin/ruby lib/workers/bin/evm_server.rb
+Group=manageiq
+UMask=0002
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/manageiq-db-ready.service
+++ b/systemd/manageiq-db-ready.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ManageIQ DB Ready
+After=network.target
+Before=evmserverd.service
+ConditionPathExists=/var/www/miq/vmdb/config/database.yml
+
+[Service]
+ExecStart=/usr/bin/manageiq-db-ready
+EnvironmentFile=/etc/default/manageiq*.properties
+TimeoutStartSec=infinity
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
All of our worker systemd service files are located in the core repo.

evmserverd / MiqServer is not.

Moving it here.

see also https://github.com/ManageIQ/manageiq-appliance/pull/342