### PR TITLE
fix_auth: bring back foreign key for ae model

### DIFF
--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -28,6 +28,11 @@ module FixAuth
 
     belongs_to :field,    :class_name => "FixMiqAeField",    :foreign_key => :field_id
 
+    # add foreign keys so includes will work
+    def self.select_columns
+      super + [:field_id]
+    end
+
     # only bring back columns that store passwords
     # we want to use joins, but using joins makes this readonly, so we're using includes instead
     def self.contenders


### PR DESCRIPTION
In rails 6.0, sometimes the `.select()` is ignored.
In rails 6.1 it is respected.

We did not have all the columns that were necessary to fix the auth for `MiqAeValue`.
Now we have corrected that and it will work in both rails 6.0 and 6.1

```
fixes:

  1) FixAuth::AuthModel#miq_ae_values should update with complex contenders
     Failure/Error: subject.run(options.merge(:silent => true))

     ActiveModel::MissingAttributeError:
       missing attribute: field_id
```

pulled out of #21652