### PR TITLE
Require container_orchestrator for is_podified? check

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -67,6 +67,8 @@ module MiqEnvironment
 
     def self.is_podified?
       return @is_podified unless @is_podified.nil?
+
+      require "container_orchestrator"
       @is_podified = is_container? && ContainerOrchestrator.available?
     end
 


### PR DESCRIPTION
`MiqEnvironment::Command.is_podified?` checks `ContainerOrchestrator.available?` and thus has to have the `ContainerOrchestrator` class required.

```
NameError: uninitialized constant MiqEnvironment::Command::ContainerOrchestrator
/var/www/miq/vmdb/lib/miq_environment.rb:70:in `is_podified?'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:53:in `ensure_log_file_permissions!'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:37:in `block in create_logger'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:36:in `tap'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:36:in `create_logger'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:67:in `create_loggers'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:17:in `init'
/var/www/miq/vmdb/config/application.rb:128:in `<class:Application>'
/var/www/miq/vmdb/config/application.rb:38:in `<module:Vmdb>'
/var/www/miq/vmdb/config/application.rb:34:in `<main>'
```