### PR TITLE
rails6.1 fix deprecated join_keys

### DIFF
--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -27,8 +27,7 @@ module MiqPreloader
     if (inverse_association = association.inverse_of)
       target_klass.where(inverse_association.name.to_sym => records).where(association.scope)
     else # assume it is a belongs_to
-      join_key = association.join_keys
-      target_klass.where(join_key.key.to_sym => records.select(join_key.foreign_key.to_sym))
+      target_klass.where(association.join_primary_key.to_sym => records.select(association.join_foreign_key.to_sym))
     end
   end
 end

--- a/tools/cleanup_duplicate_host_guest_devices.rb
+++ b/tools/cleanup_duplicate_host_guest_devices.rb
@@ -56,7 +56,7 @@ guest_devices_to_delete.each_slice(opts[:page_size]).with_index do |slice, index
 
   dependents.each do |assoc|
     delete_meth = assoc.options[:dependent]
-    foreign_key = assoc.join_keys.key
+    foreign_key = assoc.join_primary_key
 
     if %i[delete destroy].include?(delete_meth)
       assoc.klass.where(foreign_key => slice).send("#{delete_meth}_all")


### PR DESCRIPTION
extracted from https://github.com/ManageIQ/manageiq/pull/21652

## Error

```
     NoMethodError:
       undefined method `join_keys' for #<ActiveRecord::Reflection::BelongsToReflection:0x00007f86de04ccb8>
       Did you mean?  join_scope
```

This code was deprecated in rails 6.0 and removed in rails 6.1
But it works in both rails 6.0 and 6.1


## Risk

High confidence:
This code is tested in `spec/lib/miq_preloader_spec.rb`
I changed (heckle/mutant style) the left and right hand side of this join and it blew up every time.