### PR TITLE
Don't memoize a class ivar containing a translation

### DIFF
--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -50,8 +50,8 @@ class ChargebackContainerImage < Chargeback
       @data_index.store_path(:id, :container_projects, container_image.id, container_image.container_projects)
     end
 
-    @unknown_project ||= OpenStruct.new(:id => 0, :name => _('Unknown Project'), :ems_ref => _('Unknown'))
-    @unknown_image ||= OpenStruct.new(:id => 0, :full_name => _('Unknown Image'))
+    @unknown_project = OpenStruct.new(:id => 0, :name => _('Unknown Project'), :ems_ref => _('Unknown'))
+    @unknown_image   = OpenStruct.new(:id => 0, :full_name => _('Unknown Image'))
 
     load_custom_attribute_groupby(options[:groupby_label]) if options[:groupby_label].present?
 


### PR DESCRIPTION
`_()` methods are for static strings and will be evaluated by gettext.  Memoizing an
object containing them will lead to a translation occuring the first time
this code is run and in the current locale at that time.  Any changes to locales, will never cause these strings to be translated again because they're in a memoized object.

There is no performance reason to memoize here, so it's easy to just remove it.