### PR TITLE
Provide a better error message for missing report file

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -107,6 +107,8 @@ module MiqReport::ImportExport
     # @param cache [Hash] cache that holds yaml for the views
     def load_from_view_options(db, current_user = nil, options = {}, cache = {})
       filename = MiqReport.view_yaml_filename(db, current_user, options)
+      raise Errno::ENOENT, "Unable to find view yaml file for db #{db.inspect}" if filename.nil?
+
       view = load_from_filename(filename, cache)
       view.db = db if filename.ends_with?("Vm__restricted.yaml")
       view

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -184,6 +184,12 @@ RSpec.describe MiqReport::ImportExport do
       view = MiqReport.load_from_view_options(VmCloud.name, current_user)
       expect(view.extras[:filename]).to eq("ManageIQ_Providers_CloudManager_Vm")
     end
+
+    it "handles a missing yaml view" do
+      expect do
+        MiqReport.load_from_view_options("Blahblah", current_user)
+      end.to raise_error(Errno::ENOENT, /Unable to find view yaml file for db "Blahblah"/)
+    end
   end
 
   context ".load_from_filename" do


### PR DESCRIPTION
The `MiqReport.view_yaml_filename` method will return nil if all of 3 possible locations is not found.  When that nil is passed to YAML.load_file, you get the TypeError.  Instead, this PR detects that and tries to give more info about what is missing.

@agrare Please review cc @kavyanekkalapu 

Before: `TypeError (no implicit conversion of nil into String)`
After: `Errno::ENOENT: No such file or directory - Unable to find view yaml file for db "Blahblah"`