### PR TITLE
[WIP] Refactor ManageIQ setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,43 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../lib/manageiq/environment'
 
-if ARGV.any?
-  puts <<-EOS
-Usage: bin/setup
-
-Environment Variable Options:
-    SKIP_DATABASE_SETUP  Skip the creation, migration, and seeding of the database.
-    SKIP_UI_UPDATE       Skip the update of UI assets.
-    SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
-                         true in production mode since the tasks do not exist.
-EOS
-  exit 1
-end
-
-ENV["SKIP_DATABASE_SETUP"] = "true" if ENV["CI"]
-ENV["SKIP_UI_UPDATE"] = "true" if ENV["CI"]
-ENV["SKIP_TEST_RESET"] = "true" if ENV['RAILS_ENV'] == 'production'
-
-Dir.chdir(ManageIQ::Environment::APP_ROOT) do
-  ManageIQ::Environment.ensure_config_files
-
-  unless ENV["CI"]
-    puts '== Installing dependencies =='
-    ManageIQ::Environment.install_bundler
-    ManageIQ::Environment.bundle_update
-  end
-
-  ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]
-
-  unless ENV["SKIP_DATABASE_SETUP"]
-    ManageIQ::Environment.create_database
-    ManageIQ::Environment.migrate_database
-    ManageIQ::Environment.seed_database
-  end
-
-  ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
-
-  ui_thread&.join
-
-  ManageIQ::Environment.clear_logs_and_temp
-end
+require_relative "../lib/manageiq/environment"
+ManageIQ::Environment.check_cli_options
+ManageIQ::Environment.manageiq_core_setup

--- a/bin/update
+++ b/bin/update
@@ -1,43 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../lib/manageiq/environment'
 
-if ARGV.any?
-  puts <<-EOS
-Usage: bin/update
-
-Environment Variable Options:
-    SKIP_DATABASE_SETUP  Skip the migration and seeding of the database.
-    SKIP_UI_UPDATE       Skip the update of UI assets.
-    SKIP_AUTOMATE_RESET  Skip the reset of the automate domain.
-    SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
-                         true in production mode since the tasks do not exist.
-EOS
-  exit 1
-end
-
-ENV["SKIP_TEST_RESET"] = "true" if ENV["RAILS_ENV"] == "production"
-
-Dir.chdir(ManageIQ::Environment::APP_ROOT) do
-  ManageIQ::Environment.ensure_config_files
-
-  puts '== Installing dependencies =='
-  ManageIQ::Environment.install_bundler
-  ManageIQ::Environment.bundle_update
-
-  ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]
-
-  unless ENV["SKIP_DATABASE_SETUP"]
-    ManageIQ::Environment.migrate_database
-    ManageIQ::Environment.seed_database
-  end
-
-  ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
-  ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
-
-  ui_thread&.join
-
-  # Make sure update_ui is done before compiling assets
-  ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
-
-  ManageIQ::Environment.clear_logs_and_temp
-end
+require_relative "../lib/manageiq/environment"
+ManageIQ::Environment.check_cli_options
+ManageIQ::Environment.manageiq_core_update

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -3,116 +3,151 @@ require 'pathname'
 
 module ManageIQ
   module Environment
-    APP_ROOT = Pathname.new(__dir__).join("../..")
+    APP_ROOT = Pathname.new(__dir__).join("../..").expand_path
 
-    def self.manageiq_plugin_setup(plugin_root = nil)
-      # determine plugin root dir. Assume we are called from a 'bin/' script in the plugin root
-      plugin_root ||= Pathname.new(caller_locations.last.absolute_path).dirname.parent
+    def self.check_cli_options
+      return if ARGV.empty?
 
+      STDERR.puts <<~EOS
+        Usage: bin/update
+
+        Environment Variable Options:
+          SKIP_DATABASE_SETUP  Skip the creation, migration, and seeding of the database.
+          SKIP_UI_UPDATE       Skip the update of UI assets.
+          SKIP_AUTOMATE_RESET  Skip the reset of the automate domain.
+          SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
+                               true in production mode since the tasks do not exist.
+      EOS
+
+      help_requested = ARGV.size == 1 && %w[--help -h].include?(ARGV.first)
+      exit help_requested ? 0 : 1
+    end
+
+    def self.manageiq_plugin_setup(plugin_root)
       manageiq_plugin_update(plugin_root)
     end
 
-    def self.manageiq_plugin_update(plugin_root = nil)
-      # determine plugin root dir. Assume we are called from a 'bin/' script in the plugin root
-      plugin_root ||= Pathname.new(caller_locations.last.absolute_path).dirname.parent
+    def self.manageiq_plugin_update(plugin_root)
+      Dir.chdir(plugin_root) do
+        system!("bin/before_install")
+        bundle_update
+        ensure_config_files
+        setup_test_database(:task_prefix => 'app:')
+      end
+    end
 
-      setup_gemfile_lock if ENV["CI"]
-      install_bundler(plugin_root)
-      bundle_update(plugin_root)
+    def self.manageiq_core_setup
+      manageiq_core_update
+    end
 
-      ensure_config_files
+    def self.manageiq_core_update
+      if ENV["CI"]
+        ENV["SKIP_DATABASE_SETUP"] = "true"  # No need for dev database in test
+        ENV["SKIP_UI_UPDATE"] = "true"       # No need for assets in test
+        ENV["SKIP_AUTOMATE_RESET"] = "true"  # No dev database to reset into in test
+      end
 
-      setup_test_environment(:task_prefix => 'app:', :root => plugin_root) unless ENV["SKIP_TEST_RESET"]
+      ENV["SKIP_TEST_RESET"] = "true" if ENV["RAILS_ENV"] == "production"
+
+      Dir.chdir(APP_ROOT) do
+        bundle_update
+        ensure_config_files
+        update_ui_thread do
+          setup_database
+          setup_test_database
+          reset_automate_domain
+        end
+        compile_assets if ENV['RAILS_ENV'] == 'production'
+        clear_logs_and_temp
+      end
     end
 
     def self.ensure_config_files
-      config_files = {
-        "certs/v2_key.dev"           => "certs/v2_key",
-        "config/cable.yml.sample"    => "config/cable.yml",
-        "config/database.pg.yml"     => "config/database.yml",
-        "config/messaging.kafka.yml" => "config/messaging.yml",
-      }
+      logging("Ensuring config files") do
+        {
+          "certs/v2_key.dev"           => "certs/v2_key",
+          "config/cable.yml.sample"    => "config/cable.yml",
+          "config/database.pg.yml"     => "config/database.yml",
+          "config/messaging.kafka.yml" => "config/messaging.yml",
+        }.each do |source, dest|
+          file = APP_ROOT.join(dest)
+          next if file.exist?
 
-      config_files.each do |source, dest|
-        file = APP_ROOT.join(dest)
-        next if file.exist?
-        puts "Copying #{file} from template..."
-        FileUtils.cp(APP_ROOT.join(source), file)
+          puts "Copying #{file} from template..."
+          FileUtils.cp(APP_ROOT.join(source), file)
+        end
+      end
+    end
+
+    def self.bundle_update
+      if ENV["CI"]
+        # In CI, bundle install is handled by setup-ruby, so just log the lockfiles
+        %w[Gemfile.lock yarn.lock].each do |lockfile|
+          logging(lockfile) do
+            if File.exist?(lockfile)
+              puts File.read(lockfile)
+            else
+              puts "#{lockfile} does not exist"
+            end
+          end
+        end
+      else
+        logging("Updating bundle") do
+          system!("gem install bundler -v '#{bundler_version}' --conservative")
+          system!("bundle update --jobs=3")
+        end
+      end
+    end
+
+    def self.setup_database
+      return if ENV["SKIP_DATABASE_SETUP"]
+
+      logging("Updating database") do
+        system!("bin/rails db:create db:migrate db:seed")
+      end
+    end
+
+    def self.setup_test_database(task_prefix: '')
+      return if ENV["SKIP_TEST_RESET"]
+
+      logging("Resetting test environment") do
+        system!("bin/rails #{task_prefix}test:vmdb:setup")
+      end
+    end
+
+    def self.reset_automate_domain
+      return if ENV["SKIP_AUTOMATE_RESET"]
+
+      logging("Resetting Automate Domains") do
+        system!("bin/rails evm:automate:reset")
+      end
+    end
+
+    def self.compile_assets
+      logging("Compiling UI assets") do
+        system!("bin/rails evm:compile_assets")
+      end
+    end
+
+    def self.clear_logs_and_temp
+      logging("Removing old logs and tempfiles") do
+        system!("bin/rails log:clear tmp:clear")
       end
     end
 
     def self.update_ui_thread
-      puts "\n== Updating UI assets (in parallel) =="
-
-      ui_thread = Thread.new do
-        update_ui
-        puts "\n== Updating UI assets complete =="
-      end
-
+      ui_thread = Thread.new { update_ui(parallel: true) }
       ui_thread.abort_on_exception = true
-      ui_thread
+      yield
+      ui_thread.join
     end
 
-    def self.install_bundler(root = APP_ROOT)
-      system!("gem install bundler -v '#{bundler_version}' --conservative") unless ENV["GITHUB_ACTIONS"]
-    end
+    def self.update_ui(parallel: false)
+      return if ENV["SKIP_UI_UPDATE"]
 
-    def self.setup_gemfile_lock
-      # Gemfile.lock.release only applies to non-master branches and PRs to non-master branches
-      return unless ENV["GITHUB_REPOSITORY_OWNER"] == "ManageIQ" &&
-                    ENV["GITHUB_BASE_REF"] != "master" && # PR to non-master branch
-                    ENV["GITHUB_REF_NAME"] != "master" && # A non-master branch
-                    !ENV["GITHUB_REF_NAME"].to_s.start_with?("dependabot/") # Dependabot makes branches in the core repo
-
-      raise "Missing Gemfile.lock.release" unless APP_ROOT.join("Gemfile.lock.release").file?
-      FileUtils.cp(APP_ROOT.join("Gemfile.lock.release"), APP_ROOT.join("Gemfile.lock"))
-    end
-
-    def self.bundle_update(root = APP_ROOT)
-      system!("bundle update --jobs=3", :chdir => root)
-      return unless ENV["CI"]
-
-      lockfile_contents = File.read(root.join("Gemfile.lock"))
-      puts "===== Begin Gemfile.lock =====\n\n#{lockfile_contents}\n\n===== End Gemfile.lock ====="
-    end
-
-    def self.create_database
-      puts "\n== Updating database =="
-      run_rake_task("db:create")
-    end
-
-    def self.migrate_database
-      puts "\n== Migrating database =="
-      run_rake_task("db:migrate")
-    end
-
-    def self.seed_database
-      puts "\n== Seeding database =="
-      run_rake_task("db:seed")
-    end
-
-    def self.setup_test_environment(task_prefix: '', root: APP_ROOT)
-      puts "\n== Resetting tests =="
-      run_rake_task("#{task_prefix}test:vmdb:setup", :root => root)
-    end
-
-    def self.reset_automate_domain
-      puts "\n== Resetting Automate Domains =="
-      run_rake_task("evm:automate:reset")
-    end
-
-    def self.compile_assets
-      puts "\n== Recompiling assets =="
-      run_rake_task("evm:compile_assets")
-    end
-
-    def self.clear_logs_and_temp
-      puts "\n== Removing old logs and tempfiles =="
-      run_rake_task("log:clear tmp:clear")
-    end
-
-    def self.update_ui
-      system!("bundle exec rake update:ui")
+      logging("Updating UI assets #{"(in parallel)" if parallel}") do
+        system!("bin/rails update:ui")
+      end
     end
 
     def self.bundler_version
@@ -126,8 +161,11 @@ module ManageIQ
       version_requirements.map { |req| req.join(" ") }.join(", ")
     end
 
-    def self.run_rake_task(task, root: APP_ROOT)
-      system!("bin/rails #{task}", :chdir => root)
+    def self.logging(title)
+      puts ENV["CI"] ? "::group::#{title}" : "== #{title} =="
+      yield
+    ensure
+      puts "::endgroup::" if ENV["CI"]
     end
 
     def self.system!(*args)


### PR DESCRIPTION
This commit refactors the ManageIQ core and plugin setup and update to
- DRY up duplication
- Use consistent ENV vars for skipping parts
- Log nicer locally and on CI
- Prevent duplicate bundle update on CI

WIP, because I might want to refactor some of the before_install scripts from the plugins as well, similar to https://github.com/ManageIQ/manageiq-providers-amazon/pull/744