### PR TITLE
Extract remove_worker logic from MiqServer

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -72,6 +72,13 @@ class MiqServer::WorkerManagement
     @workers_lock.synchronize(:EX) { @workers.delete(worker_pid) }
   end
 
+  def find_worker(worker)
+    worker = miq_workers.find_by(:id => worker) if worker.kind_of?(Integer)
+    _log.warn("Cannot find Worker <#{worker.inspect}>") if worker.nil?
+
+    worker
+  end
+
   # remove workers from the miq_workers table and the in memory cache.
   def remove_workers(workers)
     return if workers.empty?

--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -71,4 +71,16 @@ class MiqServer::WorkerManagement
   def worker_delete(worker_pid)
     @workers_lock.synchronize(:EX) { @workers.delete(worker_pid) }
   end
+
+  # remove workers from the miq_workers table and the in memory cache.
+  def remove_workers(workers)
+    return if workers.empty?
+
+    workers.each do |w|
+      yield(w)
+      worker_delete(w.pid)
+      w.destroy
+    end
+    miq_workers.reload
+  end
 end

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -52,16 +52,9 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def clean_worker_records
-    worker_deleted = false
-    miq_workers.each do |w|
-      next unless w.is_stopped?
+    remove_workers(miq_workers.to_a.select(&:is_stopped?)) do |w|
       _log.info("SQL Record for #{w.format_full_log_msg}, Status: [#{w.status}] is being deleted")
-      worker_delete(w.pid)
-      w.destroy
-      worker_deleted = true
     end
-
-    miq_workers.reload if worker_deleted
   end
 
   def check_pending_stop

--- a/app/models/miq_server/worker_management/monitor/kill.rb
+++ b/app/models/miq_server/worker_management/monitor/kill.rb
@@ -4,13 +4,13 @@ module MiqServer::WorkerManagement::Monitor::Kill
   def kill_all_workers
     return unless my_server.is_local?
 
-    remove_unknown_workers
-    remove_workers
+    kill_unknown_worker_processes
+    kill_worker_processes
   end
 
   private
 
-  def remove_unknown_workers
+  def kill_unknown_worker_processes
     # We try, but forget to write migrations to delete orphaned worker class rows, causing this method
     # to blow up and cause the server to continually fail to start.
     # This is called very early from evm_application and ensures we attempt to call MiqWorker#kill
@@ -19,14 +19,14 @@ module MiqServer::WorkerManagement::Monitor::Kill
     if bad_workers.size.positive?
       begin
         MiqWorker.inheritance_column = "__disabled"
-        remove_workers(bad_workers)
+        kill_worker_processes(bad_workers)
       ensure
         MiqWorker.inheritance_column = "type"
       end
     end
   end
 
-  def remove_workers(workers = miq_workers)
+  def kill_worker_processes(workers = miq_workers)
     killed_workers = []
 
     workers.each do |w|

--- a/app/models/miq_server/worker_management/monitor/kill.rb
+++ b/app/models/miq_server/worker_management/monitor/kill.rb
@@ -30,7 +30,7 @@ module MiqServer::WorkerManagement::Monitor::Kill
     killed_workers = []
 
     workers.each do |w|
-      w.kill_process if MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
+      w.kill_process if w.current_or_starting?
       w.destroy
       worker_delete(w.pid)
       killed_workers << w

--- a/app/models/miq_server/worker_management/monitor/kill.rb
+++ b/app/models/miq_server/worker_management/monitor/kill.rb
@@ -27,14 +27,8 @@ module MiqServer::WorkerManagement::Monitor::Kill
   end
 
   def kill_worker_processes(workers = miq_workers)
-    killed_workers = []
-
-    workers.each do |w|
+    remove_workers(workers) do |w|
       w.kill_process if w.current_or_starting?
-      w.destroy
-      worker_delete(w.pid)
-      killed_workers << w
     end
-    miq_workers.delete(*killed_workers) unless killed_workers.empty?
   end
 end

--- a/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -7,19 +7,10 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
     clean_worker_records
 
     return true if miq_workers.all?(&:is_stopped?)
+    return false unless quiesce_workers_loop_timeout?
 
-    if self.quiesce_workers_loop_timeout?
-      killed_workers = []
-      miq_workers.each do |w|
-        w.kill
-        worker_delete(w.pid)
-        killed_workers << w
-      end
-      miq_workers.delete(*killed_workers) unless killed_workers.empty?
-      return true
-    end
-
-    false
+    remove_workers(miq_workers, &:kill)
+    true
   end
 
   def quiesce_workers_loop

--- a/app/models/miq_server/worker_management/monitor/stop.rb
+++ b/app/models/miq_server/worker_management/monitor/stop.rb
@@ -14,12 +14,8 @@ module MiqServer::WorkerManagement::Monitor::Stop
   end
 
   def stop_worker(worker, monitor_reason = nil)
-    w = worker.kind_of?(Integer) ? miq_workers.find_by(:id => worker) : worker
-
-    if w.nil?
-      _log.warn("Cannot find Worker <#{w.inspect}>")
-      return
-    end
+    w = find_worker(worker)
+    return if w.nil?
 
     msg = "Stopping #{w.format_full_log_msg}, status [#{w.status}]..."
     _log.info(msg)

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -13,7 +13,7 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
 
   def monitor_active_workers
     # Monitor all remaining current worker records
-    miq_workers.where(:status => MiqWorker::STATUSES_CURRENT_OR_STARTING).each do |worker|
+    miq_workers.find_current_or_starting.each do |worker|
       # Push the heartbeat into the database
       persist_last_heartbeat(worker)
       # Check the worker record for heartbeat timeouts

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -424,6 +424,10 @@ class MiqWorker < ApplicationRecord
     STATUSES_STOPPED.include?(status)
   end
 
+  def current_or_starting?
+    STATUSES_CURRENT_OR_STARTING.include?(status)
+  end
+
   def started?
     STATUS_STARTED == status
   end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/issues/21716

This is focused on the "killing" of our MiqServer#miq_worker and our in memory store of them.

simplify the way that we traverse the various workers that we are going to stop/kill/quiesce.

CHANGE: cut down the scope of this to just focus around the miq_worker

# Changes in the code

We had 2 code patterns for cleaning out the lists:
- `worker.destroy`, `miq_workers.reload`
- `miq_workers.delete(workers)`

If there is a reason to use one of the other, please share
