### PR TITLE
use stub_supports

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ExtManagementSystem do
+  include Spec::Support::SupportsHelper
+
   it "supports label mapping for provider subclasses" do
     expect(ExtManagementSystem.entities_for_label_mapping.keys).to include("VmOpenstack", "VmIBM")
   end
@@ -848,17 +850,29 @@ RSpec.describe ExtManagementSystem do
   end
 
   context "virtual column :supports_block_storage" do
+    it "returns false if block storage is not supported" do
+      ems = FactoryBot.create(:ext_management_system)
+      stub_supports_not(ems.class, :block_storage)
+      expect(ems.supports_block_storage).to eq(false)
+    end
+
     it "returns true if block storage is supported" do
       ems = FactoryBot.create(:ext_management_system)
-      allow(ems).to receive(:supports_block_storage).and_return(true)
+      stub_supports(ems.class, :block_storage)
       expect(ems.supports_block_storage).to eq(true)
     end
   end
 
   context "virtual column :supports_cloud_object_store_container_create" do
+    it "returns false if cloud_object_store_container_create is not supported" do
+      ems = FactoryBot.create(:ems_storage)
+      stub_supports_not(ems.class_by_ems("CloudObjectStoreContainer"), :create)
+      expect(ems.supports_cloud_object_store_container_create).to eq(false)
+    end
+
     it "returns true if cloud_object_store_container_create is supported" do
-      ems = FactoryBot.create(:ext_management_system)
-      allow(ems).to receive(:supports_cloud_object_store_container_create).and_return(true)
+      ems = FactoryBot.create(:ems_storage)
+      stub_supports(ems.class_by_ems("CloudObjectStoreContainer"), :create)
       expect(ems.supports_cloud_object_store_container_create).to eq(true)
     end
   end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe AuthenticationMixin do
   include Spec::Support::ArelHelper
+  include Spec::Support::SupportsHelper
 
   let(:host)            { FactoryBot.create(:host) }
   let(:invalid_auth)    { FactoryBot.create(:authentication, :resource => host, :status => "Invalid") }
@@ -732,7 +733,7 @@ RSpec.describe AuthenticationMixin do
         context "#change_password" do
           it "should fail if some param is blank" do
             current_password = ""
-            allow(@ems).to receive(:supports?).with(:change_password) { true }
+            stub_supports(@ems.class, :change_password)
 
             expect { @ems.change_password(current_password, new_password, confirm_password) }
               .to raise_error(MiqException::Error, "Please, fill the current_password and new_password fields.")
@@ -745,7 +746,7 @@ RSpec.describe AuthenticationMixin do
 
           it "should update the provider password" do
             allow(@ems).to receive(:raw_change_password) { true }
-            allow(@ems).to receive(:supports?).with(:change_password) { true }
+            stub_supports(@ems.class, :change_password)
 
             expect(@ems.change_password(current_password, new_password, confirm_password)).to be_truthy
           end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Zone do
+  include Spec::Support::SupportsHelper
   include_examples "AggregationMixin", "ext_management_systems"
 
   context ".seed" do
@@ -100,9 +101,8 @@ RSpec.describe Zone do
     let(:ems_not_supporting_metrics) { FactoryBot.create(:ems_cloud, :zone => zone) }
 
     before do
-      allow_any_instance_of(ExtManagementSystem).to receive(:supports?).with(:metrics).and_return(true)
-      allow(ems_supporting_metrics.class).to receive(:supports?).with(:metrics).and_return(true)
-      allow(ems_not_supporting_metrics.class).to receive(:supports?).with(:metrics).and_return(false)
+      stub_supports(ems_supporting_metrics.class, :metrics)
+      stub_supports_not(ems_not_supporting_metrics.class, :metrics)
     end
 
     it "only returns EMSs which support metrics collection" do


### PR DESCRIPTION
use `stub_supports` for supports tests.

Added some happy/sad paths to properly test a few.