### PR TITLE
User#in_all_regions

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -68,7 +68,7 @@ class MiqRequest < ApplicationRecord
   scope :with_cancel_status,  ->(status)     { where(:cancelation_status => status) }
   scope :with_type,           ->(type)       { where(:type => type) }
   scope :with_request_type,   ->(type)       { where(:request_type => type) }
-  scope :with_requester,      ->(id)         { where(:requester_id => User.with_same_userid(id).select(:id)) }
+  scope :with_requester,      ->(id)         { where(:requester_id => User.in_all_regions(id).select(:id)) }
 
   MODEL_REQUEST_TYPES = {
     :Automate       => {

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -68,7 +68,7 @@ class MiqRequest < ApplicationRecord
   scope :with_cancel_status,  ->(status)     { where(:cancelation_status => status) }
   scope :with_type,           ->(type)       { where(:type => type) }
   scope :with_request_type,   ->(type)       { where(:request_type => type) }
-  scope :with_requester,      ->(id)         { where(:requester_id => User.with_same_userid(id).collect(&:id)) }
+  scope :with_requester,      ->(id)         { where(:requester_id => User.with_same_userid(id).select(:id)) }
 
   MODEL_REQUEST_TYPES = {
     :Automate       => {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
   default_value_for :failed_login_attempts, 0
 
-  scope :with_same_userid, ->(id) { where(:userid => User.default_scoped.where(:id => id).pluck(:userid)) }
+  scope :with_same_userid, ->(id) { where(:userid => User.default_scoped.where(:id => id).select(:userid)) }
 
   def self.with_roles_excluding(identifier)
     where.not(:id => User.unscope(:select).joins(:miq_groups => :miq_product_features)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
   default_value_for :failed_login_attempts, 0
 
-  scope :with_same_userid, ->(id) { where(:userid => User.where(:id => id).pluck(:userid)) }
+  scope :with_same_userid, ->(id) { where(:userid => User.default_scoped.where(:id => id).pluck(:userid)) }
 
   def self.with_roles_excluding(identifier)
     where.not(:id => User.unscope(:select).joins(:miq_groups => :miq_product_features)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
   default_value_for :failed_login_attempts, 0
 
-  scope :with_same_userid, ->(id) { where(:userid => User.default_scoped.where(:id => id).select(:userid)) }
+  scope :in_all_regions, ->(id) { where(:userid => User.default_scoped.where(:id => id).select(:userid)) }
 
   def self.with_roles_excluding(identifier)
     where.not(:id => User.unscope(:select).joins(:miq_groups => :miq_product_features)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -745,10 +745,15 @@ RSpec.describe User do
   end
 
   describe ".with_same_userid" do
-    # this is testing the select does not break and in general, the scope works
     it "properly handles select clause" do
       u = FactoryBot.create(:user)
       expect(User.select(:id, :email).with_same_userid(u.id)).to eq([u])
+    end
+
+    it "finds records with the same userid" do
+      u = FactoryBot.create(:user)
+      u2 = FactoryBot.create(:user, :userid => u.userid, :id => ApplicationRecord.id_in_region(1, u.region_id + 1))
+      expect(User.select(:id, :email).with_same_userid(u.id)).to match_array([u, u2])
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -744,16 +744,16 @@ RSpec.describe User do
     end
   end
 
-  describe ".with_same_userid" do
+  describe ".in_all_regions" do
     it "properly handles select clause" do
       u = FactoryBot.create(:user)
-      expect(User.select(:id, :email).with_same_userid(u.id)).to eq([u])
+      expect(User.select(:id, :email).in_all_regions(u.id)).to eq([u])
     end
 
     it "finds records with the same userid" do
       u = FactoryBot.create(:user)
       u2 = FactoryBot.create(:user, :userid => u.userid, :id => ApplicationRecord.id_in_region(1, u.region_id + 1))
-      expect(User.select(:id, :email).with_same_userid(u.id)).to match_array([u, u2])
+      expect(User.in_all_regions(u.id)).to match_array([u, u2])
     end
   end
 


### PR DESCRIPTION
scoping on create and associated queries changed for rails 6.1
Using `default_scoped` lets rails know that we don't need to use the special scoping
that was present in versions before 6.0

fixe deprecation warning:

```
scoping on create changed for rails 6.1
This lets rails know that we don't need to use the special scoping
that was present in versions before 6.0
```

fixes 2 rubocops:

    Use select instead of pluck within where query method.

When we are looking up a user, we want to search the whole table.
So while rails 6.0 and before may have used special scoping to look up the userid, it was not necessary.

pulled out of #21652