### PR TITLE
Expand Supports syntax (part deux)

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -200,34 +200,32 @@ class Host < ApplicationRecord
   supports_not :vmotion_enabled
   supports     :ipmi do
     if ipmi_address.blank?
-      unsupported_reason_add(:ipmi, _("The Host is not configured for IPMI"))
+      _("The Host is not configured for IPMI")
     elsif authentication_type(:ipmi).nil?
-      unsupported_reason_add(:ipmi, _("The Host has no IPMI credentials"))
+      _("The Host has no IPMI credentials")
     elsif authentication_userid(:ipmi).blank? || authentication_password(:ipmi).blank?
-      unsupported_reason_add(:ipmi, _("The Host has invalid IPMI credentials"))
+      _("The Host has invalid IPMI credentials")
     end
   end
 
   # if you change this, please check in on VmWare#start
   supports :start do
     if !supports?(:ipmi)
-      unsupported_reason_add(:start, unsupported_reason(:ipmi))
+      unsupported_reason(:ipmi)
     elsif power_state != "off"
-      unsupported_reason_add(:start, _("The Host is not in power state off"))
+      _("The Host is not in power state off")
     end
   end
 
   supports :stop do
     if !supports?(:ipmi)
-      unsupported_reason_add(:stop, unsupported_reason(:ipmi))
+      unsupported_reason(:ipmi)
     elsif power_state != "on"
-      unsupported_reason_add(:stop, _("The Host is not in powered on"))
+      _("The Host is not in powered on")
     end
   end
 
-  supports :reset do
-    unsupported_reason_add(:reset, unsupported_reason(:ipmi)) unless supports?(:ipmi)
-  end
+  supports(:reset) { unsupported_reason(:ipmi) }
 
   def self.non_clustered
     where(:ems_cluster_id => nil)

--- a/app/models/metric/ci_mixin.rb
+++ b/app/models/metric/ci_mixin.rb
@@ -23,7 +23,7 @@ module Metric::CiMixin
     supports :capture do
       metrics_capture_klass = "#{self.class.module_parent.name}::MetricsCapture".safe_constantize
       unless metrics_capture_klass&.method_defined?(:perf_collect_metrics)
-        unsupported_reason_add(:capture, _('This provider does not support metrics collection'))
+        _('This provider does not support metrics collection')
       end
     end
   end

--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -9,9 +9,7 @@ module ComplianceMixin
              :inverse_of => :resource,
              :class_name => "Compliance"
 
-    supports :check_compliance do
-      unsupported_reason_add(:check_compliance, "No compliance policies assigned") unless has_compliance_policies?
-    end
+    supports(:check_compliance) { "No compliance policies assigned" unless has_compliance_policies? }
 
     virtual_delegate :last_compliance_status,
                      :to        => "last_compliance.compliant",

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -6,7 +6,7 @@
 #     supports :publish
 #     supports_not :fake, :reason => 'We keep it real'
 #     supports :archive do
-#       unsupported_reason_add(:archive, 'It is too good') if featured?
+#       'It is too good' if featured?
 #     end
 #   end
 #
@@ -187,7 +187,12 @@ module SupportsFeatureMixin
           unsupported.delete(feature)
           if block_given?
             begin
-              instance_eval(&block)
+              result = instance_eval(&block)
+              # if no errors yet but result was an error message
+              # then add the error
+              if !unsupported.key?(feature) && result.kind_of?(String)
+                unsupported_reason_add(feature, result)
+              end
             rescue => e
               _log.log_backtrace(e)
               unsupported_reason_add(feature, "Internal Error: #{e.message}")

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -100,10 +100,7 @@ class Service < ApplicationRecord
   scope :displayed, ->              { where(:visible => true) }
   scope :retired,   ->(bool = true) { where(:retired => bool) }
 
-  supports :reconfigure do
-    unsupported_reason_add(:reconfigure, _("Reconfigure unsupported")) unless validate_reconfigure
-  end
-
+  supports(:reconfigure) { _("Reconfigure unsupported") unless validate_reconfigure }
   supports :retire
 
   alias parent_service parent

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -72,8 +72,11 @@ class ServiceTemplate < ApplicationRecord
   scope :public_service_templates,                  ->         { where(:internal => [false, nil]) }
 
   supports :order do
-    unsupported_reason_add(:order, 'Service template does not belong to a service catalog') unless service_template_catalog
-    unsupported_reason_add(:order, 'Service template is not configured to be displayed') unless display
+    if !service_template_catalog
+      'Service template does not belong to a service catalog'
+    elsif !display
+      'Service template is not configured to be displayed'
+    end
   end
   alias orderable?     supports_order?
   alias validate_order supports_order?

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -71,17 +71,13 @@ class Storage < ApplicationRecord
 
   supports :smartstate_analysis do
     if !ext_management_system&.class&.supports?(:smartstate_analysis)
-      unsupported_reason_add(:smartstate_analysis, _("Smartstate Analysis cannot be performed on selected Datastore"))
+      _("Smartstate Analysis cannot be performed on selected Datastore")
     elsif !ext_management_system&.authentication_status_ok?
-      unsupported_reason_add(:smartstate_analysis, _("There are no EMSs with valid credentials for this Datastore"))
+      _("There are no EMSs with valid credentials for this Datastore")
     end
   end
 
-  supports :delete do
-    if vms_and_templates.any? || hosts.any?
-      unsupported_reason_add(:delete, _("Only storage without VMs and Hosts can be removed"))
-    end
-  end
+  supports(:delete) { _("Only storage without VMs and Hosts can be removed") if vms_and_templates.any? || hosts.any? }
 
   supports_not :evacuate
 

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -8,33 +8,33 @@ module Vm::Operations
   included do
     supports :html5_console do
       consup = %w[vnc webmks spice].any? { |type| send(:console_supported?, type) }
-      unsupported_reason_add(:html5_console, _("The web-based HTML5 Console is not supported")) unless consup
+      _("The web-based HTML5 Console is not supported") unless consup
     end
 
     supports :vmrc_console do
-      unsupported_reason_add(:vmrc_console, _("VMRC Console not supported")) unless console_supported?('VMRC')
+      _("VMRC Console not supported") unless console_supported?('VMRC')
     end
 
     supports :native_console do
-      unsupported_reason_add(:native_console, _("VM NATIVE Console not supported")) unless console_supported?('NATIVE')
+      _("VM NATIVE Console not supported") unless console_supported?('NATIVE')
     end
 
     supports :launch_html5_console do
-      unsupported_reason_add(:launch_html5_console, _("The web-based HTML5 Console is not available because the VM is not powered on")) unless power_state == 'on'
+      _("The web-based HTML5 Console is not available because the VM is not powered on") unless power_state == 'on'
     end
 
     supports :launch_vmrc_console do
       begin
         validate_remote_console_vmrc_support
       rescue => err
-        unsupported_reason_add(:launch_vmrc_console, _('VM VMRC Console error: %{error}') % {:error => err})
+        _('VM VMRC Console error: %{error}') % {:error => err}
       end
     end
 
     supports :launch_native_console do
       validate_native_console_support
     rescue StandardError => err
-      unsupported_reason_add(:launch_native_console, _('VM NATIVE Console error: %{error}') % {:error => err})
+      _('VM NATIVE Console error: %{error}') % {:error => err}
     end
 
     supports :collect_running_processes do
@@ -44,7 +44,7 @@ module Vm::Operations
       reason ||= N_('VM Process collection requires credentials set at the Zone level.') if my_zone.nil? || my_zone_obj.auth_user_pwd(:windows_domain).nil?
       reason ||= N_('VM Process collection requires an IP address for the VM.') if ipaddresses.blank?
 
-      unsupported_reason_add(:collect_running_processes, reason) if reason
+      reason
     end
 
     supports_not :evacuate

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -3,9 +3,11 @@ module Vm::Operations::Lifecycle
 
   included do
     supports :retire do
-      reason   = _("Retire not supported because VM is orphaned") if orphaned?
-      reason ||= _("Retire not supported because VM is archived") if archived?
-      unsupported_reason_add(:retire, reason) if reason
+      if orphaned?
+        _("Retire not supported because VM is orphaned")
+      elsif archived?
+        _("Retire not supported because VM is archived")
+      end
     end
 
     supports_not :publish

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -7,21 +7,27 @@ module Vm::Operations::Power
     api_relay_method :suspend
 
     supports :suspend do
-      msg = unsupported_reason(:control) unless supports?(:control)
-      msg ||= _('The VM is not powered on') unless vm_powered_on?
-      unsupported_reason_add(:suspend, msg) if msg
+      if !supports?(:control)
+        unsupported_reason(:control)
+      elsif !vm_powered_on?
+        _('The VM is not powered on')
+      end
     end
 
     supports :start do
-      msg = unsupported_reason(:control) unless supports?(:control)
-      msg ||= _('The VM is powered on') if vm_powered_on?
-      unsupported_reason_add(:start, msg) if msg
+      if !supports?(:control)
+        unsupported_reason(:control)
+      elsif vm_powered_on?
+        _('The VM is powered on')
+      end
     end
 
     supports :stop do
-      msg = unsupported_reason(:control) unless supports?(:control)
-      msg ||= _('The VM is not powered on') unless vm_powered_on?
-      unsupported_reason_add(:stop, msg) if msg
+      if !supports?(:control)
+        unsupported_reason(:control)
+      elsif !vm_powered_on?
+        _('The VM is not powered on')
+      end
     end
 
     supports_not :pause

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1675,11 +1675,7 @@ class VmOrTemplate < ApplicationRecord
     user
   end
 
-  supports :console do
-    unless console_supported?('spice') || console_supported?('vnc')
-      unsupported_reason_add(:console, N_("Console not supported"))
-    end
-  end
+  supports(:console) { N_("Console not supported") unless console_supported?('spice') || console_supported?('vnc') }
 
   def child_resources
     children

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -126,20 +126,19 @@ module VmOrTemplate::Operations
 
   included do
     supports :control do
-      msg = if retired?
-              _('The VM is retired')
-            elsif template?
-              _('The VM is a template')
-            elsif terminated?
-              _('The VM is terminated')
-            elsif !has_required_host?
-              _('The VM is not connected to a Host')
-            elsif disconnected?
-              _('The VM does not have a valid connection state')
-            elsif !has_active_ems?
-              _("The VM is not connected to an active Provider")
-            end
-      unsupported_reason_add(:control, msg) if msg
+      if retired?
+        _('The VM is retired')
+      elsif template?
+        _('The VM is a template')
+      elsif terminated?
+        _('The VM is terminated')
+      elsif !has_required_host?
+        _('The VM is not connected to a Host')
+      elsif disconnected?
+        _('The VM does not have a valid connection state')
+      elsif !has_active_ems?
+        _("The VM is not connected to an active Provider")
+      end
     end
     supports_not :clone
     supports_not :quick_stats

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -3,46 +3,17 @@ module VmOrTemplate::Operations::Snapshot
 
   included do
     supports :snapshot_create do
-      if supports?(:snapshots)
-        unless supports?(:control)
-          unsupported_reason_add(:snapshot_create, unsupported_reason(:control))
-        end
-      else
-        unsupported_reason_add(:snapshot_create, _("Operation not supported"))
-      end
+      unsupported_reason(:snapshots) || unsupported_reason(:control)
     end
 
     supports :remove_snapshot do
-      if supports?(:snapshots)
-        if snapshots.size <= 0
-          unsupported_reason_add(:remove_snapshot, _("No snapshots available for this VM"))
-        end
-        unless supports?(:control)
-          unsupported_reason_add(:remove_snapshot, unsupported_reason(:control))
-        end
-      else
-        unsupported_reason_add(:remove_snapshot, _("Operation not supported"))
-      end
+      unsupported_reason(:snapshots) || unsupported_reason(:control) ||
+        (_("No snapshots available for this VM") if snapshots.size <= 0)
     end
 
-    supports :remove_all_snapshots do
-      unless supports?(:remove_snapshot)
-        unsupported_reason_add(:remove_all_snapshots, unsupported_reason(:remove_snapshot))
-      end
-    end
-
-    supports :remove_snapshot_by_description do
-      unless supports?(:remove_snapshot)
-        unsupported_reason_add(:remove_snapshot_by_description, unsupported_reason(:remove_snapshot))
-      end
-    end
-
-    supports :revert_to_snapshot do
-      unless supports?(:remove_snapshot)
-        unsupported_reason_add(:revert_to_snapshot, unsupported_reason(:remove_snapshot))
-      end
-    end
-
+    supports(:remove_all_snapshots)           { unsupported_reason(:remove_snapshot) }
+    supports(:remove_snapshot_by_description) { unsupported_reason(:remove_snapshot) }
+    supports(:revert_to_snapshot)             { unsupported_reason(:remove_snapshot) }
     supports_not :snapshots
   end
 

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupportsFeatureMixin do
 
       supports :std_accept
       supports_not :std_denial, :reason => "not available"
-      supports(:dynamic_feature) { unsupported_reason_add(:dynamic_feature, "dynamically unsupported") unless attr1 }
+      supports(:dynamic_feature) { "dynamically unsupported" unless attr1 }
 
       def validate_accept
         {:available => true, :message => nil}
@@ -124,6 +124,20 @@ RSpec.describe SupportsFeatureMixin do
       expect(test_inst.supports?(:dynamic_feature)).to be_truthy
     end
 
+    it "denies implicit dynamic attrs" do
+      test_class.supports(:implicit_feature) { "dynamically unsupported" unless attr1 }
+      test_inst = test_class.new(:attr1 => false)
+
+      expect(test_inst.supports?(:implicit_feature)).to be_falsey
+    end
+
+    it "supports implicit dynamic attrs" do
+      test_class.supports(:implicit_feature) { "dynamically unsupported" unless attr1 }
+      test_inst = test_class.new(:attr1 => true)
+
+      expect(test_inst.supports?(:implicit_feature)).to be_truthy
+    end
+
     it "overrides to deny from child class" do
       child_class = define_model(nil, test_class, :std_accept => false, :module_accept => false, :dynamic_feature => false)
       test_inst = child_class.new(:attr1 => true)
@@ -158,7 +172,6 @@ RSpec.describe SupportsFeatureMixin do
 
         expect(test_inst.supports?(:std_accept)).to be_truthy
         expect(test_inst.supports?(:module_accept)).to be_truthy
-        expect(test_inst.supports?(:dynamic_feature)).to be_truthy
         expect(test_inst.supports?(:std_denial)).to be_truthy
         expect(test_inst.supports?(:dynamic_feature)).to be_truthy
 
@@ -166,7 +179,6 @@ RSpec.describe SupportsFeatureMixin do
 
         expect(test_inst.supports?(:std_accept)).to be_falsey
         expect(test_inst.supports?(:module_accept)).to be_falsey
-        expect(test_inst.supports?(:dynamic_feature)).to be_falsey
         expect(test_inst.supports?(:std_denial)).to be_falsey
         expect(test_inst.supports?(:dynamic_feature)).to be_falsey
       end
@@ -218,6 +230,13 @@ RSpec.describe SupportsFeatureMixin do
       expect(test_inst.supports?(:dynamic_feature)).to be_truthy # this recalculates the reason
 
       expect(test_inst.unsupported_reason(:dynamic_feature)).to be_nil
+    end
+
+    it "gives reason when implicit dynamic attrs" do
+      test_class.supports(:implicit_feature) {  "dynamically unsupported" unless attr1 }
+      test_inst = test_class.new(:attr1 => false)
+
+      expect(test_inst.unsupported_reason(:implicit_feature)).to eq("dynamically unsupported")
     end
   end
 
@@ -322,7 +341,7 @@ RSpec.describe SupportsFeatureMixin do
         when String
           supports_not feature, :reason => value
         when :dynamic
-          supports(feature) { unsupported_reason_add(feature, "dynamically unsupported") unless attr1 }
+          supports(feature) { "dynamically unsupported" unless attr1 }
         else
           raise "trouble defining #{feature} with #{value.class.name}"
         end


### PR DESCRIPTION
Part of project: https://github.com/ManageIQ/manageiq/issues/21179

Also merge: https://github.com/ManageIQ/manageiq-ui-classic/pull/8366

This is based upon a conversation started by @chessbyte : #21269 which started in [vmware-provider](https://github.com/ManageIQ/manageiq-providers-vmware/pull/723#discussion_r650005096)


It came up a few times and now that we have reworked supports a bit, it seemed like a good time to see revisit and see if this new syntax makes more sense.

## Ideas in discussion

### Before

```ruby
    supports :check_compliance
    supports_not :check_compliance
    supports_not :check_compliance, :reason => "Feature not available/supported"

    supports :check_compliance do
      unsupported_reason_add(:check_compliance, "No compliance policies assigned") unless has_compliance_policies?
    end
```

Most of the `supports_not` blocks have been transitioned to use the default reason:

|  #  |comment|
|----:|:------|
| 245 | `supports :feature`|
| 151 | `supports_not :feature`|
|  23 | `supports_not :feature, :reason => ""`|
| 169 | `supports :feature do ; end`|

### String Syntax

```ruby
    supports :check_compliance do
      "No compliance policies assigned" unless has_compliance_policies?
    end
```

This gives the end user more of an understanding as to why this operation is not available.
Half of the time this is an `if`/`elsif` chain.
Returning `nil` means that this feature is supported.

Of the reasons given, a quarter could just use the default value:

| %  |comment|
|---:|:------|
| 50 | multiple reasons per block|
| 25 | nondescript single reason |
| 25 | single reason|

### Boolean Syntax

We have dropped the use of returning a boolean. Most of those cases have been converted to the standard `supports` / `supports_not` syntax.