### PR TITLE
Support both dalli 3.1+ and 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "connection_pool",                                       :require => false # For Dalli
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false
-gem "dalli",                            "~>3.0.6",           :require => false
+gem "dalli",                            "~>3.0",             :require => false
 gem "default_value_for",                "~>3.3"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,6 +233,11 @@ class User < ApplicationRecord
     return unless request
     return unless (session_id = request.session_options[:id])
 
+    # dalli 3.1 switched to Abstract::PersistedStore from Abstract::Persisted and the resulting session id
+    # changed from a string to a SessionID object that can't be coerced in finders. Convert this object to string via
+    # the private_id method, see: https://github.com/rack/rack/issues/1432#issuecomment-571688819
+    session_id = session_id.private_id if session_id.respond_to?(:private_id)
+
     sessions << Session.find_or_create_by(:session_id => session_id)
   end
 

--- a/lib/extensions/rack_session_dalli_patch.rb
+++ b/lib/extensions/rack_session_dalli_patch.rb
@@ -4,35 +4,24 @@ require "rack/session/dalli"
 module RackSessionDalliPatch
   def delete_sessions(session_ids)
     session_ids.each do |session_id|
-      destroy_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
-    end
-  end
-
-  # As we monkey-patch marshal to support autoloading, Dalli can
-  # cause a load to occur. Consequently, we need to manage things
-  # carefully to prevent a deadlock between the Rails Interlock and
-  # Dalli's own exclusive lock.
-  def with_block(*args)
-    ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-      super do |dc|
-        ActiveSupport::Dependencies.interlock.running do
-          yield dc
-        end
+      if Dalli::VERSION >= "3.1.0"
+        delete_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
+      else
+        destroy_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
       end
     end
   end
 end
 
-# In commit: https://github.com/petergoldstein/dalli/commit/9f9c508afab263a2451f2209c4396daf98d33a1b
-# with_lock was renamed to with_block with a slightly different interface.
-# All versions since 2.7.7 have with_block now.
-# Additionally, we'll detect and warn if the method we depend on in our prepended module doesn't exist before we try to prepend it.
-%w[with_block destroy_session].each do |method|
-  begin
-    Rack::Session::Dalli.instance_method(method)
-  rescue NameError => err
-    warn "Dalli is missing the method our prepended code depends on: #{err}."
-    warn "Did the dalli version change?  Was the method removed or renamed upstream? See: #{__FILE__}"
+begin
+  if Dalli::VERSION >= "3.1.0"
+    Rack::Session::Dalli.instance_method('delete_session')
+  else
+    Rack::Session::Dalli.instance_method('destroy_session')
   end
+rescue NameError => err
+  warn "Dalli #{Dalli::VERSION} is missing the method our prepended code depends on: #{err}."
+  warn "Did the dalli version change?  Was the method removed or renamed upstream? See: #{__FILE__}"
 end
+
 Rack::Session::Dalli.prepend(RackSessionDalliPatch)


### PR DESCRIPTION
Prepare for a 📖 .  I need to justify why we can remove the deadlock avoidance monkey patch so I prefer to write it all down for future me, you and everyone.  😉 

## Remove the with_lock/with_block monkey patch

We originally added the `with_lock` wrapper to ensure the dalli lock and the active support dependencies lock played nice.

Our monkey patch added this here:
https://github.com/ManageIQ/manageiq/pull/7334

The AS::Dependencies lock had to play nice with the mutex found in dalli here:
https://github.com/petergoldstein/dalli/blob/v2.7.6/lib/rack/session/dalli.rb#L73-L74

Therefore we monkey patched dalli session to ensure this mutex would allow
`AS::Dependencies` lock to be released properly and avoid a deadlock between the two
locks.

Dalli renamed with_lock to with_block in 2.7.7 (yes, a patch release):
https://github.com/petergoldstein/dalli/commit/9f9c508afab263a2451f2209c4396daf98d33a1b#diff-4b41e4b33e4b095e350045d4e727d2e889890cfc0610d434459f30a267423065

The lock in `with_block` was removed in dalli 3.0.0: https://github.com/petergoldstein/dalli/commit/7be38027f36cfd5e3e8dd9fe0d2d5843bf7292da

All that for this:
The lock is gone as of 3.0.0 so we don't need to wrap `with_block` anymore!

## Dalli 3.1.0 renamed session method destroy_session to delete_session.
To avoid dynamic code, we're using simple conditionals to call the correct method
based on the version.

## Dalli 3.1.0 changed to use Abstract::PersistedStore

This was previously `Abstract::Persisted`.  This changed the session id from a string to a `SessionID` object that can't be coerced in finders.  We need to handle this for dalli 3.0/3.1 compatibility.
See: https://github.com/petergoldstein/dalli/commit/3abf71533c5288dd49c4756fb1c9f2989e263e89

## We now allow dalli both 3.0 and 3.1+.  
We can require 3.1+ and eliminate some conditionals once we're satisfied that 3.1 is working for us.