### PR TITLE
set vmdb_session to samesite

### DIFF
--- a/lib/manageiq/session/abstract_store_adapter.rb
+++ b/lib/manageiq/session/abstract_store_adapter.rb
@@ -5,8 +5,9 @@ module ManageIQ
         session_options = {}
 
         if MiqEnvironment::Command.is_appliance?
-          session_options[:secure]   = true unless ENV["ALLOW_INSECURE_SESSION"]
-          session_options[:httponly] = true
+          session_options[:secure]    = true unless ENV["ALLOW_INSECURE_SESSION"]
+          session_options[:httponly]  = true
+          session_options[:same_site] = true
         end
 
         session_options


### PR DESCRIPTION
set cookie for vmdb_session to not work with third party entities
but only work for our vmdb session (even sub domain needs to be the same)

Since the rails ui servers all have the same domain name, this works

see also https://github.com/ManageIQ/manageiq-appliance/pull/357