### PR TITLE
Add conditions to display Host CPU performance charts

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1594,6 +1594,19 @@ class Host < ApplicationRecord
     perf_hash
   end
 
+  # Display or hide certain charts
+  def cpu_mhz_available?
+    true
+  end
+
+  def cpu_ready_available?
+    true
+  end
+
+  def cpu_percent_available?
+    false
+  end
+
   # Host Discovery Types and Platforms
 
   def self.host_create_os_types

--- a/product/charts/layouts/daily_perf_charts/Host.yaml
+++ b/product/charts/layouts/daily_perf_charts/Host.yaml
@@ -23,6 +23,30 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: cpu_mhz_available?
+
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+  - max_derived_cpu_available
+  - max_derived_cpu_reserved
+
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top VMs on this day
+  - Timeline-Current-Daily:Daily events on this Host
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :trends:
+  - max_derived_cpu_reserved:Projected to hit reserve
+  - max_derived_cpu_available:Projected to hit available
+  :chart2:
+    :type: Line
+    :title: VMs
+    :columns:
+    - derived_vm_count_on
+  :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
   :type: Area
@@ -43,6 +67,7 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: cpu_ready_available?
 
 - :title: Memory (MB)
   :type: Line

--- a/product/charts/layouts/hourly_perf_charts/Host.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Host.yaml
@@ -16,6 +16,25 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: cpu_mhz_available?
+
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+  - derived_cpu_available
+  - derived_cpu_reserved
+  :menu:
+  - Chart-Vms-tophour:Top VMs during this hour
+  - Chart-Current-Daily:Back to daily
+  - Timeline-Current-Hourly:Hourly events on this Host
+  - Display-VMs-on:VMs that were running
+  :chart2:
+    :type: Line
+    :title: VMs
+    :columns:
+    - derived_vm_count_on
+  :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
   :type: Area
@@ -35,6 +54,7 @@
     :title: VMs
     :columns:
     - derived_vm_count_on
+  :applies_to_method: cpu_ready_available?
 
 - :title: Memory (MB)
   :type: Line

--- a/product/charts/layouts/realtime_perf_charts/Host.yaml
+++ b/product/charts/layouts/realtime_perf_charts/Host.yaml
@@ -22,16 +22,6 @@
   :columns:
   - cpu_usage_rate_average
   - derived_cpu_available
-#  :menu:
-#  - Chart-Vms-tophour:Top VMs during this hour
-#  - Chart-Current-Daily:Back to daily
-#  - Timeline-Current-Hourly:Hourly events on this Host
-#  - Display-VMs-on:VMs that were running
-#  :chart2:
-#    :type: Line
-#    :title: VMs
-#    :columns:
-#    - derived_vm_count_on
   :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States

--- a/product/charts/layouts/realtime_perf_charts/Host.yaml
+++ b/product/charts/layouts/realtime_perf_charts/Host.yaml
@@ -15,9 +15,28 @@
 #    :title: VMs
 #    :columns:
 #    - derived_vm_count_on
+  :applies_to_method: cpu_mhz_available?
+
+- :title: CPU (%)
+  :type: Line
+  :columns:
+  - cpu_usage_rate_average
+  - derived_cpu_available
+#  :menu:
+#  - Chart-Vms-tophour:Top VMs during this hour
+#  - Chart-Current-Daily:Back to daily
+#  - Timeline-Current-Hourly:Hourly events on this Host
+#  - Display-VMs-on:VMs that were running
+#  :chart2:
+#    :type: Line
+#    :title: VMs
+#    :columns:
+#    - derived_vm_count_on
+  :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
   :type: None
+  :applies_to_method: cpu_ready_available?
 
 - :title: Memory (MB)
   :type: Line


### PR DESCRIPTION
Unlike VMs, the list of performance charts displayed cannot be modified for Hosts at the provider level.

For a provider, we may want to be able to display a CPU usage chart, if that data is available, instead of or alongside the CPU frequency chart.

Proposed solution is to make use of the `applies_to_method` attribute for the Host CPU charts and set it to a method that can be overridden in the Provider subclass.

Screenshot shows Host performance charts for a provider that overrides `cpu_percent_available?` to return `true` and `cpu_ready_available?` and `cpu_mhz_available?` to return `false`.