### PR TITLE
Lock down pg until 1.4.x is released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,10 @@ gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
-gem "pg",                                                    :require => false
+
+# Lock down pg until 1.4.x is released with:
+# https://github.com/ged/ruby-pg/pull/467 which fixes https://github.com/ged/ruby-pg/issues/466
+gem "pg",                               "=1.3.5",            :require => false
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.3.1",         :require => false


### PR DESCRIPTION
pg 1.4.0 was released with a breaking change to the interface for the PG::Error
class:

https://github.com/ged/ruby-pg/commit/91b00d02072d67698b01af767d8a76bb95c6e9b9

It was reported in https://github.com/ged/ruby-pg/issues/466
and fixed in https://github.com/ged/ruby-pg/pull/467 but not yet released.

1.4.0  was breaking our pg logical spec as seen below
```
 1) PglogicalSubscription#backlog returns nil if error raised inside
     Failure/Error:
       MiqRegionRemote.with_remote_connection(host, port || 5432, user, decrypted_password, dbname, "postgresql", connect_timeout) do |conn|
         yield conn
       end
     ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./app/models/pglogical_subscription.rb:294:in `with_remote_connection'
     # ./app/models/pglogical_subscription.rb:289:in `remote_region_lsn'
     # ./app/models/pglogical_subscription.rb:104:in `backlog'
     # ./spec/models/pglogical_subscription_spec.rb:495:in `block (3 levels) in <top (required)>'
```
