### PR TITLE
Add a /ping response for the remote console worker and httpd configs for the pod

### DIFF
--- a/app/models/miq_remote_console_worker.rb
+++ b/app/models/miq_remote_console_worker.rb
@@ -16,4 +16,8 @@ class MiqRemoteConsoleWorker < MiqWorker
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_REMOTE_CONSOLE_WORKERS
   end
+
+  def container_port
+    3001
+  end
 end

--- a/app/models/miq_remote_console_worker.rb
+++ b/app/models/miq_remote_console_worker.rb
@@ -20,4 +20,16 @@ class MiqRemoteConsoleWorker < MiqWorker
   def container_port
     3001
   end
+
+  def configure_service_worker_deployment(definition)
+    super
+
+    definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "remote-console-httpd-config", :mountPath => "/etc/httpd/conf.d"}
+    definition[:spec][:template][:spec][:volumes] << {:name => "remote-console-httpd-config", :configMap => {:name => "remote-console-httpd-configs", :defaultMode => 420}}
+
+    if ENV["REMOTE_CONSOLE_SSL_SECRET_NAME"].present?
+      definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "remote-console-httpd-ssl", :mountPath => "/etc/pki/tls"}
+      definition[:spec][:template][:spec][:volumes] << {:name => "remote-console-httpd-ssl", :secret => {:secretName => ENV["REMOTE_CONSOLE_SSL_SECRET_NAME"], :items => [{:key => "remote_console_crt", :path => "certs/server.crt"}, {:key => "remote_console_key", :path => "private/server.key"}], :defaultMode => 400}}
+    end
+  end
 end

--- a/lib/remote_console/rack_server.rb
+++ b/lib/remote_console/rack_server.rb
@@ -62,7 +62,7 @@ module RemoteConsole
       if WebSocket::Driver.websocket?(env) && same_origin_as_host?(env) && exp.present?
         @logger.info("RemoteConsole connection initiated")
         init_proxy(env, exp[1])
-      elsif same_origin_as_host?(env) && env['REQUEST_URI'].to_s.match?(%r{^/ping$})
+      elsif env['REQUEST_URI'].to_s.match?(%r{^/ping$})
         RACK_PONG
       else
         @logger.error('Invalid RemoteConsole request or URL')

--- a/lib/remote_console/rack_server.rb
+++ b/lib/remote_console/rack_server.rb
@@ -27,8 +27,9 @@ module RemoteConsole
   class RackServer
     attr_accessor :logger
 
-    RACK_404 = [404, {'Content-Type' => 'text/plain'}, ['Not found']].freeze
-    RACK_YAY = [-1, {}, []].freeze
+    RACK_404  = [404, {'Content-Type' => 'text/plain'}, ['Not found']].freeze
+    RACK_PONG = [200, {'Content-Type' => 'text/plain'}, ['pong']].freeze
+    RACK_YAY  = [-1, {}, []].freeze
 
     def initialize(options = {})
       @logger = options.fetch(:logger, $remote_console_log)
@@ -61,6 +62,8 @@ module RemoteConsole
       if WebSocket::Driver.websocket?(env) && same_origin_as_host?(env) && exp.present?
         @logger.info("RemoteConsole connection initiated")
         init_proxy(env, exp[1])
+      elsif same_origin_as_host?(env) && env['REQUEST_URI'].to_s.match?(%r{^/ping$})
+        RACK_PONG
       else
         @logger.error('Invalid RemoteConsole request or URL')
         RACK_404

--- a/lib/remote_console/rack_server.rb
+++ b/lib/remote_console/rack_server.rb
@@ -58,7 +58,7 @@ module RemoteConsole
 
     # Rack entrypoint
     def call(env)
-      exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
+      exp = env['REQUEST_URI'].to_s.match(%r{^/ws/console/([a-zA-Z0-9]+)/?$})
       if WebSocket::Driver.websocket?(env) && same_origin_as_host?(env) && exp.present?
         @logger.info("RemoteConsole connection initiated")
         init_proxy(env, exp[1])

--- a/spec/lib/remote_console/rack_server_spec.rb
+++ b/spec/lib/remote_console/rack_server_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe RemoteConsole::RackServer do
   let(:right) { pipes.last }
 
   let(:hijack) { double }
-  let(:env) { {'REQUEST_URI' => "/ws/#{url}", 'rack.hijack' => hijack} }
+  let(:path) { "/ws/#{url}" }
+  let(:env) { {'REQUEST_URI' => path, 'rack.hijack' => hijack} }
 
   describe '#call' do
     context 'remote console' do
@@ -27,6 +28,14 @@ RSpec.describe RemoteConsole::RackServer do
         expect(subject).to receive(:init_proxy).with(env, '12345')
 
         subject.call(env)
+      end
+    end
+
+    context 'any other URL' do
+      let(:path) { '/ping' }
+
+      it 'returns with 200' do
+        expect(subject.call(env)).to eq(described_class::RACK_PONG)
       end
     end
 


### PR DESCRIPTION
This will be used for liveness and readiness probes

Part of: https://github.com/ManageIQ/manageiq-pods/issues/829