### PR TITLE
Add lifecycle operations to physical server

### DIFF
--- a/app/models/physical_server/operations.rb
+++ b/app/models/physical_server/operations.rb
@@ -5,4 +5,17 @@ module PhysicalServer::Operations
   include_concern 'Led'
   include_concern 'ConfigPattern'
   include_concern 'Lifecycle'
+
+  private
+
+  def change_state(verb)
+    unless ext_management_system
+      raise _(" A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
+            {:server => self, :name => name, :id => id}
+    end
+    options = {:uuid => ems_ref}
+    _log.info("Begin #{verb} server: #{name}  with UUID: #{ems_ref}")
+    ext_management_system.send(verb, self, options)
+    _log.info("Complete #{verb} #{self}")
+  end
 end

--- a/app/models/physical_server/operations.rb
+++ b/app/models/physical_server/operations.rb
@@ -4,4 +4,5 @@ module PhysicalServer::Operations
   include_concern 'Power'
   include_concern 'Led'
   include_concern 'ConfigPattern'
+  include_concern 'Lifecycle'
 end

--- a/app/models/physical_server/operations/led.rb
+++ b/app/models/physical_server/operations/led.rb
@@ -10,18 +10,4 @@ module PhysicalServer::Operations::Led
   def turn_off_loc_led
     change_state(:turn_off_loc_led)
   end
-
-  private
-
-  def change_state(verb)
-    unless ext_management_system
-      raise _("A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
-            {:server => self, :name => name, :id => id}
-    end
-
-    options = {:uuid => ems_ref}
-    _log.info("Begin #{verb} server: #{name} with UUID: #{ems_ref}")
-    ext_management_system.send(verb, self, options)
-    _log.info("Complete #{verb} #{self}")
-  end
 end

--- a/app/models/physical_server/operations/lifecycle.rb
+++ b/app/models/physical_server/operations/lifecycle.rb
@@ -1,0 +1,23 @@
+module PhysicalServer::Operations::Lifecycle
+  def decommission_server
+    change_state(:decommission_server)
+  end
+
+  def recommission_server
+    change_state(:recommission_server)
+  end
+
+  private
+
+  def change_state(verb)
+    unless ext_management_system
+      raise _("A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
+            {:server => self, :name => name, :id => id}
+    end
+
+    options = {:uuid => ems_ref}
+    _log.info("Begin #{verb} server: #{name} with UUID: #{ems_ref}")
+    ext_management_system.send(verb, self, options)
+    _log.info("Complete #{verb} #{self}")
+  end
+end

--- a/app/models/physical_server/operations/lifecycle.rb
+++ b/app/models/physical_server/operations/lifecycle.rb
@@ -6,18 +6,4 @@ module PhysicalServer::Operations::Lifecycle
   def recommission_server
     change_state(:recommission_server)
   end
-
-  private
-
-  def change_state(verb)
-    unless ext_management_system
-      raise _("A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
-            {:server => self, :name => name, :id => id}
-    end
-
-    options = {:uuid => ems_ref}
-    _log.info("Begin #{verb} server: #{name} with UUID: #{ems_ref}")
-    ext_management_system.send(verb, self, options)
-    _log.info("Complete #{verb} #{self}")
-  end
 end

--- a/app/models/physical_server/operations/power.rb
+++ b/app/models/physical_server/operations/power.rb
@@ -26,17 +26,4 @@ module PhysicalServer::Operations::Power
   def restart_mgmt_controller
     change_state(:restart_mgmt_controller)
   end
-
-  private
-
-  def change_state(verb)
-    unless ext_management_system
-      raise _(" A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
-            {:server => self, :name => name, :id => id}
-    end
-    options = {:uuid => ems_ref}
-    _log.info("Begin #{verb} server: #{name}  with UUID: #{ems_ref}")
-    ext_management_system.send(verb, self, options)
-    _log.info("Complete #{verb} #{self}")
-  end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6716,6 +6716,14 @@
       :description: Access Physical Server Remote Console
       :feature_type: control
       :identifier: physical_server_remote_console
+    - :name: Decommission Server
+      :description: Decommission Server
+      :feature_type: control
+      :identifier: physical_server_decommission
+    - :name: Recommission Server
+      :description: Recommission Server
+      :feature_type: control
+      :identifier: physical_server_recommission
 
 # Firmwares
 - :name: Firmwares


### PR DESCRIPTION
Cisco Intersight provider allows for physical server decommission and
recommission to and from a pool of available servers. In order to
support this operation in a provider, this commit is adding lifecycle
operations for decommission and recommission to a physical server.

