### PR TITLE
wait for db up in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,15 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+    - name: Wait for db
+      run: |
+          COUNT=1
+          while ! pg_isready ; do
+            echo "waiting for postgres to start"
+            COUNT=$(($COUNT + 1))
+            [[ $COUNT -lt 20 ]] || break
+            sleep 1
+          done
     - name: Prepare tests
       run: bin/setup
     - name: Run tests


### PR DESCRIPTION
Have github actions wait for the database to be up before running the tests

This is not necessary most of the time.
But every now and then it sneaks in so it removes a sporadic test failure
