### PR TITLE
Force native extensions to compile from source for now

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -61,6 +61,13 @@ module ManageIQ
       system!("echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc") if ENV['CI']
       system!("gem install bundler -v '#{bundler_version}' --conservative")
       system!("bundle config path #{root.join('vendor/bundle').expand_path}", :chdir => root) if ENV["CI"]
+
+      # For nokogiri 1.13.0+, native gem support was added, allowing pre-compiled binaries to be used.
+      # This provides faster and more reliable installation but assumes you have total control of the installation environment.
+      # On travis, or other CI's, we may not be able to easily install the various dev dependencies it expects.  We'll force
+      # travis to compile these extensions from source until we can use these native gems.
+      # See https://nokogiri.org/CHANGELOG.html#1130-2022-01-06
+      system!("bundle config set force_ruby_platform true") if ENV["TRAVIS"]
     end
 
     def self.setup_gemfile_lock


### PR DESCRIPTION
We can probably speed up CI by using pre-compiled native extensions but that
requires the travis/CI environment has all of the system libraries at the
versions expected by each pre-compiled extension.

For now, we'll just manually compile from source.

Note, this was done because nokogiri 1.13.0 added native gem support which
expected some runtime libraries installed.  This wasn't the case in our current
travis setup, so we'll force compilation for now until we can get this working
in CI.

See https://nokogiri.org/CHANGELOG.html#1130-2022-01-06