### PR TITLE
AuthKeyPair.raw_create_key_pair should return a hash

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -33,18 +33,13 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::Authentication
 
   def self.create_key_pair(ems_id, options)
     raise ArgumentError, _("ems cannot be nil") if ems_id.nil?
+
     ext_management_system = ExtManagementSystem.find(ems_id)
-    raise ArgumentError, _("ems cannot be found") if ext_management_system.nil?
 
     klass = ext_management_system.class_by_ems(:AuthKeyPair)
-    # TODO(maufart): add cloud_tenant to database table?
-    created_key_pair = klass.raw_create_key_pair(ext_management_system, options)
-    klass.create(
-      :name        => created_key_pair.name,
-      :fingerprint => created_key_pair.fingerprint,
-      :resource    => ext_management_system,
-      :auth_key    => created_key_pair.private_key
-    )
+
+    key_pair_opts = klass.raw_create_key_pair(ext_management_system, options)
+    klass.create(key_pair_opts.merge(:resource => ext_management_system))
   end
 
   # Delete an auth key pair as a queued task and return the task id. The queue


### PR DESCRIPTION
The raw_create_key_pair method is implemented by various different providers and expecting that a consistent intermediate object can be returned isn't viable.

Amazon already had to define a Struct so that this could work.

Instead we can return a hash containing the options that need to be passed to the `.create` call.

Provider PRs (merge all together):
* [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/746
* [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/349
* [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/784