### PR TITLE
Check if a storage has an EMS before checking authentication

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -513,6 +513,11 @@ class Storage < ApplicationRecord
       miq_task.state_active unless miq_task.nil?
     end
 
+    if ext_management_system.nil?
+      _log.warn("Storage: [#{name}] is not connected to an EMS.")
+      raise MiqException::MiqUnreachableStorage, _("Storage: [%{name}] is not connected to an EMS.") % {:name => name}
+    end
+
     unless ext_management_system.authentication_status_ok?
       message = "There are no EMSs with valid credentials connected to Storage: [#{name}] in Zone: [#{MiqServer.my_zone}]."
       _log.warn(message)


### PR DESCRIPTION
Check if a storage is archived before checking if the ems authentication is valid.

```
[----] I, [2022-03-01T07:00:24.204614 #3067362:2acbba723958]  INFO -- : MIQ(MiqAeEngine.deliver) Delivering {:event_type=>"request_storage_scan", "MiqEvent::miq_event"=>1000006731672, :miq_event_id=>1000006731672, "EventStream::event_stream"=>1000006731672, :event_stream_id=>1000006731672} for object [ManageIQ::Providers::Vmware::InfraManager::Storage.1000000000748] with state [] to Automate
[----] I, [2022-03-01T07:00:24.205190 #4179549:2acda18b9964]  INFO -- : MIQ(MiqQueue#m_callback) Message id: [1000186257665], Invoking Callback with args: [1000000369241, "error", "undefined method `authentication_status_ok?' for nil:NilClass", "nil"]
[----] I, [2022-03-01T07:00:24.205293 #4179549:2acda18b9964]  INFO -- : MIQ(Storage#scan_complete_callback) Storage ID: [1000000000001], MiqTask ID: [1000000369241], Status: [error]
[----] E, [2022-03-01T07:00:24.213019 #3067306:2b1cd29eb960] ERROR -- : MIQ(MiqQueue#deliver) Message id: [1000186257669], Error: [undefined method `authentication_status_ok?' for nil:NilClass]
[----] E, [2022-03-01T07:00:24.213148 #3067306:2b1cd29eb960] ERROR -- : [NoMethodError]: undefined method `authentication_status_ok?' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2022-03-01T07:00:24.213234 #3067306:2b1cd29eb960] ERROR -- : /var/www/miq/vmdb/app/models/storage.rb:514:in `smartstate_analysis'
```