### PR TITLE
Prevent `rake evm:deployment_status` from failing with no database

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -79,7 +79,8 @@ namespace :evm do
       "new_deployment" => 3,
       "new_replica"    => 4,
       "redeployment"   => 5,
-      "upgrade"        => 6
+      "upgrade"        => 6,
+      "no_database"    => 7
     }
 
     status = EvmApplication.deployment_status

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -179,6 +179,10 @@ class EvmApplication
     return "new_replica"    if MiqServer.my_server.nil?
     return "upgrade"        if context.needs_migration?
     "redeployment"
+  rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError => err
+    raise unless err.message.match?(/database "[^"]+" does not exist/)
+
+    "no_database"
   end
 
   def self.queue_overview


### PR DESCRIPTION
In case the database has no been created prevent `rake evm:deployment_status` from failing with
```
adam@desktop:~/src/manageiq/manageiq$ rake evm:deployment_status
** Cannot connect to the database!
** ManageIQ master, codename: Oparin
rake aborted!
ActiveRecord::NoDatabaseError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "vmdb_development" does not exist
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/postgresql_adapter.rb:50:in `rescue in postgresql_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/postgresql_adapter.rb:33:in `postgresql_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:887:in `new_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:931:in `checkout_new_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:910:in `try_to_checkout_new_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:871:in `acquire_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:593:in `checkout'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:437:in `connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:1125:in `retrieve_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_handling.rb:221:in `retrieve_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_handling.rb:189:in `connection'
/home/grare/adam/src/manageiq/manageiq/lib/tasks/evm_application.rb:175:in `deployment_status'
/home/grare/adam/src/manageiq/manageiq/lib/tasks/evm.rake:85:in `block (2 levels) in <main>'
/usr/share/rubygems-integration/all/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'

Caused by:
PG::ConnectionBad: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "vmdb_development" does not exist
/home/grare/adam/.gem/ruby/2.7.0/gems/pg-1.3.5/lib/pg/connection.rb:637:in `async_connect_or_reset'
/home/grare/adam/.gem/ruby/2.7.0/gems/pg-1.3.5/lib/pg/connection.rb:707:in `new'
/home/grare/adam/.gem/ruby/2.7.0/gems/pg-1.3.5/lib/pg.rb:69:in `connect'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/postgresql_adapter.rb:46:in `postgresql_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:887:in `new_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:931:in `checkout_new_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:910:in `try_to_checkout_new_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:871:in `acquire_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:593:in `checkout'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:437:in `connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:1125:in `retrieve_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_handling.rb:221:in `retrieve_connection'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.4.8/lib/active_record/connection_handling.rb:189:in `connection'
/home/grare/adam/src/manageiq/manageiq/lib/tasks/evm_application.rb:175:in `deployment_status'
/home/grare/adam/src/manageiq/manageiq/lib/tasks/evm.rake:85:in `block (2 levels) in <main>'
/usr/share/rubygems-integration/all/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => evm:deployment_status
(See full trace by running task with --trace)
```