### PR TITLE
Use autoload for RipperRubyParser

### DIFF
--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -67,9 +67,9 @@ class DescendantLoader
   # be defined in [depending on runtime details], the name of the class,
   # and the name of its superclass), given a path to a ruby script file.
   module Parser
-    def classes_in(filename)
-      require 'ripper_ruby_parser'
+    autoload :RipperRubyParser, 'ripper_ruby_parser'
 
+    def classes_in(filename)
       content = File.read(filename)
       begin
         parsed = RipperRubyParser::Parser.new.parse(content, filename)


### PR DESCRIPTION
Using the following script:

    rm -f tmp/cache/sti_loader.yml; be rails r 'puts Benchmark.ms { Vm.descendants }'

Before 29.3s / After 27.4s (~6.5% improvement). In addition, things like
require logging are _much_ less noisy.

---

@jrafanie Please review.  Note that this is preloaded in production, so technically it makes no difference there, and for that reason we don't need backport.  Technically it will make the build 2 seconds faster 😉 

