### PR TITLE
supports_not for new physical storage method (validate)

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -35,6 +35,7 @@ class PhysicalStorage < ApplicationRecord
 
   supports_not :create
   supports_not :delete
+  supports_not :validate
   acts_as_miq_taggable
 
   def my_zone


### PR DESCRIPTION
As part of the implementation of the new validation physical storage button. I need to add this 'supports_not :validate' command for all other storage providers that didn't implement this method.
@agrare -
related to PR - https://github.com/ManageIQ/manageiq-providers-autosde/pull/150