### PR TITLE
Configure rugged for ssh automatically

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -23,6 +23,7 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler
+  ManageIQ::Environment.bundle_config
   ManageIQ::Environment.bundle_update
 
   ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]

--- a/bin/update
+++ b/bin/update
@@ -22,6 +22,7 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler
+  ManageIQ::Environment.bundle_config
   ManageIQ::Environment.bundle_update(force: true)
 
   ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["SKIP_UI_UPDATE"]

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -37,17 +37,11 @@ class GitWorktree
     @remote_name = 'origin'
     @base_name   = File.basename(@path)
 
-    # The libssh2 library must already be installed at gem installation time
-    # for the 'ssh' feature to be available.
+    # The libssh2 library must already be installed and the `--with-ssh` build option
+    # passed at gem installation time for the 'ssh' feature to be available.
     #
-    # For Fedora/Centos, the presence of libssh2 seems to be enough to get it
-    # to build properly.
-    #
-    # For OSX:
-    #
-    #     $ brew install libssh2
     #     $ gem uninstall rugged  # if required
-    #     $ export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig"
+    #     $ bundle config set --local build.rugged --with-ssh
     #     $ bin/bundle
     #
     if @ssh_private_key && !Rugged.features.include?(:ssh)

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -18,6 +18,7 @@ module ManageIQ
 
       setup_gemfile_lock if ENV["CI"]
       install_bundler(plugin_root)
+      bundle_config(plugin_root)
       bundle_update(plugin_root, force: force_bundle_update)
 
       ensure_config_files
@@ -78,6 +79,10 @@ module ManageIQ
 
       raise "Missing Gemfile.lock.release" unless APP_ROOT.join("Gemfile.lock.release").file?
       FileUtils.cp(APP_ROOT.join("Gemfile.lock.release"), APP_ROOT.join("Gemfile.lock"))
+    end
+
+    def self.bundle_config(root = APP_ROOT)
+      system!("bundle config set --local build.rugged --with-ssh", :chdir => root)
     end
 
     def self.bundle_update(root = APP_ROOT, force: false)


### PR DESCRIPTION
Add the necessary bundle config build setting for rugged to ensure the ssh feature is enabled to bin/setup and bin/update.

Change to developer_setup to add libssh2 https://github.com/ManageIQ/guides/pull/500