### PR TITLE
Add public_network option to GCE provisioning

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -164,6 +164,15 @@
           :required: true
           :display: :edit
           :data_type: :integer
+        :public_network:
+          :values:
+            false: 0
+            true: 1
+          :description: External IP Address
+          :required: false
+          :display: :edit
+          :data_type: :boolean
+          :default: true
       :display: :show
     :service:
       :description: Catalog


### PR DESCRIPTION
Add the option to expose a public IP address for a newly provisioned GCE instance.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8388

Dependent:
* https://github.com/ManageIQ/manageiq-providers-google/pull/232

https://github.com/ManageIQ/manageiq-providers-google/issues/231