### PR TITLE
No longer preload yaml menu loader

### DIFF
--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -33,7 +33,6 @@ class MiqUiWorker < MiqWorker
     # prior to booting the puma workers.
     ApplicationHelper::Toolbar::Base.instance
     Menu::Manager.instance
-    Menu::YamlLoader.instance
   end
 
   def container_port


### PR DESCRIPTION
Dependent:

- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8171

The YamlLoader is no longer a singleton
no race condition and no stored data means no longer
need to preload it

