### PR TITLE
Server Placement. Group Files

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -87,6 +87,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :disks,             :through => :hardwares
   has_many :physical_servers,         :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
   has_many :physical_server_profiles, :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
+  has_many :placement_groups,         :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
   has_many :vm_and_template_labels, :through => :vms_and_templates, :source => :labels
   # Only taggings mapped from labels, excluding user-assigned tags.

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -42,6 +42,10 @@ module ManageIQ::Providers
           )
         end
 
+        def placement_groups
+          add_common_default_values
+        end
+
         def cloud_database_flavors
           add_common_default_values
         end

--- a/app/models/placement_group.rb
+++ b/app/models/placement_group.rb
@@ -1,0 +1,87 @@
+class PlacementGroup < ApplicationRecord
+  acts_as_miq_taggable
+  include SupportsFeatureMixin
+  include NewWithTypeStiMixin
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager", :inverse_of => :placement_groups
+  belongs_to :availability_zone
+  belongs_to :cloud_tenant
+
+  has_many :vms, :dependent => :nullify
+
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
+  def self.class_by_ems(ext_management_system)
+    ext_management_system&.class_by_ems(:PlacementGroup)
+  end
+
+  def self.my_zone(ems)
+    # TODO(pblaho): find unified way how to do that
+    ems ? ems.my_zone : MiqServer.my_zone
+  end
+
+  def my_zone
+    self.class.my_zone(ext_management_system)
+  end
+
+  def self.create_placement_group_queue(userid, ext_management_system, options = {})
+    raise ArgumentError, _("ext_management_system cannot be nil") if ext_management_system.nil?
+
+    task_opts = {
+      :action => "creating Placement Group for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'create_placement_group',
+      :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
+      :zone        => my_zone,
+      :args        => [ext_management_system.id, options]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def self.create_placement_group(ems_id, options = {})
+    raise ArgumentError, _("ems_id cannot be nil") if ems_id.nil?
+
+    ext_management_system = ExtManagementSystem.find(ems_id)
+    raise ArgumentError, _("ext_management_system cannot be found") if ext_management_system.nil?
+
+    klass = ext_management_system.class_by_ems(:Placement)
+    klass.raw_create_placement_group(ext_management_system, options)
+  end
+
+  def self.raw_create_placement_group(_ext_management_system, _options = {})
+    raise NotImplementedError, _("raw_create_placement_group must be implemented in a subclass")
+  end
+
+  def delete_placement_group_queue(userid)
+    task_opts = {
+      :action => "deleting Placement Group for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'delete_placement_group',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
+      :zone        => my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def delete_placement_group
+    raw_delete_placement_group
+  end
+
+  def raw_delete_placement_group
+    raise NotImplementedError, _("raw_delete_placement_group must be implemented in a subclass")
+  end
+end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -75,6 +75,8 @@ class VmOrTemplate < ApplicationRecord
   belongs_to                :cloud_tenant
   belongs_to                :flavor
 
+  belongs_to                :placement_group
+
   belongs_to                :storage
   belongs_to                :storage_profile
   belongs_to                :ext_management_system, :foreign_key => "ems_id", :inverse_of => :vms_and_templates

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -890,6 +890,42 @@
       :feature_type: admin
       :identifier: auth_key_pair_cloud_delete
 
+# Placement Groups
+- :name: Placement Group
+  :description: Placement Group
+  :feature_type: node
+  :identifier: placement_group
+  :children:
+  - :name: View
+    :description: View Placement Group
+    :feature_type: view
+    :identifier: placement_group_list
+  - :name: Operate
+    :description: Perform Operations on Placement Groups
+    :feature_type: control
+    :identifier: placement_group_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Placement Group
+      :feature_type: control
+      :identifier: placement_group_edit
+    - :name: Add Placement Group
+      :description: Add Placement Group
+      :feature_type: control
+      :identifier: placement_group_add
+    - :name: Delete Placement Group
+      :description: Delete Placement Group
+      :feature_type: control
+      :identifier: placement_group_delete
+    - :name: Add VM to placement group
+      :description: Add VM to Placement Group
+      :feature_type: control
+      :identifier: placement_group_add_vm
+    - :name: Remove VM from  Placement Group
+      :description: Delete VM from Placement Group
+      :feature_type: control
+      :identifier: placement_group_remove_vm
+
 # CloudVolumeSnapshot
 - :name: Cloud Volume Snapshots
   :description: Everything under Cloud Volume Snapshots

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -69,6 +69,11 @@
   :url: /availability_zone/show_list
   :rbac_feature_name: availability_zone_show_list
   :startup: true
+- :name: placement_group
+  :description: Compute / Clouds / Placement Group
+  :url: /placement_group/show_list
+  :rbac_feature_name: placement_group_list
+  :startup: true
 - :name: host_aggregates
   :description: Compute / Clouds / Host Aggregates
   :url: /host_aggregate/show_list


### PR DESCRIPTION
This is a dependent PR for adding and enabling Server Placement Group as Menu in the Core

1. Manageiq schema changes.
    https://github.com/ManageIQ/manageiq-schema/pull/644
2. Server Placement Group in ManageIQ UI Changes.
    https://github.com/ManageIQ/manageiq-ui-classic/pull/8214
3. PowerVS changes.
    https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/363
4. ManageIQ Core changes
    https://github.com/ManageIQ/manageiq/pull/21807
 

