### PR TITLE
Fix docs link for physical infra providers

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,7 +93,7 @@
   :container_provider: https://manageiq.org/docs/reference/latest/managing_providers/#containers-providers
   :infra_provider: https://manageiq.org/docs/reference/latest/managing_providers/#infrastructure-providers
   :network_provider: https://manageiq.org/docs/reference/latest/managing_providers/#network-managers
-  :physical_infra_provider: https://www.manageiq.org/docs/reference/latest/managing_providers/#discovering-physical-infrastucture-providers
+  :physical_infra_provider: https://www.manageiq.org/docs/reference/latest/managing_providers/#physical-infrastucture-providers
   :storage_manager: https://www.manageiq.org/docs/reference/latest/managing_providers/#storage-managers
 
 :drift_states:


### PR DESCRIPTION
The old docs link was not valid as there was no section for physical
infra providers.

This section was added in https://github.com/ManageIQ/manageiq-documentation/pull/1630