### PR TITLE
Fix vendor/ engine paths requested but still excluded in brakeman 5.0+

### DIFF
--- a/lib/extensions/brakeman_excludes_patch.rb
+++ b/lib/extensions/brakeman_excludes_patch.rb
@@ -1,0 +1,23 @@
+module BrakemanExcludesPatch
+  # Original code can be found here:
+  # https://github.com/presidentbeef/brakeman/blob/5a1eb49216b7087243f5ed0f17c90ea8ca696df1/lib/brakeman/app_tree.rb#L204-L216
+  #
+  # Brakeman silently excludes the vendor directory as of 5.0 by default, see:
+  # https://github.com/presidentbeef/brakeman/commit/89e40fef82a2144aaec5f6203959df39aed22c17
+  # This exclusion occurs AFTER inclusion paths via configuration such as engine paths.
+  # The patch below overrides this behavior and only excludes vendor/ files that aren't opted-in via engine paths.
+  def reject_global_excludes(paths)
+    paths.reject do |path|
+      relative_path = path.relative
+
+      # Add last check for engine_paths
+      if @skip_vendor and relative_path.include? 'vendor/' and @engine_paths.none? { |p| path.absolute.include?(p) }
+        true
+      else
+        Brakeman::AppTree::EXCLUDED_PATHS.any? do |excluded|
+          relative_path.include? excluded
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -9,6 +9,12 @@ namespace :test do
       require "vmdb/plugins"
       require "brakeman"
 
+      # Brakeman 5.0+ excludes files in the vendor directory even if they're included
+      # via engine paths.  We patch it below so that requested engine paths are not excluded.
+      require 'brakeman/app_tree'
+      require Rails.root.join('lib/extensions/brakeman_excludes_patch')
+      Brakeman::AppTree.prepend(BrakemanExcludesPatch)
+
       app_path = Rails.root.to_s
       engine_paths = Vmdb::Plugins.paths.values
 

--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -16,7 +16,7 @@ namespace :test do
       Brakeman::AppTree.prepend(BrakemanExcludesPatch)
 
       app_path = Rails.root.to_s
-      engine_paths = Vmdb::Plugins.paths.values
+      engine_paths = Vmdb::Plugins.paths.except(ManageIQ::Schema::Engine).values
 
       puts "** Running brakeman in #{app_path}"
       puts "** with engines:"


### PR DESCRIPTION
Original code can be found here:
https://github.com/presidentbeef/brakeman/blob/5a1eb49216b7087243f5ed0f17c90ea8ca696df1/lib/brakeman/app_tree.rb#L204-L216

Our CI runs with all gems in the vendor/bundle directory:
```
bundle install --jobs=3 --retry=3 --path=vendor/bundle
```

We explicitly request `Vmdb::Plugins.paths.values` to be added to brakeman's engine-paths option:
https://github.com/ManageIQ/manageiq/blob/b0eb5622b96073d474713b5e03d41fed5b832c99/lib/tasks/test_security.rake#L13-L23

Brakeman silently excludes the vendor directory as of 5.0 by default, see:
https://github.com/presidentbeef/brakeman/commit/89e40fef82a2144aaec5f6203959df39aed22c17

This exclusion occurs AFTER inclusion paths such as engine paths resulting in inclusion paths being excluded.

The patch below overrides this behavior and only excludes vendor/ files that aren't opted-in via engine paths.

Ignore schema repo for now because it's run at a completely different context
than code taking user input.

### Before:
```
== Overview ==

Controllers: 0
Models: 593
Templates: 0
Errors: 0
Security Warnings: 0
```

### After:
```
== Overview ==

Controllers: 254
Models: 1852
Templates: 850
Errors: 0
Security Warnings: 0
```