### PR TITLE
resolved product name translation issue

### DIFF
--- a/locale/zh_TW.yml
+++ b/locale/zh_TW.yml
@@ -1,4 +1,4 @@
-zh_TW:
+zh-TW:
   product:
     name: ManageIQ
     name_full: ManageIQ


### PR DESCRIPTION
Fixes a typo in `manageiq/locale/zh_TW.yml` that was preventing `Vmdb::Appliance.PRODUCT_NAME` from being assigned correctly when the locale is set to traditional Chinese. 

Before:
![image](https://user-images.githubusercontent.com/64800041/178811444-f0cefe75-745e-4264-bc3b-6d0efacb47ff.png)

After:
![image](https://user-images.githubusercontent.com/64800041/178811397-43b96646-d6fb-49a9-ad69-1b486e79d49b.png)

Likely also fixes translation issues in some other locations as well.