### PR TITLE
Multiple users being created for the same AD account

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -123,6 +123,7 @@ module Authenticator
       return user_attrs[:username] if user_attrs[:domain].nil?
 
       user_name = user_attrs[:username].split("@").first
+      user_name = user_name.split("\\").last if user_name.include?("\\")
       "#{user_name}@#{user_attrs[:domain]}".downcase
     end
 


### PR DESCRIPTION
cut domain before \ from username

It fixes user naming when created in ManageIQ.
Now, if you log in for the first time under an account like domain\user_name, a user like domain\user_name@domain will be created in ManageIQ, because manageiq thinks domain\user_name is the whole username
This creates duplicate users.
After this fix if you login first time like domain\user_name or user_name@domain or user_name@UPN_suffix or just user_name will be created one user in ManageIQ kind user_name@domain
Testing on lasker and morphy
Link to a similar problem https://talk.manageiq.org/t/multiple-users-being-created-for-the-same-ad-account/5255

---

Discussed in https://github.com/ManageIQ/manageiq/discussions/21905
