### PR TITLE
Fix machine credentials privilege escalation field

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
       :component        => 'select',
       :label            => N_('Privilege Escalation'),
       :helperText       => N_('Privilege escalation method'),
-      :name             => 'become_method',
+      :name             => 'options.become_method',
       :id               => 'become_method',
       :type             => 'choice',
       :isClearable      => true,


### PR DESCRIPTION
This PR is a replacement for PR: https://github.com/ManageIQ/manageiq/pull/21907

Fix machine credentials form to display privilege escalation value.

Before:
<img width="1414" alt="Screen Shot 2022-06-08 at 2 53 57 PM" src="https://user-images.githubusercontent.com/32444791/172694580-981d791e-cdc2-41a5-bb33-44c0c6f4d524.png">

After:
<img width="1408" alt="Screen Shot 2022-06-08 at 2 49 33 PM" src="https://user-images.githubusercontent.com/32444791/172694242-a5ac65c2-05de-4c07-ac9d-9d75213adbd9.png">

@miq-bot add_reviewer @Fryguy
@miq-bot assign @Fryguy 
@miq-bot add-label bug
