### PR TITLE
convert external_logging to simple supports type

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -88,11 +88,7 @@ class ContainerNode < ApplicationRecord
     true
   end
 
-  supports :external_logging do
-    unless ext_management_system.respond_to?(:external_logging_route_name)
-      unsupported_reason_add(:external_logging, _('This provider type does not support External Logging'))
-    end
-  end
+  supports_not :external_logging
 
   def external_logging_query
     nil # {}.to_query # TODO

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -56,11 +56,7 @@ module ManageIQ::Providers
 
     virtual_column :port_show, :type => :string
 
-    supports :external_logging do
-      unless respond_to?(:external_logging_route_name)
-        unsupported_reason_add(:external_logging, _('This provider type does not support external_logging'))
-      end
-    end
+    supports_not :external_logging
 
     supports :metrics
 


### PR DESCRIPTION
Depends upon:

- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/227

This is currently only used by openshift container managers.
So I'm not sure how the container node will support external_logging

Decided to remove the lambda and just use standard supports/supports_not
Also decided to leave the container node supports in there
