### PR TITLE
Fix the ems_custom_attributes inventory collection

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -74,7 +74,7 @@ module ManageIQ::Providers
         def ems_custom_attributes
           add_properties(
             :model_class                  => ::CustomAttribute,
-            :manager_ref                  => %i(name),
+            :manager_ref                  => %i(resource name),
             :parent_inventory_collections => %i(vms miq_templates),
           )
         end
@@ -84,8 +84,8 @@ module ManageIQ::Providers
 
           add_properties(
             :model_class                  => ::CustomAttribute,
-            :manager_ref                  => %i(name),
-            :parent_inventory_collections => %i(vms)
+            :manager_ref                  => %i(resource name),
+            :parent_inventory_collections => %i(vms miq_templates)
           )
 
           add_inventory_attributes(%i(section name value source resource))


### PR DESCRIPTION
This had a manager_ref of just `:name` but these belong to a polymorphic resource and just the name is not unique.

Adding the `:resource` to the manager_ref array makes this unique.

Spec test showing the failure: https://github.com/ManageIQ/manageiq-providers-vmware/pull/771

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/727