### PR TITLE
Remove #check_not_responding from common worker management

### DIFF
--- a/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -3,9 +3,6 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
 
   def workers_quiesced?
     # do a subset of the monitor_workers loop to allow for graceful exit
-    my_server.heartbeat
-
-    check_not_responding
     check_pending_stop
     clean_worker_records
 
@@ -43,6 +40,8 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
 
     loop do
       my_server.reload # Reload from SQL this MiqServer AND its miq_workers association
+      my_server.heartbeat
+
       break if self.workers_quiesced?
       sleep worker_monitor_poll
     end

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -32,6 +32,11 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
     super
   end
 
+  def workers_quiesced?
+    check_not_responding
+    super
+  end
+
   def check_not_responding
     worker_deleted = false
     miq_workers.each do |w|

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -210,7 +210,6 @@ RSpec.describe MiqServer do
       end
 
       it "quiesce_workers do mini-monitor_workers loop" do
-        expect(@miq_server).to receive(:heartbeat)
         expect(@miq_server.worker_manager).to receive(:quiesce_workers_loop_timeout?).never
         @worker.update(:status => MiqWorker::STATUS_STOPPED)
         @miq_server.worker_manager.workers_quiesced?


### PR DESCRIPTION
The worker_management/monitor/quiesce `#workers_quiesced?` method is common to process/systemd/kubernetes worker_management implementations but was calling a process specific `#check_not_responding` method.

```
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]: /var/www/miq/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb:8:in `workers_quiesced?': undefined local variable or method `check_not_responding' for #<MiqServer::WorkerManagement::Systemd:0x000055e61831a638> (NameError)
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]: Did you mean?  check_pending_stop
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb:46:in `block in quiesce_workers_loop'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb:44:in `loop'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb:44:in `quiesce_workers_loop'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/app/models/miq_server/worker_management/monitor/quiesce.rb:52:in `quiesce_all_workers'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/app/models/miq_server.rb:299:in `quiesce'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/app/models/miq_server.rb:288:in `shutdown'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/lib/workers/evm_server.rb:57:in `block in stop_servers'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/lib/workers/evm_server.rb:273:in `block in as_each_server'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/lib/workers/evm_server.rb:271:in `each'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/lib/workers/evm_server.rb:271:in `as_each_server'
Jan 28 15:23:42 manageiq.rb.nj.grare.com ruby[1588]:         from /var/www/miq/vmdb/lib/workers/evm_server.rb:57:in `stop_servers'
```