### PR TITLE
[WIP] Stop logging to files in production deployments

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -90,13 +90,6 @@ module Vmdb
       progname = log_file.try(:basename, ".*").to_s
 
       logger_class.new(nil, :progname => progname).tap do |logger|
-        # HACK: In order to access the "filename" of the wrapped logger, we inject it as an instance var.
-        logger.instance_variable_set(:@log_file_name, log_file_name)
-
-        def logger.filename
-          @log_file_name
-        end
-
         # HACK: In order to access the wrapped logger in test, we inject it as an instance var.
         if Rails.env.test?
           logger.instance_variable_set(:@wrapped_logger, wrapped_logger)

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -44,11 +44,12 @@ module Vmdb
       configure_external_loggers
     end
 
-    private_class_method def self.create_file_logger(log_file_name, logger_class)
-      log_file_name = ManageIQ.root.join("log", log_file_name)
-      progname      = progname_from_file(log_file_name)
+    private_class_method def self.create_file_logger(log_file, logger_class)
+      log_file = Pathname.new(log_file) if log_file.kind_of?(String)
+      log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
+      progname = log_file.try(:basename, ".*").to_s
 
-      logger_class.new(log_file_name, :progname => progname)
+      logger_class.new(log_file, :progname => progname)
     end
 
     private_class_method def self.create_container_logger(log_file_name, logger_class)
@@ -83,9 +84,10 @@ module Vmdb
       File.basename(log_file_name, ".*")
     end
 
-    private_class_method def self.create_wrapper_logger(log_file_name, logger_class, wrapped_logger)
-      log_file_name = Pathname.new(log_file_name) unless log_file_name.kind_of?(Pathname)
-      progname      = progname_from_file(log_file_name)
+    private_class_method def self.create_wrapper_logger(log_file, logger_class, wrapped_logger)
+      log_file = Pathname.new(log_file) if log_file.kind_of?(String)
+      log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
+      progname = log_file.try(:basename, ".*").to_s
 
       logger_class.new(nil, :progname => progname).tap do |logger|
         # HACK: In order to access the "filename" of the wrapped logger, we inject it as an instance var.

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Vmdb::Loggers do
 
           subject.info("test message")
 
-          expect(log_file.read).to include("test message")
+          expect(log_file.read).to include("test message") unless container_log
         end
       end
 
@@ -165,7 +165,7 @@ RSpec.describe Vmdb::Loggers do
 
           subject.info("test message")
 
-          expect(File.read(log_file)).to include("test message")
+          expect(File.read(log_file)).to include("test message") unless container_log
         end
       end
     end

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Vmdb::Loggers do
 
           subject.info("test message")
 
-          expect(log_file.string).to include("test message")
+          expect(log_file.string).to include("test message") unless container_log
         end
       end
 

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -54,10 +54,6 @@ RSpec.describe Vmdb::Loggers do
         expect(subject).to respond_to(:unknown)
       end
 
-      it "#filename" do
-        expect(subject.filename).to eq Pathname.new(log_file)
-      end
-
       it "#logdev" do
         if container_log
           expect(subject.logdev).to be_nil


### PR DESCRIPTION
Rebase of https://github.com/ManageIQ/manageiq/pull/21177 and update for more recent changes

* https://github.com/ManageIQ/manageiq/pull/21558 - logger_class changed and StringIO log_file support was added changing how the log_file_name and pathname were built
* https://github.com/ManageIQ/manageiq/pull/21562 - removed the need for `#filename`