### PR TITLE
Remove unused code.  If we need it, it can be brought back.

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -286,23 +286,6 @@ namespace :locale do
         end
       end
 
-      js_plugins = {} # currently we don't need to download any catalogs from JS/node plugins
-
-      plugins_dir = File.join(Rails.root, 'locale/plugins')
-      Dir.mkdir(plugins_dir, 0o700)
-      js_plugins.each do |plugin, content|
-        plugin_dir = File.join(plugins_dir, plugin)
-        Dir.mkdir(plugin_dir)
-        content.each do |lang, url|
-          lang_dir = File.join(plugin_dir, lang)
-          Dir.mkdir(lang_dir)
-          lang_file = "#{lang_dir}/#{url.split('/')[-1]}"
-          ManageIQ::Environment.system!("curl -f -o #{lang_file} #{url}")
-          po_files[lang] ||= []
-          po_files[lang].push(Pathname(lang_file))
-        end
-      end
-
       combined_dir = File.join(Rails.root, "locale/combined")
       Dir.mkdir(combined_dir, 0o700)
       po_files.each do |locale, files|
@@ -334,7 +317,7 @@ namespace :locale do
       # This depends on PoToJson overrides as defined in lib/tasks/po_to_json_override.rb
       Rake::Task['gettext:po_to_json'].invoke
     ensure
-      system "rm -rf #{combined_dir} #{plugins_dir}"
+      system "rm -rf #{combined_dir}"
     end
   end
 


### PR DESCRIPTION
js_plugins is empty so this is a no-op right now.  This code is already
complicated enough, let's remove this and add it if we actually get po files
from js plugins.