### PR TITLE
Add cloud volume clone feature

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -31,6 +31,7 @@ class CloudVolume < ApplicationRecord
   supports_not :update
   supports_not :attach
   supports_not :detach
+  supports_not :clone
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
 

--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -28,6 +28,29 @@ module CloudVolume::Operations
     raw_attach_volume(server_ems_ref, device)
   end
 
+  def clone_volume_queue(userid, options = {})
+  task_opts = {
+    :action => "cloning Cloud Volume for user #{userid}",
+    :userid => userid
+  }
+
+  queue_opts = {
+    :class_name  => self.class.name,
+    :method_name => 'clone_volume',
+    :instance_id => id,
+    :role        => 'ems_operations',
+    :queue_name  => ext_management_system.queue_name_for_ems_operations,
+    :zone        => ext_management_system.my_zone,
+    :args        => [options]
+  }
+
+  MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def clone_volume(options = {})
+    raw_clone_volume(options)
+  end
+
   # Detach a cloud volume as a queued task and return the task id. The queue
   # name and the queue zone are derived from the server EMS, and both a userid
   # and server EMS ref are mandatory.

--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -29,22 +29,21 @@ module CloudVolume::Operations
   end
 
   def clone_volume_queue(userid, options = {})
-  task_opts = {
-    :action => "cloning Cloud Volume for user #{userid}",
-    :userid => userid
-  }
+    task_opts = {
+      :action => "cloning Cloud Volume for user #{userid}",
+      :userid => userid
+    }
 
-  queue_opts = {
-    :class_name  => self.class.name,
-    :method_name => 'clone_volume',
-    :instance_id => id,
-    :role        => 'ems_operations',
-    :queue_name  => ext_management_system.queue_name_for_ems_operations,
-    :zone        => ext_management_system.my_zone,
-    :args        => [options]
-  }
-
-  MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'clone_volume',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => ext_management_system.my_zone,
+      :args        => [options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
   def clone_volume(options = {})

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -133,10 +133,10 @@ module VmOrTemplate::Operations::Configuration
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
-  def clone_volume(_options = {})
+  def clone_volume(options = {})
     raise _("VM has no EMS, unable to clone volume") unless ext_management_system
 
-    raw_clone_volume(_options = {})
+    raw_clone_volume(options)
   end
 
   def raw_reconfigure

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -129,6 +129,16 @@ module VmOrTemplate::Operations::Configuration
     raw_detach_volume(volume_id)
   end
 
+  def raw_clone_volume(_options = {})
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
+  def clone_volume(_options = {})
+    raise _("VM has no EMS, unable to clone volume") unless ext_management_system
+
+    raw_clone_volume(_options = {})
+  end
+
   def raw_reconfigure
     raise NotImplementedError, _("must be implemented in a subclass")
   end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -831,6 +831,10 @@
       :description: Detach a Volume
       :feature_type: admin
       :identifier: cloud_volume_detach
+    - :name: Clone
+      :description: Clone a Volume
+      :feature_type: admin
+      :identifier: cloud_volume_clone
     - :name: Remove
       :description: Remove Volumes
       :feature_type: admin


### PR DESCRIPTION
Adding a new feature to clone cloud volumes.
The IBM Power Cloud service has a feature which makes a copy of an existing cloud volume.
This is distinct from snapshots and backups.

Related PRs:
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1164
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8301

Provider PRs:
- [ ] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/390