### PR TITLE
Update physical_server_profile_spec.rb

### DIFF
--- a/spec/models/physical_server_profile_spec.rb
+++ b/spec/models/physical_server_profile_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe PhysicalServerProfile do
   describe "#queue_name_for_ems_operations" do
     context "with an active physical_server_profile" do


### PR DESCRIPTION
A PR from Cisco Intersight provider (https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/42) is failing because of this `require` which does not seem to be necessary.