### PR TITLE
Deployment is still "new_deployment" if the database isn't seeded

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -175,7 +175,7 @@ class EvmApplication
     migration_conn = ::ActiveRecord::Base.connection.schema_migration
     context        = ActiveRecord::MigrationContext.new(migration_dir, migration_conn)
 
-    return "new_deployment" if context.current_version.zero?
+    return "new_deployment" if context.current_version.zero? || MiqServer.none?
     return "new_replica"    if MiqServer.my_server.nil?
     return "upgrade"        if context.needs_migration?
     "redeployment"

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -304,7 +304,12 @@ RSpec.describe EvmApplication do
       expect(described_class.deployment_status).to eq("new_deployment")
     end
 
-    it "returns new_replica if the current server is not seeded" do
+    it "returns new_deployment if no servers are seeded" do
+      expect(described_class.deployment_status).to eq("new_deployment")
+    end
+
+    it "returns new_replica if the current server is not seeded, but others exist" do
+      FactoryBot.create(:miq_server)
       expect(described_class.deployment_status).to eq("new_replica")
     end
 


### PR DESCRIPTION
In some cases, the pod may exit after the database is migrated, but before it is seeded.  We were claiming that we were in "new_replica" status the next time it came up, but if there are no servers at all, that's not the case, it's still a "new_deployment".
