### PR TITLE
Prevent vmdb/plugins_spec from hanging if git tag defaults to sign

### DIFF
--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Vmdb::Plugins do
           else
             sha = `git rev-parse HEAD~`.strip
             `git checkout #{"-b #{options[:branch]}" if options[:branch]} #{sha} 2>/dev/null`
-            `git tag #{options[:tag]}` if options[:tag]
+            `git tag --no-sign #{options[:tag]}` if options[:tag]
           end
         end
 


### PR DESCRIPTION
If you have git configured to sign tags by default then the plugins_spec will hang while `git tag` waits for the user to write a tag message.

```
~/.gitconfig
[tag]
	sign = true
	gpgSign = true
```

```
rspec spec/lib/vmdb/plugins_spec.rb
.
hint: Waiting for your editor to close the file... Vim: Warning: Output is not to a terminal
```

```
$ ps aux | egrep 'git|vim'
adam      196223  0.0  0.0  11408  4484 pts/0    S+   10:24   0:00 git tag my_tag
adam      196224  0.0  0.0  24888 10492 pts/0    S+   10:24   0:00 /usr/bin/vim /tmp/plugins_spec20220107-195905-zashdc/.git/TAG_EDITMSG
```