### PR TITLE
Fix supports?(:refresh_ems) after mixin refactoring

### DIFF
--- a/app/models/mixins/ems_refresh_mixin.rb
+++ b/app/models/mixins/ems_refresh_mixin.rb
@@ -2,7 +2,7 @@ module EmsRefreshMixin
   extend ActiveSupport::Concern
 
   included do
-    supports :ems_refresh
+    supports :refresh_ems
   end
 
   class_methods do


### PR DESCRIPTION
The UI is checking for `supports?(:refresh_ems)` not `:ems_refresh` as
the feature name, preventing targeted refreshes from being queued from
the UI.