### PR TITLE
Only capture metrics for supported ContainerImages

### DIFF
--- a/app/models/manageiq/providers/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/container_manager/metrics_capture.rb
@@ -4,10 +4,10 @@ class ManageIQ::Providers::ContainerManager::MetricsCapture < ManageIQ::Provider
 
     MiqPreloader.preload([ems], :container_images => :tags, :container_nodes => :tags, :container_groups => [:tags, :containers => :tags])
 
-    with_archived(ems.all_container_nodes) +
-      with_archived(ems.all_container_groups) +
-      with_archived(ems.all_containers) +
-      with_archived(ems.container_images)
+    with_archived(ems.all_container_nodes.supporting(:capture)) +
+      with_archived(ems.all_container_groups.supporting(:capture)) +
+      with_archived(ems.all_containers.supporting(:capture)) +
+      with_archived(ems.container_images.supporting(:capture))
   end
 
   private


### PR DESCRIPTION
The OpenShift provider collects a mixture of ContainerImages some of which support metrics capture and some which do not.  We have an issue with ContainerImage class names (https://github.com/ManageIQ/manageiq/pull/21828) but even with that fixed fundamentally we are trying to capture metrics from ContainerImages which do not support it.

Fixes https://github.com/ManageIQ/manageiq/issues/21825