### PR TITLE
make secure header values more grep friendly

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,9 +1,17 @@
 if defined?(SecureHeaders)
+  # Please make sure these values are properly reflected in apache config:
+  # - https://github.com/ManageIQ/manageiq-appliance/blob/master/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+  # - https://github.com/ManageIQ/manageiq-pods/blob/master/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
   SecureHeaders::Configuration.default do |config|
     config.hsts = "max-age=#{20.years.to_i}"
+    # X-Frame-Options
     config.x_frame_options = 'SAMEORIGIN'
+    # X-Content-Type-Options
     config.x_content_type_options = "nosniff"
+    # X-XSS-Protection
+    # X-Permitted-Cross-Domain-Policies
     config.x_xss_protection = "1; mode=block"
+    # Content-Security-Policy
     config.csp = {
       :report_only => false,
       :default_src => ["'self'"],


### PR DESCRIPTION
We configure our secure headers in multiple places.
These headers are returned by rails, apache in pods, and apache on an appliance.

This is a reminder of where else to make these changes.

There is also a guides article with the configuration for this change but I opted to not link it