### PR TITLE
Fix global not initialized warning

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -138,12 +138,12 @@ class MiqQueue < ApplicationRecord
     end
 
     create_with_options = all.values[:create_with] || {}
-    options[:priority]    ||= create_with_options[:priority] || NORMAL_PRIORITY
-    options[:queue_name]  ||= create_with_options[:queue_name] || "generic"
-    options[:msg_timeout] ||= create_with_options[:msg_timeout] || TIMEOUT
+    options[:priority]     ||= create_with_options[:priority] || NORMAL_PRIORITY
+    options[:queue_name]   ||= create_with_options[:queue_name] || "generic"
+    options[:msg_timeout]  ||= create_with_options[:msg_timeout] || TIMEOUT
     options[:task_id]        = (defined?($_miq_worker_current_msg) && $_miq_worker_current_msg.try(:task_id)) unless options.key?(:task_id)
     options[:tracking_label] = Thread.current[:tracking_label] || options[:task_id] unless options.key?(:tracking_label)
-    options[:role]          = options[:role].to_s unless options[:role].nil?
+    options[:role]           = options[:role].to_s unless options[:role].nil?
 
     options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
 

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -141,7 +141,7 @@ class MiqQueue < ApplicationRecord
     options[:priority]    ||= create_with_options[:priority] || NORMAL_PRIORITY
     options[:queue_name]  ||= create_with_options[:queue_name] || "generic"
     options[:msg_timeout] ||= create_with_options[:msg_timeout] || TIMEOUT
-    options[:task_id]       = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
+    options[:task_id]        = (defined?($_miq_worker_current_msg) && $_miq_worker_current_msg.try(:task_id)) unless options.key?(:task_id)
     options[:tracking_label] = Thread.current[:tracking_label] || options[:task_id] unless options.key?(:tracking_label)
     options[:role]          = options[:role].to_s unless options[:role].nil?
 


### PR DESCRIPTION
Fixes the following ruby warning on each Queue put:

```
irb(main):001:0> MiqQueue.put({})
...manageiq/app/models/miq_queue.rb:144: warning: global variable `$_miq_worker_current_msg' not initialized
```

I also fixed the vertical alignment on the equals sign.  See the first commit for the "actual" change.

Similar change to what was done in https://github.com/ManageIQ/manageiq-loggers/pull/41