### PR TITLE
Use persister builder parent for manager_class instead of persister class

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -64,14 +64,7 @@ module ManageIQ::Providers
       end
 
       def manager_class
-        @manager_class ||= begin
-          provider_module = persister_class.provider_module
-          manager_module = self.class.name.split('::').last
-
-          "#{provider_module}::#{manager_module}".safe_constantize
-        rescue ::ManageIQ::Providers::Inflector::ObjectNotNamespacedError
-          nil
-        end
+        @manager_class ||= options[:parent].class
       end
 
       # Builds data for InventoryCollection

--- a/spec/models/manageiq/providers/inventory/persister/helpers/spec_parsed_data.rb
+++ b/spec/models/manageiq/providers/inventory/persister/helpers/spec_parsed_data.rb
@@ -3,7 +3,7 @@ require 'bigdecimal'
 module SpecParsedData
   def vm_data(i, data = {})
     {
-      :type            => ManageIQ::Providers::CloudManager::Vm.name,
+      :type            => ManageIQ::Providers::Amazon::CloudManager::Vm.name,
       :ems_id          => @ems.id,
       :uid_ems         => "vm_uid_ems_#{i}",
       :ems_ref         => "vm_ems_ref_#{i}",
@@ -16,7 +16,7 @@ module SpecParsedData
 
   def key_pair_data(i, data = {})
     {
-      :type          => ManageIQ::Providers::CloudManager::AuthKeyPair.name,
+      :type          => ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair.name,
       :resource_id   => @ems.id,
       :resource_type => "ExtManagementSystem",
       :name          => "key_pair_name_#{i}",
@@ -25,7 +25,7 @@ module SpecParsedData
 
   def image_data(i, data = {})
     {
-      :type               => ManageIQ::Providers::CloudManager::Template.name,
+      :type               => ManageIQ::Providers::Amazon::CloudManager::Template.name,
       :ems_id             => @ems.id,
       :uid_ems            => "image_uid_ems_#{i}",
       :ems_ref            => "image_ems_ref_#{i}",

--- a/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
     it "checks primary index attributes exist" do
       expect do
         persister.add_collection(persister.send(:cloud), :vms, {:manager_ref => %i[ems_ref ems_gref]}, {:without_sti => true})
-      end.to raise_error("Invalid definition of index :manager_ref, there is no attribute :ems_gref on model Vm")
+      end.to raise_error(/Invalid definition of index :manager_ref, there is no attribute :ems_gref on model/)
     end
 
     it "checks secondary index attributes exist" do
@@ -413,7 +413,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
           {:secondary_refs => {:by_uid_ems_and_name => %i[uid_emsa name]}},
           {:without_sti => true}
         )
-      end.to raise_error("Invalid definition of index :by_uid_ems_and_name, there is no attribute :uid_emsa on model Vm")
+      end.to raise_error(/Invalid definition of index :by_uid_ems_and_name, there is no attribute :uid_emsa on model/)
     end
 
     it "checks relation is allowed in index" do
@@ -428,9 +428,9 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
     it "checks relation is on model class" do
       expect do
         persister.add_collection(persister.send(:cloud), :vms, {}, {:without_sti => true}) do |builder|
-          builder.add_properties(:secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)})
+          builder.add_properties(:secondary_refs => {:by_lan_and_name => %i[lan name]})
         end
-      end.to raise_error("Invalid definition of index :by_availability_zone_and_name, there is no attribute :availability_zone on model Vm")
+      end.to raise_error(/Invalid definition of index :by_lan_and_name, there is no attribute :lan on model/)
     end
 
     it "checks we allow any index attributes when we use custom_saving block" do


### PR DESCRIPTION
A significant component of auto_model_class is determining the correct namespace.  Currently this is done by using the persister class (e.g. ManageIQ::Providers::Amazon::Inventory::Persister) to get the "vendor" and the builder class (e.g.
ManageIQ::Providers::Inventory::Persister::Builder::Cloud) to get the CloudManager component.

This doesn't work in a number of cases, specifically when the manager class name doesn't match the builder class such as Amazon EBS/S3 and OpenStack Cinder/Swift storage managers.

It is much more reliable to use the `parent` property as this is guaranteed to be the manager that owns the association anyway.

Cross-repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/653

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/81
- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/103
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/207
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/801

Built on: https://github.com/ManageIQ/manageiq/pull/21597