### PR TITLE
Unlock the pg gem since 1.4.1 was released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,10 +59,7 @@ gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
-
-# Lock down pg until 1.4.x is released with:
-# https://github.com/ged/ruby-pg/pull/467 which fixes https://github.com/ged/ruby-pg/issues/466
-gem "pg",                               "=1.3.5",            :require => false
+gem "pg",                               "!= 1.4.0",          :require => false # 1.4.0 caused https://github.com/ged/ruby-pg/issues/466
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.3.1",         :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
-gem "pg",                               "!= 1.4.0",          :require => false # 1.4.0 caused https://github.com/ged/ruby-pg/issues/466
+gem "pg",                               ">=1.3", "!= 1.4.0", :require => false # 1.4.0 caused https://github.com/ged/ruby-pg/issues/466
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.3.1",         :require => false


### PR DESCRIPTION
1.4.0 led to https://github.com/ged/ruby-pg/issues/466
and was fixed in https://github.com/ged/ruby-pg/pull/467

Since 1.4.1 is now released and fixes the issue, we can safely unlock pg except
for version 1.4.0.
