### PR TITLE
Remove tasks that trigger a different test environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
       timeout-minutes: 30
     - name: Prepare tests
       run: bin/setup
+    - name: Check DB access on initialization
+      run: bundle exec rake test:verify_no_db_access_loading_rails_environment
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -4,7 +4,7 @@ if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :vmdb do
     desc "Setup environment for vmdb specs"
-    task :setup => [:initialize, :verify_no_db_access_loading_rails_environment] do |rake_task|
+    task :setup => :initialize do |rake_task|
       # in case we are called from an engine or plugin, the task might be namespaced under 'app:'
       # i.e. it's 'app:test:vmdb:setup'. Then we have to call the tasks in here under the 'app:' namespace too
       app_prefix = rake_task.name.chomp('test:vmdb:setup')


### PR DESCRIPTION
Remove only the tasks that set different databases or environments.
Rails61 rake tasks are working a little differently and loading the environment earlier than before.

No dependency, but goes in conjunction with https://github.com/ManageIQ/manageiq/pull/21981