### PR TITLE
Default to miq_messaging for event_handler

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -305,6 +305,7 @@ class EmsEvent < EventStream
 
   private_class_method def self.syndicate_event(ems_id, event)
     ems = ExtManagementSystem.find(ems_id)
+    event = event.dup
     event[:ems_uid]  = ems&.uid_ems
     event[:ems_type] = ems&.class&.ems_type
 

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -33,7 +33,7 @@ class MiqQueue < ApplicationRecord
   PRIORITY_DIR    = [:higher, :lower]
 
   def self.messaging_type
-    ENV["MESSAGING_TYPE"] || Settings.prototype.messaging_type
+    ENV.fetch("MESSAGING_TYPE", nil) || Settings.messaging_type
   end
 
   def self.messaging_client(client_ref)

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -79,10 +79,10 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def get_message
-    if dequeue_method_via_drb? && @worker_monitor_drb
-      get_message_via_drb
-    elsif dequeue_method_via_miq_messaging?
+    if dequeue_method_via_miq_messaging?
       get_message_via_miq_messaging
+    elsif dequeue_method_via_drb? && @worker_monitor_drb
+      get_message_via_drb
     else
       get_message_via_sql
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1105,6 +1105,7 @@
           :queue_timeout: 120.minutes
           :dequeue_method: sql
       :event_handler:
+        :dequeue_method: miq_messaging
         :nice_delta: 7
       :generic_worker:
         :count: 2

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -862,6 +862,7 @@
   :level_policy: info
   :level_remote_console: info
   :secret_filter: []
+:messaging_type: kafka
 :notifications:
   :history:
     :purge_window_size: 1000
@@ -912,8 +913,6 @@
   :maindb: ExtManagementSystem
   :run_automate_methods_on_service_api_submit: false
   :allow_api_service_ordering: true
-:prototype:
-  :messaging_type: miq_queue
 :recommendations:
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe EmsEvent do
       end
 
       context "messaging_type: artemis" do
-        before { stub_settings_merge(:prototype => {:messaging_type => 'artemis'}) }
+        before { stub_settings_merge(:messaging_type => 'artemis') }
 
         it "Adds event to Artemis queue" do
           messaging_client = double("ManageIQ::Messaging")
@@ -134,14 +134,14 @@ RSpec.describe EmsEvent do
           }
 
           expect(messaging_client).to receive(:publish_topic).with(expected_queue_payload)
-          expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client)
+          expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client).twice
 
           described_class.add_queue('add', ems.id, event_hash)
         end
       end
 
       context "messaging_type: kafka" do
-        before { stub_settings_merge(:prototype => {:messaging_type => 'kafka'}) }
+        before { stub_settings_merge(:messaging_type => 'kafka') }
 
         it "Adds event to Kafka topic" do
           messaging_client = double("ManageIQ::Messaging")
@@ -154,14 +154,14 @@ RSpec.describe EmsEvent do
           }
 
           expect(messaging_client).to receive(:publish_topic).with(expected_queue_payload)
-          expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client)
+          expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(messaging_client).twice
 
           described_class.add_queue('add', ems.id, event_hash)
         end
       end
 
       context "messaging_type: miq_queue" do
-        before { stub_settings_merge(:prototype => {:messaging_type => 'miq_queue'}) }
+        before { stub_settings_merge(:messaging_type => 'miq_queue') }
 
         it "Adds event to MiqQueue" do
           expected_queue_payload = {

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -130,6 +130,10 @@ RSpec.describe Metric::CiMixin::Capture do
             # No to other warnings should be logged
             expect($log).not_to receive(:warn)
 
+            messaging_client = double("ManageIQ::Messaging")
+            expect(messaging_client).to receive(:publish_topic).at_least(:once)
+            expect(MiqQueue).to receive(:messaging_client).with('metrics_capture').and_return(messaging_client).at_least(:once)
+
             # sending no collection period overlap will cause hole in the data
             capture_data('2013-08-28T11:56:00Z', nil)
           end


### PR DESCRIPTION
- picking up and continuing from https://github.com/ManageIQ/manageiq/pull/21361
- set Kafka as the default messaging_type for events

i.e.
```
nasarkhan@Nasars-MacBook-Pro manageiq % kafka-console-consumer --bootstrap-server localhost:9092 --topic manageiq.ems --from-beginning
{"event_type":"test_action","source":"IBMCloud-VPC","username":"nasar123","ems_id":1,"ems_ref":"abc","timestamp":"1234","vm_uid_ems":"vm","vm_ems_ref":"vm_ref"}
{"ems_ref":"event-ref","ems_id":34000000000941,"event_type":"STUFF_HAPPENED"}
```

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/655

@miq-bot assign @agrare 
@miq-bot add_labels enhancement 
