### PR TITLE
Add an active scope to CloudDatabaseFlavor

### DIFF
--- a/app/models/cloud_database_flavor.rb
+++ b/app/models/cloud_database_flavor.rb
@@ -9,4 +9,6 @@ class CloudDatabaseFlavor < ApplicationRecord
   virtual_total :total_cloud_databases, :cloud_databases
 
   default_value_for :enabled, true
+
+  scope :active, -> { where(:enabled => true) }
 end


### PR DESCRIPTION
Simplify filtering cloud_database_flavors to only active ones by adding a scope `where(:enabled => true)`