### PR TITLE
Fix Vm advanced_settings boolean methods

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -252,7 +252,7 @@ class VmOrTemplate < ApplicationRecord
       return nil if as.nil? || as.value.nil?
 
       return case t
-             when :boolean then ActiveRecord::ConnectionAdapters::Column.value_to_boolean(as.value)
+             when :boolean then ActiveRecord::Type::Boolean.new.cast(as.value)
              when :integer then as.value.to_i
              when :float then as.value.to_f
              else as.value.to_s

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -350,6 +350,32 @@ RSpec.describe VmOrTemplate do
       @options = {:hdw_attr => :memory_mb}
     end
 
+    context "#advanced_settings" do
+      describe "#paravirtualization" do
+        context "with no advanced_setting" do
+          it "returns nil" do
+            expect(@vm.paravirtualization).to be_nil
+          end
+        end
+
+        context "with vmi.present 'false'" do
+          before { @vm.advanced_settings.create!(:name => "vmi.present", :value => "false") }
+
+          it "returns false" do
+            expect(@vm.paravirtualization).to be_falsey
+          end
+        end
+
+        context "with vmi.present 'true'" do
+          before { @vm.advanced_settings.create!(:name => "vmi.present", :value => "true") }
+
+          it "returns false" do
+            expect(@vm.paravirtualization).to be_truthy
+          end
+        end
+      end
+    end
+
     it "with no drift states" do
       expect(@vm.reconfigured_hardware_value?(@options)).to be_falsey
     end


### PR DESCRIPTION
The value_to_boolean method is long since deprecated (since rails v3.1) https://apidock.com/rails/ActiveRecord/ConnectionAdapters/Column/value_to_boolean/class

Replace with a Rails 5 compatible equivalent.

```
>> vm.advanced_settings.create!(:name => "vmi.present", :value => "true")
>> vm.advanced_settings
=> #<ActiveRecord::Associations::CollectionProxy [#<AdvancedSetting id: 123, name: "vmi.present", display_name: nil, description: nil, value: "true", default_value: nil, min: nil, max: nil, read_only: nil, resource_type: "VmOrTemplate", resource_id: 100, created_on: "2022-05-19 15:07:31", updated_on: "2022-05-19 15:07:31">]>
>> vm.paravirtualization
  AdvancedSetting Load (0.3ms)  SELECT "advanced_settings".* FROM "advanced_settings" WHERE "advanced_settings"."resource_id" = $1 AND "advanced_settings"."resource_type" = $2  [["resource_id", 100], ["resource_type", "VmOrTemplate"]]
  AdvancedSetting Inst Including Associations (0.1ms - 1rows)
Traceback (most recent call last):
       14: from bin/rails:4:in `<main>'
       13: from bootsnap (1.11.1) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
       12: from bootsnap (1.11.1) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
       11: from railties (6.0.5) lib/rails/commands.rb:18:in `<main>'
       10: from railties (6.0.5) lib/rails/command.rb:46:in `invoke'
        9: from railties (6.0.5) lib/rails/command/base.rb:69:in `perform'
        8: from thor (1.2.1) lib/thor.rb:392:in `dispatch'
        7: from thor (1.2.1) lib/thor/invocation.rb:127:in `invoke_command'
        6: from thor (1.2.1) lib/thor/command.rb:27:in `run'
        5: from railties (6.0.5) lib/rails/commands/console/console_command.rb:102:in `perform'
        4: from railties (6.0.5) lib/rails/commands/console/console_command.rb:19:in `start'
        3: from railties (6.0.5) lib/rails/commands/console/console_command.rb:70:in `start'
        2: from (irb):29
        1: from app/models/vm_or_template.rb:255:in `block (2 levels) in <class:VmOrTemplate>'
NoMethodError (undefined method `value_to_boolean' for ActiveRecord::ConnectionAdapters::Column:Class)
```