### PR TITLE
Add missing supports features for vm relocation

### DIFF
--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -2,8 +2,11 @@ module VmOrTemplate::Operations::Relocation
   extend ActiveSupport::Concern
 
   included do
+    supports_not :evacuate
     supports_not :live_migrate
     supports_not :migrate
+    supports_not :move_into_folder
+    supports_not :relocate
   end
 
   def raw_live_migrate(_options = nil)


### PR DESCRIPTION
There were a number of vm relocation operations which were missing supports features

Will follow-up with adding the matching `supports` to each provider
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/766