### PR TITLE
Fix rubocop issues in inventory collection definitions

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -87,8 +87,8 @@ module ManageIQ::Providers
 
         send(@name.to_sym) if @name.respond_to?(:to_sym) && respond_to?(@name.to_sym)
 
-        if @properties[:model_class].nil?
-          add_properties(:model_class => auto_model_class) unless @options[:without_model_class]
+        if @properties[:model_class].nil? && !(@options[:without_model_class])
+          add_properties(:model_class => auto_model_class)
         end
       end
 
@@ -244,7 +244,7 @@ module ManageIQ::Providers
       def auto_inventory_attributes
         return if @properties[:model_class].nil?
 
-        (@properties[:model_class].new.methods - ApplicationRecord.methods).grep(/^[\w]+?\=$/).collect do |setter|
+        (@properties[:model_class].new.methods - ApplicationRecord.methods).grep(/^\w+?=$/).collect do |setter|
           setter.to_s[0..setter.length - 2].to_sym
         end
       end

--- a/app/models/manageiq/providers/inventory/persister/builder/automation_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/automation_manager.rb
@@ -4,8 +4,8 @@ module ManageIQ::Providers
       class AutomationManager < ::ManageIQ::Providers::Inventory::Persister::Builder
         def authentication_configuration_script_bases
           add_properties(
-            :manager_ref                  => %i(configuration_script_base authentication),
-            :parent_inventory_collections => %i(configuration_scripts)
+            :manager_ref                  => %i[configuration_script_base authentication],
+            :parent_inventory_collections => %i[configuration_scripts]
           )
         end
 
@@ -16,8 +16,8 @@ module ManageIQ::Providers
 
         def configuration_script_payloads
           add_properties(
-            :manager_ref                  => %i(configuration_script_source manager_ref),
-            :parent_inventory_collections => %i(configuration_script_sources)
+            :manager_ref                  => %i[configuration_script_source manager_ref],
+            :parent_inventory_collections => %i[configuration_script_sources]
           )
           add_common_default_values
         end
@@ -44,13 +44,13 @@ module ManageIQ::Providers
         end
 
         def vms
-          add_properties(:manager_ref => %i(uid_ems))
+          add_properties(:manager_ref => %i[uid_ems])
         end
 
         protected
 
         def default_manager_ref
-          add_properties(:manager_ref => %i(manager_ref))
+          add_properties(:manager_ref => %i[manager_ref])
         end
 
         def add_common_default_values

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers
           add_properties(
             :name        => :auth_key_pairs,
             :association => :key_pairs,
-            :manager_ref => %i(name)
+            :manager_ref => %i[name]
           )
           add_default_values(
             :resource_id   => parent.id,
@@ -41,21 +41,21 @@ module ManageIQ::Providers
         def orchestration_stacks_resources
           add_properties(
             :model_class                  => ::OrchestrationStackResource,
-            :parent_inventory_collections => %i(orchestration_stacks)
+            :parent_inventory_collections => %i[orchestration_stacks]
           )
         end
 
         def orchestration_stacks_outputs
           add_properties(
             :model_class                  => ::OrchestrationStackOutput,
-            :parent_inventory_collections => %i(orchestration_stacks)
+            :parent_inventory_collections => %i[orchestration_stacks]
           )
         end
 
         def orchestration_stacks_parameters
           add_properties(
             :model_class                  => ::OrchestrationStackParameter,
-            :parent_inventory_collections => %i(orchestration_stacks)
+            :parent_inventory_collections => %i[orchestration_stacks]
           )
         end
 
@@ -123,11 +123,11 @@ module ManageIQ::Providers
 
           model_class = stacks_inventory_collection.model_class
 
-          stacks_parents_indexed = model_class.select(%i(id ancestry))
+          stacks_parents_indexed = model_class.select(%i[id ancestry])
                                               .where(:id => stacks_parents.values).find_each.index_by(&:id)
 
           ActiveRecord::Base.transaction do
-            model_class.select(%i(id ancestry))
+            model_class.select(%i[id ancestry])
                        .where(:id => stacks_parents.keys).find_each do |stack|
               parent = stacks_parents_indexed[stacks_parents[stack.id]]
               stack.update_attribute(:parent, parent)

--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers
         # TODO: (agrare) Targeted refreshes will require adjusting the associations / arels. (duh)
         def container_projects
           add_properties(
-            :secondary_refs => {:by_name => %i(name)},
+            :secondary_refs => {:by_name => %i[name]},
             :delete_method  => :disconnect_inv
           )
           add_common_default_values
@@ -13,7 +13,7 @@ module ManageIQ::Providers
 
         def container_quotas
           add_properties(
-            :attributes_blacklist => %i(namespace),
+            :attributes_blacklist => %i[namespace],
             :delete_method        => :disconnect_inv
           )
           add_common_default_values
@@ -21,36 +21,36 @@ module ManageIQ::Providers
 
         def container_quota_scopes
           add_properties(
-            :manager_ref                  => %i(container_quota scope),
-            :parent_inventory_collections => %i(container_quotas)
+            :manager_ref                  => %i[container_quota scope],
+            :parent_inventory_collections => %i[container_quotas]
           )
         end
 
         def container_quota_items
           add_properties(
-            :manager_ref                  => %i(container_quota resource quota_desired quota_enforced quota_observed),
+            :manager_ref                  => %i[container_quota resource quota_desired quota_enforced quota_observed],
             :delete_method                => :disconnect_inv,
-            :parent_inventory_collections => %i(container_quotas)
+            :parent_inventory_collections => %i[container_quotas]
           )
         end
 
         def container_limits
           add_properties(
-            :attributes_blacklist => %i(namespace)
+            :attributes_blacklist => %i[namespace]
           )
           add_common_default_values
         end
 
         def container_limit_items
           add_properties(
-            :manager_ref                  => %i(container_limit resource item_type),
-            :parent_inventory_collections => %i(container_limits)
+            :manager_ref                  => %i[container_limit resource item_type],
+            :parent_inventory_collections => %i[container_limits]
           )
         end
 
         def container_nodes
           add_properties(
-            :secondary_refs => {:by_name => %i(name)},
+            :secondary_refs => {:by_name => %i[name]},
             :delete_method  => :disconnect_inv
           )
           add_common_default_values
@@ -58,28 +58,28 @@ module ManageIQ::Providers
 
         def computer_systems
           add_properties(
-            :manager_ref => %i(managed_entity),
+            :manager_ref                  => %i[managed_entity],
             # TODO(lsmola) can we introspect this from the relation? Basically, the
             # :parent_inventory_collections are needed only if :association goes :through other association. Then the
             # parent is actually the root association (if we chain several :through associations). We should be able to
             # create a tree of :through associations of ems and infer the parent_inventory_collections from that?
-            :parent_inventory_collections => %i(container_nodes),
+            :parent_inventory_collections => %i[container_nodes]
           )
         end
 
         def computer_system_hardwares
           add_properties(
             :model_class                  => ::Hardware,
-            :manager_ref                  => %i(computer_system),
-            :parent_inventory_collections => %i(container_nodes),
+            :manager_ref                  => %i[computer_system],
+            :parent_inventory_collections => %i[container_nodes]
           )
         end
 
         def computer_system_operating_systems
           add_properties(
             :model_class                  => ::OperatingSystem,
-            :manager_ref                  => %i(computer_system),
-            :parent_inventory_collections => %i(container_nodes),
+            :manager_ref                  => %i[computer_system],
+            :parent_inventory_collections => %i[container_nodes]
           )
         end
 
@@ -90,7 +90,7 @@ module ManageIQ::Providers
             # TODO: (bpaskinc) should match on digest when available
             # TODO: (mslemr) provider-specific class exists (openshift), but specs fail with them (?)
             :model_class            => ::ContainerImage,
-            :manager_ref            => %i(image_ref),
+            :manager_ref            => %i[image_ref],
             :delete_method          => :disconnect_inv,
             :custom_reconnect_block => custom_reconnect_block
           )
@@ -98,14 +98,14 @@ module ManageIQ::Providers
         end
 
         def container_image_registries
-          add_properties(:manager_ref => %i(host port))
+          add_properties(:manager_ref => %i[host port])
           add_common_default_values
         end
 
         def container_groups
           add_properties(
-            :secondary_refs         => {:by_container_project_and_name => %i(container_project name)},
-            :attributes_blacklist   => %i(namespace),
+            :secondary_refs         => {:by_container_project_and_name => %i[container_project name]},
+            :attributes_blacklist   => %i[namespace],
             :delete_method          => :disconnect_inv,
             :custom_reconnect_block => custom_reconnect_block
           )
@@ -114,8 +114,8 @@ module ManageIQ::Providers
 
         def container_volumes
           add_properties(
-            :manager_ref                  => %i(parent name),
-            :parent_inventory_collections => %i(container_groups),
+            :manager_ref                  => %i[parent name],
+            :parent_inventory_collections => %i[container_groups]
           )
         end
 
@@ -131,37 +131,37 @@ module ManageIQ::Providers
         def container_port_configs
           # parser sets :ems_ref => "#{pod_id}_#{container_name}_#{port_config.containerPort}_#{port_config.hostPort}_#{port_config.protocol}"
           add_properties(
-            :parent_inventory_collections => %i(containers)
+            :parent_inventory_collections => %i[containers]
           )
         end
 
         def container_env_vars
           add_properties(
             # TODO: (agrare) old save matches on all :name, :value, :field_path - does this matter?
-            :manager_ref                  => %i(container name),
-            :parent_inventory_collections => %i(containers)
+            :manager_ref                  => %i[container name],
+            :parent_inventory_collections => %i[containers]
           )
         end
 
         def security_contexts
           add_properties(
-            :manager_ref                  => %i(resource),
-            :parent_inventory_collections => %i(containers)
+            :manager_ref                  => %i[resource],
+            :parent_inventory_collections => %i[containers]
           )
         end
 
         def container_replicators
           add_properties(
-            :secondary_refs       => {:by_container_project_and_name => %i(container_project name)},
-            :attributes_blacklist => %i(namespace)
+            :secondary_refs       => {:by_container_project_and_name => %i[container_project name]},
+            :attributes_blacklist => %i[namespace]
           )
           add_common_default_values
         end
 
         def container_services
           add_properties(
-            :secondary_refs       => {:by_container_project_and_name => %i(container_project name)},
-            :attributes_blacklist => %i(namespace),
+            :secondary_refs       => {:by_container_project_and_name => %i[container_project name]},
+            :attributes_blacklist => %i[namespace],
             :saver_strategy       => "default" # TODO: (fryguy) (perf) Can't use batch strategy because of usage of M:N container_groups relation
           )
           add_common_default_values
@@ -169,35 +169,35 @@ module ManageIQ::Providers
 
         def container_service_port_configs
           add_properties(
-            :manager_ref                  => %i(ems_ref protocol), # TODO: (lsmola) make protocol part of the ems_ref?)
-            :parent_inventory_collections => %i(container_services)
+            :manager_ref                  => %i[ems_ref protocol], # TODO: (lsmola) make protocol part of the ems_ref?)
+            :parent_inventory_collections => %i[container_services]
           )
         end
 
         def container_routes
           add_properties(
-            :attributes_blacklist => %i(namespace)
+            :attributes_blacklist => %i[namespace]
           )
           add_common_default_values
         end
 
         def container_templates
           add_properties(
-            :attributes_blacklist => %i(namespace)
+            :attributes_blacklist => %i[namespace]
           )
           add_common_default_values
         end
 
         def container_template_parameters
           add_properties(
-            :manager_ref                  => %i(container_template name),
-            :parent_inventory_collections => %i(container_templates)
+            :manager_ref                  => %i[container_template name],
+            :parent_inventory_collections => %i[container_templates]
           )
         end
 
         def container_builds
           add_properties(
-            :secondary_refs => {:by_namespace_and_name => %i(namespace name)}
+            :secondary_refs => {:by_namespace_and_name => %i[namespace name]}
           )
           add_common_default_values
         end
@@ -205,8 +205,8 @@ module ManageIQ::Providers
         def container_build_pods
           add_properties(
             # TODO: (bpaskinc) convert namespace column -> container_project_id?
-            :manager_ref    => %i(namespace name),
-            :secondary_refs => {:by_namespace_and_name => %i(namespace name)},
+            :manager_ref    => %i[namespace name],
+            :secondary_refs => {:by_namespace_and_name => %i[namespace name]}
           )
           add_common_default_values
         end
@@ -217,8 +217,8 @@ module ManageIQ::Providers
 
         def persistent_volume_claims
           add_properties(
-            :secondary_refs       => {:by_container_project_and_name => %i(container_project name)},
-            :attributes_blacklist => %i(namespace)
+            :secondary_refs       => {:by_container_project_and_name => %i[container_project name]},
+            :attributes_blacklist => %i[namespace]
           )
           add_common_default_values
         end
@@ -245,7 +245,7 @@ module ManageIQ::Providers
 
               batch_size = 100
               saved_collection.created_records.each_slice(batch_size) do |batch|
-                collection_ids = batch.collect { |x| x[:id] }
+                collection_ids = batch.pluck(:id)
                 MiqQueue.submit_job(
                   :class_name  => saved_collection.model_class.to_s,
                   :method_name => 'raise_creation_events',

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -4,78 +4,78 @@ module ManageIQ::Providers
       class InfraManager < ::ManageIQ::Providers::Inventory::Persister::Builder
         def networks
           add_properties(
-            :manager_ref                  => %i(hardware ipaddress ipv6address),
-            :parent_inventory_collections => %i(vms miq_templates),
+            :manager_ref                  => %i[hardware ipaddress ipv6address],
+            :parent_inventory_collections => %i[vms miq_templates]
           )
         end
 
         def host_networks
           add_properties(
             :model_class                  => ::Network,
-            :manager_ref                  => %i(hardware ipaddress),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[hardware ipaddress],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def guest_devices
           add_properties(
-            :manager_ref                  => %i(hardware uid_ems),
-            :parent_inventory_collections => %i(vms miq_templates),
+            :manager_ref                  => %i[hardware uid_ems],
+            :parent_inventory_collections => %i[vms miq_templates]
           )
         end
 
         def host_guest_devices
           add_properties(
             :model_class                  => ::GuestDevice,
-            :manager_ref                  => %i(hardware uid_ems),
-            :parent_inventory_collections => %i(hosts),
+            :manager_ref                  => %i[hardware uid_ems],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def host_hardwares
           add_properties(
             :model_class                  => ::Hardware,
-            :manager_ref                  => %i(host),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[host],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def host_disks
           add_properties(
             :model_class                  => ::Disk,
-            :manager_ref                  => %i(hardware device_name),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[hardware device_name],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def host_system_services
           add_properties(
             :model_class                  => ::SystemService,
-            :manager_ref                  => %i(host name),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[host name],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def snapshots
           add_properties(
-            :manager_ref                  => %i(vm_or_template uid),
-            :parent_inventory_collections => %i(vms miq_templates),
+            :manager_ref                  => %i[vm_or_template uid],
+            :parent_inventory_collections => %i[vms miq_templates]
           )
         end
 
         def host_operating_systems
           add_properties(
             :model_class                  => ::OperatingSystem,
-            :manager_ref                  => %i(host),
-            :parent_inventory_collections => %i(hosts),
+            :manager_ref                  => %i[host],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def ems_custom_attributes
           add_properties(
             :model_class                  => ::CustomAttribute,
-            :manager_ref                  => %i(resource name),
-            :parent_inventory_collections => %i(vms miq_templates),
+            :manager_ref                  => %i[resource name],
+            :parent_inventory_collections => %i[vms miq_templates]
           )
         end
 
@@ -84,17 +84,17 @@ module ManageIQ::Providers
 
           add_properties(
             :model_class                  => ::CustomAttribute,
-            :manager_ref                  => %i(resource name),
-            :parent_inventory_collections => %i(vms miq_templates)
+            :manager_ref                  => %i[resource name],
+            :parent_inventory_collections => %i[vms miq_templates]
           )
 
-          add_inventory_attributes(%i(section name value source resource))
+          add_inventory_attributes(%i[section name value source resource])
         end
 
         def ems_folders
           add_properties(
             :manager_ref          => %i[uid_ems],
-            :attributes_blacklist => %i[parent],
+            :attributes_blacklist => %i[parent]
           )
           add_common_default_values
         end
@@ -107,7 +107,7 @@ module ManageIQ::Providers
         def resource_pools
           add_properties(
             :manager_ref          => %i[uid_ems],
-            :attributes_blacklist => %i[parent],
+            :attributes_blacklist => %i[parent]
           )
           add_common_default_values
         end
@@ -147,23 +147,23 @@ module ManageIQ::Providers
 
         def host_storages
           add_properties(
-            :manager_ref                  => %i(host storage),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[host storage],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def host_switches
           add_properties(
-            :manager_ref                  => %i(host switch),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[host switch],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def host_virtual_switches
           add_properties(
-            :manager_ref                  => %i(host uid_ems),
+            :manager_ref                  => %i[host uid_ems],
             :model_class                  => Switch,
-            :parent_inventory_collections => %i(hosts)
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
@@ -178,16 +178,16 @@ module ManageIQ::Providers
 
         def lans
           add_properties(
-            :manager_ref                  => %i(switch uid_ems),
-            :parent_inventory_collections => %i(hosts),
+            :manager_ref                  => %i[switch uid_ems],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def distributed_virtual_lans
           add_properties(
             :model_class                  => Lan,
-            :manager_ref                  => %i(switch uid_ems),
-            :parent_inventory_collections => %i(distributed_virtual_switches),
+            :manager_ref                  => %i[switch uid_ems],
+            :parent_inventory_collections => %i[distributed_virtual_switches]
           )
         end
 
@@ -201,28 +201,28 @@ module ManageIQ::Providers
 
         def subnets
           add_properties(
-            :manager_ref                  => %i(lan ems_ref),
-            :parent_inventory_collections => %i(hosts),
+            :manager_ref                  => %i[lan ems_ref],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def customization_specs
-          add_properties(:manager_ref => %i(name))
+          add_properties(:manager_ref => %i[name])
 
           add_common_default_values
         end
 
         def miq_scsi_luns
           add_properties(
-            :manager_ref                  => %i(miq_scsi_target uid_ems),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[miq_scsi_target uid_ems],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
         def miq_scsi_targets
           add_properties(
-            :manager_ref                  => %i(guest_device uid_ems),
-            :parent_inventory_collections => %i(hosts)
+            :manager_ref                  => %i[guest_device uid_ems],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 
@@ -258,7 +258,7 @@ module ManageIQ::Providers
           )
 
           add_dependency_attributes(
-            :ems_folders => ->(persister) { [persister.collections[:ems_folders]] },
+            :ems_folders => ->(persister) { [persister.collections[:ems_folders]] }
           )
         end
 
@@ -271,8 +271,8 @@ module ManageIQ::Providers
           )
 
           dependency_collections = %i[clusters ems_folders datacenters hosts resource_pools storages]
-          dependency_attributes = dependency_collections.each_with_object({}) do |collection, hash|
-            hash[collection] = ->(persister) { [persister.collections[collection]].compact }
+          dependency_attributes = dependency_collections.index_with do |collection|
+            ->(persister) { [persister.collections[collection]].compact }
           end
           add_dependency_attributes(dependency_attributes)
         end

--- a/app/models/manageiq/providers/inventory/persister/builder/network_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/network_manager.rb
@@ -5,8 +5,8 @@ module ManageIQ::Providers
         def cloud_subnet_network_ports
           add_properties(
             # :model_class                  => ::CloudSubnetNetworkPort,
-            :manager_ref                  => %i(address cloud_subnet network_port),
-            :parent_inventory_collections => %i(vms network_ports load_balancers)
+            :manager_ref                  => %i[address cloud_subnet network_port],
+            :parent_inventory_collections => %i[vms network_ports load_balancers]
           )
 
           add_targeted_arel(
@@ -75,8 +75,8 @@ module ManageIQ::Providers
 
         def firewall_rules
           add_properties(
-            :manager_ref                  => %i(resource source_security_group direction host_protocol port end_port source_ip_range),
-            :parent_inventory_collections => %i(security_groups)
+            :manager_ref                  => %i[resource source_security_group direction host_protocol port end_port source_ip_range],
+            :parent_inventory_collections => %i[security_groups]
           )
         end
 
@@ -86,7 +86,7 @@ module ManageIQ::Providers
 
         def load_balancer_pools
           add_properties(
-            :parent_inventory_collections => %i(load_balancers)
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(
@@ -104,7 +104,7 @@ module ManageIQ::Providers
 
         def load_balancer_pool_members
           add_properties(
-            :parent_inventory_collections => %i(load_balancers)
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(
@@ -127,8 +127,8 @@ module ManageIQ::Providers
 
         def load_balancer_pool_member_pools
           add_properties(
-            :manager_ref                  => %i(load_balancer_pool load_balancer_pool_member),
-            :parent_inventory_collections => %i(load_balancers)
+            :manager_ref                  => %i[load_balancer_pool load_balancer_pool_member],
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(
@@ -136,7 +136,7 @@ module ManageIQ::Providers
               manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
               inventory_collection.parent.load_balancer_pool_member_pools
                 .joins(:load_balancer_pool => :load_balancers)
-                .where(:load_balancer_pools => { 'load_balancers' => { :ems_ref => manager_uuids } })
+                .where(:load_balancer_pools => {'load_balancers' => {:ems_ref => manager_uuids}})
                 .distinct
             end
           )
@@ -145,7 +145,7 @@ module ManageIQ::Providers
         def load_balancer_listeners
           add_properties(
             :use_ar_object                => true,
-            :parent_inventory_collections => %i(load_balancers),
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(
@@ -163,8 +163,8 @@ module ManageIQ::Providers
 
         def load_balancer_listener_pools
           add_properties(
-            :manager_ref                  => %i(load_balancer_listener load_balancer_pool),
-            :parent_inventory_collections => %i(load_balancers)
+            :manager_ref                  => %i[load_balancer_listener load_balancer_pool],
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(
@@ -180,7 +180,7 @@ module ManageIQ::Providers
 
         def load_balancer_health_checks
           add_properties(
-            :parent_inventory_collections => %i(load_balancers)
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(
@@ -198,8 +198,8 @@ module ManageIQ::Providers
 
         def load_balancer_health_check_members
           add_properties(
-            :manager_ref                  => %i(load_balancer_health_check load_balancer_pool_member),
-            :parent_inventory_collections => %i(load_balancers)
+            :manager_ref                  => %i[load_balancer_health_check load_balancer_pool_member],
+            :parent_inventory_collections => %i[load_balancers]
           )
 
           add_targeted_arel(

--- a/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
@@ -19,12 +19,12 @@ module ManageIQ::Providers
         end
 
         def physical_switches
-          add_properties(:manager_ref => %i(uid_ems))
+          add_properties(:manager_ref => %i[uid_ems])
           add_common_default_values
         end
 
         def customization_scripts
-          add_properties(:manager_ref => %i(manager_ref))
+          add_properties(:manager_ref => %i[manager_ref])
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
         end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -39,7 +39,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
 
     def ext_management_system
       add_properties(
-        :manager_ref       => %i(guid),
+        :manager_ref       => %i[guid],
         :custom_save_block => lambda do |ems, inventory_collection|
           ems_attrs = inventory_collection.data.first&.attributes
           ems.update!(ems_attrs) if ems_attrs
@@ -67,7 +67,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
         :attributes_blacklist   => %i[genealogy_parent parent resource_pool],
         :use_ar_object          => true, # Because of raw_power_state setter and hooks are needed for settings user
         :saver_strategy         => :default,
-        :batch_extra_attributes => %i(power_state state_changed_on previous_state),
+        :batch_extra_attributes => %i[power_state state_changed_on previous_state],
         :custom_reconnect_block => INVENTORY_RECONNECT_BLOCK
       )
 
@@ -112,9 +112,9 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
 
     def hardwares
       add_properties(
-        :manager_ref                  => %i(vm_or_template),
-        :parent_inventory_collections => %i(vms miq_templates),
-        :use_ar_object                => true, # TODO(lsmola) just because of default value on cpu_sockets, this can be fixed by separating instances_hardwares and images_hardwares
+        :manager_ref                  => %i[vm_or_template],
+        :parent_inventory_collections => %i[vms miq_templates],
+        :use_ar_object                => true # TODO(lsmola) just because of default value on cpu_sockets, this can be fixed by separating instances_hardwares and images_hardwares
       )
     end
 
@@ -141,23 +141,23 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       end
 
       add_properties(
-        :manager_ref                  => %i(vm_or_template),
-        :parent_inventory_collections => %i(vms miq_templates),
+        :manager_ref                  => %i[vm_or_template],
+        :parent_inventory_collections => %i[vms miq_templates],
         :custom_save_block            => custom_save_block
       )
     end
 
     def networks
       add_properties(
-        :manager_ref                  => %i(hardware description),
-        :parent_inventory_collections => %i(vms)
+        :manager_ref                  => %i[hardware description],
+        :parent_inventory_collections => %i[vms]
       )
     end
 
     def disks
       add_properties(
-        :manager_ref                  => %i(hardware device_name),
-        :parent_inventory_collections => %i(vms)
+        :manager_ref                  => %i[hardware device_name],
+        :parent_inventory_collections => %i[vms]
       )
     end
 
@@ -175,7 +175,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
 
     def orchestration_stacks
       add_properties(
-        :attributes_blacklist => %i(parent),
+        :attributes_blacklist => %i[parent]
       )
 
       add_common_default_values


### PR DESCRIPTION
We end up hitting rubocop warnings for these (primarily for %i() vs %i[]) when editing these files and either have to deal with them or fix them line-by-line leading to inconsistencies.

This just bulk fixes all rubocop issues in the persister inventory collection definitions.