### PR TITLE
Fixed machine credentials console errors

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -42,7 +42,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
       :helperText       => N_('Privilege escalation method'),
       :name             => 'become_method',
       :id               => 'become_method',
-      :type             => 'choice',
       :isClearable      => true,
       :options          => %w[
         sudo


### PR DESCRIPTION
Fixed console errors on add/edit credentials form for machine credentials.

Console Errors:
<img width="840" alt="Screen Shot 2022-06-09 at 11 26 22 AM" src="https://user-images.githubusercontent.com/32444791/172884942-4287fa3b-0ad1-4a97-a83f-7f6709db79b0.png">

