### PR TITLE
Vmdb::Gettext::Domains: Store po and mo paths separately and union them correctly

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -275,9 +275,7 @@ namespace :locale do
 
       po_files = {}
 
-      # TODO: Domains for po and mo are added with the same path in Vmdb::FastGettextHelper.register_locales
-      # We need to uniq them for now, otherwise we find and merge the same po files.
-      Vmdb::Gettext::Domains.paths.uniq.each do |path|
+      Vmdb::Gettext::Domains.po_paths.each do |path|
         files = ::Pathname.glob(::File.join(path, "**", "*.po"))
         files.each do |file|
           locale = file.dirname.basename.to_s

--- a/lib/vmdb/gettext/domains.rb
+++ b/lib/vmdb/gettext/domains.rb
@@ -10,16 +10,29 @@ module Vmdb
         @domains
       end
 
+      # TODO: It's unclear why you'd want to know paths regardless of the type
       def self.paths
-        @paths ||= []
-        @paths
+        @mo_paths | @po_paths
+      end
+
+      def self.mo_paths
+        @mo_paths ||= Set.new
+      end
+
+      def self.po_paths
+        @po_paths ||= Set.new
       end
 
       def self.add_domain(name, path, type = :po)
         domains << FastGettext::TranslationRepository.build(name, :path           => path,
                                                                   :type           => type,
                                                                   :report_warning => false)
-        paths << path
+        case type.to_sym
+        when :po
+          po_paths << path
+        else :mo
+          mo_paths << path
+        end
       end
 
       def self.initialize_chain_repo

--- a/lib/vmdb/gettext/domains.rb
+++ b/lib/vmdb/gettext/domains.rb
@@ -10,11 +10,6 @@ module Vmdb
         @domains
       end
 
-      # TODO: It's unclear why you'd want to know paths regardless of the type
-      def self.paths
-        @mo_paths | @po_paths
-      end
-
       def self.mo_paths
         @mo_paths ||= Set.new
       end

--- a/spec/lib/vmdb/gettext/domains_spec.rb
+++ b/spec/lib/vmdb/gettext/domains_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Vmdb::Gettext::Domains do
+  context ".add_domain" do
+    let(:name) { "test" }
+    let(:path) { "/dev/null"}
+
+    it "sets mo_paths" do
+      described_class.add_domain(name, path, :mo)
+      expect(described_class.mo_paths).to include(path)
+    end
+
+    it "sets po_paths" do
+      described_class.add_domain(name, path, :po)
+      expect(described_class.po_paths).to include(path)
+    end
+
+    it "sets paths independent from each other" do
+      path2 = "/dev/zero"
+      described_class.add_domain(name, path, :mo)
+      described_class.add_domain(name, path2, :po)
+      expect(described_class.mo_paths.count(path)).to eq(1)
+      expect(described_class.po_paths.count(path2)).to eq(1)
+
+      expect(described_class.paths.count(path)).to eq(1)
+      expect(described_class.paths.count(path2)).to eq(1)
+    end
+
+    it "paths contain no duplicates" do
+      described_class.add_domain(name, path, :mo)
+      described_class.add_domain(name, path, :mo)
+      described_class.add_domain(name, path, :po)
+      described_class.add_domain(name, path, :po)
+
+      expect(described_class.mo_paths.count(path)).to eq(1)
+      expect(described_class.po_paths.count(path)).to eq(1)
+      expect(described_class.paths.count(path)).to eq(1)
+    end
+  end
+end

--- a/spec/lib/vmdb/gettext/domains_spec.rb
+++ b/spec/lib/vmdb/gettext/domains_spec.rb
@@ -19,9 +19,6 @@ RSpec.describe Vmdb::Gettext::Domains do
       described_class.add_domain(name, path2, :po)
       expect(described_class.mo_paths.count(path)).to eq(1)
       expect(described_class.po_paths.count(path2)).to eq(1)
-
-      expect(described_class.paths.count(path)).to eq(1)
-      expect(described_class.paths.count(path2)).to eq(1)
     end
 
     it "paths contain no duplicates" do
@@ -32,7 +29,6 @@ RSpec.describe Vmdb::Gettext::Domains do
 
       expect(described_class.mo_paths.count(path)).to eq(1)
       expect(described_class.po_paths.count(path)).to eq(1)
-      expect(described_class.paths.count(path)).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Previously Vmdb::Gettext::Domains.paths contained duplicate paths, one from mo
and one from po domains.

Note, the second commit drops Vmdb::Gettext::Domains.paths entirely as it's confusing why'd you ever use it without knowing if it's for po or mo.  We can deprecate it if needed.

This is a followup to https://github.com/ManageIQ/manageiq/pull/21799, specifically: https://github.com/ManageIQ/manageiq/commit/61e4f41905d8e471ad29409fe6b866e8d11974ea