### PR TITLE
No longer delete dialog_tabs errors

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -57,7 +57,7 @@ class Dialog < ApplicationRecord
 
   def validate_children
     # To remove the meaningless error message like "Dialog tabs is invalid" when child's validation fails
-    errors[:dialog_tabs].delete("is invalid")
+    errors.delete(:dialog_tabs)
     if dialog_tabs.blank?
       errors.add(:base, _("Dialog %{dialog_label} must have at least one Tab") % {:dialog_label => label})
     end

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -19,7 +19,8 @@ class DialogTab < ApplicationRecord
   end
 
   def validate_children
-    errors[:dialog_groups].delete("is invalid")
+    # To remove the meaningless error message like "Dialog groups is invalid" when child's validation fails
+    errors.delete(:dialog_groups)
     errors.add(:base, _("Tab %{tab_label} must have at least one Box") % {:tab_label => label}) if dialog_groups.blank?
 
     dialog_groups.each do |dg|


### PR DESCRIPTION
The errors object is frozen. do not modify it
Also, not sure if these errors even exist anymore

rails 6.1 actually freezes the error object (which it should) and relies upon accessors to modify the hash.

I was not able to find any references to dialog_tabs for the errors in ui-classic. So I think this is a remnant from much older code.

@kavyanekkalapu Are you familiar with the code that would show this?

This is pulled out of #21652