### PR TITLE
Custom button set model change for API

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -28,6 +28,17 @@ class CustomButtonSet < ApplicationRecord
     replace_children(children)
   end
 
+  def self.reorder_group_index(ids)
+    sets = CustomButtonSet.where(:id => ids).index_by(&:id)
+    raise ArgumentError, "not all requested ids found" unless sets.keys.sort == ids.sort
+
+    ids.each.with_index(1) do |id, i|
+      button_set = sets[id]
+      button_set.set_data[:group_index] = i
+      button_set.save!
+    end
+  end
+
   def self.find_all_by_class_name(class_name, class_id = nil)
     ordering = ->(o) { [o.set_data[:group_index].to_s, o.name] }
 

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -81,6 +81,20 @@ RSpec.describe CustomButtonSet do
     expect(CustomButtonSet.count).to eq(2)
   end
 
+  it "#reorder_group_index" do
+    service_template1  = FactoryBot.create(:service_template)
+    custom_button1     = FactoryBot.create(:custom_button, :applies_to => service_template1)
+    custom_button2     = FactoryBot.create(:custom_button, :applies_to => service_template1)
+    set_data1          = {:applies_to_class => "ServiceTemplate", :button_order => [custom_button1.id], :group_index => 1}
+    custom_button_set1 = FactoryBot.create(:custom_button_set, :set_data => set_data1)
+    set_data2          = {:applies_to_class => "ServiceTemplate", :button_order => [custom_button2.id], :group_index => 2}
+    custom_button_set2 = FactoryBot.create(:custom_button_set, :set_data => set_data2)
+
+    CustomButtonSet.reorder_group_index([custom_button_set2.id, custom_button_set1.id])
+    expect(custom_button_set1.reload.set_data[:group_index]).to eq(2)
+    expect(custom_button_set2.reload.set_data[:group_index]).to eq(1)
+  end
+
   context '#update_children' do
     let(:vm)                { FactoryBot.create(:vm_vmware, :name => 'vm') }
     let(:custom_button_1)   { FactoryBot.create(:custom_button, :applies_to => vm) }


### PR DESCRIPTION

To solve the [task](https://github.com/ManageIQ/manageiq-ui-classic/issues/7901)
Exposing method in the model so that API can call directly.

Expected API call after the change.
curl --user username:password -i -X POST -H "Accept: application/json" -d '{ "action": "order", "resource" : {"ids": [1,2] } }'  https://domain/api/custom_button_sets

<img width="644" alt="Screenshot 2022-04-08 at 12 12 29 AM" src="https://user-images.githubusercontent.com/16753936/162376063-1fc5906a-d683-4d7f-9a19-cc53ee883815.png">

