### PR TITLE
Add missing cloud collections used by OpenStack

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -10,11 +10,23 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def cloud_resource_quotas
+          add_common_default_values
+        end
+
+        def cloud_services
+          add_common_default_values
+        end
+
         def cloud_volumes
           add_common_default_values
         end
 
         def flavors
+          add_common_default_values
+        end
+
+        def host_aggregates
           add_common_default_values
         end
 


### PR DESCRIPTION
These two collections are used by OpenStack and its derivatives but were missing from the core collection set.