### PR TITLE
Update Model.supporting(feature) to check instances

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -132,7 +132,9 @@ module SupportsFeatureMixin
 
     # scope to query all those classes that support a particular feature
     def supporting(feature)
-      where(:type => subclasses_supporting(feature).map(&:name))
+      # First find all instances where the class supports <feature> then select instances
+      # which also support <feature> (e.g. the supports block does not add an unsupported_reason)
+      where(:type => subclasses_supporting(feature).map(&:name)).select { |instance| instance.supports?(feature) }
     end
 
     # Providers that support this feature

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -189,7 +189,7 @@ class Zone < ApplicationRecord
 
   # @return [Array<ExtManagementSystem>] All emses that can collect Capacity and Utilization metrics
   def ems_metrics_collectable
-    ext_management_systems.supporting(:metrics).select { |e| e.supports?(:metrics) }
+    ext_management_systems.supporting(:metrics)
   end
 
   def ems_networks


### PR DESCRIPTION
The `Model.supporting(feature)` method currently only checks class-level supports and ignores the instance level.

For example if I have a set of VMs that are all powered on:
```
>> Vm.pluck(:power_state).uniq
=> ["on"]

# Calling .supporting returns all instances as supporting start
>> Vm.supporting(:start).count
=> 14336

# But if we check the instances that support start, none do
>> Vm.all.select { |vm| vm.supports?(:start) }
=> []
```

I think any supports_feature method that returns instances should check if those instances support the feature.  If for performance we only want to check the class level we can use a method that returns the classes which support the feature and leave it up to the caller to query instances on their own, that way it doesn't look like we're checking instance-level when we really aren't.

@kbrock @Fryguy thoughts?