### PR TITLE
Add IBM PowerVS vendor type to support new icon

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -50,6 +50,7 @@ class VmOrTemplate < ApplicationRecord
     "google"        => "Google",
     "kubevirt"      => "KubeVirt",
     "ibm_cloud"     => "IBM Cloud",
+    "ibm_power_vs"  => "IBM Power Systems Virtual Server",
     "ibm_power_vc"  => "IBM PowerVC",
     "ibm_power_hmc" => "IBM Power HMC",
     "ibm_z_vm"      => "IBM Z/VM",


### PR DESCRIPTION
Previously the IBM Power Systems Virtual Server (PowerVS) managers used
the IBM Cloud vendor type and icon. There is now a PowerVS specific icon
we can use.

Related PRs:
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/348
- https://github.com/ManageIQ/manageiq-decorators/pull/68