### PR TITLE
fix default_value_for(alias)

### DIFF
--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -17,7 +17,8 @@ class MiqProvisionRequest < MiqRequest
   validate               :must_have_user
 
   default_value_for :options,      :number_of_vms => 1
-  default_value_for(:src_vm_id)    { |r| r.get_option(:src_vm_id) }
+  default_value_for(:source_id)    { |r| r.get_option(:src_vm_id) || r.get_option(:source_id) }
+  default_value_for :source_type,  "VmOrTemplate"
 
   virtual_column :provision_type, :type => :string
 


### PR DESCRIPTION
Default value is only working for actual columns in rails 6.1 and not for column aliases

All other provision workflows use source. This is the only one left that is using `src_vm_id`

Switching over to using just `source_id` works but then the `source_type` was not set, so this PR defaults both.

Was a little concerned what would happen if we pass a non_vm for `source_id`
bit it looks like we are only passing `src_vm_id` and it is a vm.
Assuming that if someone passes in the `source_id`, they will also pass in the `source_type`

use default value with an actual column

     ActiveModel::MissingAttributeError:
       can't write unknown attribute `src_vm_id`


I am a little concerned on this one but it seems to be working well

extracted from #21652