### PR TITLE
del host initiator

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6349,6 +6349,10 @@
       :description: Add a Host Initiator
       :feature_type: admin
       :identifier: host_initiator_new
+    - :name: Remove
+      :description: Remove a Host Initiator
+      :feature_type: admin
+      :identifier: host_initiator_delete
 
   # host_initiator_group
 - :name: Host Initiator Group


### PR DESCRIPTION
This PR add new feature for host-initiators (storage), the ability to **delete an existing host-initiator**.

<img width="884" alt="Screen Shot 2022-05-03 at 13 40 41" src="https://user-images.githubusercontent.com/6840118/166441274-073a8d0c-6a8c-4030-9123-85245a50b6fb.png">

<img width="858" alt="Screen Shot 2022-05-03 at 13 41 08" src="https://user-images.githubusercontent.com/6840118/166441293-54baa577-abc5-41e8-99af-b2cee3b877d0.png">


Links
----------------
* https://github.com/ManageIQ/manageiq-ui-classic/pull/8249
* https://github.com/ManageIQ/manageiq-providers-autosde/pull/147
* https://github.com/ManageIQ/manageiq-api/pull/1157