### PR TITLE
Don't modify perms of log files on podified

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -49,7 +49,8 @@ module Vmdb
     end
 
     private_class_method def self.ensure_log_file_permissions!(log_file)
-      return unless MiqEnvironment::Command.is_appliance? && log_file.kind_of?(Pathname)
+      return unless log_file.kind_of?(Pathname)
+      return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_podified?
 
       file_perm = 0o660 # Allow members of the manageiq group to write to log files
       file_uid  = MiqEnvironment.manageiq_uid


### PR DESCRIPTION
I had expected `.is_appliance?` not to return `true` on podified but this is not the case

```
Errno::EPERM: Operation not permitted @ apply2files - /var/www/miq/vmdb/log/evm.log
/var/www/miq/vmdb/lib/vmdb/loggers.rb:39:in `chown'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:39:in `block in create_logger'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:36:in `tap'
```