### PR TITLE
Fix rails 6.1 errors is now array warnings

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -212,7 +212,7 @@ class ChargebackRateDetail < ApplicationRecord
     if temp.contiguous_tiers?
       self.chargeback_tiers.replace(tiers)
     else
-      temp.errors.each {|a, e| errors.add(a, e)}
+      temp.errors.each {|error| errors.add(error.attribute, error.message)}
     end
   end
 


### PR DESCRIPTION
Fixes this warning:
```
  In Rails 6.1, `errors` is an array of Error objects,
  therefore it should be accessed by a block with a single block
  parameter like this:

  person.errors.each do |error|
    attribute = error.attribute
    message = error.message
  end

  You are passing a block expecting two parameters,
  so the old hash behavior is simulated. As this is deprecated,
  this will result in an ArgumentError in Rails 7.0.
```