### PR TITLE
Move the snapshots inventory collection to shared

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -56,13 +56,6 @@ module ManageIQ::Providers
           )
         end
 
-        def snapshots
-          add_properties(
-            :manager_ref                  => %i[vm_or_template uid],
-            :parent_inventory_collections => %i[vms miq_templates]
-          )
-        end
-
         def host_operating_systems
           add_properties(
             :model_class                  => ::OperatingSystem,

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -110,6 +110,13 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       )
     end
 
+    def snapshots
+      add_properties(
+        :manager_ref                  => %i[vm_or_template uid],
+        :parent_inventory_collections => %i[vms miq_templates]
+      )
+    end
+
     def hardwares
       add_properties(
         :manager_ref                  => %i[vm_or_template],


### PR DESCRIPTION
Allow this collection to be used by both Infra and Cloud type managers.

Ref: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/313/files#r772395945