### PR TITLE
Add oVirt factories and vendors

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -17,6 +17,7 @@ class Host < ApplicationRecord
     # DB            Displayed
     "microsoft"       => "Microsoft",
     "redhat"          => "RedHat",
+    "ovirt"           => "Ovirt",
     "kubevirt"        => "KubeVirt",
     "vmware"          => "VMware",
     "openstack_infra" => "OpenStack Infrastructure",

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -44,6 +44,7 @@ class VmOrTemplate < ApplicationRecord
     "parallels"    => "Parallels",
     "amazon"       => "Amazon",
     "redhat"       => "RedHat",
+    "ovirt"        => "Ovirt",
     "openstack"    => "OpenStack",
     "oracle"       => "Oracle",
     "google"       => "Google",

--- a/lib/manageiq/network_discovery/discovery.rb
+++ b/lib/manageiq/network_discovery/discovery.rb
@@ -9,6 +9,7 @@ module ManageIQ
         :mswin           => "ManageIQ::Providers::Microsoft::Discovery",
         :scvmm           => "ManageIQ::Providers::Microsoft::Discovery",
         :openstack_infra => "ManageIQ::Providers::Openstack::Discovery",
+        :ovirt           => "ManageIQ::Providers::Ovirt::Discovery",
         :rhevm           => "ManageIQ::Providers::Redhat::Discovery",
         :esx             => "ManageIQ::Providers::Vmware::Discovery",
         :virtualcenter   => "ManageIQ::Providers::Vmware::Discovery",

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -210,6 +210,23 @@ FactoryBot.define do
     end
   end
 
+  factory :ems_ovirt_with_metrics_authentication,
+          :parent => :ems_ovirt do
+    after(:create) do |x|
+      x.authentications << FactoryBot.create(:authentication_redhat_metric)
+    end
+  end
+
+  factory :ems_ovirt,
+          :aliases => ["manageiq/providers/ovirt/infra_manager"],
+          :class   => "ManageIQ::Providers::Ovirt::InfraManager",
+          :parent  => :ems_infra
+
+  factory :ems_ovirt_with_authentication,
+          :parent => :ems_ovirt do
+    authtype { "default" }
+  end
+
   factory :ems_openstack_infra,
           :aliases => ["manageiq/providers/openstack/infra_manager"],
           :class   => "ManageIQ::Providers::Openstack::InfraManager",

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -46,6 +46,11 @@ FactoryBot.define do
     vmm_vendor { "redhat" }
   end
 
+  factory :host_ovirt, :parent => :host, :class => "ManageIQ::Providers::Ovirt::InfraManager::Host" do
+    sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
+    vmm_vendor { "ovirt" }
+  end
+
   factory :host_openstack_infra, :parent => :host, :class => "ManageIQ::Providers::Openstack::InfraManager::Host" do
     vmm_vendor   { "unknown" }
     ems_ref      { "openstack-perf-host" }

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
   factory :miq_provision_redhat,         :parent => :miq_provision,        :class => "ManageIQ::Providers::Redhat::InfraManager::Provision"
   factory :miq_provision_redhat_via_iso, :parent => :miq_provision_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso"
   factory :miq_provision_redhat_via_pxe, :parent => :miq_provision_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe"
+  factory :miq_provision_ovirt,          :parent => :miq_provision,        :class => "ManageIQ::Providers::Ovirt::InfraManager::Provision"
   factory :miq_provision_vmware,         :parent => :miq_provision,        :class => "ManageIQ::Providers::Vmware::InfraManager::Provision" do
     trait :clone_to_vm do
       request_type { "clone_to_vm" }

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -52,6 +52,8 @@ FactoryBot.define do
   factory(:template_google, :class => "ManageIQ::Providers::Google::CloudManager::Template", :parent => :template_cloud) { vendor { "google" } }
   factory(:template_microsoft, :class => "ManageIQ::Providers::Microsoft::InfraManager::Template", :parent => :template_infra) { vendor { "microsoft" } }
   factory(:template_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::Template", :parent => :template_infra) { vendor { "redhat" } }
+  factory(:template_ovirt, :class => "ManageIQ::Providers::Ovirt::InfraManager::Template", :parent => :template_infra) { vendor { "ovirt" } }
+
 
   factory :template_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::Template", :parent => "template_infra" do
     location { |x| "[storage] #{x.name}/#{x.name}.vmtx" }
@@ -130,6 +132,11 @@ FactoryBot.define do
         FactoryBot.create(:ems_openstack, :vms => [x])
       end
     end
+  end
+
+  factory :vm_ovirt, :class => "ManageIQ::Providers::Ovirt::InfraManager::Vm", :parent => :vm_infra do
+    vendor          { "ovirt" }
+    raw_power_state { "up" }
   end
 
   factory :vm_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::Vm", :parent => :vm_infra do


### PR DESCRIPTION
- added oVirt factories and vendors in preparation for splitting oVirt/RHV

Depends on:
- https://github.com/ManageIQ/manageiq-providers-ovirt/pull/595

@miq-bot add_label enhancement
@miq-bot assign @agrare 