### PR TITLE
Use file_fixture_path with fixture_file_upload

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.file_fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures  = false
 


### PR DESCRIPTION
This became deprecated in rails 6.1
Many many warnings ensued.

```
Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
In Rails 7.0, the path needs to be relative to `file_fixture_path`.
```
TODO: if this works, cross_repo manageiq-api, manageiq-ui-classic