### PR TITLE
Fix Storage#vm_ids_by_path when scanning a storage with no hosts mapped

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -555,7 +555,8 @@ class Storage < ApplicationRecord
 
   def vm_ids_by_path
     host_ids = hosts.collect(&:id)
-    return nil if host_ids.empty?
+    return {} if host_ids.empty?
+
     Vm.where(:host_id => host_ids).includes(:storage).inject({}) do |h, v|
       h[File.dirname(v.path)] = v.id
       h


### PR DESCRIPTION
When returning vm_ids_by_path if there are no hosts mapped return an empty has instead of `nil`

```
[----] E, [2022-03-01T07:00:23.431784 #3067198:2ad8464d797c] ERROR -- : [NoMethodError]: undefined method `[]' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2022-03-01T07:00:23.431904 #3067198:2ad8464d797c] ERROR -- : /opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-vmware-33741f14d44b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:14:in `block in datastore_file_inv_to_hashes'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-vmware-33741f14d44b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:11:in `collect'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-vmware-33741f14d44b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb:11:in `datastore_file_inv_to_hashes'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-vmware-33741f14d44b/app/models/manageiq/providers/vmware/infra_manager.rb:719:in `refresh_files_on_datastore'
/var/www/miq/vmdb/app/models/storage.rb:534:in `smartstate_analysis'
```