### PR TITLE
Bump minimum to 6.0.4.7 for CVE-2022-21831

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem "pg",                                                    :require => false
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>6.0.4", ">=6.0.4.6"
+gem "rails",                            "~>6.0.4", ">=6.0.4.7"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false


### PR DESCRIPTION
We already allowed 6.0.4.7 but this sets this as the minimum version.