### PR TITLE
Alert profile length

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -7,7 +7,7 @@ class MiqAlert < ApplicationRecord
   serialize :hash_expression
   serialize :options
 
-  validates :description, :presence => true, :uniqueness_when_changed => true
+  validates :description, :presence => true, :uniqueness_when_changed => true, :length => {:maximum => 255}
   validate :validate_automate_expressions
   validate :validate_single_expression
   validates :severity, :inclusion => { :in => SEVERITIES }


### PR DESCRIPTION
Ensure we do not save alerts with a description longer than 100 characters long
Checking on the server side

100 is an arbitrary limit.
The ui says 50, but we have a db feature for an alert that is 55 characters long