### PR TITLE
Add cloud database server model

### DIFF
--- a/app/models/cloud_database.rb
+++ b/app/models/cloud_database.rb
@@ -8,6 +8,7 @@ class CloudDatabase < ApplicationRecord
   belongs_to :cloud_tenant
   belongs_to :cloud_database_flavor
   belongs_to :resource_group
+  belongs_to :cloud_database_server
 
   serialize :extra_attributes
 

--- a/app/models/cloud_database_server.rb
+++ b/app/models/cloud_database_server.rb
@@ -1,0 +1,6 @@
+class CloudDatabaseServer < ApplicationRecord
+  include NewWithTypeStiMixin
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
+  belongs_to :resource_group
+end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -27,6 +27,7 @@ module ManageIQ::Providers
     has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_services,                :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_databases,               :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_database_servers,        :foreign_key => :ems_id, :dependent => :destroy
     has_many :key_pairs,                     :class_name  => "AuthKeyPair", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
     has_many :resource_groups,               :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -54,6 +54,10 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def cloud_database_servers
+          add_common_default_values
+        end
+
         def orchestration_stacks_resources
           add_properties(
             :model_class                  => ::OrchestrationStackResource,


### PR DESCRIPTION
The Azure provider has servers which are used to host cloud databases. This will help to persist info regarding these servers which will be useful in implementing UI components for cloud databases

Dependent:
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/513
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/653

@miq-bot assign @agrare 
@miq-bot add_labels enhancement, providers/inventory