### PR TITLE
Redo manual rename of Ibm Cic to IBM CIC

### DIFF
--- a/locale/de/manageiq.po
+++ b/locale/de/manageiq.po
@@ -54134,7 +54134,7 @@ msgstr[0] "Cloudnetz (IBM CIC)"
 msgstr[1] "Cloudnetze (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "IBM CIC-Provider"
 
 #:

--- a/locale/es/manageiq.po
+++ b/locale/es/manageiq.po
@@ -54293,7 +54293,7 @@ msgstr[0] "Red en la nube (IBM CIC)"
 msgstr[1] "Redes en la nube (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "Proveedor de IBM CIC"
 
 #:

--- a/locale/fr/manageiq.po
+++ b/locale/fr/manageiq.po
@@ -54246,7 +54246,7 @@ msgstr[0] "Réseau cloud (IBM CIC)"
 msgstr[1] "Réseaux cloud (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "Fournisseur IBM CIC"
 
 #:

--- a/locale/it/manageiq.po
+++ b/locale/it/manageiq.po
@@ -54078,8 +54078,8 @@ msgstr[0] "Rete cloud (IBM CIC)"
 msgstr[1] "Reti cloud (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
-msgstr "Provider Ibm Cic"
+msgid "IBM CIC Provider"
+msgstr "Provider IBM CIC"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:172

--- a/locale/ja/manageiq.po
+++ b/locale/ja/manageiq.po
@@ -52823,7 +52823,7 @@ msgid_plural "Cloud Networks (IBM CIC)"
 msgstr[0] "Cloud Networks (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "IBM Cic プロバイダー"
 
 #:

--- a/locale/ja/manageiq.po
+++ b/locale/ja/manageiq.po
@@ -52824,7 +52824,7 @@ msgstr[0] "Cloud Networks (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
 msgid "IBM CIC Provider"
-msgstr "IBM Cic プロバイダー"
+msgstr "IBM CIC プロバイダー"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:172

--- a/locale/ko/manageiq.po
+++ b/locale/ko/manageiq.po
@@ -52818,7 +52818,7 @@ msgid_plural "Cloud Networks (IBM CIC)"
 msgstr[0] "클라우드 네트워크(IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "IBM CIC 제공자"
 
 #:

--- a/locale/manageiq.pot
+++ b/locale/manageiq.pot
@@ -53105,7 +53105,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr ""
 
 #:

--- a/locale/pt_BR/manageiq.po
+++ b/locale/pt_BR/manageiq.po
@@ -54220,7 +54220,7 @@ msgstr[0] "Rede de nuvem (IBM CIC)"
 msgstr[1] "Redes de nuvem (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "Provedor IBM CIC"
 
 #:

--- a/locale/zh_CN/manageiq.po
+++ b/locale/zh_CN/manageiq.po
@@ -52800,7 +52800,7 @@ msgid_plural "Cloud Networks (IBM CIC)"
 msgstr[0] "云网络 (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "IBM CIC 提供者"
 
 #:

--- a/locale/zh_TW/manageiq.po
+++ b/locale/zh_TW/manageiq.po
@@ -52801,7 +52801,7 @@ msgid_plural "Cloud Networks (IBM CIC)"
 msgstr[0] "雲端網路 (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
-msgid "Ibm Cic Provider"
+msgid "IBM CIC Provider"
 msgstr "IBM Cic 提供者"
 
 #:

--- a/locale/zh_TW/manageiq.po
+++ b/locale/zh_TW/manageiq.po
@@ -52802,7 +52802,7 @@ msgstr[0] "雲端網路 (IBM CIC)"
 
 #: ../lib/manageiq/providers/ibm_cic/engine.rb:19
 msgid "IBM CIC Provider"
-msgstr "IBM Cic 提供者"
+msgstr "IBM CIC 提供者"
 
 #:
 #: ../app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb:172


### PR DESCRIPTION
Note, this is built on top of #21784 and #21785 and was extracted from those commits so we can isolate this Cic rename as a followup from those commits.  Given the churn in these files, it's impossible to isolate this change so I can rebase this PR once those others are merged.

This is a redo of the following reverted commit
5df20f7b1f3db74bdfd0d7e248a85c4500a05baa included in https://github.com/ManageIQ/manageiq/pull/21769

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21784
- [x] https://github.com/ManageIQ/manageiq/pull/21785

TODO:
- [x] Rebase once the dependent PRs are merged