### PR TITLE
Converting supports_not to use a lambda

### DIFF
--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -3,16 +3,16 @@ module MiqTemplate::Operations
 
   included do
     supports     :clone
-    supports_not :collect_running_processes, :reason => _("Process Collection is not available for Images and VM Templates.")
-    supports_not :pause,                     :reason => _("Pause Operation is not available for Images and VM Templates.")
-    supports_not :provisioning,              :reason => _("Provisioning Operation is not available for Images and VM Templates.")
-    supports_not :reboot_guest,              :reason => _("Reboot Guest Operation is not available for Images and VM Templates.")
-    supports_not :reset,                     :reason => _("Reset Operation is not available for Images and VM Templates.")
-    supports_not :retire,                    :reason => _("Retire Operation is not available for Images and VM Templates.")
-    supports_not :shutdown_guest,            :reason => _("Shutdown Guest Operation is not available for Images and VM Templates.")
-    supports_not :standby_guest,             :reason => _("Standby Guest Operation is not available for Images and VM Templates.")
-    supports_not :start,                     :reason => _("Start Operation is not available for Images and VM Templates.")
-    supports_not :stop,                      :reason => _("Stop Operation is not available for Images and VM Templates.")
-    supports_not :suspend,                   :reason => _("Suspend Operation is not available for Images and VM Templates.")
+    supports_not :collect_running_processes, :reason => N_("Process Collection is not available for Images and VM Templates.")
+    supports_not :pause,                     :reason => N_("Pause Operation is not available for Images and VM Templates.")
+    supports_not :provisioning,              :reason => N_("Provisioning Operation is not available for Images and VM Templates.")
+    supports_not :reboot_guest,              :reason => N_("Reboot Guest Operation is not available for Images and VM Templates.")
+    supports_not :reset,                     :reason => N_("Reset Operation is not available for Images and VM Templates.")
+    supports_not :retire,                    :reason => N_("Retire Operation is not available for Images and VM Templates.")
+    supports_not :shutdown_guest,            :reason => N_("Shutdown Guest Operation is not available for Images and VM Templates.")
+    supports_not :standby_guest,             :reason => N_("Standby Guest Operation is not available for Images and VM Templates.")
+    supports_not :start,                     :reason => N_("Start Operation is not available for Images and VM Templates.")
+    supports_not :stop,                      :reason => N_("Stop Operation is not available for Images and VM Templates.")
+    supports_not :suspend,                   :reason => N_("Suspend Operation is not available for Images and VM Templates.")
   end
 end


### PR DESCRIPTION
Wanted to have a conversation about these  reasons.

A bunch of supports do not have localization, while others use `N_()`. This is the only location that uses `_()`

I had thought that one form used a lambda, and the other form used numbers to determine the plurality. Couldn't find the definitions on these to nail it down.

Should we just drop the reasons for these?
Should we convert these to `N_()`?
Convert the other `N_()` to use `_()`