### PR TITLE
modify model-delete-queue functions for `host-initiator, physical-storage, volume-mapping` that it will pass the `userId` and not the `User` object

### DIFF
--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -69,10 +69,10 @@ class HostInitiator < ApplicationRecord
 
   # Delete a storage system as a queued task and return the task id. The queue
   # name and the queue zone are derived from the EMS, and a userid is mandatory.
-  def delete_host_initiator_queue(userid)
+  def delete_host_initiator_queue(user)
     task_opts = {
-      :action => "deleting host initiator for user #{userid}",
-      :userid => userid
+      :action => "deleting host initiator for user #{user.userid}",
+      :userid => user.userid
     }
     queue_opts = {
       :class_name  => self.class.name,

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -52,10 +52,10 @@ class PhysicalStorage < ApplicationRecord
 
   # Delete a storage system as a queued task and return the task id. The queue
   # name and the queue zone are derived from the EMS, and a userid is mandatory.
-  def delete_physical_storage_queue(userid)
+  def delete_physical_storage_queue(user)
     task_opts = {
-      :action => "deleting PhysicalStorage for user #{userid}",
-      :userid => userid
+      :action => "deleting PhysicalStorage for user #{user.userid}",
+      :userid => user.userid
     }
     queue_opts = {
       :class_name  => self.class.name,

--- a/app/models/volume_mapping.rb
+++ b/app/models/volume_mapping.rb
@@ -36,10 +36,10 @@ class VolumeMapping < ApplicationRecord
 
   # Delete a volume mapping as a queued task and return the task id. The queue
   # name and the queue zone are derived from the EMS, and a userid is mandatory.
-  def delete_volume_mapping_queue(userid)
+  def delete_volume_mapping_queue(user)
     task_opts = {
-      :action => "deleting VolumeMapping for user #{userid}",
-      :userid => userid
+      :action => "deleting VolumeMapping for user #{user.userid}",
+      :userid => user.userid
     }
     queue_opts = {
       :class_name  => self.class.name,


### PR DESCRIPTION
When I delete `host-initiator`, `physical-storage` or `volume-mapping` and I open Tasks the **User** attribute get wrong value of the `User` object instead of the `userId`.
![Error message the server returns a](https://user-images.githubusercontent.com/6840118/177151189-d9e8c060-440f-46a8-bc01-590fe3c12a56.png)
![image](https://user-images.githubusercontent.com/6840118/177151518-0a9e9a6a-1acb-4fb0-b056-6d6f9a45f5f7.png)
