### PR TITLE
Change documentation default target to new window

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -807,7 +807,7 @@
   :path:
 :help_menu:
   :documentation:
-    :type: default
+    :type: new_window
   :product:
     :type: new_window
   :about:


### PR DESCRIPTION
Change documentation default open window to new tab instead of self. because, once doc link is opened we  do not have any link to come back to env.

**Before**

<img width="912" alt="Screen Shot 2022-02-17 at 9 02 31 PM" src="https://user-images.githubusercontent.com/37085529/154603536-6a8ba643-102f-4a54-97a6-14cf6f5011f7.png">


**After**

<img width="1071" alt="Screen Shot 2022-02-17 at 8 59 41 PM" src="https://user-images.githubusercontent.com/37085529/154603551-2d5d323b-9b0d-4dab-b637-afbbfc253ce4.png">


@miq-bot assign @Fryguy 
@miq-bot add-label bug, najdorf/yes?
@miq-bot add_reviewer @Fryguy 