### PR TITLE
Explain why we still need to autoload from yaml/marshal

### DIFF
--- a/config/initializers/marshal_autoloader.rb
+++ b/config/initializers/marshal_autoloader.rb
@@ -1,3 +1,7 @@
+# Note, this is used to autoload constants serialized via marshal from one process and loaded in another such
+# as through args in the MiqQueue. An alternative would be to eager load all of our autoload_paths in all
+# processes or load just the classes that are marshaled, which may be far less classes and locations than when
+# we originally wrote this initializer.
 module MarshalAutoloader
   def load(data)
     super

--- a/config/initializers/yaml_autoloader.rb
+++ b/config/initializers/yaml_autoloader.rb
@@ -5,6 +5,9 @@
 # added in psych 2.0.0:
 # https://github.com/ruby/psych/commit/2c644e184192975b261a81f486a04defa3172b3f
 # Note, ruby 2.4.0 shipped with psych 2.2.2+.  This class_loader would not work with ruby 2.3 and older.
+#
+# Note, this is used to autoload constants serialized as yaml from one process and loaded in another such as through
+# args in the MiqQueue. An alternative would be to eager load all of our autoload_paths in all processes.
 Psych::Visitors::ToRuby.prepend Module.new {
   def resolve_class(klass_name)
     (class_loader.class != Psych::ClassLoader::Restricted && klass_name && klass_name.safe_constantize) || super

--- a/config/initializers/yaml_autoloader.rb
+++ b/config/initializers/yaml_autoloader.rb
@@ -4,7 +4,6 @@
 # Psych::ClassLoader::Restricted is the class_loader if you use safe_load and was
 # added in psych 2.0.0:
 # https://github.com/ruby/psych/commit/2c644e184192975b261a81f486a04defa3172b3f
-# Note, ruby 2.4.0 shipped with psych 2.2.2+.  This class_loader would not work with ruby 2.3 and older.
 #
 # Note, this is used to autoload constants serialized as yaml from one process and loaded in another such as through
 # args in the MiqQueue. An alternative would be to eager load all of our autoload_paths in all processes.


### PR DESCRIPTION
Also, drop the irrelevant 2.3/2.4 comment since both have been EOL for nearly 2 years.

Good eye @chessbyte, that 2.3/2.4 comment is confusing now... let me know if you have suggestions to better explain the need for this tech debt.