### PR TITLE
Use persister directly in Builder class

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -33,21 +33,21 @@ module ManageIQ::Providers
       # Creates builder and builds data for inventory collection
       # @param name [Symbol, Array] InventoryCollection.association value. <name> method not called when Array
       #        (optional) method with this name also used for concrete inventory collection specific properties
-      # @param persister_class [Class] used for "guessing" model_class
+      # @param persister [ManageIQ::Providers::Inventory::Persister] used for "guessing" model_class
       # @param options [Hash]
-      def self.prepare_data(name, persister_class, options = {}, &block)
-        new(name, persister_class, default_options.merge(options)).tap do |builder|
+      def self.prepare_data(name, persister, options = {}, &block)
+        new(name, persister, default_options.merge(options)).tap do |builder|
           builder.construct_data(&block)
         end
       end
 
-      attr_accessor :name, :parent, :persister_class, :properties, :inventory_object_attributes,
+      attr_accessor :name, :parent, :persister, :properties, :inventory_object_attributes,
                     :default_values, :dependency_attributes, :options, :adv_settings, :shared_properties
 
       # @see prepare_data()
-      def initialize(name, persister_class, options = self.class.default_options)
+      def initialize(name, persister, options = self.class.default_options)
         @name = name
-        @persister_class = persister_class
+        @persister = persister
 
         @properties = {}
         @inventory_object_attributes = []
@@ -144,7 +144,7 @@ module ManageIQ::Providers
       end
 
       # Evaluates lambda blocks
-      def evaluate_lambdas!(persister)
+      def evaluate_lambdas!
         @default_values = evaluate_lambdas_on(@default_values, persister)
         @dependency_attributes = evaluate_lambdas_on(@dependency_attributes, persister)
       end
@@ -198,7 +198,7 @@ module ManageIQ::Providers
       #
       # @example derives model_class from amazon
       #
-      #   @persister_class = ManageIQ::Providers::Amazon::Inventory::Persister::CloudManager
+      #   @manager_class = ManageIQ::Providers::Amazon::CloudManager
       #   @name = :vms
       #
       #   returns - <provider_module>::<manager_module>::<@name.classify>
@@ -206,7 +206,7 @@ module ManageIQ::Providers
       #
       # @example derives model_class from @name only
       #
-      #   @persister_class = ManageIQ::Providers::Inventory::Persister
+      #   @manager_class = nil
       #   @name = :vms
       #
       #   returns ::Vm

--- a/app/models/manageiq/providers/inventory/persister/builder/automation_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/automation_manager.rb
@@ -34,9 +34,7 @@ module ManageIQ::Providers
 
         def credentials
           default_manager_ref
-          add_default_values(
-            :resource => ->(persister) { persister.manager }
-          )
+          add_default_values(:resource => manager)
         end
 
         def inventory_root_groups
@@ -54,9 +52,7 @@ module ManageIQ::Providers
         end
 
         def add_common_default_values
-          add_default_values(
-            :manager => ->(persister) { persister.manager }
-          )
+          add_default_values(:manager => manager)
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -100,8 +100,8 @@ module ManageIQ::Providers
           )
 
           add_dependency_attributes(
-            :orchestration_stacks           => ->(persister) { [persister.collections[:orchestration_stacks]] },
-            :orchestration_stacks_resources => ->(persister) { [persister.collections[:orchestration_stacks_resources]] }
+            :orchestration_stacks           => [persister.collections[:orchestration_stacks]],
+            :orchestration_stacks_resources => [persister.collections[:orchestration_stacks_resources]]
           )
         end
 
@@ -118,8 +118,8 @@ module ManageIQ::Providers
           )
 
           add_dependency_attributes(
-            :vms           => ->(persister) { [persister.collections[:vms]] },
-            :miq_templates => ->(persister) { [persister.collections[:miq_templates]] }
+            :vms           => [persister.collections[:vms]],
+            :miq_templates => [persister.collections[:miq_templates]]
           )
         end
       end

--- a/app/models/manageiq/providers/inventory/persister/builder/configuration_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/configuration_manager.rb
@@ -4,12 +4,12 @@ module ManageIQ::Providers
       class ConfigurationManager < ::ManageIQ::Providers::Inventory::Persister::Builder
         def configuration_profiles
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def configured_systems
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -214,7 +214,7 @@ module ManageIQ::Providers
 
         def persistent_volumes
           skip_sti
-          add_default_values(:parent => ->(persister) { persister.manager })
+          add_default_values(:parent => persister.manager)
         end
 
         def persistent_volume_claims

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -278,7 +278,7 @@ module ManageIQ::Providers
             :custom_save_block => relationship_save_block(:relationship_key => :parent, :parent_type => "EmsFolder")
           )
 
-          add_dependency_attributes(persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact)
+          add_dependency_attributes(:vms =>persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact)
         end
 
         def vm_resource_pools

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -253,7 +253,7 @@ module ManageIQ::Providers
           )
 
           add_dependency_attributes(
-            :ems_folders => ->(persister) { [persister.collections[:ems_folders]] }
+            :ems_folders => [persister.collections[:ems_folders]]
           )
         end
 
@@ -266,9 +266,7 @@ module ManageIQ::Providers
           )
 
           dependency_collections = %i[clusters ems_folders datacenters hosts resource_pools storages]
-          dependency_attributes = dependency_collections.index_with do |collection|
-            ->(persister) { [persister.collections[collection]].compact }
-          end
+          dependency_attributes = dependency_collections.index_with { |collection| [persister.collections[collection]].compact }
           add_dependency_attributes(dependency_attributes)
         end
 
@@ -280,9 +278,7 @@ module ManageIQ::Providers
             :custom_save_block => relationship_save_block(:relationship_key => :parent, :parent_type => "EmsFolder")
           )
 
-          add_dependency_attributes(
-            :vms => ->(persister) { persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact }
-          )
+          add_dependency_attributes(persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact)
         end
 
         def vm_resource_pools
@@ -296,7 +292,7 @@ module ManageIQ::Providers
           )
 
           add_dependency_attributes(
-            :vms => ->(persister) { persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact }
+            :vms => persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact
           )
         end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/network_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/network_manager.rb
@@ -215,8 +215,8 @@ module ManageIQ::Providers
 
         protected
 
-        def add_common_default_values
-          add_default_values(:ext_management_system => ->(persister) { persister.network_manager })
+        def manager
+          parent || persister.network_manager
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -22,16 +22,11 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
   # @see documentation https://github.com/ManageIQ/guides/tree/master/providers/persister/inventory_collections.md
   #
   def add_collection(builder_class, collection_name, extra_properties = {}, settings = {}, &block)
-    builder = builder_class.prepare_data(collection_name,
-                                         self.class,
-                                         make_builder_settings(settings),
-                                         &block)
+    builder = builder_class.prepare_data(collection_name, self, make_builder_settings(settings), &block)
 
     builder.add_properties(extra_properties) if extra_properties.present?
-
     builder.add_properties({:manager_uuids => references(collection_name)}, :if_missing) if targeted?
-
-    builder.evaluate_lambdas!(self)
+    builder.evaluate_lambdas!
 
     collections[collection_name] = builder.to_inventory_collection
   end

--- a/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
@@ -37,7 +37,7 @@ module ManageIQ::Providers
         def customization_scripts
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => persister.manager.id)
         end
 
         # Asset details

--- a/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
@@ -5,13 +5,13 @@ module ManageIQ::Providers
         def customization_script_media
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager => manager)
+          add_default_values(:ext_management_system => manager)
         end
 
         def customization_script_ptables
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager => manager)
+          add_default_values(:ext_management_system => manager)
         end
 
         def operating_system_flavors

--- a/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
@@ -5,66 +5,66 @@ module ManageIQ::Providers
         def customization_script_media
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def customization_script_ptables
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def operating_system_flavors
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:provisioning_manager_id => parent_id)
+          add_default_values(:provisioning_manager => manager)
         end
 
         def configuration_locations
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:provisioning_manager_id => parent_id)
+          add_default_values(:provisioning_manager => manager)
         end
 
         def configuration_organizations
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:provisioning_manager_id => parent_id)
+          add_default_values(:provisioning_manager => manager)
         end
 
         def configuration_tags
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def configuration_architectures
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def configuration_compute_profiles
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def configuration_domains
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def configuration_environments
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
 
         def configuration_realms
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => parent_id)
+          add_default_values(:manager => manager)
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -202,12 +202,12 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
 
     protected
 
-    def parent_id
-      parent&.id || ->(persister) { persister.manager.id }
+    def add_common_default_values
+      add_default_values(:ext_management_system => manager)
     end
 
-    def add_common_default_values
-      add_default_values(:ems_id => parent_id)
+    def manager
+      parent || persister.manager
     end
 
     def relationship_save_block(relationship_key:, relationship_type: :ems_metadata, parent_type: nil)

--- a/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
@@ -2,27 +2,17 @@ require "inventory_refresh"
 require_relative 'test_persister'
 
 RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
-  before :each do
-    @ems = FactoryBot.create(:ems_cloud)
-    @persister = create_persister
-  end
-
-  def create_persister
-    TestPersister.new(@ems, InventoryRefresh::TargetCollection.new(:manager => @ems))
-  end
-
+  let!(:persister) { TestPersister.new(ems, InventoryRefresh::TargetCollection.new(:manager => ems)) }
+  let(:ems) { FactoryBot.create(:ems_cloud) }
   let(:adv_settings) { {:strategy => :local_db_find_missing_references, :saver_strategy => :concurrent_safe_batch} }
 
   let(:cloud) { ::ManageIQ::Providers::Inventory::Persister::Builder::CloudManager }
-
   let(:network) { ::ManageIQ::Providers::Inventory::Persister::Builder::NetworkManager }
-
-  let(:persister_class) { ::ManageIQ::Providers::Inventory::Persister }
 
   # --- association ---
 
   it 'assigns association automatically to InventoryCollection' do
-    ic = cloud.prepare_data(:vms, persister_class, :without_sti => true).to_inventory_collection
+    ic = cloud.prepare_data(:vms, persister, :without_sti => true).to_inventory_collection
 
     expect(ic.association).to eq :vms
   end
@@ -34,13 +24,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "derives existing model_class without persister's class" do
-    data = cloud.prepare_data(:vms, persister_class, :without_sti => true).to_hash
+    data = cloud.prepare_data(:vms, persister, :without_sti => true).to_hash
 
     expect(data[:model_class]).to eq ::Vm
   end
 
   it "replaces derived model_class if model_class defined manually" do
-    data = cloud.prepare_data(:vms, persister_class, :without_sti => true) do |builder|
+    data = cloud.prepare_data(:vms, persister, :without_sti => true) do |builder|
       builder.add_properties(:model_class => ::MiqTemplate)
     end.to_hash
 
@@ -48,19 +38,19 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't try to derive model_class when disabled" do
-    data = cloud.prepare_data(:vms, persister_class, :without_model_class => true).to_hash
+    data = cloud.prepare_data(:vms, persister, :without_model_class => true).to_hash
 
     expect(data[:model_class]).to be_nil
   end
 
   it "throws exception if model_class should be namespaced but isn't" do
-    expect { cloud.prepare_data(:vms, persister_class) }.to raise_error(
+    expect { cloud.prepare_data(:vms, persister) }.to raise_error(
       ::ManageIQ::Providers::Inventory::Persister::Builder::NotSubclassedError
     )
   end
 
   it 'throws exception if model_class not specified' do
-    builder = cloud.prepare_data(:non_existing_ic, persister_class)
+    builder = cloud.prepare_data(:non_existing_ic, persister)
 
     expect { builder.to_inventory_collection }.to raise_error(::ManageIQ::Providers::Inventory::Persister::Builder::MissingModelClassError, /NonExistingIc/)
   end
@@ -68,7 +58,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- adv. settings (TODO: link to gui)---
 
   it 'assigns Advanced settings' do
-    builder = cloud.prepare_data(:tmp, persister_class, :without_model_class => true, :adv_settings => adv_settings)
+    builder = cloud.prepare_data(:tmp, persister, :without_model_class => true, :adv_settings => adv_settings)
     data = builder.to_hash
 
     expect(data[:strategy]).to eq :local_db_find_missing_references
@@ -76,7 +66,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't overwrite defined properties by Advanced settings" do
-    data = cloud.prepare_data(:vms, persister_class, :without_sti => true, :adv_settings => adv_settings) do |builder|
+    data = cloud.prepare_data(:vms, persister, :without_sti => true, :adv_settings => adv_settings) do |builder|
       builder.add_properties(:strategy => :custom)
     end.to_hash
 
@@ -87,13 +77,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- shared properties ---
 
   it 'applies shared properties' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true, :shared_properties => {:uuid => 1}).to_hash
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true, :shared_properties => {:uuid => 1}).to_hash
 
     expect(data[:uuid]).to eq 1
   end
 
   it "doesn't overwrite defined properties by shared properties" do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true, :shared_properties => {:uuid => 1}) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true, :shared_properties => {:uuid => 1}) do |builder|
       builder.add_properties(:uuid => 2)
     end.to_hash
 
@@ -103,7 +93,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- properties ---
 
   it 'adds properties with add_properties repeatedly' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_properties(:first => 1, :second => 2)
       builder.add_properties(:third => 3)
     end.to_hash
@@ -114,7 +104,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'overrides properties in :overwrite mode' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_properties(:param => 1)
       builder.add_properties({:param => 2}, :overwrite)
     end.to_hash
@@ -123,7 +113,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't override properties in :if_missing mode" do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_properties(:param => 1)
       builder.add_properties({:param => 2}, :if_missing)
     end.to_hash
@@ -132,7 +122,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'adds property by method_missing' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_some_tmp_param(:some_value)
     end.to_hash
 
@@ -142,7 +132,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- default values ---
 
   it 'adds default_values repeatedly' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_default_values(:ems_id => 10)
       builder.add_default_values(:ems_id => 20)
       builder.add_default_values(:tmp_id => 30)
@@ -153,32 +143,32 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'transforms lambdas in default_values' do
-    bldr = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    bldr = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_default_values(:ems_id => ->(persister) { persister.manager.id })
     end
-    bldr.evaluate_lambdas!(@persister)
+    bldr.evaluate_lambdas!
 
     data = bldr.to_hash
 
-    expect(data[:default_values][:ems_id]).to eq(@persister.manager.id)
+    expect(data[:default_values][:ems_id]).to eq(persister.manager.id)
   end
 
   # --- inventory object attributes ---
 
   it 'derives inventory object attributes automatically' do
-    data = cloud.prepare_data(:vms, persister_class, :without_sti => true).to_hash
+    data = cloud.prepare_data(:vms, persister, :without_sti => true).to_hash
 
     expect(data[:inventory_object_attributes]).not_to be_empty
   end
 
   it "doesn't derive inventory_object_attributes automatically when disabled" do
-    data = cloud.prepare_data(:vms, persister_class, :without_sti => true, :auto_inventory_attributes => false).to_hash
+    data = cloud.prepare_data(:vms, persister, :without_sti => true, :auto_inventory_attributes => false).to_hash
 
     expect(data[:inventory_object_attributes]).to be_empty
   end
 
   it 'can add inventory_object_attributes manually' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
     end.to_hash
 
@@ -186,7 +176,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'can remove inventory_object_attributes' do
-    data = cloud.prepare_data(:tmp, persister_class, :without_model_class => true) do |builder|
+    data = cloud.prepare_data(:tmp, persister, :without_model_class => true) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
       builder.remove_inventory_attributes(%i(attr2))
     end.to_hash
@@ -195,7 +185,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'can clear all inventory_object_attributes' do
-    data = cloud.prepare_data(:vms, persister_class, :without_sti => true) do |builder|
+    data = cloud.prepare_data(:vms, persister, :without_sti => true) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
       builder.clear_inventory_attributes!
     end.to_hash

--- a/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
@@ -418,8 +418,10 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
 
     it "checks relation is allowed in index" do
       persister.add_collection(persister.send(:cloud), :vms) do |builder|
-        builder.add_properties(:model_class    => ::ManageIQ::Providers::CloudManager::Vm,
-                               :secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)})
+        builder.add_properties(
+          :model_class    => ::ManageIQ::Providers::CloudManager::Vm,
+          :secondary_refs => {:by_availability_zone_and_name => %i[availability_zone name]}
+        )
       end
 
       expect(persister.vms.index_proxy.send(:data_indexes).keys).to match_array(%i(manager_ref by_availability_zone_and_name))


### PR DESCRIPTION
Currently the persister_class is passed in to the builder and then a
lambda is used to access the persister instance in a number of places.

This doesn't make much sense when we can simply pass in the persister to
the Builder and add it as an instance variable.