### PR TITLE
Cleanup OperatingSystem model

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -11,27 +11,27 @@ class OperatingSystem < ApplicationRecord
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy
 
   @@os_map = [
-    ["windows_generic", %w(winnetenterprise w2k3 win2k3 server2003 winnetstandard servernt)],
-    ["windows_generic", %w(winxppro winxp)],
-    ["windows_generic", %w(vista longhorn)],
-    ["windows_generic", %w(win2k win2000)],
-    ["windows_generic", %w(microsoft windows winnt)],
-    ["linux_ubuntu",    %w(ubuntu)],
-    ["linux_chrome",    %w(chromeos)],
-    ["linux_chromium",  %w(chromiumos)],
-    ["linux_suse",      %w(suse sles)],
-    ["linux_redhat",    %w(redhat rhel)],
-    ["linux_fedora",    %w(fedora)],
-    ["linux_gentoo",    %w(gentoo)],
-    ["linux_centos",    %w(centos)],
-    ["linux_debian",    %w(debian)],
-    ["linux_coreos",    %w(coreos)],
-    ["linux_esx",       %w(vmnixx86 vmwareesxserver esxserver vmwareesxi)],
-    ["linux_solaris",   %w(solaris)],
-    ["linux_oracle",    %w(oracle)],
-    ["linux_generic",   %w(linux)],
-    ["unix_aix",        %w(aix vios)],
-    ["ibm_i",           %w(ibmi)]
+    ["windows_generic", %w[winnetenterprise w2k3 win2k3 server2003 winnetstandard servernt]],
+    ["windows_generic", %w[winxppro winxp]],
+    ["windows_generic", %w[vista longhorn]],
+    ["windows_generic", %w[win2k win2000]],
+    ["windows_generic", %w[microsoft windows winnt]],
+    ["linux_ubuntu",    %w[ubuntu]],
+    ["linux_chrome",    %w[chromeos]],
+    ["linux_chromium",  %w[chromiumos]],
+    ["linux_suse",      %w[suse sles]],
+    ["linux_redhat",    %w[redhat rhel]],
+    ["linux_fedora",    %w[fedora]],
+    ["linux_gentoo",    %w[gentoo]],
+    ["linux_centos",    %w[centos]],
+    ["linux_debian",    %w[debian]],
+    ["linux_coreos",    %w[coreos]],
+    ["linux_esx",       %w[vmnixx86 vmwareesxserver esxserver vmwareesxi]],
+    ["linux_solaris",   %w[solaris]],
+    ["linux_oracle",    %w[oracle]],
+    ["linux_generic",   %w[linux]],
+    ["unix_aix",        %w[aix vios]],
+    ["ibm_i",           %w[ibmi]]
   ]
 
   def self.add_elements(vm, xmlNode)
@@ -113,7 +113,7 @@ class OperatingSystem < ApplicationRecord
       osName = obj.hardware.guest_os
       # if we get generic linux or unknown back see if the vm name is better
       norm_os = OperatingSystem.normalize_os_name(osName)
-      if norm_os == "linux_generic" || norm_os == "unknown"
+      if ["linux_generic", "unknown"].include?(norm_os)
         vm_name = OperatingSystem.normalize_os_name(obj.name)
         return vm_name unless vm_name == "unknown"
       end

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -32,7 +32,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_generic",   %w[linux]],
     ["unix_aix",        %w[aix vios]],
     ["ibm_i",           %w[ibmi]]
-  ]
+  ].freeze
 
   def self.add_elements(vm, xmlNode)
     add_missing_elements(vm, xmlNode, "system/os")
@@ -73,11 +73,11 @@ class OperatingSystem < ApplicationRecord
     end
   end
 
-  def self.normalize_os_name(osName)
-    findStr = osName.downcase.gsub(/[^a-z0-9]/, "")
-    OS_MAP.each do |a|
-      a[1].each do |n|
-        return a[0] unless findStr.index(n).nil?
+  def self.normalize_os_name(os_name)
+    clean_os_name = os_name.downcase.gsub(/[^a-z0-9]/, "")
+    OS_MAP.each do |normalized_name, candidate_names|
+      candidate_names.each do |candidate|
+        return normalized_name if clean_os_name.include?(candidate)
       end
     end
     "unknown"

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -10,7 +10,7 @@ class OperatingSystem < ApplicationRecord
   has_many   :event_logs, :dependent => :destroy
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy
 
-  @@os_map = [
+  OS_MAP = [
     ["windows_generic", %w[winnetenterprise w2k3 win2k3 server2003 winnetstandard servernt]],
     ["windows_generic", %w[winxppro winxp]],
     ["windows_generic", %w[vista longhorn]],
@@ -75,7 +75,7 @@ class OperatingSystem < ApplicationRecord
 
   def self.normalize_os_name(osName)
     findStr = osName.downcase.gsub(/[^a-z0-9]/, "")
-    @@os_map.each do |a|
+    OS_MAP.each do |a|
       a[1].each do |n|
         return a[0] unless findStr.index(n).nil?
       end

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -84,35 +84,35 @@ class OperatingSystem < ApplicationRecord
   end
 
   def self.image_name(obj)
-    osName = nil
+    os_name = nil
 
     # Select most accurate name field
     os = obj.operating_system
     if os
       # check the given field names for possible matching value
-      osName = [:distribution, :product_type, :product_name].each do |field|
+      os_name = [:distribution, :product_type, :product_name].each do |field|
         os_field = os.send(field)
         break(os_field) if os_field && OperatingSystem.normalize_os_name(os_field) != "unknown"
       end
 
       # If the normalized name comes back as unknown, nil out the value so we can get it from another field
-      if osName.kind_of?(String)
-        osName = nil if OperatingSystem.normalize_os_name(osName) == "unknown"
+      if os_name.kind_of?(String)
+        os_name = nil if OperatingSystem.normalize_os_name(os_name) == "unknown"
       else
-        osName = nil
+        os_name = nil
       end
     end
 
     # If the OS Name is still blank check the 'user_assigned_os'
-    if osName.nil? && obj.respond_to?(:user_assigned_os) && obj.user_assigned_os
-      osName = obj.user_assigned_os
+    if os_name.nil? && obj.respond_to?(:user_assigned_os) && obj.user_assigned_os
+      os_name = obj.user_assigned_os
     end
 
     # If the OS Name is still blank check the hardware table
-    if osName.nil? && obj.hardware && !obj.hardware.guest_os.nil?
-      osName = obj.hardware.guest_os
+    if os_name.nil? && obj.hardware && !obj.hardware.guest_os.nil?
+      os_name = obj.hardware.guest_os
       # if we get generic linux or unknown back see if the vm name is better
-      norm_os = OperatingSystem.normalize_os_name(osName)
+      norm_os = OperatingSystem.normalize_os_name(os_name)
       if ["linux_generic", "unknown"].include?(norm_os)
         vm_name = OperatingSystem.normalize_os_name(obj.name)
         return vm_name unless vm_name == "unknown"
@@ -120,10 +120,10 @@ class OperatingSystem < ApplicationRecord
     end
 
     # If the OS Name is still blank use the name field from the object given
-    osName = obj.name if osName.nil?
+    os_name = obj.name if os_name.nil?
 
     # Normalize name to match existing icons
-    OperatingSystem.normalize_os_name(osName)
+    OperatingSystem.normalize_os_name(os_name)
   end
 
   def self.platform(obj)

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -45,7 +45,7 @@ class OperatingSystem < ApplicationRecord
 
     nh.delete(:type)
     if vm.operating_system.nil?
-      vm.operating_system = OperatingSystem.new(nh)
+      vm.operating_system = new(nh)
     else
       vm.operating_system.update(nh)
     end
@@ -92,12 +92,12 @@ class OperatingSystem < ApplicationRecord
       # check the given field names for possible matching value
       os_name = [:distribution, :product_type, :product_name].each do |field|
         os_field = os.send(field)
-        break(os_field) if os_field && OperatingSystem.normalize_os_name(os_field) != "unknown"
+        break(os_field) if os_field && normalize_os_name(os_field) != "unknown"
       end
 
       # If the normalized name comes back as unknown, nil out the value so we can get it from another field
       if os_name.kind_of?(String)
-        os_name = nil if OperatingSystem.normalize_os_name(os_name) == "unknown"
+        os_name = nil if normalize_os_name(os_name) == "unknown"
       else
         os_name = nil
       end
@@ -112,9 +112,9 @@ class OperatingSystem < ApplicationRecord
     if os_name.nil? && obj.hardware && !obj.hardware.guest_os.nil?
       os_name = obj.hardware.guest_os
       # if we get generic linux or unknown back see if the vm name is better
-      norm_os = OperatingSystem.normalize_os_name(os_name)
+      norm_os = normalize_os_name(os_name)
       if ["linux_generic", "unknown"].include?(norm_os)
-        vm_name = OperatingSystem.normalize_os_name(obj.name)
+        vm_name = normalize_os_name(obj.name)
         return vm_name unless vm_name == "unknown"
       end
     end
@@ -123,7 +123,7 @@ class OperatingSystem < ApplicationRecord
     os_name = obj.name if os_name.nil?
 
     # Normalize name to match existing icons
-    OperatingSystem.normalize_os_name(os_name)
+    normalize_os_name(os_name)
   end
 
   def self.platform(obj)


### PR DESCRIPTION
Mostly rubocop type stuff...

- `rubocop -a` on OperatingSystem
- Use a constant instead of class var
- Use clearer variable names
- Prefer snake_case
- Prefer .include? over .index
- Remove redundant OperatingSystem.calls

@jrafanie Please review.