### PR TITLE
implemented validation storage system button

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6627,6 +6627,10 @@
       :description: Remove a Physical Storage
       :feature_type: admin
       :identifier: physical_storage_delete
+    - :name: Validate
+      :description: Validate a Physical Storage
+      :feature_type: admin
+      :identifier: physical_storage_validate
 
 # Physical Servers
 - :name: Physical Servers


### PR DESCRIPTION
# Description
We implemented a 'validate-storage' rest API on the AutoSDE side to have the ability to validate the storage system credentials before we send the creation task to the queue. With this feature, we're saving time and can change the credentials (if there are provided some invalid parameters) without waiting for the response of the queued task.
I implemented the validate button on the attaching storage system page. So we can press the button and validate that the provided parameters are valid. If they are valid, AutoSDE saved this validation request and when we'll press the submit button, the queue task will not validate another time but just take the object that has been created by the previous validation request.

# Illustration video
![validate-button](https://user-images.githubusercontent.com/33315712/170862025-b21a66e4-b01c-42da-b8d5-eb1b01eec873.gif)

# Links
https://github.com/ManageIQ/manageiq-ui-classic/pull/8279
https://github.com/ManageIQ/manageiq-api/pull/1163
https://github.com/ManageIQ/manageiq-providers-autosde/pull/149
