### PR TITLE
Add IBM Cloud Infrastructure Center provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,6 +126,10 @@ group :google, :manageiq_default do
   manageiq_plugin "manageiq-providers-google"
 end
 
+group :ibm_cic, :manageiq_default do
+  manageiq_plugin "manageiq-providers-ibm_cic"
+end
+
 group :ibm_cloud, :manageiq_default do
   manageiq_plugin "manageiq-providers-ibm_cloud"
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -51,6 +51,7 @@ class VmOrTemplate < ApplicationRecord
     "ibm_cloud"    => "IBM Cloud",
     "ibm_power_vc" => "IBM PowerVC",
     "ibm_power_vm" => "IBM PowerVM",
+    "ibm_z_vm"     => "IBM Z/VM",
     "unknown"      => "Unknown"
   }
 


### PR DESCRIPTION
Add the provider plugin for IBM Cloud Infrastructure Center (CIC)

https://www.ibm.com/products/cloud-infrastructure-center

This is an Openstack subclass provider.