### PR TITLE
Only wait for ansible-runner pid in run_async

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -218,9 +218,11 @@ module Ansible
         begin
           fetch_galaxy_roles(playbook_or_role_args)
 
-          result = wait_for(base_dir, "artifacts/result/command") do
-            AwesomeSpawn.run("ansible-runner", :env => env_vars_hash, :params => params)
-          end
+          result = if async?(ansible_runner_method)
+                     wait_for(base_dir, "pid") { AwesomeSpawn.run("ansible-runner", :env => env_vars_hash, :params => params) }
+                   else
+                     AwesomeSpawn.run("ansible-runner", :env => env_vars_hash, :params => params)
+                   end
 
           res = response(base_dir, ansible_runner_method, result, debug)
         ensure


### PR DESCRIPTION
Ansible-runner only creates a `pid` file when running as a daemon in the background.  We should only wait for this file to be created when we are running async otherwise it is enough to wait for the ansible-runner command to return.

Follow-up to https://github.com/ManageIQ/manageiq/pull/22046