### PR TITLE
Add provider object mixin to cloud db model

### DIFF
--- a/app/models/cloud_database.rb
+++ b/app/models/cloud_database.rb
@@ -1,5 +1,6 @@
 class CloudDatabase < ApplicationRecord
   include NewWithTypeStiMixin
+  include ProviderObjectMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant


### PR DESCRIPTION
- This will be required for future enhancements regarding cloud database lifecycle operations in various providers

@miq-bot add_label enhancement
@miq-bot assign @agrare 
