### PR TITLE
Fix class_for_platform method

### DIFF
--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -15,7 +15,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
   # @return [Constant] A scoped provider constant name.
   #
   def self.class_for_platform(platform)
-    classy = platform.classify
+    classy = find_matching_constant("ManageIQ::Providers::#{platform}") ? platform : platform.classify
 
     find_matching_constant("MiqProvision#{classy}Workflow") ||
       find_matching_constant("ManageIQ::Providers::#{classy}::CloudManager::ProvisionWorkflow") ||


### PR DESCRIPTION
Required for: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/341

The .classify method will, among other things, "un-pluralize". There's
an edge case where the plural form is the proper name - for example
'IbmCloud::PowerVirtualServers'. We used the service's official name,
with the plural ending.

This commit allows the 'platform' to be set to the exact class name
instead of snake case.