### PR TITLE
Extract parent_id from add_common_default_values

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/configuration_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/configuration_manager.rb
@@ -4,12 +4,12 @@ module ManageIQ::Providers
       class ConfigurationManager < ::ManageIQ::Providers::Inventory::Persister::Builder
         def configuration_profiles
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def configured_systems
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/provisioning_manager.rb
@@ -5,66 +5,66 @@ module ManageIQ::Providers
         def customization_script_media
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def customization_script_ptables
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def operating_system_flavors
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:provisioning_manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:provisioning_manager_id => parent_id)
         end
 
         def configuration_locations
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:provisioning_manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:provisioning_manager_id => parent_id)
         end
 
         def configuration_organizations
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:provisioning_manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:provisioning_manager_id => parent_id)
         end
 
         def configuration_tags
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def configuration_architectures
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def configuration_compute_profiles
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def configuration_domains
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def configuration_environments
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
 
         def configuration_realms
           skip_sti
           add_properties(:manager_ref => %i[manager_ref])
-          add_default_values(:manager_id => ->(persister) { persister.manager.id })
+          add_default_values(:manager_id => parent_id)
         end
       end
     end

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -202,9 +202,12 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
 
     protected
 
+    def parent_id
+      parent&.id || ->(persister) { persister.manager.id }
+    end
+
     def add_common_default_values
-      ems = parent&.id || ->(persister) { persister.manager.id }
-      add_default_values(:ems_id => ems)
+      add_default_values(:ems_id => parent_id)
     end
 
     def relationship_save_block(relationship_key:, relationship_type: :ems_metadata, parent_type: nil)


### PR DESCRIPTION
The configuration and provisioning managers' inventory collections have their own logic for setting default values for the owning manager.

Update to use the standardized add_common_default_values which unifies how to find the parent manager id when refreshing multiple managers.  This brings these in line with the rest of the types of managers.

Required for:
* https://github.com/ManageIQ/manageiq-providers-foreman/pull/103