### PR TITLE
Including AsyncDeleteMixin

### DIFF
--- a/app/models/cloud_database.rb
+++ b/app/models/cloud_database.rb
@@ -1,4 +1,5 @@
 class CloudDatabase < ApplicationRecord
+  include AsyncDeleteMixin
   include NewWithTypeStiMixin
   include ProviderObjectMixin
   include SupportsFeatureMixin


### PR DESCRIPTION
The `AsyncDeleteMixin` is needed so that https://github.com/ManageIQ/manageiq-ui-classic/pull/8339 can use it when the user does `Delete a Cloud Database`. Specifically because calling on the `super` [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/8339/files#diff-8692b5e0014feb2866dbbd823dca4d01172136870fe3902f40957de3b321e623R25-R26) we will eventually hit [this line](https://github.com/ManageIQ/manageiq-ui-classic/blob/a5307ec06dc1a80d5f4e0fb1766e900cbf9f274c/app/controllers/mixins/ems_common/core.rb#L13) which uses `destroy_queue` that `AsyncDeleteMixin` gives us. 