### PR TITLE
Add VMDB::Util.http_proxy method returning a hash

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -29,6 +29,10 @@ module ManageIQ::Providers
       self.class.http_proxy_uri
     end
 
+    def http_proxy
+      self.class.http_proxy
+    end
+
     supports_not :native_console
 
     def console_url
@@ -50,6 +54,10 @@ module ManageIQ::Providers
 
     def self.http_proxy_uri
       VMDB::Util.http_proxy_uri(ems_type.try(:to_sym)) || VMDB::Util.http_proxy_uri
+    end
+
+    def self.http_proxy
+      VMDB::Util.http_proxy(ems_type.try(:to_sym)) || VMDB::Util.http_proxy
     end
 
     def self.default_blacklisted_event_names

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -1,19 +1,26 @@
 module VMDB
   module Util
-    def self.http_proxy_uri(proxy_config = :default)
+    def self.http_proxy(proxy_config = :default)
       proxy = ::Settings.http_proxy[proxy_config].to_hash
       proxy = ::Settings.http_proxy.to_hash unless proxy[:host]
       return nil if proxy[:host].blank?
 
-      user     = proxy.delete(:user)
-      user &&= CGI.escape(user)
-      password = proxy.delete(:password)
-      password &&= CGI.escape(password)
-      userinfo = "#{user}:#{password}".chomp(":") unless user.blank?
+      proxy
+    end
 
-      proxy[:userinfo]   = userinfo
+    def self.http_proxy_uri(proxy_config = :default)
+      proxy = http_proxy(proxy_config)
+      return if proxy.nil?
+
+      user       = proxy.delete(:user)
+      user     &&= CGI.escape(user)
+      password   = proxy.delete(:password)
+      password &&= CGI.escape(password)
+      userinfo   = "#{user}:#{password}".chomp(":") if user.present?
+
+      proxy[:userinfo] = userinfo
       proxy[:scheme] ||= "http"
-      proxy[:port] &&= proxy[:port].to_i
+      proxy[:port]   &&= proxy[:port].to_i
 
       URI::Generic.build(proxy)
     end


### PR DESCRIPTION
Some providers require separate proxy fields not one single URI, rather than take the URI and split it up we should be able to have access to the hash right from Settings.

Required for:
* https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/65