### PR TITLE
Fix Physical Server Profile features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6745,19 +6745,43 @@
       :description: Recommission Server
       :feature_type: control
       :identifier: physical_server_recommission
-    - :name: Assign Server Profile
-      :description: Assign Server Profile
-      :feature_type: control
-      :identifier: physical_server_assign_server_profile
-    - :name: Deploy Server Profile
-      :description: Deploy Server Profile
-      :feature_type: control
-      :identifier: physical_server_deploy_server_profile
-    - :name: Unassign Server Profile
-      :description: Unassign Server Profile
-      :feature_type: control
-      :identifier: physical_server_unassign_server_profile
 
+# Physical Server Profiles
+- :name: Physical Server Profiles
+  :description: Everything under Physical Server Profiles
+  :feature_type: node
+  :identifier: physical_server_profile
+  :children:
+  - :name: View
+    :description: View Physical Server Profile
+    :feature_type: view
+    :identifier: physical_server_profile_view
+    :children:
+    - :name: List
+      :description: Display Lists of Physical Server Profiles
+      :feature_type: view
+      :identifier: physical_server_profile_show_list
+    - :name: Show
+      :description: Display Individual Physical Server Profile
+      :feature_type: view
+      :identifier: physical_server_profile_show
+  - :name: Operate
+    :description: Perform Operations on Physical Server Profiles
+    :feature_type: control
+    :identifier: physical_server_profile_control
+    :children:
+    - :name: Assign Server
+      :description: Assign Server
+      :feature_type: control
+      :identifier: physical_server_profile_assign_server
+    - :name: Deploy Server
+      :description: Deploy Server assigned to Server Profile
+      :feature_type: control
+      :identifier: physical_server_profile_deploy_server
+    - :name: Unassign Server
+      :description: Unassign Server
+      :feature_type: control
+      :identifier: physical_server_profile_unassign_server
 
 # Firmwares
 - :name: Firmwares


### PR DESCRIPTION
To be consistent with the API / collection definition, MiQ features related to server profiles must be structured as their own entity.

This PR redefines the server profile features added in #21840.
The three 'operate' features are redefined (server assignment, server deployment, server unassignment): physical server gets assigned to a server profile, not the other way around. Beside this, we are also adding the 'view' features for a single server profile and for a list of them.