### PR TITLE
add supports :create for scripts

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -2,7 +2,7 @@ class Authentication < ApplicationRecord
   acts_as_miq_taggable
   include_concern 'ImportExport'
   include YAMLImportExportMixin
-
+  include SupportsFeatureMixin
   include NewWithTypeStiMixin
   def self.new(*args, &block)
     if self == Authentication && (args.empty? || args.first.kind_of?(Hash))

--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -22,4 +22,5 @@ class ConfigurationScriptBase < ApplicationRecord
   scope :with_manager, ->(manager_id) { where(:manager_id => manager_id) }
 
   include ProviderObjectMixin
+  include SupportsFeatureMixin
 end

--- a/app/models/configuration_script_source.rb
+++ b/app/models/configuration_script_source.rb
@@ -1,6 +1,8 @@
 class ConfigurationScriptSource < ApplicationRecord
   acts_as_miq_taggable
 
+  include SupportsFeatureMixin
+
   has_many    :configuration_script_payloads, :dependent => :destroy
   belongs_to  :authentication
   belongs_to  :manager, :class_name => "ExtManagementSystem"

--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::CloudManager::AuthKeyPair < ::Authentication
-  include SupportsFeatureMixin
-
   acts_as_miq_taggable
   has_and_belongs_to_many :vms, :join_table => :key_pairs_vms, :foreign_key => :authentication_id
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -7,6 +7,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }
   validates :scm_branch, :presence => true
 
+  supports :create
+
   default_value_for :scm_type,   "git"
   default_value_for :scm_branch, "master"
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -8,6 +8,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
 
   after_create :set_manager_ref
 
+  supports :create
+
   COMMON_ATTRIBUTES = {}.freeze
   EXTRA_ATTRIBUTES = {}.freeze
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze


### PR DESCRIPTION
Blocks:

- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/274


to get away from respond_to?(:create) kind of behavior,
adding `supports :create` to `EmbeddedAnsible`:

Credential
ConfigurationScriptSource

this has been a trend and was brought up in ManageIQ/manageiq-api#1116
