### PR TITLE
Force upgrade to dalli 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "connection_pool",                                       :require => false # For Dalli
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false
-gem "dalli",                            "~>3.0",             :require => false
+gem "dalli",                            "~>3.1.0",           :require => false
 gem "default_value_for",                "~>3.3"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false

--- a/lib/extensions/rack_session_dalli_patch.rb
+++ b/lib/extensions/rack_session_dalli_patch.rb
@@ -4,21 +4,13 @@ require "rack/session/dalli"
 module RackSessionDalliPatch
   def delete_sessions(session_ids)
     session_ids.each do |session_id|
-      if Dalli::VERSION >= "3.1.0"
-        delete_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
-      else
-        destroy_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
-      end
+      delete_session(ManageIQ::Session.fake_request.env, session_id, :drop => true)
     end
   end
 end
 
 begin
-  if Dalli::VERSION >= "3.1.0"
-    Rack::Session::Dalli.instance_method('delete_session')
-  else
-    Rack::Session::Dalli.instance_method('destroy_session')
-  end
+  Rack::Session::Dalli.instance_method('delete_session')
 rescue NameError => err
   warn "Dalli #{Dalli::VERSION} is missing the method our prepended code depends on: #{err}."
   warn "Did the dalli version change?  Was the method removed or renamed upstream? See: #{__FILE__}"


### PR DESCRIPTION
Built on top of #21619
Specifically: https://github.com/ManageIQ/manageiq/commit/bd0a0cc5d21cae85ab2a0c52379f1b66ed3ae5a2
This prior PR/commit can be backported if we want to drop the no longer needed
mutex / synchronize but remain with dalli 3.0.

This PR/commit eliminates some complexity by dropping support for dalli 3.0.

Dalli doesn't necessarily follow semver so I chose to allow patches on 3.1 only.
