### PR TITLE
Use bootsnap 1.8.1 for psych 4 / 3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be requi
 gem "ancestry",                         "~>4.1.0",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
-gem "bootsnap",                         ">= 1.4.2",          :require => false
+gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load
 gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"


### PR DESCRIPTION
Psych unsafe_load was added for psych 4 / 3 compatibility but was only available
in 3.3.2 and newer.

Prior to this change, bootsnap 1.8.0 would be break on psych 3.3.1 and older.

Bootsnap added psych 4 compatibility in 1.8.0 by using unsafe_load but this
doesn't work with 3.3.1 or older:
https://github.com/Shopify/bootsnap/pull/368

Bootnap 1.8.1 allows older versions of psych to be compatible via:
https://github.com/Shopify/bootsnap/pull/369

Discovered this possible problem while debugging https://github.com/ManageIQ/sprint_statistics/pull/70
