### PR TITLE
Fix wwpn_candidate ext_management_system foreign_key

### DIFF
--- a/app/models/wwpn_candidate.rb
+++ b/app/models/wwpn_candidate.rb
@@ -1,4 +1,4 @@
 class WwpnCandidate < ApplicationRecord
-  belongs_to :ext_management_system
+  belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :physical_storage
 end


### PR DESCRIPTION
The WwpnCandidate model had an invalid `belongs_to
:ext_management_system` association definition since the foreign_key is
`:ems_id` not `:ext_management_system_id` which results in the following
error when trying to save using the association:
```
     ActiveModel::UnknownAttributeError:
       unknown attribute 'ext_management_system_id' for WwpnCandidate.
```

Fix for failures seen https://github.com/ManageIQ/manageiq-cross_repo-tests/runs/6626030455?check_suite_focus=true for this PR https://github.com/ManageIQ/manageiq/pull/21656