### PR TITLE
Remove Image Right-Size and Reconfigure Identifiers

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5609,14 +5609,6 @@
         :description: Refresh relationships and power states for all items related of Images
         :feature_type: control
         :identifier: image_refresh
-      - :name: Right Size Recommendations
-        :description: CPU/Memory Recommendations of Images
-        :feature_type: control
-        :identifier: image_right_size
-      - :name: Reconfigure
-        :description: Reconfigure the Memory/CPUs of  Images
-        :feature_type: control
-        :identifier: image_reconfigure
       - :name: Edit Tags
         :description: Edit Image Tags
         :feature_type: control


### PR DESCRIPTION
We cannot reconfigure or resize images.

@miq-bot assign @agrare 
@miq-bot add-label bug, najdorf/yes?
@miq-bot add_reviewer @agrare 