### PR TITLE
Add virtual attributes to be used in views

### DIFF
--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -35,6 +35,7 @@ class ConfiguredSystem < ApplicationRecord
   delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
   delegate :name, :to => :provider,                      :prefix => true, :allow_nil => true
   delegate :name, :to => :orchestration_stack,           :prefix => true, :allow_nil => true
+  virtual_delegate :name, :to => :inventory_root_group, :prefix => true, :allow_nil => true, :type => :string
   delegate :my_zone, :provider, :zone, :to => :manager
   delegate :queue_name_for_ems_operations, :to => :manager, :allow_nil => true
 

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -22,11 +22,7 @@ class ContainerService < ApplicationRecord
 
   acts_as_miq_taggable
 
-  virtual_column :container_groups_count, :type => :integer
-
-  def container_groups_count
-    number_of(:container_groups)
-  end
+  virtual_total :container_groups_count, :container_groups
 
   include Metric::CiMixin
 

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -46,8 +46,7 @@ class GenericObjectDefinition < ApplicationRecord
 
   before_destroy    :check_not_in_use
 
-  delegate :count, :to => :generic_objects, :prefix => true, :allow_nil => false
-  virtual_column :generic_objects_count, :type => :integer
+  virtual_delegate :count, :to => :generic_objects, :prefix => true, :allow_nil => false, :type => :integer
 
   FEATURES.each do |feature|
     define_method("property_#{feature}s") do

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -137,7 +137,8 @@ class Host < ApplicationRecord
   virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true, :type => :string
   virtual_column :vmm_vendor_display,           :type => :string
   virtual_column :ipmi_enabled,                 :type => :boolean
-  virtual_column :archived, :type => :boolean
+  virtual_attribute :archived, :boolean, :arel => ->(t) { t.grouping(t[:ems_id].eq(nil)) }
+  virtual_column :normalized_state, :type => :string
 
   virtual_has_many   :resource_pools,                               :uses => :all_relationships
   virtual_has_many   :miq_scsi_luns,                                :uses => {:hardware => {:storage_adapters => {:miq_scsi_targets => :miq_scsi_luns}}}
@@ -1692,14 +1693,15 @@ class Host < ApplicationRecord
     end
   end
 
-  def archived?
-    ems_id.nil?
+  def archived
+    has_attribute?("archived") ? self["archived"] : ems_id.nil?
   end
-  alias archived archived?
+  alias archived? archived
 
   def normalized_state
     return 'archived' if archived?
-    return power_state unless power_state.nil?
+    return power_state if power_state.present?
+
     "unknown"
   end
 

--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -2,11 +2,7 @@ class IsoDatastore < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :iso_datastore
   has_many   :iso_images, :dependent => :destroy
 
-  virtual_column :name, :type => :string, :uses => :ext_management_system
-
-  def name
-    ext_management_system.try(:name)
-  end
+  virtual_delegate :name, :to => :ext_management_system, :allow_nil => true, :type => :string
 
   # Synchronize advertised images as a queued task. The
   # queue name and the queue zone are derived from the EMS.

--- a/app/models/manageiq/providers/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/automation_manager/configured_system.rb
@@ -1,7 +1,2 @@
 class ManageIQ::Providers::AutomationManager::ConfiguredSystem < ::ConfiguredSystem
-  virtual_column  :inventory_root_group_name, :type => :string, :uses => :inventory_root_group
-
-  def inventory_root_group_name
-    inventory_root_group.name
-  end
 end

--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -2,7 +2,7 @@ class PersistentVolume < ContainerVolume
   acts_as_miq_taggable
   include NewWithTypeStiMixin
   serialize :capacity, Hash
-  delegate :name, :to => :parent, :prefix => true
+  virtual_delegate :name, :to => :parent, :prefix => true, :allow_nil => true, :type => :string
   has_many :container_volumes, -> { where(:type => 'ContainerVolume') }, :through => :persistent_volume_claim
   has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'
   alias_attribute :container_groups, :parents

--- a/app/models/security_policy.rb
+++ b/app/models/security_policy.rb
@@ -13,7 +13,7 @@ class SecurityPolicy < ApplicationRecord
   has_many :security_policy_rules, :foreign_key => :security_policy_id, :dependent => :destroy
   alias rules security_policy_rules
 
-  virtual_total :rules_count, :rules
+  virtual_total :rules_count, :security_policy_rules
 
   def self.class_by_ems(ext_management_system)
     ext_management_system&.class_by_ems(:SecurityPolicy)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -146,6 +146,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :is_evm_appliance,                     :type => :boolean,    :uses => :miq_server
   virtual_column :os_image_name,                        :type => :string,     :uses => [:operating_system, :hardware]
   virtual_column :platform,                             :type => :string,     :uses => [:operating_system, :hardware]
+  virtual_column :product_name,                         :type => :string,     :uses => [:operating_system]
   virtual_column :vendor_display,                       :type => :string
   virtual_column :v_owning_cluster,                     :type => :string,     :uses => :ems_cluster
   virtual_column :v_owning_resource_pool,               :type => :string,     :uses => :all_relationships

--- a/spec/models/configured_system_spec.rb
+++ b/spec/models/configured_system_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ConfiguredSystem do
+  include Spec::Support::ArelHelper
+
   it "#counterparts" do
     vm  = FactoryBot.create(:vm)
     cs1 = FactoryBot.create(:configured_system, :counterpart => vm)
@@ -6,6 +8,25 @@ RSpec.describe ConfiguredSystem do
     cs3 = FactoryBot.create(:configured_system, :counterpart => vm)
 
     expect(cs1.counterparts).to match_array([vm, cs2, cs3])
+  end
+
+  describe "#inventory_root_group_name" do
+    it "handles no inventory root group" do
+      system = ConfiguredSystem.new
+      expect(system.inventory_root_group_name).to be_nil
+    end
+
+    it "handles inventory root group in ruby" do
+      folder = FactoryBot.create(:ems_folder)
+      system = ConfiguredSystem.new(:inventory_root_group => folder)
+      expect(system.inventory_root_group_name).to eq(folder.name)
+    end
+
+    it "handles inventory root group in sql" do
+      folder = FactoryBot.create(:ems_folder)
+      FactoryBot.create(:configured_system, :inventory_root_group => folder)
+      expect(virtual_column_sql_value(ConfiguredSystem, "inventory_root_group_name")).to eq(folder.name)
+    end
   end
 
   describe "#queue_name_for_ems_operations" do

--- a/spec/models/container_service_spec.rb
+++ b/spec/models/container_service_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ContainerService do
+  let(:group) { FactoryBot.create(:container_group_with_assoc) }
+  let(:ems) { group.ext_management_system }
+  let(:project) { group.container_project }
+  let(:service) { FactoryBot.create(:container_service, :ext_management_system => ems, :container_project => project) }
+
+  describe "#container_groups_count" do
+    it "counts singles" do
+      service.container_groups << group
+      expect(service.reload.container_groups_count).to eq(1)
+    end
+  end
+end

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe GenericObjectDefinition do
       }
     )
   end
+  let(:objects) { FactoryBot.create_list(:generic_object, 2, :generic_object_definition => definition) }
 
   it "doesn't access database when unchanged model is saved" do
     m = FactoryBot.create(:generic_object_definition)
@@ -392,6 +393,13 @@ RSpec.describe GenericObjectDefinition do
         }
         expect(definition.custom_actions).to match(expected)
       end
+    end
+  end
+
+  describe '#generic_objects_count' do
+    it "counts" do
+      objects
+      expect(definition.generic_objects_count).to eq(objects.size)
     end
   end
 

--- a/spec/models/iso_datastore_spec.rb
+++ b/spec/models/iso_datastore_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe IsoDatastore do
+  include Spec::Support::ArelHelper
+
   let(:ems) { FactoryBot.create(:ems_redhat) }
   let(:iso_datastore) { FactoryBot.create(:iso_datastore, :ext_management_system => ems) }
 
@@ -34,6 +36,17 @@ RSpec.describe IsoDatastore do
             .to receive(:advertised_images)
           advertised_images
         end
+      end
+    end
+
+    describe "#name" do
+      it "has a name" do
+        expect(iso_datastore.name).to eq(ems.name)
+      end
+
+      it "fetches name via sql" do
+        iso_datastore
+        expect(virtual_column_sql_value(IsoDatastore, "name")).to eq(ems.name)
       end
     end
   end

--- a/spec/models/security_policy_spec.rb
+++ b/spec/models/security_policy_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe SecurityPolicy do
+  include Spec::Support::ArelHelper
+
+  let(:policy) { FactoryBot.create(:security_policy) }
+
+  let(:rules) { FactoryBot.create_list(:security_policy_rule, 2, :security_policy => policy) }
+
+  describe "#rules" do
+    it "matches security_policy_rules" do
+      rules
+
+      expect(policy.rules.order(:id)).to eq(rules)
+    end
+  end
+
+  describe "#rules_count" do
+    it "calculates in ruby" do
+      rules
+      expect(policy.rules_count).to eq(2)
+    end
+
+    it "calculates in the database" do
+      rules
+      expect(virtual_column_sql_value(SecurityPolicy, "rules_count")).to eq(2)
+    end
+  end
+end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1507,6 +1507,27 @@ RSpec.describe VmOrTemplate do
     end
   end
 
+  describe "#product_name" do
+    it "handles no os" do
+      expect(vm.product_name).to be_blank
+    end
+
+    it "uses os" do
+      os = OperatingSystem.create!(:product_name => "test")
+      vm = FactoryBot.create(:vm_or_template, :operating_system => os)
+
+      expect(vm.product_name).to eq(os.product_name)
+    end
+
+    it "uses parent os" do
+      os = OperatingSystem.create!(:product_name => "test")
+      parent = FactoryBot.create(:vm_or_template, :operating_system => os)
+      vm = FactoryBot.create(:vm_or_template, :genealogy_parent => parent)
+
+      expect(vm.product_name).to eq(os.product_name)
+    end
+  end
+
   describe '#normalized_state' do
     let(:klass) { :vm_vmware }
     let(:storage) { FactoryBot.create(:storage_vmware) }


### PR DESCRIPTION
## Note

This is a 9 file +14/-25. The specs make it look much bigger.

## Problem
A number of columns in reports are not virtual_attributes.
When we are trying to produce sql for a report, and it is not a virtual attribute or a real attribute, active record just puts the column name into the sql and sees what happens. (Spoiler: it blows up)

We see that with the following error:

```
[----] F, [2022-03-23T17:49:46.093226 #87286:b4aa0] FATAL -- : Error caught: [ActiveRecord::StatementInvalid] PG::UndefinedColumn: ERROR:  column vms.product_name does not exist
LINE 1: SELECT DISTINCT "vms"."product_name" AS alias_0, "vms"."id" ...
                        ^
```

## Reports/columns affected

|Model           |Column                     |before|effect|after|effect|
|:---------------|:---                       |:---|:---|:---|:---|
|ConfiguredSystem|inventory_root_group_name  |method|error|virtual_delegate (in parent)|sql||
|ContainerService|container_group_count      |virtual_attribute|ruby|virtual_delegate|sql|
|GenericObjectDefinition|generic_object_count|virtual_attribute|ruby|virtual_total|sql|
|Host            |archived                   |virtual_attribute|error / not in report|virtual_attribute|sql|
|Host            |normalized_state           |method|error|virtual_attribute|ruby|
|IsoDatastore    |name                       |virtual_attribute|ruby|virtual_delegate|sql|
|PersistentVolume|parent_name                |delegate|error|virtual_delegate|sql|
|PhysicalStorage |power_state                |not found|unknown|unchanged
|Playbook        |repository                 |not found|unknown|unchanged
|SecurityPolicy  |rules_count                |virtual_total|ruby|virtual_total|sql|
|CloudManager::Template|image\?              |virtual_attribute|ruby|unchanged|ruby|
|VmOrTemplate    |product_name               |ruby|error|virtual_attribute|ruby|

- Most of the reports that use these attributes are `product/views/{Model}.yaml`.
- The two **effect** columns explain what happens when the view is sorted by that column (before and after).
  - **error**: the report blows up
  - **ruby**: all records are downloaded into memory, sorted in ruby, and ids are stored in the session.
  - **sql**: the results are paged in sql (preferred). 
- `Host#archived` is not in a report, but it would throw an error if it was chosen by the user in the dynamic choice.

`virtual_attributes` were converted into `virtual_delegates` or `virtual_totals` because they have less code associated, are sql friendly, and they are less prone to errors. 

## Solution

The solution is to declare all attributes defined in reports so when we are constructing the sql, we can properly detect if the attribute should go into the sql or not.

## Risk

All changed attributes are now under test. (8/17 file changes are specs)

## Related

see also:

- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8186
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8195

fixes issue from (among others)

- https://github.com/ManageIQ/manageiq-ui-classic/pull/7781