### PR TITLE
[WIP] Touch a worker.started file after worker initialization

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -229,6 +229,10 @@ class MiqWorker < ApplicationRecord
     self.class.fetch_worker_settings_from_server(miq_server, options)
   end
 
+  def started_file
+    @started_file ||= Workers::MiqDefaults.started_file(guid)
+  end
+
   def heartbeat_file
     @heartbeat_file ||= Workers::MiqDefaults.heartbeat_file(guid)
   end

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -110,6 +110,7 @@ class ContainerOrchestrator
         {:name => "HOME",                    :value => Rails.root.join("tmp").to_s},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
+        {:name => "WORKER_STARTED_FILE",     :value => Rails.root.join("tmp", "worker.startup").to_s},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
         {:name => "ENCRYPTION_KEY",          :valueFrom => {:secretKeyRef=>{:name => "app-secrets", :key => "encryption-key"}}}

--- a/lib/workers/miq_defaults.rb
+++ b/lib/workers/miq_defaults.rb
@@ -18,6 +18,11 @@ module Workers
       STOPPING_TIMEOUT
     end
 
+    def self.started_file(guid = nil)
+      guid ||= "miq_worker"
+      ENV["WORKER_STARTED_FILE"] || File.expand_path("../../../tmp/#{guid}.started", __FILE__)
+    end
+
     def self.heartbeat_file(guid = nil)
       guid ||= "miq_worker"
       ENV["WORKER_HEARTBEAT_FILE"] || File.expand_path("../../../tmp/#{guid}.hb", __FILE__)


### PR DESCRIPTION
Currently when workers are running under Systemd we use SD_NOTIFY to signal that a worker has started, Kubernetes also has a "startup probe" which waits for an indication that the worker is started before starting the readiness probe.

We can touch a startup file that a k8s startup probe can check when we mark the worker as "STARTED"