### PR TITLE
Fix aws provision form required validation

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow/dialog_field_validation.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow/dialog_field_validation.rb
@@ -1,9 +1,18 @@
 # These methods are available for dialog field validation, do not erase.
 module ManageIQ::Providers::CloudManager::ProvisionWorkflow::DialogFieldValidation
   def validate_cloud_subnet(field, values, dlg, fld, value)
-    return nil unless value.blank?
-    return nil if get_value(values[:cloud_network]).to_i.zero?
-    return nil unless get_value(values[field]).blank?
+    return nil if value.present?
+    return nil if get_value(values[:placement_auto])
+    return nil if get_value(values[field]).present?
+
+    "#{required_description(dlg, fld)} is required"
+  end
+
+  def validate_cloud_network(field, values, dlg, fld, value)
+    return nil if value.present?
+    return nil if get_value(values[:placement_auto])
+    return nil if get_value(values[field]).present?
+
     "#{required_description(dlg, fld)} is required"
   end
 end

--- a/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
@@ -159,7 +159,8 @@
             :method: :allowed_cloud_networks
           :description: Virtual Private Cloud
           :auto_select_single: false
-          :required: false
+          :required: true
+          :required_method: :validate_cloud_network
           :display: :edit
           :data_type: :integer
         :cloud_subnet:


### PR DESCRIPTION
Fixed an issue where the vm provision form for the AWS provider was able to be submitted without inputting a required value for the cloud subnet field. I don't have an AWS provider or vms to test this on but based on my code inspection and tests on other providers it seems like this line was the issue: `return nil if get_value(values[:cloud_network]).to_i.zero?`. This line I believe means that the `validate_cloud_subnet` function was returning `nil` when the `cloud_network` field was empty when it should instead continue through the function and return the string stating that the field is required.

Since the `cloud_subnet` field is required and will only be able to have options in the dropdown when a `cloud_network` is selected then the `cloud_network` field also needs to be required.

@miq-bot add_reviewer @Fryguy, @agrare
@miq-bot assign @Fryguy, @agrare 
@miq-bot add-label bug