### PR TITLE
Skip other validations checks when checking hostname

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -196,7 +196,10 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def hostname_format_valid?
+    return unless hostname_required?
+    return unless hostname.present? # Presence is checked elsewhere
     return if hostname.ipaddress? || hostname.hostname?
+
     errors.add(:hostname, _("format is invalid."))
   end
 


### PR DESCRIPTION
The hostname presence validation can happen after the
hostname_format_valid? validation, causing a nil reference error if
hostname is not passed. This commit defers the presence check in a
similar way to hostname_uniqueness_valid?

@agrare Please review.