### PR TITLE
Fixed firmware registries refresh missing feature error

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6854,6 +6854,11 @@
       :description: Display Individual Firmware
       :feature_type: view
       :identifier: firmware_show
+    - :name: Reload Current Display
+      :description: Reload Current Display
+      :feature_type: view
+      :hidden: true
+      :identifier: firmware_registries_reload
 
 # Guest Devices
 - :name: Guest Devices


### PR DESCRIPTION
Fixed a missing feature bug for firmware registries.

Before:
<img width="1383" alt="Screen Shot 2022-06-22 at 12 31 24 PM" src="https://user-images.githubusercontent.com/32444791/175098411-258d1dee-a06c-409d-adea-bc03a6347cf0.png">

After:
<img width="1408" alt="Screen Shot 2022-06-22 at 1 18 23 PM" src="https://user-images.githubusercontent.com/32444791/175098556-00d2432b-f16a-40f6-9500-0d47b709128f.png">


