### PR TITLE
Require rails 6.0.4.2+ for CVE-2021-44528

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "pg",                                                    :require => false
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>6.0.4", ">=6.0.4.1"
+gem "rails",                            "~>6.0.4", ">=6.0.4.2"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false


### PR DESCRIPTION
We previously allowed 6.0.4.2 but now we enforce this as a minimum.