### PR TITLE
Make dalli clients threadsafe, use a pool for session/token store

### DIFF
--- a/lib/manageiq/session/mem_cache_store_adapter.rb
+++ b/lib/manageiq/session/mem_cache_store_adapter.rb
@@ -13,7 +13,8 @@ module ManageIQ
           :key             => "_vmdb_session",
           :memcache_server => MiqMemcached.server_address,
           :namespace       => "MIQ:VMDB",
-          :value_max_bytes => 10.megabytes,
+          :pool_size       => 10,
+          :value_max_bytes => 10.megabytes
         )
       end
     end

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -7,7 +7,10 @@ module MiqMemcached
 
   def self.default_client_options
     options = {
-      :pool_size => 1,
+      # Direct Dalli Clients won't use connection pool but will be threadsafe.
+      # ActiveSupport::Cache::MemCacheStore and ManageIQ::Session::MemCacheStoreAdapter
+      # use threadsafe but also accept connection pool options.
+      :threadsafe => true
     }
 
     if ENV["MEMCACHED_ENABLE_SSL"]

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -52,8 +52,8 @@ class TokenStore
     MiqMemcached.default_client_options.merge(
       {
         :namespace  => "MIQ:TOKENS:#{namespace.upcase}",
-        :threadsafe => true,
-        :expires_in => token_ttl
+        :expires_in => token_ttl,
+        :pool_size  => 10,
       }
     )
   end


### PR DESCRIPTION
One off dalli clients can get by with just thread safety and not need a pool.
At this point, we should be threadsafe by default.

Our session used by the UI and token store used by the API are likely to
have concurrent requests so we not only need to be threadsafe but also use a
pool.

Previously, in https://github.com/ManageIQ/manageiq/commit/49c1132983aa346f94f821964f7eb3ea7c46ff7e#diff-395a4ac087f9efbc29d305a5da65853725c23c1ec1b2556bf38875abf1bf6632R14
we set the `pool_size` to 1 in the `MiqMemcached.default_client_options`. Note,
this isn't an option to Dalli Client so it was ignored.  But, we merged these
defaults in the `ManageIQ::Session::MemCacheStoreAdapter#session_options` and
`TokenStore.cache_store_options`, resulting in a connection_pool of size 1, which
is honored in these two stores.

If a session or token store connection isn't checked back into the pool, another
thread will get an ugly error that can bubble up to the user:

`FATAL -- production: Error caught: [ConnectionPool::TimeoutError] Waited 5 sec`