### PR TITLE
fix aggregate virtual totals to return a grouping element

### DIFF
--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -121,7 +121,7 @@ module Service::Aggregation
         subselect = base_service_aggregation_join(subselect, subtree_services, options)
         join_on_disks(subselect) if options[:include_disks]
 
-        subselect.where(aggregation_where_clause(t, subtree_services))
+        t.grouping(subselect.where(aggregation_where_clause(t, subtree_services)))
       end
     end
 

--- a/spec/models/service/aggregation_spec.rb
+++ b/spec/models/service/aggregation_spec.rb
@@ -7,35 +7,73 @@ RSpec.describe Service do
     service.save
   end
 
-  it "#aggregate_all_vm_memory_on_disk will not raise when the attribute is nil" do
-    expect(service).to receive(:has_attribute?).with("aggregate_all_vm_memory_on_disk").and_return(true)
-    expect { service.aggregate_all_vm_memory_on_disk }.not_to raise_error
+  describe "#aggregate_all_vm_memory" do
+    it "sql" do
+      svc = Service.select(:id, :aggregate_all_vm_memory_on_disk).find_by(:id => service.id)
+      expect(svc.aggregate_all_vm_memory).to eq(2048)
+      expect(svc.has_attribute?(:aggregate_all_vm_memory_on_disk)).to be(true)
+    end
+
+    it "ruby" do
+      expect(service.aggregate_all_vm_memory).to eq(2048)
+      expect(service.has_attribute?(:aggregate_all_vm_memory_on_disk)).to be(false)
+    end
   end
 
-  it "#aggregate_all_vm_memory" do
-    expect(service.aggregate_all_vm_memory).to eq(2048)
+  describe "#aggregate_all_vm_cpus" do
+    it "sql" do
+      svc = Service.select(:id, :aggregate_all_vm_cpus).find_by(:id => service.id)
+      expect(svc.aggregate_all_vm_cpus).to eq(4)
+    end
+
+    it "ruby" do
+      expect(service.aggregate_all_vm_cpus).to eq(4)
+    end
   end
 
-  it "#aggregate_all_vm_cpus" do
-    expect(service.aggregate_all_vm_cpus).to eq(4)
+  describe "#aggregate_all_vm_disk_count" do
+    before do
+      FactoryBot.create_list(:disk, 2, :hardware => hardware, :device_type => 'disk')
+    end
+
+    it "sql" do
+      svc = Service.select(:id, :aggregate_all_vm_disk_count).find_by(:id => service.id)
+      expect(service.aggregate_all_vm_disk_count).to eq(2)
+    end
+
+    it "ruby" do
+      expect(service.aggregate_all_vm_disk_count).to eq(2)
+    end
   end
 
-  it "#aggregate_all_vm_disk_count" do
-    FactoryBot.create_list(:disk, 2, :hardware => hardware, :device_type => 'disk')
+  describe "#aggregate_all_vm_disk_space_allocated" do
+    before do
+      FactoryBot.create(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
+      FactoryBot.create(:disk, :size => 1024, :hardware => hardware)
+    end
 
-    expect(service.aggregate_all_vm_disk_count).to eq(2)
+    it "sql" do
+      svc = Service.select(:id, :aggregate_all_vm_disk_space_allocated).find_by(:id => service.id)
+      expect(svc.aggregate_all_vm_disk_space_allocated).to eq(11_264)
+    end
+
+    it "ruby" do
+      expect(service.aggregate_all_vm_disk_space_allocated).to eq(11_264)
+    end
   end
 
-  it "#aggregate_all_vm_disk_space_allocated" do
-    FactoryBot.create(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
-    FactoryBot.create(:disk, :size => 1024, :hardware => hardware)
+  describe "#aggregate_all_vm_memory_on_disk" do
+    before do
+      FactoryBot.build(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
+    end
 
-    expect(service.aggregate_all_vm_disk_space_allocated).to eq(11_264)
-  end
+    it "sql" do
+      svc = Service.select(:id, :aggregate_all_vm_memory_on_disk).find_by(:id => service.id)
+      expect(svc.aggregate_all_vm_memory_on_disk).to eq(2_147_483_648)
+    end
 
-  it "#aggregate_all_vm_memory_on_disk" do
-    FactoryBot.build(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
-
-    expect(service.aggregate_all_vm_memory_on_disk).to eq(2_147_483_648)
+    it "ruby" do
+      expect(service.aggregate_all_vm_memory_on_disk).to eq(2_147_483_648)
+    end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -203,17 +203,17 @@ RSpec.describe Service do
       expect(@service.all_vms).to    match_array [@vm, @vm1, @vm1, @vm2]
     end
 
-    it "#v_total_vms" do
-      expect(@service.v_total_vms).to eq 4
-      expect(@service.attribute_present?(:v_total_vms)).to eq false
-    end
+    describe "#v_total_vms" do
+      it "sql" do
+        service = Service.select(:id, :v_total_vms).find_by(:id => @service.id)
+        expect(service.v_total_vms).to eq 4
+        expect(service.attribute_present?(:v_total_vms)).to eq true
+      end
 
-    it "#v_total_vms with arel" do
-      service = Service.select(:id, :v_total_vms)
-                       .where(:id => @service.id)
-                       .first
-      expect(service.v_total_vms).to eq 4
-      expect(service.attribute_present?(:v_total_vms)).to eq true
+      it "ruby" do
+        expect(@service.v_total_vms).to eq 4
+        expect(@service.attribute_present?(:v_total_vms)).to eq false
+      end
     end
 
     it "#direct_service" do


### PR DESCRIPTION
### Problem

Virtual attributes now require :arel to return a grouping element (aka parenthesis).
This has always been a requirement, but it was more lenient before.

The latest version of `virtual_attributes` gem now requires a grouping element.

### Before

The virtual attribute `Service#v_total_vms` defined custom arel that returned a `SelectManager` node.

### After

The virtual attribute `Service#v_total_vms` defines custom arel that returns a `Grouping` node.

### Additional changes

Fixed tests to test both ruby derived values and sql derived values

