### PR TITLE
Remove orphaned v2v migration shortcuts

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -289,21 +289,6 @@
   :url: /container_topology
   :rbac_feature_name: container_topology_view
   :startup: true
-- :name: migration
-  :description: Migration / Migration Plans
-  :url: /migration/#plans
-  :rbac_feature_name: migration
-  :startup: true
-- :name: mappings
-  :description: Migration / Infrastructure Mappings
-  :url: /migration/#mappings
-  :rbac_feature_name: mappings
-  :startup: true
-- :name: migration_settings
-  :description: Migration / Migration Settings
-  :url: /migration/#settings
-  :rbac_feature_name: migration_settings
-  :startup: true
 - :name: ems_configuration
   :description: Configuration / Providers
   :url: ems_configuration/show_list


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7994

Ironically, they were neglected when we added v2v and added later in commit 53e764f70a9f3d8d743d54da0a3e4d49a8bdd071
Of course, I missed them when removing v2v in:
https://github.com/ManageIQ/manageiq/pull/21515

Which was part of the larger issue:
https://github.com/ManageIQ/manageiq/issues/21379

NOTE:  v2v removal wasn't in morphy, so this is morphy/no