### PR TITLE
Adding "instance_publish" as CloudManager feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5516,6 +5516,10 @@
         :description: Reconfigure Instance
         :feature_type: control
         :identifier: instance_resize
+      - :name: Publish Instance to a Template
+        :description: Request to Publish Instance to a Template
+        :feature_type: control
+        :identifier: instance_publish
       - :name: Migrate Instance
         :description: Migrate Instance
         :feature_type: control

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -19,6 +19,11 @@
   :expires_in: 7.days
   :level: :success
   :audience: tenant
+- :name: automate_template_published
+  :message: Template %{subject} has been published.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
 - :name: vm_retired
   :message: Virtual Machine %{subject} has been retired.
   :expires_in: 7.days


### PR DESCRIPTION
This is to support adding the "publish to template" menu action for an instance in Cloud manager context, like what Infra manager can do for a VM already. Combined with a change on UI side, this would enable a Cloud provider to show and execute such operation, also known as "clone to template."

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>
