### PR TITLE
don't test hostname on mac

### DIFF
--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe MiqEnvironment do
 
     context "Host Info" do
       example "fully_qualified_domain_name" do
+        skip if RUBY_PLATFORM.include?("darwin")
         expect(described_class.fully_qualified_domain_name).to eq(`hostname -f`.chomp)
       end
 


### PR DESCRIPTION
On the mac `hostname -f` does not consistently return a fully qualified hostname.
This is a linux vs bsd difference with the `-f` flag

This test has always failed for me on the mac.
Prefer for the test suite to be green.

@Fryguy Is this test green on our mac?

```
MiqEnvironment
  with linux platform
    Host Info
      fully_qualified_domain_name (FAILED - 1)

Failures:

  1) MiqEnvironment with linux platform Host Info fully_qualified_domain_name
     Failure/Error: expect(described_class.fully_qualified_domain_name).to eq(`hostname -f`.chomp)

       expected: "kbrock-ibm"
            got: "kbrock-ibm.localdomain"

       (compared using ==)
```