### PR TITLE
Remove shim to backwards support AvailabilityMixin

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -78,19 +78,6 @@ module SupportsFeatureMixin
 
   # query the instance if the feature is supported or not
   def supports?(feature)
-    # remnants of AvailabilityMixin
-    # remove this respond_to block once the validates_feature methods are gone
-    method_name = "validate_#{feature}"
-    if respond_to?(method_name)
-      # e.g.: {:available => true,  :message => nil}
-      rslts = send(method_name)
-      if rslts.kind_of?(Hash) && rslts.key?(:available)
-        unsupported.delete(feature)
-        unsupported_reason_add(feature, rslts[:message]) unless rslts[:available]
-        return rslts[:available]
-      end
-    end
-    # /AvailabilityMixin
     public_send("supports_#{feature}?")
   end
 

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -28,14 +28,6 @@ RSpec.describe SupportsFeatureMixin do
       supports :std_accept
       supports_not :std_denial, :reason => "not available"
       supports(:dynamic_feature) { "dynamically unsupported" unless attr1 }
-
-      def validate_accept
-        {:available => true, :message => nil}
-      end
-
-      def validate_denial
-        {:available => false, :message => "deny via validate"}
-      end
     end
   end
 
@@ -96,11 +88,6 @@ RSpec.describe SupportsFeatureMixin do
   end
 
   describe '#supports?' do
-    it "translates availability" do
-      expect(test_inst.supports?(:accept)).to be_truthy
-      expect(test_inst.supports?(:denial)).to be_falsey
-    end
-
     it "handles base supports" do
       expect(test_inst.supports?(:std_accept)).to be_truthy
       expect(test_inst.supports?(:module_accept)).to be_truthy
@@ -199,11 +186,6 @@ RSpec.describe SupportsFeatureMixin do
   end
 
   describe '#unsupported_reason' do
-    it "handles availability" do
-      expect(test_inst.unsupported_reason(:accept)).to be_nil
-      expect(test_inst.unsupported_reason(:denial)).to eq "deny via validate"
-    end
-
     it "handles supports" do
       expect(test_inst.unsupported_reason(:std_accept)).to be_nil
       expect(test_inst.unsupported_reason(:module_accept)).to be_nil


### PR DESCRIPTION
part of ManageIQ/manageiq#21179

We put this shim in place to help us migrate to SupportsFeatureMixin
It is no longer necessary

