### PR TITLE
for specs, ensure is_appliance is not cached

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -120,7 +120,7 @@ module MiqEnvironment
 
     def self.which
       case Sys::Platform::IMPL
-      when :linux
+      when :linux, :macosx
         "which"
       else
         raise "Not yet supported platform: #{Sys::Platform::IMPL}"


### PR DESCRIPTION
in MiqEnvironment, we cache some of the environment answers

this change uncaches those answers to get the loggers specs running

fixes issue introduced in #21724 that only fails when running tests on a mac

```
rspec --seed 19491 spec/lib/vmdb/loggers_spec.rb

  1) Vmdb::Loggers.create_logger in an appliance environment sets the log file owner and permissions
     Failure/Error: raise "Not yet supported platform: #{Sys::Platform::IMPL}"

     RuntimeError:
       Not yet supported platform: macosx

rspec ./spec/lib/vmdb/loggers_spec.rb:181 # Vmdb::Loggers.create_logger in an appliance environment sets the log file owner and permissions
```
