### PR TITLE
Drop log_decorator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem "inventory_refresh",                "~>1.0",             :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
-gem "log_decorator",                    "~>0.1",             :require => false
 gem "manageiq-api-client",              "~>0.3.4",           :require => false
 gem "manageiq-loggers",                 "~>1.0",             :require => false
 gem "manageiq-messaging",               "~>1.0", ">=1.0.3",  :require => false

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -97,9 +97,6 @@ module Vmdb
       require 'awesome_spawn'
       AwesomeSpawn.logger = $log
 
-      require 'log_decorator'
-      LogDecorator.logger = $log
-
       require 'inventory_refresh'
       InventoryRefresh.logger = $log
     end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/amazon_ssa_support/pull/75.  That
is the final component needing this change, after which we won't need
log_decorator anymore.

@agrare Please review.
