### PR TITLE
Service request connected to Automation request

### DIFF
--- a/app/models/automation_task.rb
+++ b/app/models/automation_task.rb
@@ -22,6 +22,7 @@ class AutomationTask < MiqRequestTask
     args[:miq_group_id]     = options[:miq_group_id] || User.find(options[:user_id]).current_group.id
     args[:tenant_id]        = options[:tenant_id] || User.find(options[:user_id]).current_tenant.id
     args[:automate_message] = options[:message]
+    args[:attrs][:dialog_param_parent_request_id] = miq_request_id unless miq_request_id.nil?
 
     MiqAeEngine.deliver(args)
   end

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -14,6 +14,7 @@ class MiqRequest < ApplicationRecord
   belongs_to :requester,         :class_name  => "User"
   belongs_to :tenant
   belongs_to :service_order
+  belongs_to :parent, :class_name => "MiqRequest"
   has_many   :miq_approvals,     :dependent   => :destroy
   has_many   :miq_request_tasks, :dependent   => :destroy
 
@@ -508,7 +509,8 @@ class MiqRequest < ApplicationRecord
     values[:src_ids] = Array.wrap(values[:src_ids]) unless values[:src_ids].nil?
     request_type = values.delete(:__request_type__) || request_types.first
     initiator = values.delete(:__initiated_by__) || 'user'
-    request = create!(:options => values, :requester => requester, :request_type => request_type, :initiated_by => initiator)
+    parent_id = values[:request_options]&.delete(:parent_id)
+    request = create!(:options => values, :requester => requester, :request_type => request_type, :initiated_by => initiator, :parent_id => parent_id)
 
     request.post_create(auto_approve)
   end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -404,6 +404,7 @@ class ServiceTemplate < ApplicationRecord
 
   def provision_request(user, options = nil, request_options = {})
     request_options[:provision_workflow] = true
+    request_options[:parent_id] = options.delete('param_parent_request_id') unless options['param_parent_request_id'].nil?
     result = order(user, options, request_options)
     raise result[:errors].join(", ") if result[:errors].any?
     result[:request]


### PR DESCRIPTION

Workflow at a high level: 

1. Automation request gets created and immediately returns the data to the API user
2. Request goes to queue and creates an automation task
3. Automation task creates the ServiceTemplateProvisionRequest
4. New provision request creates request task and processes the ansible task

Since the new request created in the queue we cannot return the id along with API result. User has to create a second API call to the system to get the child request. Like GET "http://localhost:3000/api/requests?filter[]=parent_id=425=" 
 <img width="1773" alt="Screenshot 2022-02-04 at 7 39 46 PM" src="https://user-images.githubusercontent.com/16753936/152543287-44f06148-338c-423d-8234-7d480c62c284.png">

Rspec: 
![Screenshot 2022-02-04 at 1 09 34 PM](https://user-images.githubusercontent.com/16753936/152543440-662a3b89-fea0-4bc6-a537-6e4e3e9f45d3.png)

Links
-----

* This [PR](https://github.com/ManageIQ/manageiq-schema/pull/638) should get merged before this one.

