### PR TITLE
Fix IBM Power HMC vendor type

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -36,24 +36,24 @@ class VmOrTemplate < ApplicationRecord
 
   VENDOR_TYPES = {
     # DB            Displayed
-    "azure"        => "Azure",
-    "azure_stack"  => "AzureStack",
-    "vmware"       => "VMware",
-    "microsoft"    => "Microsoft",
-    "xen"          => "XenSource",
-    "parallels"    => "Parallels",
-    "amazon"       => "Amazon",
-    "redhat"       => "RedHat",
-    "ovirt"        => "Ovirt",
-    "openstack"    => "OpenStack",
-    "oracle"       => "Oracle",
-    "google"       => "Google",
-    "kubevirt"     => "KubeVirt",
-    "ibm_cloud"    => "IBM Cloud",
-    "ibm_power_vc" => "IBM PowerVC",
-    "ibm_power_vm" => "IBM PowerVM",
-    "ibm_z_vm"     => "IBM Z/VM",
-    "unknown"      => "Unknown"
+    "azure"         => "Azure",
+    "azure_stack"   => "AzureStack",
+    "vmware"        => "VMware",
+    "microsoft"     => "Microsoft",
+    "xen"           => "XenSource",
+    "parallels"     => "Parallels",
+    "amazon"        => "Amazon",
+    "redhat"        => "RedHat",
+    "ovirt"         => "Ovirt",
+    "openstack"     => "OpenStack",
+    "oracle"        => "Oracle",
+    "google"        => "Google",
+    "kubevirt"      => "KubeVirt",
+    "ibm_cloud"     => "IBM Cloud",
+    "ibm_power_vc"  => "IBM PowerVC",
+    "ibm_power_hmc" => "IBM Power HMC",
+    "ibm_z_vm"      => "IBM Z/VM",
+    "unknown"       => "Unknown"
   }
 
   POWER_OPS = %w(start stop suspend reset shutdown_guest standby_guest reboot_guest)


### PR DESCRIPTION
Use "IBM Power HMC" consistently as the vendor. "IBM PowerVM" isn't
_wrong_, but ManageIQ uses vendor to display the Provider type (and
icon) so consistency is preferred.

Required for: https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/38