### PR TITLE
use REGION env to set the db region

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -1,74 +1,6 @@
 require 'awesome_spawn'
 require 'evm_rake_helper'
 
-# TODO: move into DatabaseYml
-# TODO: can we use EvmDatabseOps directly?
-module EvmDba
-  def self.database_configuration_file
-    File.expand_path(File.join(Rails.root, 'config', 'database.yml'))
-  end
-
-  def self.load_config
-    require 'yaml'
-    YAML::load((IO.read(self.database_configuration_file)))
-  end
-
-  def self.local?
-    config = self.load_config[Rails.env]
-    return false unless config['adapter'] == 'postgresql'
-    return %w( 127.0.0.1 localhost ).include?(config['host']) || config['host'].blank?
-  end
-
-  def self.with_options(*option_types, &block)
-    require 'optimist'
-
-    Optimist.options(EvmRakeHelper.extract_command_options) do
-      option_types.each do |type|
-        case type
-        when :db_credentials
-          opt :username,           "Username",                     :type => :string
-          opt :password,           "Password",                     :type => :string
-          opt :hostname,           "Hostname",                     :type => :string
-          opt :port,               "Port",                         :type => :string
-          opt :dbname,             "Database name",                :type => :string
-        when :local_file
-          opt :local_file,         "Destination file",             :type => :string, :required => true
-        when :remote_file
-          opt :skip_directory,     "Don't add backup directory",   :type => :boolean, :default => false
-          opt :remote_file_name,   "Destination depot filename",   :type => :string
-        when :splitable
-          opt :byte_count,         "Size to split files into",     :type => :string
-        when :remote_uri
-          opt :uri,                "Destination depot URI",        :type => :string, :required => true
-          opt :uri_username,       "Destination depot username",   :type => :string
-          opt :uri_password,       "Destination depot password",   :type => :string
-        when :aws
-          opt :aws_region,         "Destination depot AWS region", :type => :string
-        when :exclude_table_data
-          opt :exclude_table_data, "Tables to exclude data",       :type => :strings
-        end
-      end
-      instance_exec(&block) if block_given?
-    end.delete_nils
-  end
-
-  DB_OPT_KEYS = [:dbname, :username, :password, :hostname, :port, :exclude_table_data, :byte_count].freeze
-  def self.collect_db_opts(opts)
-    db_opts = {}
-    DB_OPT_KEYS.each { |k| db_opts[k] = opts[k] if opts[k] }
-    db_opts
-  end
-
-  CONNECT_OPT_KEYS = %i(uri uri_username uri_password aws_region remote_file_name skip_directory).freeze
-  def self.collect_connect_opts(opts)
-    connect_opts = {}
-    CONNECT_OPT_KEYS.each { |k| connect_opts[k] = opts[k] if opts[k] }
-    connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-    connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
-    connect_opts
-  end
-end
-
 namespace :evm do
   namespace :db do
     desc 'Start the local ManageIQ EVM Database (VMDB)'
@@ -132,42 +64,22 @@ namespace :evm do
       exit 1
     end
 
+    # this is used by the appliance console to create a db
     # Example usage:
-    #   RAILS_ENV=production bin/rake evm:db:region -- --region 99
+    #   RAILS_ENV=production REGION=99 bin/rake evm:db:region
+    # Alt usage:
+    #   RAILS_ENV=production REGION=99 VERBOSE=false bin/rake db:reset db:seed
 
     desc 'Set the region of the current ManageIQ EVM Database (VMDB)'
-    task :region do
-      opts = EvmDba.with_options do
-        opt :region, "Region number", :type => :integer, :required => ENV["REGION"].blank?
-      end
+    task :region => "evm:db:reset" do
+      region = ENV["REGION"]
 
-      Dir.chdir(Rails.root)
-      begin
-        #TODO: Raise an error if region is not valid
-        ENV["REGION"] = opts[:region].to_s if opts[:region]
-        region = ENV["REGION"]
-
-        region_file = Rails.root.join("REGION")
-        if File.exist?(region_file)
-          old_region = File.read(region_file)
-          File.delete(region_file)
-        end
-
-        puts "Resetting #{Rails.env} database to region #{region}..."
-        ENV['VERBOSE'] = 'false' # Do not flood the output with migration details
-        Rake::Task['evm:db:reset'].invoke
-
-        puts "Initializing region and database..."
-        # Create the region from our REGION file, initialize a new miq_database row for this region
-        AwesomeSpawn.run!("bin/rails runner", :params => ["MiqDatabase.seed; MiqRegion.seed"])
-      rescue => err
-        message = err.kind_of?(AwesomeSpawn::CommandResultError) ? err.result.error : err.message
-        STDERR.puts "Encountered issue setting up Database using region #{region}: #{message}\n"
-        File.write(region_file, old_region) if old_region
-        raise
-      end
-
-      exit # exit so that parameters to the first rake task are not run as rake tasks
+      puts "Initializing region and database..."
+      AwesomeSpawn.run!("bin/rails runner", :params => ["MiqDatabase.seed; MiqRegion.seed"])
+    rescue => err
+      message = err.kind_of?(AwesomeSpawn::CommandResultError) ? err.result.error : err.message
+      STDERR.puts "Encountered issue setting up Database using region #{region}: #{message}\n"
+      raise
     end
   end
 end


### PR DESCRIPTION
DEPENDS UPON:
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/182
- [x] Release of manageiq-appliance_console with https://github.com/ManageIQ/manageiq-appliance_console/pull/182
- [x] https://github.com/ManageIQ/manageiq-appliance/pull/361

## Goal

Remove custom logic we have for setting up a database.
I'm trying to remove custom logic for basic rails functions in general as this current rails upgrade is giving us a little pushback.

### appliance console

This rake task is called by the appliance console

Using cli parameters in general with rake tasks is a bit tricky and most tasks tend to use environment variables instead. Going towards an environment variable helps us transition to using regular rails tasks, in this case `rake db:migrate`

We added the ability to handle FILE, ENV, or parameter in [d584c2cb11](https://github.com/ManageIQ/manageiq/pull/17257)
Now it is time to remove the command line/file option parameter option

### pods

Pods are doing it the way I want [[ref]](https://github.com/ManageIQ/manageiq-pods/blob/ee806cf910691bba18df4f443d16388f7ccfaeb5/images/manageiq-orchestrator/container-assets/entrypoint#L31)

```
REGION=123 rake db:migrate
```