### PR TITLE
Don't call ContainerOrchestrator from MiqEnvironment

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -68,8 +68,9 @@ module MiqEnvironment
     def self.is_podified?
       return @is_podified unless @is_podified.nil?
 
-      require "container_orchestrator"
-      @is_podified = is_container? && ContainerOrchestrator.available?
+      @is_podified = is_container? &&
+                     File.exist?("/run/secrets/kubernetes.io/serviceaccount/token") &&
+                     File.exist?("/run/secrets/kubernetes.io/serviceaccount/ca.crt")
     end
 
     def self.is_appliance?

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -61,12 +61,16 @@ RSpec.describe MiqEnvironment do
       end
 
       context "production build questions" do
+        let(:token_file) { "/run/secrets/kubernetes.io/serviceaccount/token" }
+        let(:ca_file)    { "/run/secrets/kubernetes.io/serviceaccount/ca.crt" }
+
         def container_conditions
           stub_const("ENV", ENV.to_h.merge("CONTAINER" => "true"))
         end
 
         def podified_conditions
-          expect(ContainerOrchestrator).to receive(:available?).and_return(true)
+          allow(File).to receive(:exist?).with(token_file).and_return(true)
+          allow(File).to receive(:exist?).with(ca_file).and_return(true)
           container_conditions
         end
 


### PR DESCRIPTION
`MiqEnvironment::Command.is_podified?` ends up being called before rails
extensions are loaded causing the require to file on include_concern.

`ContainerOrchestrator.available?` simply checks the existence of two
files and can be inlined into `is_podified?` directly.