### PR TITLE
fix cloud_volume_snapshat_create_queue

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -192,6 +192,7 @@ class CloudVolume < ApplicationRecord
     raise NotImplementedError, _("available_vms must be implemented in a subclass")
   end
 
+  # TODO(kbrock): remove when this is moved from ui-classic to manageiq-api
   def create_volume_snapshot_queue(userid, options = {})
     ext_management_system.class_by_ems(:CloudVolumeSnapshot)&.create_snapshot_queue(userid, self, options)
   end

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -36,19 +36,19 @@ class CloudVolumeSnapshot < ApplicationRecord
     }
 
     queue_opts = {
-      :class_name  => cloud_volume.class.name,
-      :instance_id => cloud_volume.id,
-      :method_name => 'create_volume_snapshot',
+      :class_name  => name,
+      :method_name => 'create_snapshot',
       :role        => 'ems_operations',
       :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => my_zone(ext_management_system),
-      :args        => [options]
+      :args        => [cloud_volume.id, options]
     }
 
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
-  def self.create_snapshot(cloud_volume, options)
+  def self.create_snapshot(cloud_volume_id, options)
+    cloud_volume = CloudVolume.find(cloud_volume_id)
     raw_create_snapshot(cloud_volume, options)
   end
 


### PR DESCRIPTION
When I moved the create snapshot from cloud volume to the
snapshot class, I did not properly move the queuing method across

I had planned on leaving the old queuing method in cloud volume,
so I'm not sure where I screwed up. Regardless, this is calling
a method that does not exist.

This changes the queue method to something that works
