### PR TITLE
Remove ENV CI GITHUB_ACTIONS checks via smarter gem installation

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -21,11 +21,9 @@ ENV["SKIP_TEST_RESET"] = "true" if ENV['RAILS_ENV'] == 'production'
 Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.ensure_config_files
 
-  unless ENV["CI"]
-    puts '== Installing dependencies =='
-    ManageIQ::Environment.install_bundler
-    ManageIQ::Environment.bundle_update
-  end
+  puts '== Installing dependencies =='
+  ManageIQ::Environment.install_bundler
+  ManageIQ::Environment.bundle_update
 
   ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]
 

--- a/bin/update
+++ b/bin/update
@@ -22,7 +22,7 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler
-  ManageIQ::Environment.bundle_update
+  ManageIQ::Environment.bundle_update(force: true)
 
   ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]
 

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -9,16 +9,16 @@ module ManageIQ
       # determine plugin root dir. Assume we are called from a 'bin/' script in the plugin root
       plugin_root ||= Pathname.new(caller_locations.last.absolute_path).dirname.parent
 
-      manageiq_plugin_update(plugin_root)
+      manageiq_plugin_update(plugin_root, force_bundle_update: false)
     end
 
-    def self.manageiq_plugin_update(plugin_root = nil)
+    def self.manageiq_plugin_update(plugin_root = nil, force_bundle_update: true)
       # determine plugin root dir. Assume we are called from a 'bin/' script in the plugin root
       plugin_root ||= Pathname.new(caller_locations.last.absolute_path).dirname.parent
 
       setup_gemfile_lock if ENV["CI"]
       install_bundler(plugin_root)
-      bundle_update(plugin_root)
+      bundle_update(plugin_root, force: force_bundle_update)
 
       ensure_config_files
 
@@ -72,8 +72,8 @@ module ManageIQ
       FileUtils.cp(APP_ROOT.join("Gemfile.lock.release"), APP_ROOT.join("Gemfile.lock"))
     end
 
-    def self.bundle_update(root = APP_ROOT)
-      if system("bundle check", [:out, :err] => "/dev/null")
+    def self.bundle_update(root = APP_ROOT, force: false)
+      if !force && system("bundle check", [:out, :err] => "/dev/null")
         puts "== bundle check passed... skipping update =="
       else
         system!("bundle update --jobs=3", :chdir => root)

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -59,9 +59,9 @@ module ManageIQ
       #   * Using it to retrieve the bundle's information on the bundler version is successful.
       #     This means the dependency tree is fully resolved and the currently active bundler's
       #     bundle executable is in the bundle and matches the dependency requirements.
-      return if system("which bundle", [:out, :err] => "/dev/null") && system("bundle info bundler", [:out, :err] => "/dev/null")
+      return if system("which bundle", [:out, :err] => "/dev/null") && system("bundle info bundler", [:out, :err] => "/dev/null", :chdir => root)
 
-      system!("gem install bundler -v '#{bundler_version}' --conservative")
+      system!("gem install bundler -v '#{bundler_version}' --conservative", :chdir => root)
     end
 
     def self.setup_gemfile_lock
@@ -76,7 +76,7 @@ module ManageIQ
     end
 
     def self.bundle_update(root = APP_ROOT, force: false)
-      if !force && system("bundle check", [:out, :err] => "/dev/null")
+      if !force && system("bundle check", [:out, :err] => "/dev/null", :chdir => root)
         puts "== Bundle up to date... Skipping bundle update =="
       else
         system!("bundle update --jobs=3", :chdir => root)

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -54,11 +54,14 @@ module ManageIQ
     end
 
     def self.install_bundler(root = APP_ROOT)
-      if system("which bundle", [:out, :err] => "/dev/null") && system("bundle info bundler", [:out, :err] => "/dev/null")
-        puts "== proper bundler detected... skipping bundler install =="
-      else
-        system!("gem install bundler -v '#{bundler_version}' --conservative")
-      end
+      # We can avoid installing bundler on two conditions:
+      #   * The bundle command exists
+      #   * Using it to retrieve the bundle's information on the bundler version is successful.
+      #     This means the dependency tree is fully resolved and the currently active bundler's
+      #     bundle executable is in the bundle and matches the dependency requirements.
+      return if system("which bundle", [:out, :err] => "/dev/null") && system("bundle info bundler", [:out, :err] => "/dev/null")
+
+      system!("gem install bundler -v '#{bundler_version}' --conservative")
     end
 
     def self.setup_gemfile_lock
@@ -74,7 +77,7 @@ module ManageIQ
 
     def self.bundle_update(root = APP_ROOT, force: false)
       if !force && system("bundle check", [:out, :err] => "/dev/null")
-        puts "== bundle check passed... skipping update =="
+        puts "== Bundle up to date... Skipping bundle update =="
       else
         system!("bundle update --jobs=3", :chdir => root)
       end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -54,7 +54,11 @@ module ManageIQ
     end
 
     def self.install_bundler(root = APP_ROOT)
-      system!("gem install bundler -v '#{bundler_version}' --conservative") unless ENV["GITHUB_ACTIONS"]
+      if system("which bundle", [:out, :err] => "/dev/null") && system("bundle info bundler", [:out, :err] => "/dev/null")
+        puts "== proper bundler detected... skipping bundler install =="
+      else
+        system!("gem install bundler -v '#{bundler_version}' --conservative")
+      end
     end
 
     def self.setup_gemfile_lock
@@ -69,7 +73,11 @@ module ManageIQ
     end
 
     def self.bundle_update(root = APP_ROOT)
-      system!("bundle update --jobs=3", :chdir => root)
+      if system("bundle check", [:out, :err] => "/dev/null")
+        puts "== bundle check passed... skipping update =="
+      else
+        system!("bundle update --jobs=3", :chdir => root)
+      end
       return unless ENV["CI"]
 
       lockfile_contents = File.read(root.join("Gemfile.lock"))


### PR DESCRIPTION
The install_bundler and bundle_update methods were changed to detect if there
was no work to be done and return early.  If bundler is installed and the
correct version, install_bundler should do nothing.  If the full bundle is
already resolved and all gems are located, bundle_update should do nothing.

By adding these checks, we can remove some of the implementation details for
CI and GITHUB_ACTIONS done via some ENV checks.

Additionally, we maintain the logic that `bin/update` should always run
`bundle update` when run from core or a plugin.

TODO:
- [x] test plugin bin/update bin/setup https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/624