### PR TITLE
rename CloudVolume.attach_volume to attach

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -30,6 +30,8 @@ class CloudVolume < ApplicationRecord
   supports_not :create
   supports_not :snapshot_create
   supports_not :update
+  supports_not :attach
+  supports_not :detach
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
 


### PR DESCRIPTION
## Overview

We've never officially stated the name of the operation to attach and detach a cloud volume for supports. Either way, it is missing from `CloudVolume` base.

- Renaming from `CloudVolume#attach_volume` to `attach`
- renaming from `CloudVolume#detach_volume` to `detach`

## Includes

- [ ] https://github.com/ManageIQ/manageiq-api/pull/1156
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/373
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8247
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/767
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/794


## Concerns

- Not sure exactly how `CustomButton` and supports works, but maybe the name is linked to `attach_volume` dynamically?
- It looks like `attach_volume` has been the name of this functionality for a while.
- Pretty sure this handles all the ui classic cases. (there were 3 main use cases)

## Affects

This affects the api around cloud volumes that @MelsHyrule is putting into place