### PR TITLE
Fix RBAC for Folders (descendent of VMs)

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -51,10 +51,12 @@ class Entitlement < ApplicationRecord
   def set_managed_filters(filter)
     set_filters("managed", filter)
   end
+  alias managed_filters= set_managed_filters
 
   def set_belongsto_filters(filter)
     set_filters("belongsto", filter)
   end
+  alias belongsto_filter= set_belongsto_filters
 
   def remove_tag_from_managed_filter(filter_to_remove)
     if get_managed_filters.present?

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1218,6 +1218,29 @@ RSpec.describe Rbac::Filterer do
       expect(results).to match_array(expected_objects)
     end
 
+    describe "#rbac_filtered_objects" do
+      # tree 1
+      let(:ems)     { FactoryBot.create(:ems_vmware) }
+      let(:folder)  { FactoryBot.create(:ems_folder, :ext_management_system => ems) }
+      let(:vm)      { FactoryBot.create(:vm_vmware, :ext_management_system => ems).tap { |vm| folder.add_child(vm) } }
+      # tree 2
+      let(:ems2)    { FactoryBot.create(:ems_vmware) }
+      let(:folder2) { FactoryBot.create(:ems_folder, :ext_management_system => ems2) }
+      let(:vm2)     { FactoryBot.create(:vm_vmware, :ext_management_system => ems2).tap { |vm| folder2.add_child(vm) } }
+
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+        user.current_group.update(:entitlement => Entitlement.create!(:managed_filters => [[@tags[2]]]))
+      end
+
+      it "properly calls RBAC" do
+        vm.tag_with(@tags[2], :ns => '*')
+        vm2
+
+        expect(Rbac.filtered(EmsFolder, :match_via_descendants => "VmOrTemplate", :user => user)).to eq([folder])
+      end
+    end
+
     context "with User and Group" do
       context 'with tags' do
         let!(:tagged_group) { FactoryBot.create(:miq_group, :tenant => default_tenant) }


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/21516

We preload to avoid N+1 in our map
But some of the relations are not associations
(i.e.: parent_blue_folders and resource_pool)

So we are only using preload for those that are associations.

This fixes:
```
DEPRECATION WARNING: Vm.parent_blue_folders does not exist (called from preload at manageiq/lib/miq_preloader.rb:7)
```

And fixes a rails 6.1 blowup