### PR TITLE
Explicitly set log file owner/permissions

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -22,6 +22,22 @@ module MiqEnvironment
     local_addr&.ip_address
   end
 
+  def self.manageiq_uid
+    @manageiq_uid ||= begin
+      Process::UID.from_name("manageiq") if Command.is_appliance?
+    rescue ArgumentError
+      nil
+    end
+  end
+
+  def self.manageiq_gid
+    @manageiq_gid ||= begin
+      Process::GID.from_name("manageiq") if Command.is_appliance?
+    rescue ArgumentError
+      nil
+    end
+  end
+
   class Command
     EVM_KNOWN_COMMANDS = %w[apachectl memcached memcached-tool nohup service systemctl].freeze
 

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -34,12 +34,9 @@ module Vmdb
       progname = log_file.try(:basename, ".*").to_s
 
       logger_class.new(log_file, :progname => progname).tap do |logger|
-        if ENV["APPLIANCE"] && log_file.kind_of?(Pathname)
-          manageiq_uid = Process::UID.from_name("manageiq")
-          manageiq_gid = Process::GID.from_name("manageiq")
-
+        if MiqEnvironment::Command.is_appliance? && log_file.kind_of?(Pathname)
           File.chmod(0o660, log_file)
-          File.chown(manageiq_uid, manageiq_gid, log_file)
+          File.chown(MiqEnvironment.manageiq_uid, MiqEnvironment.manageiq_gid, log_file)
         end
 
         broadcast_logger = create_broadcast_logger


### PR DESCRIPTION
Log files are created anytime the rails environment is loaded, including a number of utilities that run before evmserverd.service even starts.

Workers running as the manageiq user will create log files with `manageiq:manageiq` owner but utilities running as root will create them with `root:manageiq` which prevents workers from starting up.

Fixes https://github.com/ManageIQ/manageiq-appliance/issues/349