### PR TITLE
[WIP] add end2end test for create ph_storage

### DIFF
--- a/spec/fixtures/end2end/physical_storage.json
+++ b/spec/fixtures/end2end/physical_storage.json
@@ -1,0 +1,7 @@
+{
+  "name"                       : "svc-178",
+  "password"                   : "<password>",
+  "user"                       : "<user>",
+  "physical_storage_family_id" : 123,
+  "management_ip"              : "9.151.159.178"
+}


### PR DESCRIPTION
Since MIQ has no system-tests, we have been toying with an idea of simulating system tests by stitching unit tests back-to-back.

below are a set of PR with a very basic POC demonstrating the idea.
https://github.com/ManageIQ/manageiq/pull/21622
https://github.com/ManageIQ/manageiq-providers-autosde/pull/122
https://github.com/ManageIQ/manageiq-ui-classic/pull/7993


general outline of the approach
------------
Usually when someone submits a PR, they only run unit-tests in the repo that they changed. However, the change might affect flows in other repositories. 
In the POC we have a scenario where we create a new Physical Storage. It involves filling a JS form. The data from the form is submitted through the API to the appropriate create method in the backend, and the backend sends a request to the EMS. 
To cover this scenario we would write two tests. 
One in the UI would check that the form’s state matches what we need to send to the API. 
In the backend, we’d check that calling the create method of the controller with the correct parameters results in the correct API calls to the EMS. 
This would cover the end-to-end scenario but have a problem. 
If anyone were to change the backend, they’d adjust the tests for the backend but would not know to adjust the complementary tests for the UI. The two tests covering the scenario would drift apart over time and no longer cover a coherent flow. 
To overcome this, we couple the backend test to the UI form test through a separate set of tests. It these meta-tests make sure that the UI test’s state matches the input to the backend test. 
This way if anyone changes either the backend or the UI they will need to make sure the entire scenario still works. 

