### PR TITLE
Add supports cloud object store container create

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -294,7 +294,7 @@ class ExtManagementSystem < ApplicationRecord
   supports_attribute :feature => :cloud_tenants
   supports_attribute :feature => :volume_multiattachment
   supports_attribute :feature => :volume_resizing
-  supports_attribute :feature => :cloud_object_store_container_create
+  supports_attribute :supports_cloud_object_store_container_create, :child_model => "CloudObjectStoreContainer"
   supports_attribute :feature => :cinder_volume_types
   supports_attribute :feature => :cloud_subnet_create
   supports_attribute :feature => :cloud_volume


### PR DESCRIPTION
Fixes the provider list in the cloud object store container form to include Openstack providers as well as Amazon providers.

Before:
<img width="1350" alt="PR Master Before" src="https://user-images.githubusercontent.com/32444791/160392806-5271d3de-b71c-442a-918a-0ba3722769f2.png">

After:
<img width="1364" alt="PR Master After" src="https://user-images.githubusercontent.com/32444791/160392809-a9457695-b42a-4520-ae74-3599d7c0f6ce.png">

Co-depends:
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/754