### PR TITLE
Add `supports?(:events)` to ExtManagementSystem

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -139,20 +139,20 @@ class ExtManagementSystem < ApplicationRecord
 
   serialize :options
 
-  supports_not :catalog
   supports_not :add_host_initiator
   supports_not :add_storage
   supports_not :add_volume_mapping
   supports_not :admin_ui
   supports_not :assume_role
   supports_not :block_storage
+  supports_not :catalog
   supports_not :change_password
   supports_not :cloud_object_store_container_create
   supports_not :cloud_subnet_create
   supports_not :cloud_tenant_mapping
   supports_not :cloud_volume_create
-  supports_not :create_iso_datastore
   supports_not :console
+  supports_not :create_iso_datastore
   supports_not :discovery
   supports_not :label_mapping
   supports_not :metrics

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -154,6 +154,7 @@ class ExtManagementSystem < ApplicationRecord
   supports_not :console
   supports_not :create_iso_datastore
   supports_not :discovery
+  supports_not :events
   supports_not :label_mapping
   supports_not :metrics
   supports_not :object_storage


### PR DESCRIPTION
A number of providers have conditional support for event collection.

Typically this depends on if credentials for a particular endpoint have been configured (e.g. Openstack) or if some service has been enabled on the provider (e.g. Azure/GCE).

We can use this for example in https://github.com/ManageIQ/manageiq-providers-google/pull/216