### PR TITLE
Fix supports publish true in base Vm class

### DIFF
--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -8,12 +8,7 @@ module Vm::Operations::Lifecycle
       unsupported_reason_add(:retire, reason) if reason
     end
 
-    supports :publish do
-      reason   = _("Publish not supported because VM is blank")    if blank?
-      reason ||= _("Publish not supported because VM is orphaned") if orphaned?
-      reason ||= _("Publish not supported because VM is archived") if archived?
-      unsupported_reason_add(:publish, reason) if reason
-    end
+    supports_not :publish
 
     api_relay_method :retire do |options|
       options


### PR DESCRIPTION
Rather than providers which support publish indicating as such in their plugins this was set to true in core and providers which do not support it had supports_not.

This inversion meant that new providers automatically got supports?(:publish) => true even if they did not have this implemented.

This is only supported today by VMware and Ovirt, SCVMM has `supports_not :publish`.  Ovirt has `supports :publish` in their provider already so we only need to add to VMware and remove from SCVMM.

This was converted from validate_* to supports in https://github.com/ManageIQ/manageiq/pull/12198 and simply maintained the same logic of true in core and false in specific providers.

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/807

Follow-up:
* Remove supports_not from scvmm