### PR TITLE
Fix eligible_for_provisioning calling active on Array

### DIFF
--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -31,7 +31,7 @@ class MiqTemplate < VmOrTemplate
   end
 
   def self.eligible_for_provisioning
-    supporting(:provisioning).active
+    where(:type => subclasses_supporting(:provisioning).map(&:name)).active
   end
 
   def self.without_volume_templates


### PR DESCRIPTION
`supporting(feature)` returns an array of instances and also checks the instance-level supports, prior to the `.supporting()` method being added this explicitly skipped checking instance level supports in favor of using `.where.not(:ems_id => nil)` for performance since the only instance level unsupported reasons are not being connected to an EMS.  This is not perfect but good enough and give a nice performance boost.

This switches back to doing class-level support checks

Broken by https://github.com/ManageIQ/manageiq/pull/21729
`eligible_for_provisioning` changed by https://github.com/ManageIQ/manageiq/pull/21553/files#diff-d28a0e496492eea62a86aacbeaeb7415ecb1b5ab526923dde65ab13ec022a4eaL34-R34