### PR TITLE
Clear token store in tests

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -34,8 +34,9 @@ module EvmSpecHelper
     yield if block_given?
   ensure
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
+    TokenStore.token_caches.clear if defined?(TokenStore)
 
-    clear_instance_variables(MiqEnvironment::Command)
+    clear_instance_variables(MiqEnvironment::Command) if defined?(MiqEnvironment::Command)
     clear_instance_variable(MiqProductFeature, :@feature_cache) if defined?(MiqProductFeature)
     clear_instance_variable(MiqProductFeature, :@obj_cache) if defined?(MiqProductFeature)
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)


### PR DESCRIPTION
Alternate to https://github.com/ManageIQ/manageiq-api/pull/1171

When we override the session store, the TokenStore sometimes holds references
to older sessions.

This seems to happen when we are using non memory session stores:
```ruby
stub_settings_merge(:server => {:session_store => session_store_value})
```

We were getting sporadic errors in manageiq-api, and suspect this as the culprit.

This change ensures the session store is cleared out.

Attempting to resolve https://github.com/ManageIQ/manageiq-api/pull/1129