### PR TITLE
Support changes for `become_method` becoming a column

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -37,13 +37,16 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
       :type       => 'password',
     },
     {
-      :component        => 'select',
-      :label            => N_('Privilege Escalation'),
-      :helperText       => N_('Privilege escalation method'),
-      :name             => 'options.become_method',
-      :id               => 'become_method',
-      :isClearable      => true,
-      :options          => %w[
+      :component    => 'select',
+      :label        => N_('Privilege Escalation'),
+      :helperText   => N_('Privilege escalation method'),
+      :name         => 'become_method',
+      :id           => 'become_method',
+      :isClearable  => true,
+      :clearedValue => nil,
+      :placeholder  => N_('None'),
+      :simpleValue  => true,
+      :options      => %w[
         sudo
         su
         pbrum
@@ -100,14 +103,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)   if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock) if attrs.key?(:ssh_key_unlock)
 
-    if attrs[:become_method]
-      attrs[:options] = { :become_method => attrs.delete(:become_method) }
-    end
-
     attrs
-  end
-
-  def become_method
-    options && options[:become_method]
   end
 end

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -24,7 +24,7 @@ module Ansible
       def become_args
         {
           :become_user   => auth.become_username,
-          :become_method => auth.options.try(:[], :become_method) || "sudo"
+          :become_method => auth.become_method || "sudo"
         }.delete_blanks
       end
 

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Ansible::Runner::MachineCredential do
         :become_username   => "root",
         :become_password   => "othersecret",
         :auth_key_password => "keypass",
-        :options           => {:become_method => "su"}
+        :become_method     => "su",
       }
       FactoryBot.create(:embedded_ansible_machine_credential, auth_attributes)
     end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -185,9 +185,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credenti
         :become_password   => "secret3",
         :become_username   => "admin",
         :auth_key_password => "secret4",
-        :options           => {
-          :become_method => "sudo"
-        }
+        :become_method     => "sudo"
       }
     end
     let(:expected_values) do
@@ -204,9 +202,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credenti
         :auth_key_encrypted          => expected_ssh_key.present? ? ManageIQ::Password.try_encrypt(expected_ssh_key) : expected_ssh_key,
         :become_password_encrypted   => ManageIQ::Password.try_encrypt("secret3"),
         :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret4"),
-        :options                     => {
-          :become_method => "sudo"
-        }
       }
     end
     let(:params_to_attrs) { [:auth_key, :auth_key_password, :become_method] }


### PR DESCRIPTION
Depends:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/650

Allows for become_method to be updated directly instead of `options: { :become_method }`. Also, updated the become_method field to correctly set the initial value, correctly send the only the chosen value instead of the whole object, send `nil` when the field is cleared and updated the place holder to `None` instead of `<Choose>`.

Before:
<img width="1405" alt="Screen Shot 2022-06-29 at 1 24 04 PM" src="https://user-images.githubusercontent.com/32444791/176498880-f8ef647c-dc2a-4652-a395-cfc7fbfd245e.png">

After:
<img width="1405" alt="Screen Shot 2022-06-29 at 1 23 23 PM" src="https://user-images.githubusercontent.com/32444791/176498918-aed15961-748b-4ff6-9d1d-3b8130f70c4d.png">
<img width="1405" alt="Screen Shot 2022-06-29 at 1 23 35 PM" src="https://user-images.githubusercontent.com/32444791/176498909-b4a72dfc-6b2e-4844-a449-59bf5a504bb0.png">


@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @Fryguy
@miq-bot assign @Fryguy 
@miq-bot add-label bug
