### PR TITLE
Simplify inefficient regexes in MiqLdap

### DIFF
--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -1,4 +1,5 @@
 require 'net/ldap'
+require 'net/ldap/dn'
 
 class MiqLdap
   include Vmdb::Logging
@@ -266,16 +267,30 @@ class MiqLdap
     dn.split(",").collect { |i| i.downcase.strip }.join(",")
   end
 
+  def self.dn?(str)
+    Net::LDAP::DN.new(str).to_a.any?
+  rescue Net::LDAP::Error
+    false
+  end
+
   def dn?(str)
-    !!(str =~ /^([a-z|0-9|A-Z]+ *=[^,]+[,| ]*)+$/)
+    self.class.dn?(str)
+  end
+
+  def self.upn?(str)
+    str.to_s.match?(/.@./)
   end
 
   def upn?(str)
-    !!(str =~ /^.+@.+$/)
+    self.class.upn?(str)
+  end
+
+  def self.domain_username?(str)
+    str.to_s.match?(/^[a-zA-Z][a-zA-Z0-9.-]+\\./)
   end
 
   def domain_username?(str)
-    !!(str =~ /^([a-zA-Z][a-zA-Z0-9.-]+)\\.+$/)
+    self.class.domain_username?(str)
   end
 
   def fqusername(username)

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -278,4 +278,53 @@ RSpec.describe MiqLdap do
       expect(ldap.fqusername('myuserid@mycompany.com')).to eq('myuserid@mycompany.com')
     end
   end
+
+  describe ".dn?" do
+    {
+      "dc=mycompany,dc=com"                            => true,
+      "cn=myuser,ou=people,ou=prod,dc=example,dc=com"  => true,
+      "cn=my@user,ou=people,ou=prod,dc=example,dc=com" => true,
+      "myuserid"                                       => false,
+      "my\\user\\id"                                   => false,
+      "myuserid@mycompany.com"                         => false,
+      nil                                              => false,
+      ""                                               => false,
+    }.each do |s, expectation|
+      it "with case: #{s.inspect}" do
+        expect(described_class.dn?(s)).to be expectation
+      end
+    end
+  end
+
+  describe ".upn?" do
+    {
+      "myuserid"               => false,
+      "my\\user\\id"           => false,
+      "myuserid@mycompany.com" => true,
+      "myuserid@"              => false,
+      "@mycompany.com"         => false,
+      nil                      => false,
+      ""                       => false,
+    }.each do |s, expectation|
+      it "with case: #{s.inspect}" do
+        expect(described_class.upn?(s)).to be expectation
+      end
+    end
+  end
+
+  describe ".domain_username?" do
+    {
+      "myuserid"               => false,
+      "my\\user\\id"           => true,
+      "myuserid@mycompany.com" => false,
+      "\\user\\id"             => false,
+      "my\\"                   => false,
+      nil                      => false,
+      ""                       => false,
+    }.each do |s, expectation|
+      it "with case: #{s.inspect}" do
+        expect(described_class.domain_username?(s)).to be expectation
+      end
+    end
+  end
 end


### PR DESCRIPTION
While the goal is to ultimately remove MiqLdap, for now it still exists,
and the regex for dn? is inefficient in a way that causes CodeQL to mark
it as a High vulnerability.

This commit removes the dn? Regex entirely by leveraging Net::LDAP::DN
to do the parsing for us, which is likely more accurate anyway.

Additionally, this commit simplifies the upn? Regex entirey, as it's
just a simple check for a '@' character, and simplifies the
domain_username? Regex to only look at the start of the string.

---

Fixes https://github.com/ManageIQ/manageiq/security/code-scanning/33 and
https://github.com/ManageIQ/manageiq/security/code-scanning/34

Inefficient regular expression - High - CWE-1333 CWE-400 CWE-730
A regular expression that requires exponential time to match certain
inputs can be a performance bottleneck, and may be vulnerable to
denial-of-service attacks.

---

@jrafanie Please review.