### PR TITLE
Add ability to get the container orchestrator's pod

### DIFF
--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -81,7 +81,22 @@ class ContainerOrchestrator
     kube_connection.watch_pods(default_get_options.merge(:resource_version => resource_version))
   end
 
+  # Returns the pod with the given hostname in the given namespace.
+  def get_pod_by_namespace_and_hostname(namespace, hostname)
+    kube_connection.get_pods(:namespace => namespace).detect { |i| i.metadata.name == hostname }
+  end
+
+  # Returns the pod for this container orchestrator.
+  #
+  # NOTE: It is presumed that this method is only called from within the
+  #       container orchestrator process itself, as it uses environment info
+  #       that only the running orchestrator pod will have.
+  def my_pod
+    get_pod_by_namespace_and_hostname(my_namespace, ENV["HOSTNAME"])
+  end
+
   private
+
   def default_get_options
     {:namespace => my_namespace, :label_selector => [app_name_selector, orchestrated_by_selector].join(",")}
   end

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -317,6 +317,30 @@ RSpec.describe ContainerOrchestrator do
           subject.watch_pods(100)
         end
       end
+
+      it "#get_pod_by_namespace_and_hostname" do
+        pods = [
+          double("pod", :metadata => double("pod-metadata", :name => "3r1-ui-abcdef123-xyz12")),
+          double("pod", :metadata => double("pod-metadata", :name => "3r1-api-bcdefa123-yza12")),
+          double("pod", :metadata => double("pod-metadata", :name => "orchestrator-cdefab1234-zab12"))
+        ]
+        expect(kube_connection_stub).to receive(:get_pods).with(:namespace => namespace).and_return(pods)
+
+        expect(subject.get_pod_by_namespace_and_hostname(namespace, "3r1-ui-abcdef123-xyz12")).to eq pods.first
+      end
+
+      it "#my_pod" do
+        stub_const("ENV", ENV.to_h.merge("HOSTNAME" => "orchestrator-cdefab1234-zab12"))
+        pods = [
+          double("pod", :metadata => double("pod-metadata", :name => "3r1-ui-abcdef123-xyz12")),
+          double("pod", :metadata => double("pod-metadata", :name => "3r1-api-bcdefa123-yza12")),
+          double("pod", :metadata => double("pod-metadata", :name => "orchestrator-cdefab1234-zab12"))
+        ]
+        expect(kube_connection_stub).to receive(:get_pods).with(:namespace => namespace).and_return(pods)
+        orchestrator_pod = pods.last
+
+        expect(subject.my_pod).to eq orchestrator_pod
+      end
     end
   end
 end


### PR DESCRIPTION
@bdunne Please review.

I extracted `get_pod_by_namespace_and_hostname` into its own method, but if you think that's overkill I can remove it.