### PR TITLE
Automatically determine the python path by asking ansible

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -412,6 +412,7 @@ module Ansible
       PYTHON3_MODULE_PATHS = %w[
         /var/lib/awx/venv/ansible/lib/python3.6/site-packages
         /var/lib/manageiq/venv/lib/python3.6/site-packages
+        /var/lib/manageiq/venv/lib/python3.8/site-packages
       ].freeze
       def python3_modules_path
         @python3_modules_path ||= begin

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -410,13 +410,20 @@ module Ansible
       end
 
       PYTHON3_MODULE_PATHS = %w[
-        /usr/lib64/python3.6/site-packages
         /var/lib/awx/venv/ansible/lib/python3.6/site-packages
         /var/lib/manageiq/venv/lib/python3.6/site-packages
       ].freeze
       def python3_modules_path
         @python3_modules_path ||= begin
-          determine_existing_python_paths_for(*PYTHON3_MODULE_PATHS).join(File::PATH_SEPARATOR)
+          paths = [ansible_python_path.presence, *PYTHON3_MODULE_PATHS].compact
+          determine_existing_python_paths_for(*paths).join(File::PATH_SEPARATOR)
+        end
+      end
+
+      def ansible_python_path
+        @ansible_python_path ||= begin
+          path = `ansible --version 2>/dev/null`.split("\n").grep(/ansible python module location/).first.to_s.split(" = ").last.to_s
+          path.present? ? File.dirname(path) : path
         end
       end
 


### PR DESCRIPTION
Part of #22009

This allows us to avoid hardcoding the module path and sets up the expectation of which one is "right"

@agrare Please review.