### PR TITLE
Don't allow bundler v2.3.19 due to rubygems.manageiq.org issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler: 2.3.18
         bundler-cache: true
       timeout-minutes: 30
     - name: Prepare tests

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "ancestry",                         "~>4.1.0",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load
-gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false
+gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", "!= 2.3.19", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "connection_pool",                                       :require => false # For Dalli


### PR DESCRIPTION
Bundler version 2.3.19 has issues with gems from :source => "rubygems.manageiq.org" treating them as local gems and then fails to find them.

```
$ grep ')!' Gemfile.lock
  handsoap (= 0.2.5.5)!
  jquery-rjs (= 0.1.1.2)!
  manageiq-gems-pending (> 0)!
  mime-types (~> 3.0)!
  ruport (= 1.7.0.3)!
```

```
   == Resetting tests ==
  ** override_gem("manageiq-ui-classic", :path=>"/home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-ui-classic@5bd08d254fc851a5e3604f735d56fb99362a013c") at /home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-ui-classic@5bd08d254fc851a5e3604f735d56fb99362a013c/spec/manageiq/bundler.d/overrides.rb:1
  /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:271:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'mime-types (~> 3.0)' in locally installed gems. (Bundler::GemNotFound)
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:254:in `map!'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:254:in `verify_gemfile_dependencies_are_found!'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:49:in `start'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/resolver.rb:24:in `resolve'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/definition.rb:480:in `reresolve'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/definition.rb:283:in `resolve'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/definition.rb:488:in `materialize'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/definition.rb:191:in `specs'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/definition.rb:247:in `specs_for'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/runtime.rb:18:in `setup'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler.rb:163:in `setup'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/setup.rb:20:in `block in <top (required)>'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/ui/shell.rb:136:in `with_level'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/ui/shell.rb:88:in `silence'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.19/lib/bundler/setup.rb:20:in `<top (required)>'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
  	from /opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
  	from bin/rails:11:in `<main>'
  
  == Command ["bin/rails app:test:vmdb:setup"] failed in /home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-ui-classic@5bd08d254fc851a5e3604f735d56fb99362a013c ==
```

https://github.com/ManageIQ/manageiq-cross_repo-tests/runs/7560259747?check_suite_focus=true#step:6:2766