### PR TITLE
Bump worker count of UI and API to 2

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1165,9 +1165,11 @@
       :vm_scan_dispatcher_stale_message_timeout: 2.minutes
     :ui_worker:
       :connection_pool_size: 8
+      :count: 2
       :nice_delta: 1
     :web_service_worker:
       :connection_pool_size: 8
+      :count: 2
       :nice_delta: 1
     :remote_console_worker:
       :connection_pool_size: 14

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -1,4 +1,11 @@
 RSpec.describe MiqUiWorker do
+  describe ".worker_settings" do
+    it "count defaults to 2" do
+      EvmSpecHelper.local_miq_server
+      expect(described_class.worker_settings[:count]).to eq 2
+    end
+  end
+
   context ".all_ports_in_use" do
     before do
       require 'util/miq-process'

--- a/spec/models/miq_web_service_worker_spec.rb
+++ b/spec/models/miq_web_service_worker_spec.rb
@@ -1,4 +1,11 @@
 RSpec.describe MiqWebServiceWorker do
+  describe ".worker_settings" do
+    it "count defaults to 2" do
+      EvmSpecHelper.local_miq_server
+      expect(described_class.worker_settings[:count]).to eq 2
+    end
+  end
+
   it "preload_for_worker_role autoloads api collection classes and descendants" do
     allow(EvmDatabase).to receive(:seeded_primordially?).and_return(true)
     expect(MiqWebServiceWorker).to receive(:configure_secret_token)


### PR DESCRIPTION
This allows for traffic to route to the second worker if the first
worker goes down, which is a typical HA setup.
