### PR TITLE
Host supports starting from standby

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -198,13 +198,16 @@ class Host < ApplicationRecord
   supports_not :vmotion_enabled
 
   supports :start do
-    validate_ipmi("off")
+    msg = validate_ipmi("off")
+    unsupported_reason_add(:start, msg) if msg
   end
   supports :stop do
-    validate_ipmi("on")
+    msg = validate_ipmi("on")
+    unsupported_reason_add(:stop, msg) if msg
   end
   supports :reset do
-    validate_ipmi
+    msg = validate_ipmi
+    unsupported_reason_add(:reset, msg) if msg
   end
 
   def self.non_clustered

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -522,8 +522,8 @@ RSpec.describe Host do
     end
   end
 
-  describe "#validate_ipmi (private)" do
-    subject { host.send(:validate_ipmi) }
+  describe "#supports (validate_ipmi portion)" do
+    subject { host.unsupported_reason(:reset) }
 
     context "host does not have ipmi address" do
       let(:host) { FactoryBot.create(:host) }


### PR DESCRIPTION
- fix supports to actually fail (was always passing)
- fix start to support standby status in vmware

I need backup for testing these scenarios. The issue is purely theoretical

---

supports was checking the ipmi status, but not failing supports when the check failed.
(nor setting a reason)

Now it sets the failure when the ipmi check fails

---

Before, supports?(:start) only returns true when power_state was off
So you couldn't supports?(:start) AND have a power_state of standby at the same time.
So you couldn't power up from standby

Now, Hosts can supports?(:start) with a power_state of standby or off. (standby is only for vmware)

Now, the Host.start is more similar to the logic for all other host actions.