### PR TITLE
Add IBM Power HMC to host vendor types

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -21,6 +21,7 @@ class Host < ApplicationRecord
     "kubevirt"        => "KubeVirt",
     "vmware"          => "VMware",
     "openstack_infra" => "OpenStack Infrastructure",
+    "ibm_power_hmc"   => "IBM Power HMC",
     "unknown"         => "Unknown",
     nil               => "Unknown",
   }.freeze


### PR DESCRIPTION
Required to display the IBM Power HMC icon in the host "VMM Information".