### PR TITLE
Migrate and seed db from plugin bin/update

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -22,6 +22,11 @@ module ManageIQ
 
       ensure_config_files
 
+      unless ENV["CI"]
+        migrate_database
+        seed_database
+      end
+
       setup_test_environment(:task_prefix => 'app:', :root => plugin_root) unless ENV["SKIP_TEST_RESET"]
     end
 


### PR DESCRIPTION
When running `bin/update` from a plugin (e.g. manageiq-ui-classic) we should migrate and seed the database the same as is done in core.

Running `bin/update` already will `git pull` in `spec/manageiq` to
update the core code, running migrations ensures that no issues arise from having missing migrations while developing in a plugin.