### PR TITLE
Delete a deployment with multiple failed pods only once

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -42,7 +42,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
   def failed_deployments(restart_count = 5)
     # TODO: This logic might flag deployments that are hitting memory/cpu limits or otherwise not really 'failed'
-    current_pods.values.select { |h| h[:last_state_terminated] && h.fetch(:container_restarts, 0) > restart_count }.collect { |h| h[:label_name] }.uniq
+    current_pods.values.select { |h| h[:last_state_terminated] && h.fetch(:container_restarts, 0) > restart_count }.pluck(:label_name).uniq
   end
 
   def sync_deployment_settings

--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -42,7 +42,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
   def failed_deployments(restart_count = 5)
     # TODO: This logic might flag deployments that are hitting memory/cpu limits or otherwise not really 'failed'
-    current_pods.values.select { |h| h[:last_state_terminated] && h.fetch(:container_restarts, 0) > restart_count }.collect { |h| h[:label_name] }
+    current_pods.values.select { |h| h[:last_state_terminated] && h.fetch(:container_restarts, 0) > restart_count }.collect { |h| h[:label_name] }.uniq
   end
 
   def sync_deployment_settings


### PR DESCRIPTION
Previously, we tracked pods in the current_pods and collected the names of the
deployments for failed pods.  If two or more pods in the same deployment were
considered "failed", the same deployment would appear twice and we'd try to
remove it twice.  Now, we unique the list of deployments.

This is more obvious when looking at logs recently:

```
{"@timestamp":"2022-03-16T14:30:23.019170, ..., "message":"MIQ(ContainerOrchestrator#delete_deployment) Deleting [17-ui] in namespace: XXX"}
{"@timestamp":"2022-03-16T14:30:23.019588, ..., "message":"MIQ(ContainerOrchestrator#patch_deployment) deployment_name: 17-ui, data: {:spec=>{:replicas=>0}}"}
{"@timestamp":"2022-03-16T14:30:23.100805, ..., "message":"MIQ(ContainerOrchestrator#delete_deployment) Deleting [17-ui] in namespace: XXX"}
{"@timestamp":"2022-03-16T14:30:23.101172, ..., "message":"MIQ(ContainerOrchestrator#patch_deployment) deployment_name: 17-ui, data: {:spec=>{:replicas=>0}}"}
```
