### PR TITLE
Fix BinaryBlob purge_date exception

### DIFF
--- a/app/models/binary_blob/purging.rb
+++ b/app/models/binary_blob/purging.rb
@@ -9,7 +9,7 @@ class BinaryBlob < ApplicationRecord
       end
 
       def purge_date
-        ::Settings.binary_blob.keep_orphaned.to_i_with_method.ago.utc
+        ::Settings.binary_blob.keep_orphaned.to_i_with_method.seconds.ago.utc
       end
 
       def purge_window_size

--- a/spec/models/binary_blob/purging_spec.rb
+++ b/spec/models/binary_blob/purging_spec.rb
@@ -2,6 +2,18 @@ RSpec.describe BinaryBlob do
   let(:purge_time) { 1.month.ago.round }
 
   context "::Purging" do
+    describe ".purge_date" do
+      it "returns a date" do
+        expect(described_class.purge_date).to be_kind_of(Time)
+      end
+
+      it "changes with settings" do
+        stub_settings_merge(:binary_blob => {:keep_orphaned => "1.minute"})
+
+        expect(described_class.purge_date).to be_within(1.second).of(60.seconds.ago.utc)
+      end
+    end
+
     describe ".purge_by_scope" do
       it "purges all non-resource rows and expired StateVarHash ones" do
         # BinaryBlob with no resource


### PR DESCRIPTION
`[NoMethodError]: undefined method 'ago' for 2629746:Integer`

Introduced by https://github.com/ManageIQ/manageiq/pull/21399

Fixes https://github.com/ManageIQ/manageiq/issues/21717