### PR TITLE
Use EvmSpecHelper.local_server

### DIFF
--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe EvmDatabase do
 
   describe ".raise_server_event" do
     it "adds to queue request to raise 'evm_event'" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       described_class.raise_server_event("db_failover_executed")
       record = MiqQueue.last
       expect(record.class_name). to eq "MiqEvent"

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe EvmDatabase do
   end
 
   describe ".run_failover_monitor" do
-    let!(:server) { EvmSpecHelper.local_guid_miq_server_zone[1] }
+    let!(:server) { EvmSpecHelper.local_miq_server }
     let(:monitor) { ManageIQ::PostgresHaAdmin::FailoverMonitor.new }
     let(:subscriptions) do
       [

--- a/spec/lib/task_helpers/exports/widgets_spec.rb
+++ b/spec/lib/task_helpers/exports/widgets_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TaskHelpers::Exports::Widgets do
   end
 
   before do
-    _guid, _server, _zone = EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
 
     MiqReport.seed_report("Vendor and Guest OS")
     MiqWidget.seed_widget("chart_vendor_and_guest_os")

--- a/spec/lib/task_helpers/imports/widgets_spec.rb
+++ b/spec/lib/task_helpers/imports/widgets_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TaskHelpers::Imports::Widgets do
     let(:options) { { :source => source } }
 
     before do
-      _guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       FactoryBot.create(:user_admin, :userid => "admin")
     end
 

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -5,7 +5,7 @@ require Rails.root.join("lib", "tasks", "evm_application")
 RSpec.describe EvmApplication do
   context ".server_state" do
     it "with a valid status" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       expect(EvmApplication.server_state).to eq("started")
     end

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Authenticator::Database do
 
       context "with too many failed login attempts" do
         before do
-          EvmSpecHelper.create_guid_miq_server_zone
+          EvmSpecHelper.local_miq_server
           alice.update(:failed_login_attempts => 4)
           allow(alice).to receive(:unlock_queue)
         end
@@ -79,9 +79,7 @@ RSpec.describe Authenticator::Database do
     context "with bad password" do
       let(:password) { 'incorrect' }
 
-      before do
-        EvmSpecHelper.create_guid_miq_server_zone
-      end
+      before { EvmSpecHelper.local_miq_server }
 
       it "fails" do
         expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "The username or password you entered is incorrect.")
@@ -117,9 +115,7 @@ RSpec.describe Authenticator::Database do
     context "with unknown username" do
       let(:username) { 'bob' }
 
-      before do
-        EvmSpecHelper.create_guid_miq_server_zone
-      end
+      before { EvmSpecHelper.local_miq_server }
 
       it "fails" do
         expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Authenticator::Httpd do
 
     allow(User).to receive(:authenticator).and_return(subject)
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
   end
 
   before do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Authenticator::Ldap do
 
     allow(User).to receive(:authenticator).and_return(subject)
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
   end
 
   before do

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Authenticator do
     let(:groups) { FactoryBot.create_list(:miq_group, 2) }
 
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
     end
 
     it 'Updates the user groups when no matching groups' do

--- a/spec/models/chargeback_configured_system_spec.rb
+++ b/spec/models/chargeback_configured_system_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ChargebackConfiguredSystem do
     ManageIQ::Showback::InputMeasure.seed
     MiqEnterprise.seed
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     cat = FactoryBot.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
     c = FactoryBot.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = c.tag

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ChargebackContainerImage do
     ChargeableField.seed
     MiqEnterprise.seed
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     @node = FactoryBot.create(:container_node, :name => "node")
     @image = FactoryBot.create(:container_image, :ext_management_system => ems)
     @label = FactoryBot.build(:custom_attribute, :name => "version/1.2/_label-1", :value => "test/1.0.0  rc_2", :section => 'docker_labels')

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ChargebackContainerProject do
     MiqEnterprise.seed
     ManageIQ::Showback::InputMeasure.seed
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     @project = FactoryBot.create(:container_project, :name => "my project", :ext_management_system => ems,
                                   :created_on => month_beginning)
 

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ChargebackVm do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     Timecop.travel(report_run_time)
     vm
   end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ChargebackVm do
     ManageIQ::Showback::InputMeasure.seed
     MiqEnterprise.seed
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     cat = FactoryBot.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
     c = FactoryBot.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by(:name => "/managed/environment/prod")

--- a/spec/models/compliance/purging_spec.rb
+++ b/spec/models/compliance/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Compliance do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container/purging_spec.rb
+++ b/spec/models/container/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Container do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container_group/purging_spec.rb
+++ b/spec/models/container_group/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ContainerGroup do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container_image/purging_spec.rb
+++ b/spec/models/container_image/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ContainerImage do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container_node/purging_spec.rb
+++ b/spec/models/container_node/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ContainerNode do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container_project/purging_spec.rb
+++ b/spec/models/container_project/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ContainerProject do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container_quota/purging_spec.rb
+++ b/spec/models/container_quota/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ContainerQuota do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/container_quota_item/purging_spec.rb
+++ b/spec/models/container_quota_item/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ContainerQuotaItem do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DriftState do
     end
 
     it "#purge_timer" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       Timecop.freeze(Time.now) do
         described_class.purge_timer
@@ -44,7 +44,7 @@ RSpec.describe DriftState do
 
     context "#purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
         described_class.purge_queue(:remaining, 1)
       end
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -3,7 +3,7 @@ require "inventory_refresh"
 RSpec.describe EmsRefresh do
   context ".queue_refresh" do
     before do
-      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       @ems = FactoryBot.create(:ems_vmware, :zone => zone)
     end
 
@@ -48,7 +48,7 @@ RSpec.describe EmsRefresh do
 
   context "stopping targets unbounded growth" do
     before do
-      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       @ems = FactoryBot.create(:ems_vmware, :zone => zone)
     end
 
@@ -98,7 +98,7 @@ RSpec.describe EmsRefresh do
 
   context ".queue_refresh_task" do
     before do
-      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       @ems  = FactoryBot.create(:ems_vmware, :zone => zone)
       @ems2 = FactoryBot.create(:ems_vmware, :zone => zone)
     end

--- a/spec/models/event_stream/purging_spec.rb
+++ b/spec/models/event_stream/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe EventStream do
   context "::Purging" do
     context ".purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
       let(:purge_time) { (Time.zone.now + 10).round }
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -816,7 +816,7 @@ RSpec.describe ExtManagementSystem do
   end
 
   describe ".create_from_params" do
-    let(:zone)   { EvmSpecHelper.create_guid_miq_server_zone.last }
+    let(:zone)   { EvmSpecHelper.local_miq_server.zone }
     let(:params) { {"name" => "My Provider", "zone_id" => zone.id.to_s, "type" => "ManageIQ::Providers::Amazon::CloudManager", "provider_region" => "us-east-1"} }
     let(:endpoints) { [{"role" => "default"}] }
 

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -1,12 +1,11 @@
 RSpec.describe FileDepotFtp do
-  before do
-    _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-  end
-
+  let!(:server)        { EvmSpecHelper.local_miq_server }
+  let(:server_name_id) { "#{server.name}_#{server.id}" }
+  let(:zone_name_id)   { "#{server.zone.name}_#{server.zone.id}" }
   let(:connection)     { double("FtpConnection") }
   let(:uri)            { "ftp://server.example.com/uploads" }
   let(:file_depot_ftp) { FileDepotFtp.new(:uri => uri) }
-  let(:log_file)       { LogFile.new(:resource => @miq_server, :local_file => "/tmp/file.txt") }
+  let(:log_file)       { LogFile.new(:resource => server, :local_file => "/tmp/file.txt") }
   let(:ftp_mock) do
     Class.new do
       attr_reader :pwd, :content
@@ -81,28 +80,19 @@ RSpec.describe FileDepotFtp do
   end
 
   context "#upload_file" do
+    let(:region_key) { "Current_region_unknown_#{zone_name_id}_#{server_name_id}.txt".gsub(/\s+/, "_") }
     it 'uploads file to vsftpd with existing directory structure' do
-      vsftpd = vsftpd_mock.new('uploads' =>
-                              {"#{@zone.name}_#{@zone.id}" =>
-                              {"#{@miq_server.name}_#{@miq_server.id}" => {}}})
+      vsftpd = vsftpd_mock.new('uploads' => {zone_name_id => {server_name_id => {}}})
       expect(file_depot_ftp).to receive(:connect).and_return(vsftpd)
       file_depot_ftp.upload_file(log_file)
-      expect(vsftpd.content).to eq('uploads' =>
-                                   {"#{@zone.name}_#{@zone.id}" =>
-                                   {"#{@miq_server.name}_#{@miq_server.id}" =>
-                                   {"Current_region_unknown_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}.txt".gsub(/\s+/, "_") =>
-                                   log_file.local_file}}})
+      expect(vsftpd.content).to eq('uploads' => {zone_name_id => {server_name_id => {region_key =>log_file.local_file}}})
     end
 
     it 'uploads file to vsftpd with empty /uploads directory' do
       vsftpd = vsftpd_mock.new('uploads' => {})
       expect(file_depot_ftp).to receive(:connect).and_return(vsftpd)
       file_depot_ftp.upload_file(log_file)
-      expect(vsftpd.content).to eq('uploads' =>
-                                   {"#{@zone.name}_#{@zone.id}" =>
-                                   {"#{@miq_server.name}_#{@miq_server.id}" =>
-                                   {"Current_region_unknown_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}.txt".gsub(/\s+/, "_") =>
-                                   log_file.local_file}}})
+      expect(vsftpd.content).to eq('uploads' => {zone_name_id => {server_name_id => {region_key => log_file.local_file}}})
     end
 
     it "already exists" do

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FileDepotFtp do
   let(:ftp_mock) do
     Class.new do
       attr_reader :pwd, :content
+
       def initialize(content = {})
         @pwd = '/'
         @content = content
@@ -27,6 +28,7 @@ RSpec.describe FileDepotFtp do
         local = @content
         path.split('/').each do |dir|
           next if dir.empty?
+
           local = local[dir]
           raise Net::FTPPermError, '550 Failed to change directory.' if local.nil?
         end
@@ -41,7 +43,7 @@ RSpec.describe FileDepotFtp do
         l = local(pwd + path)
         l.respond_to?(:keys) ? l.keys : []
       rescue
-        return []
+        []
       end
 
       def mkdir(dir)
@@ -56,7 +58,6 @@ RSpec.describe FileDepotFtp do
       end
     end
   end
-
 
   context "#file_exists?" do
     it "true if file exists" do

--- a/spec/models/firmware_registry_spec.rb
+++ b/spec/models/firmware_registry_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe FirmwareRegistry do
-  before  { EvmSpecHelper.create_guid_miq_server_zone }
+  before  { EvmSpecHelper.local_miq_server }
   subject { FactoryBot.create(:firmware_registry) }
 
   describe '#destroy' do

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe GitRepository do
 
       context "when repo deletion has no errors" do
         before do
-          EvmSpecHelper.create_guid_miq_server_zone
+          EvmSpecHelper.local_miq_server
         end
 
         it "deletes the repo and the directory" do
@@ -315,7 +315,7 @@ RSpec.describe GitRepository do
         end
 
         before do
-          EvmSpecHelper.create_guid_miq_server_zone
+          EvmSpecHelper.local_miq_server
           other_servers
         end
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Host do
   context "power operations" do
     let(:power_state) { "off" }
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       @ems = FactoryBot.create(:ext_management_system, :tenant => FactoryBot.create(:tenant))
       @host = FactoryBot.create(:host, :ems_id => @ems.id, :power_state => power_state)
     end
@@ -641,7 +641,7 @@ RSpec.describe Host do
 
   describe "#scan" do
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       @host = FactoryBot.create(:host_vmware)
       FactoryBot.create(:miq_event_definition, :name => :request_host_scan)
       # admin user is needed to process Events

--- a/spec/models/log_collection_spec.rb
+++ b/spec/models/log_collection_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "LogCollection" do
   before do
-    _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    @miq_server = EvmSpecHelper.local_miq_server
+    @zone = @miq_server.zone
   end
 
   context "active log_collection" do

--- a/spec/models/log_file_spec.rb
+++ b/spec/models/log_file_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe LogFile do
   context "With server and zone" do
     before do
-      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
       @miq_server.create_log_file_depot!(:type => "FileDepotFtpAnonymous", :uri => "test")
       @miq_server.save
     end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
 
     describe "#raw_stdout_via_worker" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
         allow(described_class).to receive(:find).and_return(job)
 
         allow(MiqTask).to receive(:wait_for_taskid) do

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe MeteringContainerImage do
 
     MiqEnterprise.seed
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     @node = FactoryBot.create(:container_node, :name => "node")
     @label = FactoryBot.build(:custom_attribute, :name => "version/1.2/_label-1", :value => "test/1.0.0  rc_2", :section => 'docker_labels')
     @image = FactoryBot.create(:container_image, :ext_management_system => ems, :docker_labels => [@label])

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MeteringContainerProject do
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     MiqEnterprise.seed
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     Timecop.travel(report_run_time)
   end
 

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MeteringVm do
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     MiqEnterprise.seed
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     Timecop.travel(report_run_time)
   end
 

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Metric::CiMixin::Capture do
   require ManageIQ::Providers::Openstack::Engine.root.join("spec/tools/openstack_data/openstack_data_test_helper")
-  let(:zone) { EvmSpecHelper.create_guid_miq_server_zone[2] }
+  let(:zone) { EvmSpecHelper.local_miq_server.zone }
   let(:mock_meter_list) { OpenstackMeterListData.new }
   let(:mock_stats_data) { OpenstackMetricStatsData.new }
   let(:metering) do

--- a/spec/models/metric/config_settings_spec.rb
+++ b/spec/models/metric/config_settings_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Metric::ConfigSettings do
   before do
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
   end
 
   describe ".host_overhead_cpu" do

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Metric::Purging do
 
   context "::Purging" do
     it "#purge_all_timer" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       Timecop.freeze(Time.now) do
         described_class.purge_all_timer
@@ -79,7 +79,7 @@ RSpec.describe Metric::Purging do
   end
 
   context "#purge_realtime" do
-    before { EvmSpecHelper.create_guid_miq_server_zone }
+    before { EvmSpecHelper.local_miq_server }
     let(:vm1) { FactoryBot.create(:vm_vmware) }
 
     it "deletes mid day" do
@@ -110,7 +110,7 @@ RSpec.describe Metric::Purging do
     end
 
     it "deletes just after new years" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       Timecop.freeze('2018-01-01T02:12:00Z') do
         (0..16).each do |hours|
@@ -125,7 +125,7 @@ RSpec.describe Metric::Purging do
     end
 
     it "deletes just after daylight savings (spring forward)" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       Timecop.freeze('2017-03-12T08:12:00Z') do # 2:00am+05 EST is time of change
         # this is overkill. since we prune every 21 minutes, there will only be ~1 table with data
         (0..16).each do |hours|
@@ -140,7 +140,7 @@ RSpec.describe Metric::Purging do
     end
 
     it "deletes just after daylight savings (fallback)" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       Timecop.freeze('2017-11-05T08:12:00Z') do # 2:00am+05 EST is time of change
         # this is overkill. since we prune every 21 minutes, there will only be ~1 table with data
         (0..16).each do |hours|

--- a/spec/models/miq_provision_configured_system_request_spec.rb
+++ b/spec/models/miq_provision_configured_system_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MiqProvisionConfiguredSystemRequest do
   let(:request)           { FactoryBot.create(:miq_provision_configured_system_request, :requester => admin, :options => {:src_configured_system_ids => [configured_system.id]}) }
   let(:vm_amazon)         { FactoryBot.create(:vm_amazon) }
 
-  before { _guid, _server, @zone1 = EvmSpecHelper.create_guid_miq_server_zone }
+  before { @zone1 = EvmSpecHelper.local_miq_server.zone }
 
   it("#my_role should be 'ems_operations'") { expect(request.my_role).to eq('ems_operations') }
   it("#originating_controller should be 'configured_system'") { expect(request.originating_controller).to eq('configured_system') }

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe MiqProvisionRequest do
       end
 
       context "when calling quota methods" do
-        before { EvmSpecHelper.create_guid_miq_server_zone }
+        before { EvmSpecHelper.local_miq_server }
 
         it "should return a hash for quota methods" do
           [:vms_by_group, :vms_by_owner, :retired_vms_by_group, :retired_vms_by_owner, :provisions_by_group, :provisions_by_owner,

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe MiqQueue do
 
   context "worker" do
     before do
-      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
 
       @worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
       @msg = FactoryBot.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :task_id => "task123", :handler => @worker)
@@ -369,7 +369,7 @@ RSpec.describe MiqQueue do
     before do
       MiqRegion.seed
       Zone.seed
-      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     it "should put one message on queue" do
@@ -604,7 +604,7 @@ RSpec.describe MiqQueue do
 
   context "#put_unless_exists" do
     before do
-      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     it "should put a unique message on the queue if method_name is different" do
@@ -696,7 +696,7 @@ RSpec.describe MiqQueue do
 
   context "#put_or_update" do
     before do
-      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     it "should respect hash updates in put_or_update for create" do

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -792,7 +792,7 @@ RSpec.describe MiqQueue do
 
     context "with a single server" do
       it "creates a queue item for the server" do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
         MiqQueue.broadcast(queue_params)
 
         expect(queue_items.count).to eq(1)
@@ -813,7 +813,7 @@ RSpec.describe MiqQueue do
       end
 
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
         other_servers.last.role = other_role.name
       end
 
@@ -850,9 +850,7 @@ RSpec.describe MiqQueue do
   end
 
   describe ".unqueue" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
+    before { EvmSpecHelper.local_miq_server }
 
     # NOTE: default queue_name, state, zone
     it "should unqueue a message" do

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe MiqQueue do
   specify { expect(FactoryBot.build(:miq_queue)).to be_valid }
 
-  context "#deliver" do
-    before do
-      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-    end
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+  let(:zone)       { miq_server.zone }
 
+  context "#deliver" do
+    before { miq_server }
     it "requires class_name" do
       msg = MiqQueue.new(:class_name => nil)
       status, message, result = msg.deliver
@@ -33,12 +33,12 @@ RSpec.describe MiqQueue do
     end
 
     it "uses object with instance_id" do
-      msg = MiqQueue.new(:class_name => "MiqServer", :instance_id => @miq_server.id, :method_name => "my_zone")
+      msg = MiqQueue.new(:class_name => "MiqServer", :instance_id => miq_server.id, :method_name => "my_zone")
 
       status, message, result = msg.deliver
       expect(status).to eq(MiqQueue::STATUS_OK)
       expect(message).to eq("Message delivered successfully")
-      expect(result).to eq(@miq_server.my_zone)
+      expect(result).to eq(miq_server.my_zone)
     end
 
     it "handles record not found" do
@@ -84,9 +84,9 @@ RSpec.describe MiqQueue do
     end
 
     it "doesn't pass target_id if an instance_id is passed" do
-      expect(MiqServer).to receive(:find).with(@miq_server.id).and_return(@miq_server)
-      expect(@miq_server).to receive(:my_zone).and_return("MY ZONE")
-      msg = MiqQueue.new(:class_name => "MiqServer", :instance_id => @miq_server.id, :method_name => "my_zone", :target_id => @miq_server.id)
+      expect(MiqServer).to receive(:find).with(miq_server.id).and_return(miq_server)
+      expect(miq_server).to receive(:my_zone).and_return("MY ZONE")
+      msg = MiqQueue.new(:class_name => "MiqServer", :instance_id => miq_server.id, :method_name => "my_zone", :target_id => miq_server.id)
 
       status, message, result = msg.deliver
       expect(status).to eq(MiqQueue::STATUS_OK)
@@ -109,7 +109,7 @@ RSpec.describe MiqQueue do
     it "works with MiqQueueRetryLater(deliver_on)" do
       deliver_on = Time.now.utc + 1.minute
       allow(Storage).to receive(:scan_eligible_storages).and_raise(MiqException::MiqQueueRetryLater.new(:deliver_on => deliver_on))
-      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'Storage', :method_name => 'scan_eligible_storages')
+      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => miq_server, :class_name => 'Storage', :method_name => 'scan_eligible_storages')
       status, message, result = msg.deliver
 
       expect(status).to eq(MiqQueue::STATUS_RETRY)
@@ -122,7 +122,7 @@ RSpec.describe MiqQueue do
 
       allow(Storage).to receive(:scan_timer).and_raise(MiqException::MiqQueueRetryLater.new)
       msg.state   = MiqQueue::STATE_DEQUEUE
-      msg.handler = @miq_server
+      msg.handler = miq_server
       status, _message, _result = msg.deliver
 
       expect(status).to eq(MiqQueue::STATUS_RETRY)
@@ -133,7 +133,7 @@ RSpec.describe MiqQueue do
     it "sets last_exception on raised Exception" do
       ex = StandardError.new("something blewup")
       allow(MiqServer).to receive(:pidfile).and_raise(ex)
-      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'pidfile')
+      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => miq_server, :class_name => 'MiqServer', :method_name => 'pidfile')
       expect(msg._log).to receive(:error).with(/Error:/)
       expect(msg._log).to receive(:log_backtrace)
       status, message, _result = msg.deliver
@@ -147,7 +147,7 @@ RSpec.describe MiqQueue do
     it "sets the User.current_user" do
       user = FactoryBot.create(:user_with_group, :name => 'Freddy Kreuger')
       msg = FactoryBot.create(:miq_queue, :state       => MiqQueue::STATE_DEQUEUE,
-                                          :handler     => @miq_server,
+                                          :handler     => miq_server,
                                           :class_name  => 'Storage',
                                           :method_name => 'create_scan_task',
                                           :user_id     => user.id,
@@ -296,10 +296,8 @@ RSpec.describe MiqQueue do
 
   context "deliver to queue" do
     before do
-      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-
       @t1 = Time.parse("Wed Apr 20 00:15:00 UTC 2011")
-      @msg = FactoryBot.create(:miq_queue, :zone => @zone.name, :role => "role1", :priority => 20, :created_on => @t1)
+      @msg = FactoryBot.create(:miq_queue, :zone => zone.name, :role => "role1", :priority => 20, :created_on => @t1)
     end
 
     it "should requeue a message with new message id" do
@@ -307,7 +305,7 @@ RSpec.describe MiqQueue do
         :class_name  => 'MiqAeEngine',
         :method_name => 'deliver',
         :args        => ['rq_message', 1, ["A", "B", "C"], 'AUTOMATION', 'gp', 'warn', 'automate message', 'ae_fsm_started', 'ae_state_started', 'ae_state_retries'],
-        :zone        => @zone.name,
+        :zone        => zone.name,
         :role        => 'automate',
         :msg_timeout => 60.minutes,
         :no_such_key => 'Does not exist'
@@ -328,7 +326,7 @@ RSpec.describe MiqQueue do
         :class_name  => 'MiqAeEngine',
         :method_name => 'deliver',
         :args        => ['rq_message', 1, ["A", "B", "C"], 'AUTOMATION', 'gp', 'warn', 'automate message', 'ae_fsm_started', 'ae_state_started', 'ae_state_retries'],
-        :zone        => @zone.name,
+        :zone        => zone.name,
         :role        => 'automate',
         :msg_timeout => 60.minutes
       }
@@ -350,9 +348,7 @@ RSpec.describe MiqQueue do
 
   context "worker" do
     before do
-      @miq_server = EvmSpecHelper.local_miq_server
-
-      @worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
+      @worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server_id => miq_server.id)
       @msg = FactoryBot.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :task_id => "task123", :handler => @worker)
     end
 
@@ -369,7 +365,7 @@ RSpec.describe MiqQueue do
     before do
       MiqRegion.seed
       Zone.seed
-      @miq_server = EvmSpecHelper.local_miq_server
+      miq_server
     end
 
     it "should put one message on queue" do
@@ -603,9 +599,7 @@ RSpec.describe MiqQueue do
   end
 
   context "#put_unless_exists" do
-    before do
-      @miq_server = EvmSpecHelper.local_miq_server
-    end
+    before { miq_server }
 
     it "should put a unique message on the queue if method_name is different" do
       msg1 = MiqQueue.put(
@@ -695,9 +689,7 @@ RSpec.describe MiqQueue do
   end
 
   context "#put_or_update" do
-    before do
-      @miq_server = EvmSpecHelper.local_miq_server
-    end
+    before { miq_server }
 
     it "should respect hash updates in put_or_update for create" do
       MiqQueue.put_or_update(
@@ -733,12 +725,12 @@ RSpec.describe MiqQueue do
 
     it "supports a Class object for the class name(deprecated)" do
       expect(ActiveSupport::Deprecation).to receive(:warn).with(/use a String for class_name/, anything)
-      msg = MiqQueue.put_or_update(:class_name => MiqServer, :instance_id => @miq_server.id, :method_name => "my_zone")
+      msg = MiqQueue.put_or_update(:class_name => MiqServer, :instance_id => miq_server.id, :method_name => "my_zone")
 
       status, message, result = msg.deliver
       expect(status).to eq(MiqQueue::STATUS_OK)
       expect(message).to eq("Message delivered successfully")
-      expect(result).to eq(@miq_server.my_zone)
+      expect(result).to eq(miq_server.my_zone)
     end
 
     it "should use args param to find messages on the queue" do

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MiqRegion do
 
     context "with cloud and infra EMSes" do
       before do
-        _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+        zone = EvmSpecHelper.local_miq_server.zone
         ems_vmware = FactoryBot.create(:ems_vmware, :zone => zone)
         ems_openstack = FactoryBot.create(:ems_openstack, :zone => zone)
         ems_redhat = FactoryBot.create(:ems_redhat, :zone => zone)

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe MiqReportResult do
     end
 
     it "#purge_timer" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       Timecop.freeze(Time.now) do
         described_class.purge_timer
@@ -73,7 +73,7 @@ RSpec.describe MiqReportResult do
 
     context "#purge_queue" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
         described_class.purge_queue(:remaining, 1)
       end
 

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -702,7 +702,7 @@ RSpec.describe MiqReport do
         let(:user_admin) { FactoryBot.create(:user_admin) }
 
         before do
-          EvmSpecHelper.create_guid_miq_server_zone
+          EvmSpecHelper.local_miq_server
           rollup_params = {:capture_interval_name => 'daily', :time_profile_id => time_profile.id }
           add_metric_rollups_for([vm], first_rollup_timestamp...last_rollup_timestamp, 24.hours, rollup_params)
         end
@@ -1077,7 +1077,7 @@ RSpec.describe MiqReport do
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed
       ChargebackRate.seed
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
     end
 
     context "chargeback based on container images" do

--- a/spec/models/miq_request_task/post_install_callback_spec.rb
+++ b/spec/models/miq_request_task/post_install_callback_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MiqRequestTask::PostInstallCallback do
     end
 
     it "with remote ui url" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       MiqServer.first.update(:ipaddress => "192.0.2.1", :has_active_userinterface => true)
       expect(task.post_install_callback_url).to eq("https://192.0.2.1/miq_request/post_install_callback?task_id=#{task.id}")
     end

--- a/spec/models/miq_schedule/filters_spec.rb
+++ b/spec/models/miq_schedule/filters_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe MiqSchedule::Filters do
 
   let(:filter_type) { "Base" }
 
-  before do
-    EvmSpecHelper.create_guid_miq_server_zone
-  end
+  before { EvmSpecHelper.local_miq_server }
 
   subject do
     schedule.build_hash_filter_expression(value, other_value, filter_type)

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe MiqSchedule do
-  before { EvmSpecHelper.create_guid_miq_server_zone }
+  before { EvmSpecHelper.local_miq_server }
 
   context "import/export" do
     let(:user) { FactoryBot.create(:user) }

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MiqScheduleWorker::Jobs do
     end
 
     it "with an EMS" do
-      _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       FactoryBot.create(:ems_vmware, :zone => zone)
       described_class.new.ems_refresh_timer(ManageIQ::Providers::Vmware::InfraManager)
 
@@ -62,9 +62,9 @@ RSpec.describe MiqScheduleWorker::Jobs do
   end
 
   context "with guid, server, zone" do
-    let!(:guid_server_zone) { EvmSpecHelper.create_guid_miq_server_zone }
-    let(:guid) { guid_server_zone.first }
-    let(:zone) { guid_server_zone.last }
+    let!(:server) { EvmSpecHelper.local_miq_server }
+    let(:guid) { server.guid }
+    let(:zone) { server.zone }
 
     context "queues for miq_server process" do
       it "#vmdb_database_connection_log_statistics" do

--- a/spec/models/miq_server/at_startup_spec.rb
+++ b/spec/models/miq_server/at_startup_spec.rb
@@ -1,12 +1,10 @@
 RSpec.describe MiqServer, "::AtStartup" do
   describe ".clean_dequeued_messages" do
-    before do
-      _guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-    end
+    let!(:miq_server) { EvmSpecHelper.local_miq_server }
 
     context "where worker has a message in dequeue" do
       it "should cleanup message on startup" do
-        worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
+        worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server => miq_server)
         msg = FactoryBot.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => worker)
 
         described_class.clean_dequeued_messages
@@ -16,7 +14,7 @@ RSpec.describe MiqServer, "::AtStartup" do
       end
 
       it "deletes shutdown_and_exit messages" do
-        worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
+        worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server => miq_server)
         FactoryBot.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => worker,
                            :method_name => "shutdown_and_exit")
         described_class.clean_dequeued_messages
@@ -26,7 +24,7 @@ RSpec.describe MiqServer, "::AtStartup" do
 
     context "where worker on other server has a message in dequeue" do
       it "should not cleanup message on startup" do
-        other_miq_server = FactoryBot.create(:miq_server, :zone => @zone)
+        other_miq_server = FactoryBot.create(:miq_server, :zone => miq_server.zone)
         other_worker = FactoryBot.create(:miq_ems_refresh_worker, :miq_server_id => other_miq_server.id)
         msg = FactoryBot.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => other_worker)
 

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe MiqServer, "::ConfigurationManagement" do
       end
 
       it "does not overwrite the servers zone_id if the config value is invalid" do
-        _guid, miq_server, zone = EvmSpecHelper.local_guid_miq_server_zone
+        miq_server = EvmSpecHelper.local_miq_server
+        zone = miq_server.zone
 
         miq_server.send(:immediately_reload_settings)
 

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Server Environment Management" do
 
   context "#check_disk_usage" do
     before do
-      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
       allow(@miq_server).to receive_messages(:disk_usage_threshold => 70)
     end
 

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -83,8 +83,9 @@ RSpec.describe MiqServer do
     let(:miq_task) { FactoryBot.create(:miq_task) }
 
     before do
-      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      @miq_server2          = FactoryBot.create(:miq_server, :zone => @zone)
+      @miq_server  = EvmSpecHelper.local_miq_server
+      @zone        = @miq_server.zone
+      @miq_server2 = FactoryBot.create(:miq_server, :zone => @zone)
     end
 
     context "#pg_data_log_patterns" do

--- a/spec/models/miq_server/status_management_spec.rb
+++ b/spec/models/miq_server/status_management_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe MiqServer do
   context "StatusManagement" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     # for now, just making sure there are no syntax errors

--- a/spec/models/miq_server/worker_management/monitor/kill_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kill_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe MiqServer::WorkerManagement::Monitor::Kill do
   context "#kill_all_workers" do
-    let(:server)   { EvmSpecHelper.create_guid_miq_server_zone.second }
+    let(:server)   { EvmSpecHelper.local_miq_server }
     let(:is_local) { true }
     let(:worker)   do
       FactoryBot.create(:miq_generic_worker, :pid => 1234, :status => MiqWorker::STATUS_STARTING, :miq_server => server).tap do |w|

--- a/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe MiqServer do
   context "WorkerManagement::Monitor::SystemLimits" do
     before do
-      _, @server, = EvmSpecHelper.create_guid_miq_server_zone
+      @server = EvmSpecHelper.local_miq_server
       @monitor_settings = YAML.load(<<-EOS
         :kill_algorithm:
           :name: used_swap_percent_gt_value

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe MiqServer::WorkerManagement::Systemd do
   let(:units)           { [] }
-  let(:server)          { EvmSpecHelper.create_guid_miq_server_zone.second }
+  let(:server)          { EvmSpecHelper.local_miq_server }
   let(:systemd_manager) { double("DBus::Systemd::Manager") }
 
   before do

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MiqServer do
 
   context "instance" do
     before do
-      @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @miq_server = EvmSpecHelper.local_miq_server
     end
 
     describe "#monitor_myself" do
@@ -77,14 +77,6 @@ RSpec.describe MiqServer do
         @miq_server.monitor_myself
         expect(Notification.count).to eq(0)
       end
-    end
-
-    it "should have proper guid" do
-      expect(@miq_server.guid).to eq(@guid)
-    end
-
-    it "should have default zone" do
-      expect(@miq_server.zone.name).to eq(@zone.name)
     end
 
     it "cannot assign to maintenance zone" do
@@ -333,8 +325,8 @@ RSpec.describe MiqServer do
 
   describe "#zone_description" do
     it "delegates to zone" do
-      _, miq_server, zone = EvmSpecHelper.create_guid_miq_server_zone
-      expect(miq_server.zone_description).to eq(zone.description)
+      miq_server = EvmSpecHelper.local_miq_server
+      expect(miq_server.zone_description).to eq(miq_server.zone.description)
     end
   end
 

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe MiqUiWorker do
   end
 
   context ".all_ports_in_use" do
+    let(:zone) { server1.zone }
+    let(:server1) { EvmSpecHelper.local_miq_server }
     before do
       require 'util/miq-process'
       allow(MiqProcess).to receive(:is_worker?).and_return(false)
-
-      _guid, server1, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
       @worker1 = FactoryBot.create(:miq_ui_worker, :miq_server => server1, :uri => "http://0.0.0.0:3000", :status => 'started')
       @worker2 = FactoryBot.create(:miq_ui_worker, :miq_server => server1, :uri => "http://0.0.0.0:3001", :status => 'started')
@@ -27,7 +27,7 @@ RSpec.describe MiqUiWorker do
     end
 
     it "current vs. remote servers" do
-      server2 = FactoryBot.create(:miq_server, :zone => @zone)
+      server2 = FactoryBot.create(:miq_server, :zone => zone)
       @worker2.miq_server = server2
       @worker2.save
       expect(MiqUiWorker.all_ports_in_use).to eq([3000])

--- a/spec/models/miq_widget/chart_content_spec.rb
+++ b/spec/models/miq_widget/chart_content_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Widget Chart Content" do
   let(:widget) { MiqWidget.find_by(:description => "chart_vendor_and_guest_os") }
   before do
-    _guid, _server, _zone = EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
 
     MiqReport.seed_report("Vendor and Guest OS")
     MiqWidget.seed_widget("chart_vendor_and_guest_os")

--- a/spec/models/miq_widget/report_content_spec.rb
+++ b/spec/models/miq_widget/report_content_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MiqWidget, "::ReportContent" do
   before do
     MiqReport.seed_report("Vendor and Guest OS")
 
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     @admin       = FactoryBot.create(:user_admin)
     @admin_group = @admin.current_group
     FactoryBot.create_list(:vm_vmware, vm_count)

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe MiqWorker do
     end
 
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       stub_settings(settings)
     end
 
@@ -364,7 +364,7 @@ RSpec.describe MiqWorker do
 
     context "#destroy" do
       context "where it has messages it's handling" do
-        before { EvmSpecHelper.local_guid_miq_server_zone }
+        before { EvmSpecHelper.local_miq_server }
         let(:miq_task) do
           queue_opts = {:class_name => "MiqServer", :method_name => "my_server", :args => []}
           task_opts  = {:name => "Thing1", :userid => "admin"}
@@ -426,8 +426,8 @@ RSpec.describe MiqWorker do
     end
 
     describe "#kill_async" do
-      let!(:remote_server) { EvmSpecHelper.remote_guid_miq_server_zone[1] }
-      let!(:local_server)  { EvmSpecHelper.local_guid_miq_server_zone[1] }
+      let!(:remote_server) { EvmSpecHelper.remote_miq_server }
+      let!(:local_server)  { EvmSpecHelper.local_miq_server }
 
       it "queues local worker to local server" do
         worker = FactoryBot.create(:miq_worker, :miq_server => local_server)

--- a/spec/models/mixins/custom_actions_mixin_spec.rb
+++ b/spec/models/mixins/custom_actions_mixin_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CustomActionsMixin do
     let!(:custom_button_event_2) { FactoryBot.create(:custom_button_event, :target => cloud_tenant) }
 
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
     end
 
     it "returns all custom button events for super admin user" do

--- a/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
@@ -1,10 +1,7 @@
 RSpec.describe PerEmsTypeWorkerMixin do
   let(:worker)       { FactoryBot.create(:miq_ems_metrics_collector_worker) }
   let(:worker_class) { worker.class }
-
-  before do
-    _guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-  end
+  let!(:server)       { EvmSpecHelper.local_miq_server }
 
   describe ".workers" do
     it "is 0 with no providers" do
@@ -12,7 +9,7 @@ RSpec.describe PerEmsTypeWorkerMixin do
     end
 
     context "with a provider" do
-      let!(:provider) { FactoryBot.create(:ems_vmware, :with_authentication, :zone => @zone) }
+      let!(:provider) { FactoryBot.create(:ems_vmware, :with_authentication, :zone => server.zone) }
 
       it "is 0 without the role active" do
         expect(worker_class.workers).to eq(0)
@@ -21,8 +18,8 @@ RSpec.describe PerEmsTypeWorkerMixin do
       context "with the role active" do
         before do
           ServerRole.seed
-          @server.role = "ems_metrics_collector"
-          @server.assigned_server_roles.update(:active => true)
+          server.role = "ems_metrics_collector"
+          server.assigned_server_roles.update(:active => true)
         end
 
         it "is the number configured" do

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PerEmsWorkerMixin do
   before do
-    _guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryBot.create(:ems_vmware, :with_unvalidated_authentication, :zone => zone)
+    server = EvmSpecHelper.local_miq_server
+    @ems = FactoryBot.create(:ems_vmware, :with_unvalidated_authentication, :zone => server.zone)
     @ems_queue_name = "ems_#{@ems.id}"
 
     # General stubbing for testing any worker (methods called during initialize)

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ProcessTasksMixin do
     end
 
     it "queues a message for the specified task" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       test_class.process_tasks(:task => "test_method", :ids => [5], :userid => "admin")
 
       message = MiqQueue.first
@@ -54,7 +54,7 @@ RSpec.describe ProcessTasksMixin do
     end
 
     it "defaults the userid to system in the queue message" do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       test_class.process_tasks(:task => "test_method", :ids => [5])
 
       message = MiqQueue.first

--- a/spec/models/policy_event/purging_spec.rb
+++ b/spec/models/policy_event/purging_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe PolicyEvent do
   context "::Purging" do
     context ".purge_timer" do
       before do
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
 
       it "with nothing in the queue" do

--- a/spec/models/retirement_manager_spec.rb
+++ b/spec/models/retirement_manager_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe RetirementManager do
   describe "#check" do
     it "with retirement date, runs retirement checks" do
-      _, _, zone = EvmSpecHelper.local_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       ems = FactoryBot.create(:ems_openstack_with_authentication, :zone => zone)
 
       orchestration_stack = FactoryBot.create(:orchestration_stack, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Authenticator::Ldap do
   before do
-    EvmSpecHelper.create_guid_miq_server_zone
+    EvmSpecHelper.local_miq_server
     @auth_config = {
       :authentication => {
         :mode        => "ldap",

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -3,7 +3,7 @@ require 'bcrypt'
 RSpec.describe "User Password" do
   context "With admin user" do
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       @old = 'smartvm'
       @admin = FactoryBot.create(:user, :userid          => 'admin',

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe User do
       @miq_ldap = double('miq_ldap')
       allow(@miq_ldap).to receive_messages(:bind => false)
 
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
     end
 
     it "will fail task if user object not found in ldap" do
@@ -401,7 +401,7 @@ RSpec.describe User do
     let(:user) { FactoryBot.create(:user, :password => "dummy") }
 
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
     end
 
     it "should login with good username/password" do
@@ -711,7 +711,7 @@ RSpec.describe User do
         stub_settings_merge(:authentication => @auth_oidc_config)
 
         FactoryBot.create(:miq_group, user_group_details)
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
       end
 
       it "returns nil with an invalid request for OIDC" do

--- a/spec/models/vm_cloud_reconfigure_request_spec.rb
+++ b/spec/models/vm_cloud_reconfigure_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe VmCloudReconfigureRequest do
   let(:vm_hardware)   { FactoryBot.build(:hardware, :virtual_hw_version => "07") }
   let(:vm_amazon)     { FactoryBot.create(:vm_amazon, :hardware => vm_hardware, :host => host, :ext_management_system => FactoryBot.create(:ext_management_system)) }
 
-  before { _guid, _server, @zone1 = EvmSpecHelper.create_guid_miq_server_zone }
+  before { @zone1 = EvmSpecHelper.local_miq_server.zone }
 
   it("#my_role should be 'ems_operations'") { expect(request.my_role).to eq('ems_operations') }
   it("#vm is present") { expect(request.vm).to eq(vm_amazon) }

--- a/spec/models/vm_migrate_request_spec.rb
+++ b/spec/models/vm_migrate_request_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe VmMigrateRequest do
   let(:request)       { FactoryBot.create(:vm_cloud_reconfigure_request, :requester => admin, :options => {:src_ids => [vm_amazon.id]}) }
   let(:vm_amazon)     { FactoryBot.create(:vm_amazon, :ext_management_system => FactoryBot.create(:ems_amazon)) }
 
-  before { _guid, _server, @zone1 = EvmSpecHelper.create_guid_miq_server_zone }
+  before { @zone1 = EvmSpecHelper.local_miq_server.zone }
 
   it("#my_role should be 'ems_operations'") { expect(request.my_role).to eq('ems_operations') }
   it("#vm is present") { expect(request.vm).to eq(vm_amazon) }

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1367,7 +1367,7 @@ RSpec.describe VmOrTemplate do
     let(:vm_blue2)       { VmOrTemplate.find_by(:name => "vm_blue2") }
 
     let!(:ems) do
-      _, _, zone = EvmSpecHelper.local_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       FactoryBot.create(:ems_vmware, :zone => zone).tap do |ems|
         build_vmware_folder_structure!(ems)
         folder_blue1.add_child(FactoryBot.create(:vm_vmware, :name => "vm_blue1", :ems_id => ems.id))

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe VmReconfigureRequest do
   let(:vm_vmware)     { FactoryBot.create(:vm_vmware, :hardware => vm_hardware, :host => host) }
   let(:zone2)         { FactoryBot.create(:zone, :name => "zone_2") }
 
-  before { _guid, _server, @zone1 = EvmSpecHelper.create_guid_miq_server_zone }
+  before { @zone1 = EvmSpecHelper.local_miq_server.zone }
 
   it("#my_role should be 'ems_operations'") { expect(request.my_role).to eq('ems_operations') }
 

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Vm do
   context "#invoke_tasks_local" do
     before do
       Zone.seed
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
 
       @host = FactoryBot.create(:host)
       @vm = FactoryBot.create(:vm_vmware, :host => @host)
@@ -169,7 +169,7 @@ RSpec.describe Vm do
 
   context "#start" do
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       @host = FactoryBot.create(:host_vmware)
       @vm = FactoryBot.create(:vm_vmware,
                                :host      => @host,
@@ -203,7 +203,7 @@ RSpec.describe Vm do
 
   context "#scan" do
     before do
-      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.local_miq_server
       @host = FactoryBot.create(:host_vmware)
       @vm = FactoryBot.create(
         :vm_vmware,

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Zone do
 
   context "when dealing with clouds" do
     before do
-      _, _, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @zone = EvmSpecHelper.local_miq_server.zone
     end
 
     it "returns the set of ems_clouds" do


### PR DESCRIPTION
This is just how we create a local server in spec.
We have a bunch of aliases and helper methods around creating a local miq server.

2 commits:

- if we are not looking at the results, just use the simplest version.
- if we want the miq_server, no reason to extract guid/zone to then have to code around them.

The second commit makes for much better readability.
The first commit is just something that rubs me wrong.
Although, I think @Fryguy may like the word `create` in there.


I'm debuging some issues and saw this and just threw out this `s//g`. Though I did double check each line that I changed.