### PR TITLE
fix Host#host_hardware relation

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -87,7 +87,7 @@ class Host < ApplicationRecord
                             :inverse_of => :host
   has_many                  :host_aggregate_hosts, :dependent => :destroy
   has_many                  :host_aggregates, :through => :host_aggregate_hosts
-  has_many :host_hardwares, :class_name => 'Hardware', :source => :hardware, :dependent => :nullify
+  has_many :host_hardwares, :class_name => 'Hardware', :dependent => :nullify
   has_many :vm_hardwares,   :class_name => 'Hardware', :through => :vms_and_templates, :source => :hardware
 
   # Physical server reference


### PR DESCRIPTION
### Problem

`Host.has_many :host_hardwares` is not ~~polymorphic~~ using a `through`, so the `source` option is not necessary and does not make sense.

### Solution

The solution is to remove the option.

### Why fix it now?

This change is needed for rails 6.1 but does not require rails 6 to be merged

### Fixes

```
Failure/Error: has_many :host_hardwares, :class_name => 'Hardware', :source => :hardware, :dependent => :nullify

ArgumentError:
  Unknown key: :source.

```

