### PR TITLE
Fix fallout from deleting failed deployments

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -52,7 +52,13 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
       if deployment_resource_constraints_changed?(worker)
         _log.info("Constraints changed, patching deployment: [#{worker.worker_deployment_name}]")
-        worker.patch_deployment
+
+        begin
+          worker.patch_deployment
+        rescue => err
+          _log.warn("Failure patching deployment: [#{worker.worker_deployment_name}] for worker: id: [#{worker.id}], system_uid: [#{worker.system_uid}]. Error: [#{err}]... skipping")
+          next
+        end
       end
       checked_deployments << worker.worker_deployment_name
     end

--- a/spec/models/miq_server/worker_management/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/kubernetes_spec.rb
@@ -351,6 +351,15 @@ RSpec.describe MiqServer::WorkerManagement::Kubernetes do
       expect(worker3).to receive(:patch_deployment)
       server.worker_manager.sync_deployment_settings
     end
+
+    it "skips worker classes missing their deployment" do
+      allow(server.worker_manager).to receive(:miq_workers).and_return([worker1, worker3])
+      allow(server.worker_manager).to receive(:deployment_resource_constraints_changed?).with(worker1).and_return(true)
+      allow(server.worker_manager).to receive(:deployment_resource_constraints_changed?).with(worker3).and_return(true)
+      allow(worker1).to receive(:patch_deployment).and_raise(StandardError.new("AHHHHHH!"))
+      expect(worker3).to receive(:patch_deployment)
+      server.worker_manager.sync_deployment_settings
+    end
   end
 
   context "deployment_resource_constraints_changed?" do


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/21789

* Rescue errors patching the deployments, log it, and skip this worker.  This is the commit that prevents an error patching the deployment from causing a delay until the orphaned worker row is removed.

I'm curious what you think @agrare since you debugged the same issue and noticed this backtrace:

```
[Kubeclient::ResourceNotFoundError]: deployments.apps \"17-amazon-cloud-metrics-collector\" not found  Method:[block (2 levels) in <class:LogProxy>]
.../gems/kubeclient-4.9.2/lib/kubeclient/common.rb:130:in `rescue in handle_exception'
.../gems/kubeclient-4.9.2/lib/kubeclient/common.rb:120:in `handle_exception'
.../gems/kubeclient-4.9.2/lib/kubeclient/common.rb:420:in `patch_entity'
.../gems/kubeclient-4.9.2/lib/kubeclient/common.rb:257:in `block (2 levels) in define_entity_methods'
.../gems/kubeclient-4.9.2/lib/kubeclient/common.rb:101:in `method_missing'
/var/www/miq/vmdb/lib/container_orchestrator.rb:21:in `patch_deployment'
/var/www/miq/vmdb/app/models/miq_worker/container_common.rb:52:in `patch_deployment'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:55:in `block in sync_deployment_settings'
.../gems/activerecord-6.0.4.6/lib/active_record/relation/delegation.rb:88:in `each'
.../gems/activerecord-6.0.4.6/lib/active_record/relation/delegation.rb:88:in `each'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:50:in `sync_deployment_settings'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:20:in `sync_from_system'
/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:19:in `monitor_workers'
```

The logging of the warning looks like the following:
```
[----] W, [2022-03-31T14:38:06.148412 #34055:8ed0]  WARN -- evm: MIQ(MiqServer::WorkerManagement::Kubernetes#sync_deployment_settings) Failure patching deployment: [25r32-generic] for worker: id: [25000000000013], system_uid: []. Error: [AHHHHHH!]... skipping
```


Note, `patch_deployment` has no rescue around it and it's unclear of any situation in which you want to ignore any exceptions:  https://github.com/ManageIQ/manageiq/blob/7a173240b0c4fe707e6943495de27bb3589e9bcc/lib/container_orchestrator.rb#L19-L22

Whereas `delete_deployment` does for the obvious case when the deployment is already deleted:
https://github.com/ManageIQ/manageiq/blob/7a173240b0c4fe707e6943495de27bb3589e9bcc/lib/container_orchestrator.rb#L48-L54




