### PR TITLE
Undo complicated rake tasks no longer needed

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -100,28 +100,10 @@ namespace :evm do
     end
 
     desc "Seed the ManageIQ EVM Database (VMDB) with defaults"
-    task :seed do
-      Rake::Task['db:seed'].invoke
-    end
+    task :seed => "db:seed"
 
     desc "Destroys the ManageIQ EVM Database (VMDB) of all tables, views and indices"
-    task :destroy do
-      begin
-        Rake::Task['environment'].invoke
-      rescue => err
-        # Allow "destroying" a database that doesn't exist
-        raise unless err.message =~ /does not exist$/
-      end
-
-      Rake::Task['db:drop'].invoke
-      Rake::Task['db:create'].invoke
-
-      # db:create creates a temporary connection to the default database, but doesn't
-      # remove the connection in the event of a failed create, so we drop the connection
-      # and reestablish it to the environment's database.
-      ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
-    end
+    task :destroy => %w[environment db:drop db:create]
 
     desc "Resets the ManageIQ EVM Database (VMDB) of all tables, views and indices"
     task :reset => [:destroy, 'db:migrate']

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -29,11 +29,14 @@ namespace :test do
     end
   end
 
-  task :setup_db => :initialize do
-    ENV["REGION"] ||= (rand(99) + 1).to_s # Ensure we have a random, non-0, region
-    puts "** Preparing database with REGION #{ENV["REGION"]}"
+  task :setup_db => [:initialize, :setup_region] do
     reset_task = defined?(ENGINE_ROOT) ? 'app:evm:db:reset' : 'evm:db:reset'
     Rake::Task[reset_task].invoke
+  end
+
+  task :setup_region do
+    ENV["REGION"] ||= (rand(99) + 1).to_s # Ensure we have a random, non-0, region
+    puts "** Preparing database with REGION #{ENV["REGION"]}"
   end
 
   task :spec_deps => [:initialize, 'evm:compile_sti_loader']


### PR DESCRIPTION
###  `evm:db:seed`

`Rake::Task['environment'].invoke` 87ed9bc9dd7
It was introduced to avoid error when resetting a non-existing database. Rails has since fixed this

### `evm:db:destroy`

`Rake::['db:drop'].invoke` (and :create) fa37b84c
introduced for SqlServer. No longer using SqlServer (Postgres always worked w/ original)
this is actually rolling back to the original code pre SqlServer

### `set_region`

`:setup_region` -- set this up like we have in [manageiq-schema]
The test setup, initialize, and others just set an environment variable. Do the same here.

[manageiq-schema]: https://github.com/ManageIQ/manageiq-schema/blob/master/lib/tasks_private/spec.rake