### PR TITLE
Add msg_timeout option to Job#queue_signal

### DIFF
--- a/app/models/job/state_machine.rb
+++ b/app/models/job/state_machine.rb
@@ -51,7 +51,7 @@ module Job::StateMachine
     end
   end
 
-  def queue_signal(*args, priority: MiqQueue::NORMAL_PRIORITY, role: nil, deliver_on: nil, server_guid: nil, queue_name: nil)
+  def queue_signal(*args, priority: MiqQueue::NORMAL_PRIORITY, role: nil, deliver_on: nil, server_guid: nil, queue_name: nil, msg_timeout: nil)
     MiqQueue.put(
       :class_name  => self.class.name,
       :method_name => "signal",
@@ -63,7 +63,8 @@ module Job::StateMachine
       :task_id     => guid,
       :args        => args,
       :deliver_on  => deliver_on,
-      :server_guid => server_guid
+      :server_guid => server_guid,
+      :msg_timeout => msg_timeout
     )
   end
 


### PR DESCRIPTION
When running Ansible::Runner on podified the state machine is run all in one queue_message.  This means if the state machine takes longer than 10 minutes (default queue msg_timeout) so being able to control this timeout is critical.