### PR TITLE
Use standard errors#add_error interface

### DIFF
--- a/app/models/asset_tag_import.rb
+++ b/app/models/asset_tag_import.rb
@@ -114,4 +114,10 @@ class AssetTagImport
       end
     end
   end
+
+  # part of the errors interface
+  # not bothering with localization
+  def self.human_attribute_name(attr_name, *_)
+    attr_name
+  end
 end

--- a/app/models/classification_import.rb
+++ b/app/models/classification_import.rb
@@ -108,4 +108,10 @@ class ClassificationImport
       end
     end
   end
+
+  # part of the errors interface
+  # not bothering with localization
+  def self.human_attribute_name(attr_name, *_)
+    attr_name
+  end
 end

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -185,34 +185,34 @@ class GenericObjectDefinition < ApplicationRecord
 
   def validate_property_attributes
     properties[:attributes].each do |name, type|
-      errors[:properties] << "attribute [#{name}] is not of a recognized type: [#{type}]" unless TYPE_MAP.key?(type.to_sym)
-      errors[:properties] << "invalid attribute name: [#{name}]" unless REG_ATTRIBUTE_NAME =~ name
+      errors.add(:properties, "attribute [#{name}] is not of a recognized type: [#{type}]") unless TYPE_MAP.key?(type.to_sym)
+      errors.add(:properties, "invalid attribute name: [#{name}]") unless REG_ATTRIBUTE_NAME.match?(name)
     end
   end
 
   def validate_property_associations
     invalid_models = properties[:associations].values - ALLOWED_ASSOCIATION_TYPES
-    errors[:properties] << "invalid models for association: [#{invalid_models.join(",")}]" unless invalid_models.empty?
+    errors.add(:properties, "invalid models for association: [#{invalid_models.join(",")}]") unless invalid_models.empty?
 
     properties[:associations].each do |name, _klass|
-      errors[:properties] << "invalid association name: [#{name}]" unless REG_ATTRIBUTE_NAME =~ name
+      errors.add(:properties, "invalid association name: [#{name}]") unless REG_ATTRIBUTE_NAME.match?(name)
     end
   end
 
   def validate_property_methods
     properties[:methods].each do |name|
-      errors[:properties] << "invalid method name: [#{name}]" unless REG_METHOD_NAME =~ name
+      errors.add(:properties, "invalid method name: [#{name}]") unless REG_METHOD_NAME.match?(name)
     end
   end
 
   def validate_property_name_unique
     common = property_keywords.group_by(&:to_s).select { |_k, v| v.size > 1 }.collect(&:first)
-    errors[:properties] << "property name has to be unique: [#{common.join(",")}]" unless common.blank?
+    errors.add(:properties, "property name has to be unique: [#{common.join(",")}]") if common.present?
   end
 
   def validate_supported_property_features
     if properties.keys.any? { |f| !f.to_s.singularize.in?(FEATURES) }
-      errors[:properties] << "only these features are supported: [#{FEATURES.join(", ")}]"
+      errors.add(:properties, "only these features are supported: [#{FEATURES.join(", ")}]")
     end
   end
 
@@ -222,7 +222,7 @@ class GenericObjectDefinition < ApplicationRecord
 
   def check_not_in_use
     return true if generic_objects.empty?
-    errors[:base] << "Cannot delete the definition while it is referenced by some generic objects"
+    errors.add(:base, "Cannot delete the definition while it is referenced by some generic objects")
     throw :abort
   end
 

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -217,7 +217,7 @@ class OrchestrationTemplate < ApplicationRecord
 
   def check_not_in_use
     return true unless in_use?
-    errors[:base] << "Cannot delete the template while it is used by some orchestration stacks"
+    errors.add(:base, "Cannot delete the template while it is used by some orchestration stacks")
     throw :abort
   end
 end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -110,7 +110,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   def check_retirement_potential
     return true unless retirement_potential?
     error_text = 'Destroy aborted.  Active Services require retirement resources associated with this instance.'
-    errors[:base] << error_text
+    errors.add(:base, error_text)
     throw :abort
   end
 

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChargebackRateDetail do
                                                  :chargeable_field   => field,
                                                  :chargeback_rate_id => invalid_chargeback_rate_id)
       expect(chargeback_rate_detail).to be_invalid
-      expect(chargeback_rate_detail.errors.messages).to include(:chargeback_rate => [/can't be blank/])
+      expect(chargeback_rate_detail.errors[:chargeback_rate]).to include(/can't be blank/)
     end
   end
 

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ChargebackRate do
       expect(cbr).to_not be_destroyed
 
       expect(cbr.errors.count).to be(1)
-      expect(cbr.errors.first).to include("rate is assigned and cannot be deleted")
+      expect(cbr.errors.full_messages).to include(/rate is assigned and cannot be deleted/)
     end
 
     it "when default" do
@@ -70,7 +70,7 @@ RSpec.describe ChargebackRate do
       cbr.destroy
       expect(cbr).to_not be_destroyed
       expect(cbr.errors.count).to be(1)
-      expect(cbr.errors.first).to include("default rate cannot be deleted")
+      expect(cbr.errors.full_messages).to include(/default rate cannot be deleted/)
     end
 
     it "when non-default with default description" do
@@ -78,7 +78,7 @@ RSpec.describe ChargebackRate do
       cbr.destroy
       expect(cbr).to_not be_destroyed
       expect(cbr.errors.count).to be(1)
-      expect(cbr.errors.first).to include("default rate cannot be deleted")
+      expect(cbr.errors.full_messages).to include(/default rate cannot be deleted/)
     end
 
     it "when non-default" do

--- a/spec/models/miq_bulk_import_spec.rb
+++ b/spec/models/miq_bulk_import_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MiqBulkImport do
       ati = AssetTagImport.upload('VmOrTemplate', @file)
       expect(ati.stats[:bad]).to eq(1)
       expect(ati.stats[:good]).to eq(0)
-      ati.errors.all? { |attr,| expect(attr.to_s).to eq('vmortemplatenotfound') }
+      ati.errors.full_messages.all? { |error| expect(error).to match(/vmortemplatenotfound/) }
     end
 
     it ".upload" do
@@ -46,7 +46,7 @@ RSpec.describe MiqBulkImport do
       ci = ClassificationImport.upload(@file)
       expect(ci.stats[:bad]).to eq(1)
       expect(ci.stats[:good]).to eq(0)
-      ci.errors.all? { |attr,| expect(attr.to_s).to eq('vmnotfound') }
+      ci.errors.full_messages.all? { |error| expect(error).to match(/vmnotfound/) }
     end
 
     it ".upload with no category" do
@@ -54,7 +54,7 @@ RSpec.describe MiqBulkImport do
       ci = ClassificationImport.upload(@file)
       expect(ci.stats[:bad]).to eq(1)
       expect(ci.stats[:good]).to eq(0)
-      ci.errors.all? { |attr,| expect(attr.to_s).to eq('categorynotfound') }
+      ci.errors.full_messages.all? { |error| expect(error).to match(/categorynotfound/) }
     end
 
     it ".upload" do

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe MiqPolicy do
                      "ExtManagementSystem, Host, PhysicalServer, Vm"
 
       expect(policy).not_to be_valid
-      expect(policy.errors.messages).to include(:towhat => [towhat_error])
+      expect(policy.errors.messages).to eq(:towhat => [towhat_error])
     end
   end
 end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe MiqWidgetSet do
     it "validates that MiqWidgetSet#name cannot contain \"|\" " do
       widget_set = MiqWidgetSet.create(:name => 'TEST|TEST')
 
-      expect(widget_set.errors.messages).to include(:name => ["cannot contain \"|\""])
+      expect(widget_set.errors[:name]).to include("cannot contain \"|\"")
     end
 
     let(:other_group) { FactoryBot.create(:miq_group) }
@@ -55,16 +55,16 @@ RSpec.describe MiqWidgetSet do
     it "validates that MiqWidgetSet has unique description per group and userid" do
       widget_set = MiqWidgetSet.create(:description => @ws_group.description, :owner => group)
 
-      expect(widget_set.errors.messages).to include(:description => ["must be unique for this group and userid"])
+      expect(widget_set.errors[:description]).to include("must be unique for this group and userid")
 
       widget_set = MiqWidgetSet.create(:description => @ws_group.description, :owner => nil)
-      expect(widget_set.errors.messages).not_to include(:description => ["must be unique for this group and userid"])
+      expect(widget_set.errors[:description]).not_to include("must be unique for this group and userid")
 
       widget_set = MiqWidgetSet.create(:description => @ws_group.description, :owner => other_group)
-      expect(widget_set.errors.messages).not_to include(:description => ["must be unique for this group and userid"])
+      expect(widget_set.errors[:description]).not_to include("must be unique for this group and userid")
 
       widget_set = MiqWidgetSet.create(:description => @ws_group.description, :owner => other_group)
-      expect(widget_set.errors.messages).not_to include(:description => ["must be unique for this group and userid"])
+      expect(widget_set.errors[:description]).not_to include("must be unique for this group and userid")
 
       FactoryBot.create(:miq_widget_set, :description => @ws_group.description, :owner => other_group, :userid => "x")
       FactoryBot.create(:miq_widget_set, :description => @ws_group.description, :owner => other_group, :userid => "y")
@@ -72,34 +72,34 @@ RSpec.describe MiqWidgetSet do
       expect(other_userids).to match_array(%w[x y])
 
       other_widget_set = MiqWidgetSet.create(:description => @ws_group.description, :owner => other_group, :userid => "x")
-      expect(other_widget_set.errors.messages).to include(:description => ["must be unique for this group and userid"])
+      expect(other_widget_set.errors[:description]).to include("must be unique for this group and userid")
     end
 
     it "validates that there is at least one widget in set_data" do
       widget_set = MiqWidgetSet.create
 
-      expect(widget_set.errors.messages).to include(:set_data => ["One widget must be selected(set_data)"])
+      expect(widget_set.errors[:set_data]).to include("One widget must be selected(set_data)")
     end
 
     it "validates that widgets in set_data have to exist" do
       unknown_id = MiqWidgetSet.maximum(:id) + 1
       widget_set = MiqWidgetSet.create(:set_data => {:col1 => [unknown_id]})
 
-      expect(widget_set.errors.messages).to include(:set_data => ["Unable to find widget ids: #{unknown_id}"])
+      expect(widget_set.errors[:set_data]).to include("Unable to find widget ids: #{unknown_id}")
     end
 
     it "validates that group_id has to be present for non-read_only widget sets" do
       widget_set = MiqWidgetSet.create(:read_only => false)
-      expect(widget_set.errors.messages).to include(:group_id => ["can't be blank"])
+      expect(widget_set.errors[:group_id]).to include("can't be blank")
 
       widget_set = MiqWidgetSet.create(:read_only => true)
-      expect(widget_set.errors.messages).not_to include(:set_data => ["can't be blank"])
+      expect(widget_set.errors[:group_id]).not_to include("can't be blank")
     end
 
     it "works with HashWithIndifferentAccess set_data" do
       widget_set = MiqWidgetSet.create(:set_data => HashWithIndifferentAccess.new({:col1 => []}))
 
-      expect(widget_set.errors.messages).to include(:set_data => ["One widget must be selected(set_data)"])
+      expect(widget_set.errors[:set_data]).to include("One widget must be selected(set_data)")
     end
   end
 
@@ -129,7 +129,7 @@ RSpec.describe MiqWidgetSet do
 
     it "the belong to group is being deleted" do
       expect { expect { group.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed) }.to_not(change { MiqWidgetSet.count })
-      expect(group.errors[:base][0]).to eq("The group has users assigned that do not belong to any other group")
+      expect(group.errors[:base]).to include("The group has users assigned that do not belong to any other group")
     end
 
     it "being deleted" do


### PR DESCRIPTION
### Overview

This has been the standard way to add errors since at least rails 3.0.

Updating our code to be compatible for future versions of rails.

### Errors removed

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated.
Please call `ActiveModel::Errors#add` instead. (called from check_not_in_use at
/Users/kbrock/src/manageiq/app/models/orchestration_template.rb:220)
```

NOTE: There are no tests on GenericObjectDefinition#property_*s: But since these errors do not work differently from other errors on fields, I do not think this introduces much risk

### 6.0 and 6.1 friendly

I did resort to `errors.full_messages` which have been around since the beginning.
Unfortunately these messages are localized so it does introduce some risk if run on non english speaking systems.
But we can update this when we upgrade to rails 7.0 in the not too distant future

### Previously part of rails 6.1 pr

pulled out of https://github.com/ManageIQ/manageiq/pull/21652