### PR TITLE
Add Server Profiles features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6724,6 +6724,19 @@
       :description: Recommission Server
       :feature_type: control
       :identifier: physical_server_recommission
+    - :name: Assign Server Profile
+      :description: Assign Server Profile
+      :feature_type: control
+      :identifier: physical_server_assign_server_profile
+    - :name: Deploy Server Profile
+      :description: Deploy Server Profile
+      :feature_type: control
+      :identifier: physical_server_deploy_server_profile
+    - :name: Unassign Server Profile
+      :description: Unassign Server Profile
+      :feature_type: control
+      :identifier: physical_server_unassign_server_profile
+
 
 # Firmwares
 - :name: Firmwares


### PR DESCRIPTION
In order for Cisco Intersight provider to be able to inject the toolbar,
we need to add additional features related to server profiles. There are
three that are relevant: profile assignment, deployment and
unassignment.