### PR TITLE
[WIP] Ensure orchestration_template content is a string

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -43,7 +43,7 @@ class OrchestrationTemplate < ApplicationRecord
         true
       else
         klass = hash[:type].present? ? hash[:type].constantize : self
-        md5s << klass.calc_md5(with_universal_newline(hash[:content]))
+        md5s << klass.calc_md5(with_universal_newline(hash[:content].to_s))
         false
       end
     end


### PR DESCRIPTION
```
[NoMethodError]: undefined method `encode' for []:Array  Method:[block (2 levels) in <class:LogProxy>]
/var/www/miq/vmdb/app/models/orchestration_template.rb:211:in `with_universal_newline'
/var/www/miq/vmdb/app/models/orchestration_template.rb:46:in `block in find_or_create_by_contents'
/var/www/miq/vmdb/app/models/orchestration_template.rb:40:in `reject'
/var/www/miq/vmdb/app/models/orchestration_template.rb:40:in `find_or_create_by_contents'
```