### PR TITLE
Add a common cross_link_vms inventory collection

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -74,6 +74,16 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       add_common_default_values
     end
 
+    def cross_link_vms
+      add_properties(
+        :arel           => Vm,
+        :model_class    => Vm,
+        :parent         => nil,
+        :secondary_refs => {:by_uid_ems => %i[uid_ems]},
+        :strategy       => :local_db_find_references
+      )
+    end
+
     def vm_and_template_labels
       # TODO(lsmola) make a generic CustomAttribute IC and move it to base class
       add_properties(


### PR DESCRIPTION
It is fairly common for providers to attempt to cross-link inventory to vms from other providers, for example Ansible Tower linking configured systems up to VMs collected from a native Infra/Cloud provider.

Currently the method to do this is re-defined in each provider, but we can move this definition to a shared location in core.

Provider PRs:
* https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/272
* https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/73
* https://github.com/ManageIQ/manageiq-providers-nsxt/pull/57
* https://github.com/ManageIQ/manageiq-providers-nuage/pull/262