### PR TITLE
Use type when defining a deprecated attribute

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -97,7 +97,7 @@ class Host < ApplicationRecord
 
   serialize :settings, Hash
 
-  deprecate_attribute :address,  :hostname
+  deprecate_attribute :address,  :hostname, :type => :string
   alias_attribute     :state,    :power_state
   alias_attribute     :to_s,     :name
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -4,7 +4,7 @@ class MiqSchedule < ApplicationRecord
   include_concern 'Filters'
 
   include YamlImportExportMixin
-  deprecate_attribute :towhat, :resource_type
+  deprecate_attribute :towhat, :resource_type, :type => :string
 
   validates :name, :uniqueness_when_changed => {:scope => [:userid, :resource_type]}
   validates :name, :description, :resource_type, :run_at, :presence => true

--- a/app/models/mixins/deprecation_mixin.rb
+++ b/app/models/mixins/deprecation_mixin.rb
@@ -15,9 +15,9 @@ module DeprecationMixin
       virtual_belongs_to(old_belongs_to)
     end
 
-    def deprecate_attribute(old_attribute, new_attribute)
+    def deprecate_attribute(old_attribute, new_attribute, type:)
       deprecate_attribute_methods(old_attribute, new_attribute)
-      virtual_attribute(old_attribute, -> { type_for_attribute(new_attribute.to_s) })
+      virtual_attribute(old_attribute, type)
       hide_attribute(old_attribute)
     end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -105,7 +105,7 @@ class Service < ApplicationRecord
 
   alias parent_service parent
   alias_attribute :service, :parent
-  deprecate_attribute :display, :visible
+  deprecate_attribute :display, :visible, :type => :boolean
   virtual_belongs_to :service
 
   def power_states


### PR DESCRIPTION
## Problem

Since we do not want to introspect a class at class load time.
we are not able to derive a column type at load time.

### Before

We pass a block for the attribute type to allow us to derive the type at runtime.

### After

Now that we no longer use the delayed introspection, but just define it.
We loose the nice auto introspection aspect.

### Why change?

This feature was used with virtual delegation. Due to race conditions/deadlocks,
we removed it from delegations, so the delayed introspection was only used for deprecation.

~~I would like to use the rails `attributes` api for `virtual_attributes`.~~
~~That does not support delayed type definition.~~
~~Removing this feature makes a transition to more standard rails easier.~~
- We are defining the sql type in all places except here.
- I'd like to get rid of this introspection since it feels similar to the race condition we saw before. (Since this introspection is of the current class, this will not be a problem. But I'd like to avoid it none the less)