### PR TITLE
stub_supports handles string or symbol

### DIFF
--- a/spec/lib/supports_helper_spec.rb
+++ b/spec/lib/supports_helper_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe 'SupportsHelper' do
       expect(Post.supports?(:delete)).to be true
       expect(Post.new.supports?(:delete)).to be true
     end
+
+    it "overrides supports (string) from false to true" do
+      expect(Post.supports?(:delete)).to be false
+
+      stub_supports(Post, "delete")
+
+      expect(Post.supports?(:delete)).to be true
+      expect(Post.new.supports?(:delete)).to be true
+    end
   end
 
   context "stub_supports_not" do

--- a/spec/support/supports_helper.rb
+++ b/spec/support/supports_helper.rb
@@ -4,6 +4,7 @@ module Spec
       # when testing requests, ensure the model supports a certain attribute
       def stub_supports(model, feature = :update, supported: true)
         model = model.class unless model.kind_of?(Class)
+        feature = feature.to_sym
 
         receive_supports = receive(:supports?).with(feature).and_return(supported)
         allow(model).to receive_supports
@@ -14,6 +15,7 @@ module Spec
 
       def stub_supports_not(model, feature = :update, reason = nil)
         model = model.class unless model.kind_of?(Class)
+        feature = feature.to_sym
 
         stub_supports(model, feature, :supported => false)
 


### PR DESCRIPTION
Automatically converts the feature to a symbol.

Dynamic code that handles the stubbing of supports no longer needs a `to_sym`