### PR TITLE
Add missing cloud_volume_backups collection for openstack cinder_manager

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
@@ -14,6 +14,10 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def cloud_volume_backups
+          add_common_default_values
+        end
+
         def cloud_object_store_objects
           add_common_default_values
         end


### PR DESCRIPTION
Without this defined in core the ems_id has to be set by the provider, which prevents it from using more standard add_collection methods

Required for:
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/764