### PR TITLE
Allow updating gems before locking

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -192,6 +192,8 @@ namespace :release do
       exit 1
     end
 
+    update_gems = ENV["UPDATE_GEMS"].to_s.split(" ")
+
     root = Pathname.new(__dir__).join("../..")
 
     # Ensure that local and global bundler.d is not enabled
@@ -210,6 +212,13 @@ namespace :release do
       File.write(appliance_deps_file, appliance_deps)
 
       FileUtils.cp(root.join("Gemfile.lock.release"), root.join("Gemfile.lock"))
+
+      if update_gems.any?
+        Bundler.with_unbundled_env do
+          puts "** Updating gems #{update_gems.join(", ")}"
+          exit $?.exitstatus unless system({"APPLIANCE" => "true"}, "bundle update --conservative --patch #{update_gems.join(" ")}", :chdir => root)
+        end
+      end
 
       platforms = %w[
         ruby


### PR DESCRIPTION
Normally a bundle update would be sufficient for updating gems, but
because of the way we need to link in the appliance console, and avoid
bundler.d items, it's easier to just tack this into the
generate_lockfile method. In the future we might want to break this up
into two separate parts and also share some code with the rake release
command that also does something similar.

@bdunne Please review.  This is an example usage and is what I used to update the lockfile in #21662:

```sh
RELEASE_BRANCH=morphy UPDATE_GEMS="actionpack activerecord railties activesupport actionview activemodel" be rake release:generate_lockfile
```

