### PR TITLE
console_url is now available on both Physical Infra and Cloud Providers

### DIFF
--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -26,7 +26,7 @@ class ConfigurationProfile < ApplicationRecord
 
   delegate :my_zone, :provider, :zone, :to => :manager
 
-  supports_not :console
+  supports_not :native_console
 
   virtual_has_one :configuration_architecture,  :class_name => 'ConfigurationArchitecture', :uses => :configuration_tags
   virtual_has_one :configuration_compute_profile, :class_name => 'ConfigurationProfile',    :uses => :configuration_tags

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -41,7 +41,7 @@ class ConfiguredSystem < ApplicationRecord
   virtual_delegate :cpu_total_cores, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
   virtual_delegate :ram_size, :to => "hardware.memory_mb", :allow_nil => true, :default => 0, :type => :integer
 
-  supports_not :console
+  supports_not :native_console
 
   virtual_column  :my_zone,                            :type => :string
   virtual_column  :configuration_architecture_name,    :type => :string

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -29,6 +29,12 @@ module ManageIQ::Providers
       self.class.http_proxy_uri
     end
 
+    supports_not :native_console
+
+    def console_url
+      raise NotImplementedError, _("console_url must be implemented in a subclass")
+    end
+
     # copy my attributes to a child manager
     # child managers need to be in lock step with this manager
     def propagate_child_manager_attributes(child, name = nil)

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -143,20 +143,6 @@ module ManageIQ::Providers
 
     alias total_vms count_vms
 
-    supports :console do
-      unless console_supported?
-        unsupported_reason_add(:console, N_("Console not supported"))
-      end
-    end
-
-    def console_supported?
-      false
-    end
-
-    def console_url
-      raise MiqException::Error, _("Console not supported")
-    end
-
     def self.firmware_update_class
       self::FirmwareUpdateTask
     end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -492,6 +492,10 @@
       :description: Re-check Authentication Status of Cloud Providers
       :feature_type: control
       :identifier: ems_cloud_recheck_auth_status
+    - :name: Native Console
+      :description: Provides the native webconsole of the Cloud Provider
+      :feature_type: control
+      :identifier: ems_native_console
   - :name: Modify
     :description: Modify Cloud Providers
     :feature_type: admin
@@ -1082,6 +1086,10 @@
       :description: Open Admin UI for Infrastructure Providers
       :feature_type: control
       :identifier: ems_infra_admin_ui
+    - :name: Native Console
+      :description: Provides the native webconsole of the Cloud Provider
+      :feature_type: control
+      :identifier: ems_native_console
   - :name: Modify
     :description: Modify Infrastructure Providers
     :feature_type: admin

--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -46,17 +46,17 @@ RSpec.describe ManageIQ::Providers::PhysicalInfraManager do
     expect(ps.supports?(:console)).to be(false)
   end
 
-  it 'will return false if console is not supported' do
+  it 'will check supports?(:native_console) returns false' do
     ps = FactoryBot.create(:ems_physical_infra,
                             :name     => "LXCA",
                             :hostname => "0.0.0.0")
-    expect(ps.console_supported?).to be(false)
+    expect(ps.supports?(:native_console)).to be(false)
   end
 
   it 'will raise exception for console url if console is not supported' do
     ps = FactoryBot.create(:ems_physical_infra,
-                            :name     => "LXCA",
-                            :hostname => "0.0.0.0")
-    expect { ps.console_url }.to raise_error(MiqException::Error)
+                           :name     => "LXCA",
+                           :hostname => "0.0.0.0")
+    expect { ps.console_url }.to raise_error(NotImplementedError)
   end
 end


### PR DESCRIPTION
Need this in both the places, as PowerVC and PowerVS both have this function and I realized that it is not existing in base class. Also same exist in the Physical Infra manager also. This will take care of other cloud/infra providers which do not provide any.

Please also see associated PRs:

- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/357
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/51
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/79
- [ ] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/363
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8149
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8177
