### PR TITLE
Cloud volume snapshot queue methods

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -189,4 +189,8 @@ class CloudVolume < ApplicationRecord
   def available_vms
     raise NotImplementedError, _("available_vms must be implemented in a subclass")
   end
+
+  def create_volume_snapshot_queue(userid, options = {})
+    ext_management_system.class_by_ems(:CloudVolumeSnapshot)&.create_snapshot_queue(userid, self, options)
+  end
 end

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -26,6 +26,36 @@ class CloudVolumeSnapshot < ApplicationRecord
     self.class.my_zone(ext_management_system)
   end
 
+  def self.create_snapshot_queue(userid, cloud_volume, options = {})
+    raise ArgumentError, "Must provide a cloud volume with a provider" if cloud_volume&.ext_management_system.nil?
+
+    ext_management_system = cloud_volume.ext_management_system
+    task_opts = {
+      :action => "creating volume snapshot in #{ext_management_system.inspect} for #{cloud_volume.inspect} with #{options.inspect}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => cloud_volume.class.name,
+      :instance_id => cloud_volume.id,
+      :method_name => 'create_volume_snapshot',
+      :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => my_zone(ext_management_system),
+      :args        => [options]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def self.create_snapshot(cloud_volume, options)
+    raw_create_snapshot(cloud_volume, options)
+  end
+
+  def self.raw_create_snapshot(_cloud_volume, _options)
+    raise NotImplementedError, _("raw_create_snapshot must be implemented in a subclass")
+  end
+
   # Delete a cloud volume snapshot as a queued task and return the task id. The
   # queue name and the queue zone are derived from the EMS. The userid is
   # optional and defaults to 'system'.

--- a/spec/support/supports_helper.rb
+++ b/spec/support/supports_helper.rb
@@ -15,11 +15,10 @@ module Spec
 
         stub_supports(model, feature, :supported => false)
 
-        if reason
-          receive_reason = receive(:unsupported_reason).with(feature).and_return(reason)
-          allow(model).to(receive_reason)
-          allow_any_instance_of(model).to(receive_reason)
-        end
+        reason ||= SupportsFeatureMixin.reason_or_default(reason)
+        receive_reason = receive(:unsupported_reason).with(feature).and_return(reason)
+        allow(model).to(receive_reason)
+        allow_any_instance_of(model).to(receive_reason)
       end
     end
   end


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq-api/pull/1134

moved snapshot methods from providers to core