### PR TITLE
Use yaml_unsafe_load to handle symbols

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.3.1",         :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>6.0.4", ">=6.0.4.8"
+gem "rails",                            "~>6.0.4", ">=6.0.5.1"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false

--- a/config/application.rb
+++ b/config/application.rb
@@ -89,6 +89,9 @@ module Vmdb
     config.action_cable.allow_same_origin_as_host = true
     config.action_cable.mount_path = '/ws/notifications'
 
+    # Use yaml_unsafe_load for column serialization to handle Symbols
+    config.active_record.use_yaml_unsafe_load = true
+
     # Customize any additional options below...
 
     config.autoload_paths += config.eager_load_paths


### PR DESCRIPTION
Prevent `Psych::DisallowedClass: Tried to load unspecified class: Symbol` while seeding due to the default change during the rails 6.0.5.1 release.

https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017#releases-2

NOTE the changelog has `config.active_storage.use_yaml_unsafe_load` but the actual config option is `config.active_record.use_yaml_unsafe_load`


```
$ rails db:seed
** ManageIQ master, codename: Oparin
rails aborted!
Psych::DisallowedClass: Tried to load unspecified class: Symbol
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/coders/yaml_column.rb:50:in `yaml_load'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/coders/yaml_column.rb:26:in `load'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/type/serialized.rb:22:in `deserialize'
/home/grare/adam/.gem/ruby/2.7.0/gems/activemodel-6.0.5.1/lib/active_model/type/helpers/mutable.rb:8:in `cast'
/home/grare/adam/.gem/ruby/2.7.0/gems/activemodel-6.0.5.1/lib/active_model/attribute.rb:174:in `type_cast'
/home/grare/adam/.gem/ruby/2.7.0/gems/activemodel-6.0.5.1/lib/active_model/attribute.rb:42:in `value'
/home/grare/adam/.gem/ruby/2.7.0/gems/activemodel-6.0.5.1/lib/active_model/attribute_set.rb:28:in `transform_values'
/home/grare/adam/.gem/ruby/2.7.0/gems/activemodel-6.0.5.1/lib/active_model/attribute_set.rb:28:in `to_hash'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/attribute_methods.rb:261:in `attributes'
/home/grare/adam/.gem/ruby/2.7.0/gems/default_value_for-3.4.0/lib/default_value_for.rb:160:in `block in set_default_values'
/home/grare/adam/.gem/ruby/2.7.0/gems/default_value_for-3.4.0/lib/default_value_for.rb:155:in `each'
/home/grare/adam/.gem/ruby/2.7.0/gems/default_value_for-3.4.0/lib/default_value_for.rb:155:in `set_default_values'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:428:in `block in make_lambda'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:238:in `block in halting_and_conditional'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:517:in `block in invoke_after'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:517:in `each'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:517:in `invoke_after'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:136:in `run_callbacks'
/home/grare/adam/.gem/ruby/2.7.0/gems/activesupport-6.0.5.1/lib/active_support/callbacks.rb:825:in `_run_initialize_callbacks'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/core.rb:337:in `initialize'
/home/grare/adam/.gem/ruby/2.7.0/gems/default_value_for-3.4.0/lib/default_value_for.rb:143:in `initialize'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/inheritance.rb:70:in `new'
/home/grare/adam/.gem/ruby/2.7.0/gems/activerecord-6.0.5.1/lib/active_record/inheritance.rb:70:in `new'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_user_role.rb:93:in `block in seed_from_array'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_user_role.rb:90:in `each'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_user_role.rb:90:in `seed_from_array'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_user_role.rb:80:in `seed'
```