### PR TITLE
Bump rails for CVE-2022-22577 and CVE-2022-27777

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem "pg",                                                    :require => false
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>6.0.4", ">=6.0.4.7"
+gem "rails",                            "~>6.0.4", ">=6.0.4.8"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false


### PR DESCRIPTION
We previously allowed 6.0.4.8 but this change requires these code changes
for ActionPack and ActionView as a minimum version.