### PR TITLE
Move the HostAggregate.*_queue methods to base class

### DIFF
--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -25,6 +25,90 @@ class HostAggregate < ApplicationRecord
 
   virtual_total :total_vms, :vms
 
+  def self.create_aggregate_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "creating Host Aggregate for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => ext_management_system.class.class_by_ems("HostAggregate"),
+      :method_name => 'create_aggregate',
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => [ext_management_system.id, options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def update_aggregate_queue(userid, options = {})
+    task_opts = {
+      :action => "updating Host Aggregate for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'update_aggregate',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def delete_aggregate_queue(userid)
+    task_opts = {
+      :action => "deleting Host Aggregate for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'delete_aggregate',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def add_host_queue(userid, new_host)
+    task_opts = {
+      :action => "Adding Host to Host Aggregate for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'add_host',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => [new_host.id]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def remove_host_queue(userid, old_host)
+    task_opts = {
+      :action => "Removing Host from Host Aggregate for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'remove_host',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => [old_host.id]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
   PERF_ROLLUP_CHILDREN = [:vms]
 
   def perf_rollup_parents(_interval_name = nil)

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -41,6 +41,10 @@ class HostAggregate < ApplicationRecord
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
+  def self.create_aggregate(*_args)
+    raise NotImplementedError, _("create_aggregate must be implemented in a subclass")
+  end
+
   def update_aggregate_queue(userid, options = {})
     task_opts = {
       :action => "updating Host Aggregate for user #{userid}",
@@ -56,6 +60,10 @@ class HostAggregate < ApplicationRecord
       :args        => [options]
     }
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def update_aggregate(*_args)
+    raise NotImplementedError, _("update_aggregate must be implemented in a subclass")
   end
 
   def delete_aggregate_queue(userid)
@@ -75,6 +83,10 @@ class HostAggregate < ApplicationRecord
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
+  def delete_aggregate(*_args)
+    raise NotImplementedError, _("delete_aggregate must be implemented in a subclass")
+  end
+
   def add_host_queue(userid, new_host)
     task_opts = {
       :action => "Adding Host to Host Aggregate for user #{userid}",
@@ -92,6 +104,10 @@ class HostAggregate < ApplicationRecord
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
+  def add_host(*_args)
+    raise NotImplementedError, _("add_host must be implemented in a subclass")
+  end
+
   def remove_host_queue(userid, old_host)
     task_opts = {
       :action => "Removing Host from Host Aggregate for user #{userid}",
@@ -107,6 +123,10 @@ class HostAggregate < ApplicationRecord
       :args        => [old_host.id]
     }
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def remove_host(*_args)
+    raise NotImplementedError, _("remove_host must be implemented in a subclass")
   end
 
   PERF_ROLLUP_CHILDREN = [:vms]


### PR DESCRIPTION
The top-level *_queue methods typically live in the base class and then call out to the child class for implementation of the operation.

Follow-ups:
- https://github.com/ManageIQ/manageiq-providers-openstack/pull/778