### PR TITLE
[WIP] Use auto-model-class for ContainerImages

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -88,8 +88,6 @@ module ManageIQ::Providers
           add_properties(
             # TODO: (bpaskinc) old save matches on [:image_ref, :container_image_registry_id]
             # TODO: (bpaskinc) should match on digest when available
-            # TODO: (mslemr) provider-specific class exists (openshift), but specs fail with them (?)
-            :model_class            => ::ContainerImage,
             :manager_ref            => %i[image_ref],
             :delete_method          => :disconnect_inv,
             :custom_reconnect_block => custom_reconnect_block


### PR DESCRIPTION
Having the `:model_class` set to `::ContainerImage` meant that auto_model_class was not being called, causing any records which did not have a `:type` explicitly set by the parser would end up having a type set to the base `::ContainerImage` class.

In the case of openshift, only images from an image registry had their `:type` set to `ManageIQ::Providers::Openshift::ContainerManager::ContainerImage`

This will require a data migration and likely changes to the Kubernetes provider because it doesn't appear that they have a subclass for this

Cross-repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/632

Follow-up PRs:
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/761
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/500
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/463
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/224
- [ ] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/54
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/801
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/646

https://github.com/ManageIQ/manageiq/issues/21825