### PR TITLE
Fix Host calling run_ipmi_command before supports check

### DIFF
--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -125,10 +125,11 @@ RSpec.describe Host do
   end
 
   context "power operations" do
+    let(:power_state) { "off" }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       @ems = FactoryBot.create(:ext_management_system, :tenant => FactoryBot.create(:tenant))
-      @host = FactoryBot.create(:host, :ems_id => @ems.id)
+      @host = FactoryBot.create(:host, :ems_id => @ems.id, :power_state => power_state)
     end
 
     context "#start" do


### PR DESCRIPTION
During some recent refactoring the `Host#start` method now calls the `run_ipmi_command` before checking if the host supports IPMI.

https://github.com/ManageIQ/manageiq/pull/21912/files#diff-9daa2c365cb8a7cb177648fe53854dae6588080e089b01333768fcb5da8ff4aeR320