### PR TITLE
display events for physical storage

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -78,6 +78,7 @@ class EmsEvent < EventStream
     process_availability_zone_in_event!(event_hash)
     process_cluster_in_event!(event_hash)
     process_container_entities_in_event!(event_hash)
+    process_physical_storage_in_event!(event_hash)
 
     # Write the event
     new_event = create_event(event_hash)
@@ -134,6 +135,10 @@ class EmsEvent < EventStream
         event[:host_name] ||= host.name
       end
     end
+  end
+
+  def self.process_physical_storage_in_event!(event, options = {})
+    process_object_in_event!(PhysicalStorage, event, options)
   end
 
   def self.process_container_entities_in_event!(event, _options = {})

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -26,6 +26,7 @@ class EventStream < ApplicationRecord
   belongs_to :container_node
 
   belongs_to :physical_server
+  belongs_to :physical_storage
   belongs_to :physical_chassis, :inverse_of => :event_streams
   belongs_to :physical_switch, :inverse_of => :event_streams
 

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6645,6 +6645,10 @@
       :description: Display Individual Physical Storage
       :feature_type: view
       :identifier: physical_storage_show
+    - :name: Timeline
+      :description: Display Timelines for Physical Storage
+      :feature_type: view
+      :identifier: physical_storage_timeline
   - :name: Operate
     :description: Perform Operations on Physical Storages
     :feature_type: control
@@ -6679,7 +6683,6 @@
       :description: Validate a Physical Storage
       :feature_type: admin
       :identifier: physical_storage_validate
-
 # Physical Servers
 - :name: Physical Servers
   :description: Everything under Physical Servers

--- a/spec/factories/physical_storage.rb
+++ b/spec/factories/physical_storage.rb
@@ -1,11 +1,7 @@
 FactoryBot.define do
   factory :physical_storage,
-          :class => "ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage" do
-    name { "test_physical_storage" }
-  end
-
-  factory :physical_storage_autosde,
-          :parent => :physical_storage do
+          :class => "::PhysicalStorage" do
+    sequence(:name) { |n| "physical_storage_#{seq_padded_for_sorting(n)}" }
     sequence(:ems_ref) { |n| "some-uuid-#{seq_padded_for_sorting(n)}" }
   end
 end

--- a/spec/factories/physical_storage.rb
+++ b/spec/factories/physical_storage.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :physical_storage,
+          :class => "ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage" do
+    name { "test_physical_storage" }
+  end
+
+  factory :physical_storage_autosde,
+          :parent => :physical_storage do
+    sequence(:ems_ref) { |n| "some-uuid-#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -521,23 +521,23 @@ RSpec.describe EmsEvent do
   end
 
   context 'Physical Storage Events' do
-    let(:ems)   { FactoryBot.create(:ems_autosde) }
-    let(:physical_storage) { FactoryBot.create(:physical_storage_autosde, :ems_ref => "ems1", :ext_management_system => ems) }
-    before do
-      @event_hash = {
-        :event_type               => "autosde_critical_alert",
+    let(:ems)   { FactoryBot.create(:ems_storage) }
+    let(:physical_storage) { FactoryBot.create(:physical_storage, :name => "my-storage", :ems_ref => "ems1", :ext_management_system => ems) }
+    let(:event_hash) {
+      {
+        :event_type               => "physical_storage_alert",
         :ems_ref                  => "1",
         :physical_storage_ems_ref => physical_storage.ems_ref,
         :ems_id                   => ems.id,
         :message                  => "description"
       }
-    end
+    }
 
     it "test process_physical_storage_in_event!" do
-      EmsEvent.process_physical_storage_in_event!(@event_hash)
-      expect(@event_hash.keys).to include(:physical_storage_id, :physical_storage_name)
-      expect(@event_hash[:physical_storage_id]).not_to be_nil
-      expect(@event_hash[:physical_storage_name]).not_to be_nil
+      event = EmsEvent.add(ems.id, event_hash)
+      expect(event.attributes.keys).to include('physical_storage_id', 'physical_storage_name')
+      expect(event.physical_storage_id).to eq(physical_storage.id)
+      expect(event.physical_storage_name).to eq(physical_storage.name)
     end
   end
 end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -519,4 +519,25 @@ RSpec.describe EmsEvent do
       end
     end
   end
+
+  context 'Physical Storage Events' do
+    let(:ems)   { FactoryBot.create(:ems_autosde) }
+    let(:physical_storage) { FactoryBot.create(:physical_storage_autosde, :ems_ref => "ems1", :ext_management_system => ems) }
+    before do
+      @event_hash = {
+        :event_type               => "autosde_critical_alert",
+        :ems_ref                  => "1",
+        :physical_storage_ems_ref => physical_storage.ems_ref,
+        :ems_id                   => ems.id,
+        :message                  => "description"
+      }
+    end
+
+    it "test process_physical_storage_in_event!" do
+      EmsEvent.process_physical_storage_in_event!(@event_hash)
+      expect(@event_hash.keys).to include(:physical_storage_id, :physical_storage_name)
+      expect(@event_hash[:physical_storage_id]).not_to be_nil
+      expect(@event_hash[:physical_storage_name]).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
* Following this PR: https://github.com/ManageIQ/manageiq-providers-autosde/pull/151
This is an implementation of the monitoring page for physical storage where we'll show our critical alerts (storage events).

Before:
![image](https://user-images.githubusercontent.com/33315712/180793645-fbba6ec8-fdb6-425c-9028-123cf77961df.png)

After:
![image](https://user-images.githubusercontent.com/33315712/180792764-f926449c-d76a-4aca-ae34-da2110fb7f11.png)

# related PRs:
- https://github.com/ManageIQ/manageiq-schema/pull/656
- https://github.com/ManageIQ/manageiq-providers-autosde/pull/154
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8373