### PR TITLE
[OPARIN] Add Gemfile.lock.release for Oparin

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -1,0 +1,1301 @@
+GIT
+  remote: https://github.com/ManageIQ/amazon_ssa_support.git
+  revision: 44dcb0084013466679cf6306ba3579d0aeb400b7
+  branch: oparin
+  specs:
+    amazon_ssa_support (0.1.0)
+      aws-sdk-ec2 (~> 1.0)
+      aws-sdk-s3 (~> 1.0)
+      aws-sdk-sqs (~> 1.0)
+      manageiq-gems-pending (~> 0)
+      manageiq-smartstate (~> 0.2)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-api
+  revision: c887240df229338eb497b3865aec4f469e3c185e
+  branch: oparin
+  specs:
+    manageiq-api (4.4.0.pre.pre)
+      config
+      jbuilder (~> 2.5, != 2.9.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-automation_engine
+  revision: 53d7a1f2a533b53dc29f607fbca7e687013e3993
+  branch: oparin
+  specs:
+    manageiq-automation_engine (0.1.0)
+      rubyzip (~> 2.0.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-consumption
+  revision: 7b1f72d17b75fd079d186fc84d4e296b4986113a
+  branch: oparin
+  specs:
+    manageiq-consumption (0.0.1)
+      hashdiff (~> 1.0)
+      money-rails (~> 1.9)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-content
+  revision: 04c320d60cd910a936b1f335f970ebcb8cf3457c
+  branch: oparin
+  specs:
+    manageiq-content (0.1.0)
+      savon (~> 2.11.1)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-decorators
+  revision: e34605e8fbc9a1476102a33afd0c0eb8797fda9a
+  branch: oparin
+  specs:
+    manageiq-decorators (0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-gems-pending.git
+  revision: 4a0973da178ced18c3651f244330d0e86a5e1f20
+  branch: oparin
+  specs:
+    manageiq-gems-pending (0.1.0)
+      activesupport (~> 6.0)
+      awesome_spawn (~> 1.5)
+      aws-sdk-s3 (~> 1.0)
+      bundler (~> 2.1, >= 2.1.4, != 2.2.10)
+      erubis (= 2.7.0)
+      fog-openstack (~> 0.3)
+      more_core_extensions (~> 4.4)
+      nokogiri (~> 1.13, >= 1.13.6)
+      sys-proctable (~> 1.2.5)
+      sys-uname (~> 1.2.1)
+      winrm (~> 2.1)
+      winrm-elevated (~> 1.0.1)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-amazon
+  revision: 8c2cea3a8a5f2c1068f72c7da68878db2207eb1c
+  branch: oparin
+  specs:
+    manageiq-providers-amazon (0.1.0)
+      aws-sdk-cloudformation (~> 1.0)
+      aws-sdk-cloudwatch (~> 1.0)
+      aws-sdk-core (~> 3.114)
+      aws-sdk-ec2 (~> 1.0)
+      aws-sdk-elasticloadbalancing (~> 1.0)
+      aws-sdk-iam (~> 1.0)
+      aws-sdk-rds (~> 1.0)
+      aws-sdk-s3 (~> 1.0, >= 1.96.1)
+      aws-sdk-servicecatalog (~> 1.0)
+      aws-sdk-sns (~> 1.0)
+      aws-sdk-sqs (~> 1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ansible_tower
+  revision: e6d0d7da320f308e70654cdb97408b84d82d6a27
+  branch: oparin
+  specs:
+    manageiq-providers-ansible_tower (0.1.0)
+      ansible_tower_client (~> 0.20, >= 0.21.2)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-autosde
+  revision: 1939a10c1aa1e58e0a89684c59f16b4c114f363e
+  branch: oparin
+  specs:
+    manageiq-providers-autosde (0.1.0)
+      autosde_openapi_client (~> 1.1.0)
+      typhoeus (~> 1.4)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-awx
+  revision: 52f8a21abe3bfec4155f748379cdadbe36adc588
+  branch: oparin
+  specs:
+    manageiq-providers-awx (0.1.0)
+      ansible_tower_client (~> 0.20, >= 0.21.2)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-azure
+  revision: a0577382a57065b32227f3ec01e7e00f44470c01
+  branch: oparin
+  specs:
+    manageiq-providers-azure (0.1.0)
+      azure-armrest (~> 0.14)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-azure_stack
+  revision: 23ab19f3d68c71b6ff87ac79c89a5b139fc18a80
+  branch: oparin
+  specs:
+    manageiq-providers-azure_stack (0.1.0)
+      azure_mgmt_compute (~> 0.20)
+      azure_mgmt_monitor (~> 0.17)
+      azure_mgmt_network (~> 0.24)
+      azure_mgmt_resources (~> 0.18)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-cisco_intersight
+  revision: e8202323abdcd8c571a1133d03296b1ea0d93dec
+  branch: oparin
+  specs:
+    manageiq-providers-cisco_intersight (0.1.0)
+      intersight_client (~> 0.1, >= 0.1.5)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-foreman
+  revision: afb39ddad4f3fdd751d7ae637a70cd085031fa12
+  branch: oparin
+  specs:
+    manageiq-providers-foreman (0.1.0)
+      foreman_api_client (~> 1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-google
+  revision: 96fc2e568b0042676ba69c2f398e002e273e61a4
+  branch: oparin
+  specs:
+    manageiq-providers-google (0.1.0)
+      fog-google (~> 1.18)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ibm_cic
+  revision: f1cca8557a1e1f83b2d7ffd4660bc88f6cff21bb
+  branch: oparin
+  specs:
+    manageiq-providers-ibm_cic (0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ibm_cloud
+  revision: 7dc65cb6b02ab7d64c37fee398e0df8e58202d49
+  branch: oparin
+  specs:
+    manageiq-providers-ibm_cloud (0.1.0)
+      ibm-cloud-sdk (~> 0.1)
+      ibm_cloud_activity_tracker (~> 0.1, >= 0.1.1)
+      ibm_cloud_databases (~> 0.1)
+      ibm_cloud_global_tagging (~> 0.1)
+      ibm_cloud_iam (~> 1.0)
+      ibm_cloud_power (~> 2.0)
+      ibm_cloud_resource_controller (~> 2.0)
+      ibm_vpc (~> 0.1)
+      prometheus-api-client (~> 0.6)
+      rest-client (~> 2.1)
+      sshkey (~> 1.8.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc
+  revision: a26ab688968be245d7ed3faeb399d0bf1bf68c41
+  branch: oparin
+  specs:
+    manageiq-providers-ibm_power_hmc (0.1.0)
+      ibm_power_hmc (~> 0.12.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ibm_power_vc
+  revision: 99e2398da003440e8fbb55de0e52e60d110ee850
+  branch: oparin
+  specs:
+    manageiq-providers-ibm_power_vc (0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ibm_terraform
+  revision: fba10ab053f7fc9d036309558a8be77aa0ef3942
+  branch: oparin
+  specs:
+    manageiq-providers-ibm_terraform (0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-kubernetes
+  revision: 2a9d027e20fdec961074e1882d63d1ee7964bd2b
+  branch: oparin
+  specs:
+    manageiq-providers-kubernetes (0.1.0)
+      image-inspector-client (~> 2.0)
+      kubeclient (~> 4.6)
+      more_core_extensions (>= 3.6, < 5)
+      prometheus-alert-buffer-client (~> 0.3.0)
+      prometheus-api-client (~> 0.6)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-kubevirt
+  revision: e250ce3b7e4d120e5adc788439fea5baef828e8c
+  branch: oparin
+  specs:
+    manageiq-providers-kubevirt (0.1.0)
+      fog-kubevirt (~> 1.0, >= 1.3.5)
+      manageiq-providers-kubernetes (~> 0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-lenovo
+  revision: 89d30bbf586ff4dfae3e10c9e8d0dbdf3604da3d
+  branch: oparin
+  specs:
+    manageiq-providers-lenovo (0.2.0)
+      xclarity_client (~> 0.6.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-nsxt
+  revision: ec420efb3b7ba5eb31c32a6a2f8a8c1a8c683ce3
+  branch: oparin
+  specs:
+    manageiq-providers-nsxt (0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-nuage
+  revision: 2b9b390cbac8870b084e0d877136cd5d8373c24e
+  branch: oparin
+  specs:
+    manageiq-providers-nuage (0.1.0)
+      excon (~> 0.71)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-openshift
+  revision: 0ee740b707fc82cb545f376e7f8d1e17091dab30
+  branch: oparin
+  specs:
+    manageiq-providers-openshift (0.1.0)
+      manageiq-providers-kubernetes (~> 0.1.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-openstack
+  revision: ddd9709c809d24d696975ee6911f7eba7b0feba0
+  branch: oparin
+  specs:
+    manageiq-providers-openstack (0.1.0)
+      activesupport (~> 6.0)
+      bunny (~> 2.1.0)
+      excon (~> 0.71)
+      fog-openstack (>= 0.3.10)
+      more_core_extensions (>= 3.2, < 5)
+      parallel (~> 1.12)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-oracle_cloud
+  revision: 0a069fdde3744bbf567b26941065f5f714371a4a
+  branch: oparin
+  specs:
+    manageiq-providers-oracle_cloud (0.1.0)
+      oci (~> 2.18)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-ovirt
+  revision: f42150007f44eb9eeb11af65c71020512d84bd3c
+  branch: oparin
+  specs:
+    manageiq-providers-ovirt (0.1.0)
+      ovirt-engine-sdk (~> 4.4.0)
+      ovirt_metrics (~> 3.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization
+  revision: c3ad4e5a78237fcb4ac61bf3a82b28ca0d70fba4
+  branch: oparin
+  specs:
+    manageiq-providers-red_hat_virtualization (0.1.0)
+      ovirt-engine-sdk (~> 4.4.0)
+      ovirt_metrics (~> 3.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-redfish
+  revision: 89693b4b585cd0f5cae56033f0d16f6e3320d3ec
+  branch: oparin
+  specs:
+    manageiq-providers-redfish (0.1.0)
+      redfish_client (~> 0.5.1)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-scvmm
+  revision: 43468c4055aeb5ad45b66e1570f4dc655468c681
+  branch: oparin
+  specs:
+    manageiq-providers-scvmm (0.1.0)
+      addressable (~> 2.4)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-providers-vmware
+  revision: 7d41145ac6df7380ac09c519e3e18d4d5779d852
+  branch: oparin
+  specs:
+    manageiq-providers-vmware (0.1.0)
+      ffi-vix_disk_lib (~> 1.1)
+      fog-vcloud-director (~> 0.3.0)
+      rbvmomi2 (~> 3.3)
+      vmware_web_service (~> 3.0)
+      vsphere-automation-sdk (~> 0.4.7)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-schema
+  revision: c327e967fd3e1db750e91d135ace22ca701000db
+  branch: oparin
+  specs:
+    manageiq-schema (0.1.0)
+      activerecord-id_regions (~> 0.3.2)
+      ancestry
+      linux_admin (~> 2.0)
+      manageiq-password (< 2)
+      more_core_extensions (>= 3.5, < 5)
+      pg
+      rails (>= 6.0.4, < 7.0)
+
+GIT
+  remote: https://github.com/ManageIQ/manageiq-ui-classic
+  revision: 3525a55518b0c132948103ae1378f359a3caf778
+  branch: oparin
+  specs:
+    manageiq-ui-classic (0.1.0)
+      execjs (= 2.8.1)
+      high_voltage (~> 3.0.0)
+      more_core_extensions (>= 3.2, < 5)
+      rails (>= 6.0.4, < 7.0)
+      sass-rails
+      uglifier (~> 4.2.0)
+      webpacker (~> 2.0.0)
+
+GEM
+  remote: https://rubygems.manageiq.org/
+  specs:
+    handsoap (0.2.5.5)
+      nokogiri (>= 1.2.3)
+    jquery-rjs (0.1.1.2)
+      jquery-rails
+      rails (>= 3.2)
+    mime-types (3.0.0)
+      mini_mime (>= 0.1.1)
+    ruport (1.7.0.3)
+      pdf-writer (= 1.1.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (6.1.6.1)
+      actionpack (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (6.1.6.1)
+      actionpack (= 6.1.6.1)
+      activejob (= 6.1.6.1)
+      activerecord (= 6.1.6.1)
+      activestorage (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      mail (>= 2.7.1)
+    actionmailer (6.1.6.1)
+      actionpack (= 6.1.6.1)
+      actionview (= 6.1.6.1)
+      activejob (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (6.1.6.1)
+      actionview (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      rack (~> 2.0, >= 2.0.9)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (6.1.6.1)
+      actionpack (= 6.1.6.1)
+      activerecord (= 6.1.6.1)
+      activestorage (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      nokogiri (>= 1.8.5)
+    actionview (6.1.6.1)
+      activesupport (= 6.1.6.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (6.1.6.1)
+      activesupport (= 6.1.6.1)
+      globalid (>= 0.3.6)
+    activemodel (6.1.6.1)
+      activesupport (= 6.1.6.1)
+    activerecord (6.1.6.1)
+      activemodel (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+    activerecord-id_regions (0.3.2)
+      activerecord (>= 5.0, < 7.0)
+      activesupport (>= 5.0, < 7.0)
+      pg
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
+    activerecord-virtual_attributes (6.1.1)
+      activerecord (~> 6.1.0)
+    activestorage (6.1.6.1)
+      actionpack (= 6.1.6.1)
+      activejob (= 6.1.6.1)
+      activerecord (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (6.1.6.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    acts_as_tree (2.9.1)
+      activerecord (>= 3.0.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    akami (1.3.1)
+      gyoku (>= 0.4.0)
+      nokogiri
+    american_date (1.2.0)
+    amq-protocol (2.3.2)
+    ancestry (4.1.0)
+      activerecord (>= 5.2.6)
+    ansible_tower_client (0.21.3)
+      activesupport
+      faraday
+      faraday_middleware
+      more_core_extensions (~> 4.0)
+    apipie-bindings (0.0.15)
+      json (>= 1.2.1)
+      oauth
+      rest-client (>= 1.6.5)
+    autosde_openapi_client (1.1.40)
+      typhoeus (~> 1.0, >= 1.0.1)
+    awesome_spawn (1.5.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.619.0)
+    aws-sdk-cloudformation (1.70.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-cloudwatch (1.66.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.132.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-ec2 (1.327.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-elasticloadbalancing (1.40.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-iam (1.69.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-kms (1.58.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-rds (1.153.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.114.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sdk-servicecatalog (1.72.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sns (1.53.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sqs (1.51.1)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.5.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    azure-armrest (0.15.0)
+      activesupport (>= 4.2.2)
+      addressable (~> 2.8)
+      azure-signature (~> 0.3.0)
+      json (~> 2)
+      memoist (~> 0.15)
+      parallel (~> 1.22)
+      rest-client (~> 2.1.0)
+    azure-signature (0.3.0)
+      activesupport (>= 4.2.2)
+      addressable (~> 2)
+    azure_mgmt_compute (0.22.0)
+      ms_rest_azure (~> 0.12.0)
+    azure_mgmt_monitor (0.19.0)
+      ms_rest_azure (~> 0.12.0)
+    azure_mgmt_network (0.26.1)
+      ms_rest_azure (~> 0.12.0)
+    azure_mgmt_resources (0.18.2)
+      ms_rest_azure (~> 0.12.0)
+    bcrypt (3.1.18)
+    bcrypt_pbkdf (1.1.0)
+    binary_struct (2.1.0)
+    bootsnap (1.13.0)
+      msgpack (~> 1.2)
+    builder (3.2.4)
+    bunny (2.1.0)
+      amq-protocol (>= 2.0.0)
+    byebug (11.1.3)
+    color (1.8)
+    concurrent-ruby (1.1.10)
+    config (2.2.3)
+      deep_merge (~> 1.2, >= 1.2.1)
+      dry-validation (~> 1.0, >= 1.0.0)
+    connection_pool (2.2.5)
+    crass (1.0.6)
+    dalli (3.1.6)
+    dbus-systemd (1.1.2)
+      ruby-dbus (~> 0.14)
+    declarative (0.0.20)
+    deep_merge (1.2.2)
+    default_value_for (3.4.0)
+      activerecord (>= 3.2.0, < 7.0)
+    docker-api (1.33.6)
+      excon (>= 0.38.0)
+      json
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dry-configurable (0.15.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.6)
+    dry-container (0.10.1)
+      concurrent-ruby (~> 1.0)
+    dry-core (0.8.1)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.3.0)
+    dry-initializer (3.1.1)
+    dry-logic (1.2.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-schema (1.9.3)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.13, >= 0.13.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.0)
+      dry-types (~> 1.5)
+    dry-types (1.5.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
+    dry-validation (1.8.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.8, >= 1.8.0)
+    elif (0.1.0)
+    erubi (1.11.0)
+    erubis (2.7.0)
+    escape_utils (1.3.0)
+    et-orbi (1.2.7)
+      tzinfo
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
+    excon (0.92.4)
+    execjs (2.8.1)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.7)
+      faraday (>= 0.8.0)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
+    fast_gettext (2.0.3)
+    ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
+    ffi-vix_disk_lib (1.2.0)
+      ffi
+    fog-core (2.1.0)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-google (1.19.0)
+      fog-core (< 2.3)
+      fog-json (~> 1.2)
+      fog-xml (~> 0.1.0)
+      google-apis-compute_v1 (~> 0.14)
+      google-apis-dns_v1 (~> 0.12)
+      google-apis-iamcredentials_v1 (~> 0.6)
+      google-apis-monitoring_v3 (~> 0.12)
+      google-apis-pubsub_v1 (~> 0.7)
+      google-apis-sqladmin_v1beta4 (~> 0.13)
+      google-apis-storage_v1 (~> 0.6)
+      google-cloud-env (~> 1.2)
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-kubevirt (1.3.7)
+      fog-core (~> 2.1)
+      kubeclient (>= 4.9.3, < 5.0.0)
+    fog-openstack (0.3.10)
+      fog-core (>= 1.45, <= 2.1.0)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-vcloud-director (0.3.1)
+      fog-core (>= 1.40)
+      fog-xml
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    foreman_api_client (1.0.1)
+      apipie-bindings (= 0.0.15)
+      rest-client (~> 2.0)
+    formatador (0.3.0)
+    forwardable (1.3.2)
+    fugit (1.5.3)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
+    gettext (3.4.3)
+      erubi
+      locale (>= 2.0.5)
+      prime
+      text (>= 1.3.0)
+    gettext_i18n_rails (1.7.2)
+      fast_gettext (>= 0.9.0)
+    gettext_i18n_rails_js (1.3.1)
+      gettext (>= 3.0.2)
+      gettext_i18n_rails (>= 0.7.1)
+      po_to_json (>= 1.0.0)
+      rails (>= 3.2.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    google-apis-compute_v1 (0.47.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-core (0.7.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.16.2, < 2.a)
+      httpclient (>= 2.8.1, < 3.a)
+      mini_mime (~> 1.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+      rexml
+      webrick
+    google-apis-dns_v1 (0.25.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-iamcredentials_v1 (0.13.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-monitoring_v3 (0.32.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-pubsub_v1 (0.25.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-sqladmin_v1beta4 (0.33.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-apis-storage_v1 (0.18.0)
+      google-apis-core (>= 0.7, < 2.a)
+    google-cloud-env (1.6.0)
+      faraday (>= 0.17.3, < 3.0)
+    googleauth (1.2.0)
+      faraday (>= 0.17.3, < 3.a)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
+    gssapi (1.3.1)
+      ffi (>= 1.0.1)
+    gyoku (1.4.0)
+      builder (>= 2.1.2)
+      rexml (~> 3.0)
+    hamlit (2.11.1)
+      temple (>= 0.8.2)
+      thor
+      tilt
+    hashdiff (1.0.1)
+    high_voltage (3.0.0)
+    highline (1.6.21)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    httpclient (2.8.3)
+    httpi (2.5.0)
+      rack
+      socksify
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    ibm-cloud-sdk (0.1.11)
+      httparty
+      rest-client
+    ibm_cloud_activity_tracker (0.1.1)
+      concurrent-ruby (~> 1.0)
+      http (~> 4.4.1)
+      ibm_cloud_sdk_core (~> 1.1.1)
+      jwt (~> 2.2.1)
+    ibm_cloud_databases (0.1.0)
+      concurrent-ruby (~> 1.0)
+      http (~> 4.4.1)
+      ibm_cloud_sdk_core (~> 1.1.1)
+      jwt (~> 2.2.1)
+    ibm_cloud_global_tagging (0.1.1)
+      ibm_cloud_sdk_core (~> 1.1.3)
+    ibm_cloud_iam (1.0.2)
+      typhoeus (~> 1.0, >= 1.0.1)
+    ibm_cloud_power (2.0.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+    ibm_cloud_resource_controller (2.0.1)
+      ibm_cloud_sdk_core (~> 1.1.1)
+    ibm_cloud_sdk_core (1.1.3)
+      concurrent-ruby (~> 1.0)
+      http (~> 4.4.0)
+      jwt (~> 2.2.1)
+    ibm_power_hmc (0.12.0)
+      rest-client (~> 2.1)
+    ibm_vpc (0.4.0)
+      concurrent-ruby (~> 1.0)
+      http (~> 4.4.1)
+      ibm_cloud_sdk_core (~> 1.1.3)
+      jwt (~> 2.2.1)
+    image-inspector-client (2.0.0)
+      json
+      recursive-open-struct (~> 1.0)
+      rest-client (~> 2.0)
+    inifile (3.0.0)
+    iniparse (1.5.0)
+    intersight_client (0.1.5)
+      typhoeus (~> 1.0, >= 1.0.1)
+    inventory_refresh (1.1.0)
+      activerecord (>= 5.0, < 7.0)
+      more_core_extensions (>= 3.5, < 5)
+      pg (> 0)
+    ipaddress (0.8.3)
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
+    jmespath (1.6.1)
+    jquery-rails (4.5.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    json (2.6.2)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    jsonpath (1.1.2)
+      multi_json
+    jwt (2.2.3)
+    kubeclient (4.9.3)
+      http (>= 3.0, < 5.0)
+      jsonpath (~> 1.0)
+      recursive-open-struct (~> 1.1, >= 1.1.1)
+      rest-client (~> 2.0)
+    linux_admin (2.0.2)
+      awesome_spawn (~> 1.3)
+      inifile
+      more_core_extensions (~> 4.0)
+      net-ssh (~> 4.2.0)
+      nokogiri (>= 1.8.5, < 2, != 1.10.2, != 1.10.1, != 1.10.0)
+      openscap
+    linux_block_device (0.2.1)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    little-plugger (1.1.4)
+    locale (2.1.3)
+    logging (2.3.1)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.14)
+    loofah (2.18.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    manageiq-api-client (0.3.6)
+      activesupport (>= 5.0, < 7.0)
+      faraday (~> 1.0.0)
+      faraday_middleware (~> 1.0)
+      json (~> 2.3)
+      more_core_extensions
+      query_relation
+    manageiq-appliance_console (7.1.0)
+      activerecord (~> 6.1.6, >= 6.1.6.1)
+      activesupport (~> 6.1.6, >= 6.1.6.1)
+      awesome_spawn (~> 1.4)
+      bcrypt (~> 3.1.10)
+      bcrypt_pbkdf (>= 1.0, < 2.0)
+      highline (~> 1.6.21)
+      i18n (>= 0.8)
+      linux_admin (~> 2.0)
+      manageiq-password (< 2)
+      net-scp (~> 1.2.1)
+      optimist (~> 3.0)
+      pg
+      pg-logical_replication
+      rbnacl (>= 3.2, < 5.0)
+    manageiq-loggers (1.0.1)
+      activesupport (>= 5.0)
+      manageiq-password (< 2)
+    manageiq-messaging (1.1.1)
+      activesupport (>= 5.2.4.3, < 7.0)
+      rdkafka (~> 0.8)
+      stomp (~> 1.4.4)
+    manageiq-password (1.1.0)
+    manageiq-postgres_ha_admin (3.1.4)
+      activesupport (>= 5.0, < 7.0)
+      awesome_spawn (~> 1.4)
+      manageiq-password (< 2)
+      pg
+      pg-dsn_parser (~> 0.1)
+    manageiq-smartstate (0.8.1)
+      activesupport
+      awesome_spawn (~> 1.5)
+      azure-armrest (~> 0.9)
+      binary_struct (~> 2.1)
+      iniparse
+      linux_block_device (~> 0.2.1)
+      manageiq-password (< 2)
+      memory_buffer (>= 0.1.0)
+      rufus-lru (~> 1.0.3)
+      sys-uname (~> 1.2.1)
+      uuidtools (~> 2.1)
+      vmware_web_service (~> 3.0)
+    manageiq-ssh-util (0.1.1)
+      activesupport
+      net-sftp (~> 2.1)
+      net-ssh (~> 4.2)
+    marcel (1.0.2)
+    memoist (0.16.2)
+    memory_buffer (0.1.0)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
+    minitest (5.16.3)
+    monetize (1.12.0)
+      money (~> 6.12)
+    money (6.13.8)
+      i18n (>= 0.6.4, <= 2)
+    money-rails (1.15.0)
+      activesupport (>= 3.0)
+      monetize (~> 1.9)
+      money (~> 6.13)
+      railties (>= 3.0)
+    more_core_extensions (4.4.0)
+      activesupport
+      sync
+    ms_rest (0.7.6)
+      concurrent-ruby (~> 1.0)
+      faraday (>= 0.9, < 2.0.0)
+      timeliness (~> 0.3.10)
+    ms_rest_azure (0.12.0)
+      concurrent-ruby (~> 1.0)
+      faraday (>= 0.9, < 2.0.0)
+      faraday-cookie_jar (~> 0.0.6)
+      ms_rest (~> 0.7.6)
+    msgpack (1.5.4)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.2.3)
+    net-ldap (0.16.3)
+    net-ping (1.7.8)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.2.0)
+    netrc (0.11.0)
+    nio4r (2.5.8)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
+    nori (2.6.0)
+    oauth (0.5.10)
+    oci (2.18.0)
+      inifile (~> 3.0, >= 3.0.0)
+      json (>= 1.4.6, < 3.0.0)
+      jwt (~> 2.1)
+    openscap (0.4.9)
+      ffi (>= 1.0.9)
+    optimist (3.0.1)
+    os (1.1.4)
+    ovirt-engine-sdk (4.4.1)
+      json (>= 1, < 3)
+    ovirt_metrics (3.1.0)
+      activerecord (>= 5.0, < 7.0)
+      pg
+    parallel (1.22.1)
+    pdf-writer (1.1.8)
+      color (>= 1.4.0)
+      transaction-simple (~> 1.3)
+    pg (1.4.3)
+    pg-dsn_parser (0.1.0)
+    pg-logical_replication (1.2.0)
+      pg
+    po_to_json (1.0.1)
+      json (>= 1.6.0)
+    prime (0.1.2)
+      forwardable
+      singleton
+    prometheus-alert-buffer-client (0.3.0)
+      faraday (>= 0.9.2, < 2.0.0)
+    prometheus-api-client (0.6.2)
+      faraday (>= 0.9, < 2.0.0)
+    public_suffix (4.0.7)
+    puma (4.3.12)
+      nio4r (~> 2.0)
+    qpid_proton (0.30.0)
+    query_relation (0.1.1)
+      activesupport
+      more_core_extensions
+    raabro (1.4.0)
+    racc (1.6.0)
+    rack (2.2.4)
+    rack-attack (6.5.0)
+      rack (>= 1.0, < 3)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (6.1.6.1)
+      actioncable (= 6.1.6.1)
+      actionmailbox (= 6.1.6.1)
+      actionmailer (= 6.1.6.1)
+      actionpack (= 6.1.6.1)
+      actiontext (= 6.1.6.1)
+      actionview (= 6.1.6.1)
+      activejob (= 6.1.6.1)
+      activemodel (= 6.1.6.1)
+      activerecord (= 6.1.6.1)
+      activestorage (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      bundler (>= 1.15.0)
+      railties (= 6.1.6.1)
+      sprockets-rails (>= 2.0.0)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.3)
+      loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
+    railties (6.1.6.1)
+      actionpack (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+    rake (13.0.6)
+    rb-fsevent (0.11.1)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rbnacl (4.0.2)
+      ffi
+    rbvmomi2 (3.3.0)
+      builder (~> 3.2)
+      json (~> 2.3)
+      nokogiri (~> 1.12, >= 1.12.5)
+      optimist (~> 3.0)
+    rdkafka (0.12.0)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    recursive-open-struct (1.1.3)
+    redfish_client (0.5.4)
+      excon (~> 0.71)
+      server_sent_events (~> 0.1)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    retriable (3.1.2)
+    rexml (3.2.5)
+    ripper_ruby_parser (1.5.1)
+      sexp_processor (~> 4.10)
+    ruby-dbus (0.18.1)
+      rexml
+    ruby-progressbar (1.7.5)
+    rubyntlm (0.6.3)
+    rubyzip (2.0.0)
+    rufus-lru (1.0.7)
+    rufus-scheduler (3.8.2)
+      fugit (~> 1.1, >= 1.1.6)
+    rugged (1.5.0.1)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
+    savon (2.11.2)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.4.0)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
+    sd_notify (0.1.1)
+    secure_headers (3.9.0)
+      useragent
+    server_sent_events (0.1.3)
+    sexp_processor (4.16.1)
+    signet (0.17.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    singleton (0.1.1)
+    snmp (1.2.0)
+    socksify (1.7.1)
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sshkey (1.8.0)
+    stomp (1.4.10)
+    surro-gate (1.0.5)
+      concurrent-ruby
+    sync (0.5.0)
+    sys-filesystem (1.4.3)
+      ffi (~> 1.1)
+    sys-proctable (1.2.6)
+      ffi
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
+    systemd-journal (1.4.2)
+      ffi (~> 1.9)
+    systemu (2.6.5)
+    temple (0.8.2)
+    terminal (2.0.0)
+      escape_utils (~> 1.0)
+    text (1.3.1)
+    thor (1.2.1)
+    tilt (2.0.11)
+    timeliness (0.3.10)
+    trailblazer-option (0.1.2)
+    transaction-simple (1.4.0.2)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    uber (0.1.0)
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
+    useragent (0.16.10)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
+    uuidtools (2.2.0)
+    vmware_web_service (3.1.0)
+      activesupport (>= 5.2.4.3, < 7.0)
+      ffi-vix_disk_lib (~> 1.1)
+      handsoap (~> 0.2.5)
+      httpclient (~> 2.8.0)
+      more_core_extensions (>= 3.2, < 5)
+    vsphere-automation-appliance (0.4.7)
+      vsphere-automation-cis (~> 0.4.6)
+      vsphere-automation-runtime (~> 0.4.6)
+    vsphere-automation-cis (0.4.7)
+      vsphere-automation-runtime (~> 0.4.6)
+    vsphere-automation-content (0.4.7)
+      vsphere-automation-cis (~> 0.4.6)
+      vsphere-automation-runtime (~> 0.4.6)
+    vsphere-automation-runtime (0.4.7)
+    vsphere-automation-sdk (0.4.7)
+      vsphere-automation-appliance (~> 0.4.6)
+      vsphere-automation-cis (~> 0.4.6)
+      vsphere-automation-content (~> 0.4.6)
+      vsphere-automation-runtime (~> 0.4.6)
+      vsphere-automation-vapi (~> 0.4.6)
+      vsphere-automation-vcenter (~> 0.4.6)
+    vsphere-automation-vapi (0.4.7)
+      vsphere-automation-cis (~> 0.4.6)
+      vsphere-automation-runtime (~> 0.4.6)
+    vsphere-automation-vcenter (0.4.7)
+      vsphere-automation-cis (~> 0.4.6)
+      vsphere-automation-runtime (~> 0.4.6)
+    wasabi (3.7.0)
+      addressable
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
+    webpacker (2.0)
+      activesupport (>= 4.2)
+      multi_json (~> 1.2)
+      railties (>= 4.2)
+    webrick (1.7.0)
+    websocket-driver (0.6.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    wim_parser (1.0.1)
+      binary_struct (~> 2.1)
+      nokogiri (~> 1.10)
+    winrm (2.3.6)
+      builder (>= 2.1.2)
+      erubi (~> 1.8)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0, >= 0.6.3)
+    winrm-elevated (1.0.1)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
+    winrm-fs (1.3.5)
+      erubi (~> 1.8)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 2.0)
+      winrm (~> 2.0)
+    xclarity_client (0.6.9)
+      faraday (>= 0.9, < 2.0.0)
+      faraday-cookie_jar (~> 0.0.6)
+      httpclient (~> 2.8.3)
+      json-schema (~> 2.8.0)
+      uuid (~> 2.3.8)
+    zeitwerk (2.6.0)
+
+PLATFORMS
+  powerpc64le-linux
+  ruby
+  x86_64-darwin
+  x86_64-darwin-21
+  x86_64-linux
+
+DEPENDENCIES
+  activerecord-session_store (~> 2.0)
+  activerecord-virtual_attributes (~> 6.1.1)
+  acts_as_tree (~> 2.7)
+  amazon_ssa_support!
+  american_date
+  ancestry (~> 4.1.0)
+  aws-sdk-s3 (~> 1.0)
+  bcrypt (~> 3.1.10)
+  bootsnap (>= 1.8.1)
+  bundler (~> 2.1, >= 2.1.4, != 2.2.10)
+  byebug
+  color (~> 1.8)
+  config (~> 2.2, >= 2.2.3)
+  connection_pool
+  dalli (~> 3.1.0)
+  dbus-systemd (~> 1.1.0)
+  default_value_for (~> 3.3)
+  docker-api (~> 1.33.6)
+  elif (= 0.1.0)
+  et-orbi (>= 1.2.2)
+  fast_gettext (~> 2.0.1)
+  gettext_i18n_rails (~> 1.7.2)
+  gettext_i18n_rails_js (~> 1.3.0)
+  hamlit (~> 2.11.0)
+  handsoap (= 0.2.5.5)!
+  inifile (~> 3.0)
+  inventory_refresh (~> 1.0)
+  jquery-rjs (= 0.1.1.2)!
+  kubeclient (~> 4.0)
+  linux_admin (~> 2.0, >= 2.0.1)
+  listen (~> 3.2)
+  manageiq-api!
+  manageiq-api-client (~> 0.3.6)
+  manageiq-appliance_console (~> 7.1)
+  manageiq-automation_engine!
+  manageiq-consumption!
+  manageiq-content!
+  manageiq-decorators!
+  manageiq-gems-pending (> 0)!
+  manageiq-loggers (~> 1.0)
+  manageiq-messaging (~> 1.0, >= 1.1.0)
+  manageiq-password (~> 1.0)
+  manageiq-postgres_ha_admin (~> 3.1, >= 3.1.4)
+  manageiq-providers-amazon!
+  manageiq-providers-ansible_tower!
+  manageiq-providers-autosde!
+  manageiq-providers-awx!
+  manageiq-providers-azure!
+  manageiq-providers-azure_stack!
+  manageiq-providers-cisco_intersight!
+  manageiq-providers-foreman!
+  manageiq-providers-google!
+  manageiq-providers-ibm_cic!
+  manageiq-providers-ibm_cloud!
+  manageiq-providers-ibm_power_hmc!
+  manageiq-providers-ibm_power_vc!
+  manageiq-providers-ibm_terraform!
+  manageiq-providers-kubernetes!
+  manageiq-providers-kubevirt!
+  manageiq-providers-lenovo!
+  manageiq-providers-nsxt!
+  manageiq-providers-nuage!
+  manageiq-providers-openshift!
+  manageiq-providers-openstack!
+  manageiq-providers-oracle_cloud!
+  manageiq-providers-ovirt!
+  manageiq-providers-red_hat_virtualization!
+  manageiq-providers-redfish!
+  manageiq-providers-scvmm!
+  manageiq-providers-vmware!
+  manageiq-schema!
+  manageiq-smartstate (~> 0.8.1)
+  manageiq-ssh-util (~> 0.1.1)
+  manageiq-ui-classic!
+  memoist (~> 0.16.0)
+  mime-types (~> 3.0)!
+  money (~> 6.13.5)
+  more_core_extensions
+  net-ldap (~> 0.16.1)
+  net-ping (~> 1.7.4)
+  openscap (~> 0.4.8)
+  optimist (~> 3.0)
+  pg (>= 1.4.1)
+  pg-dsn_parser (~> 0.1.0)
+  pg-logical_replication (~> 1.2)
+  puma (~> 4.2)
+  qpid_proton (~> 0.30.0)
+  query_relation (~> 0.1.0)
+  rack (>= 2.2.3.1)
+  rack-attack (~> 6.5.0)
+  rails (~> 6.1.6, >= 6.1.6.1)
+  rails-i18n (~> 6.x)
+  rake (>= 12.3.3)
+  responders (~> 3.0)
+  rest-client (~> 2.1.0)
+  ripper_ruby_parser (~> 1.5.1)
+  ruby-dbus
+  ruby-progressbar (~> 1.7.0)
+  rubyzip (~> 2.0.0)
+  rufus-scheduler
+  rugged (~> 1.5.0)
+  ruport (= 1.7.0.3)!
+  sd_notify (~> 0.1.0)
+  secure_headers (~> 3.9)
+  snmp (~> 1.2.0)
+  sprockets (~> 3.7.2)
+  sshkey (~> 1.8.0)
+  surro-gate (~> 1.0.5)
+  sync (~> 0.5)
+  sys-filesystem (~> 1.4.3)
+  systemd-journal (~> 1.4.2)
+  terminal
+  websocket-driver (~> 0.6.3)
+  wim_parser (~> 1.0)
+
+BUNDLED WITH
+   2.3.20

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -209,9 +209,9 @@ namespace :release do
       if update_gems.any?
         cmd =
           if update_gems == ["*"]
-            "bundle update --conservative --patch #{update_gems.join(" ")}"
-          else
             "bundle update" # Update everything regardless of patch level
+          else
+            "bundle update --conservative --patch #{update_gems.join(" ")}"
           end
 
         Bundler.with_unbundled_env do

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -198,7 +198,13 @@ namespace :release do
     end
 
     begin
-      FileUtils.cp(root.join("Gemfile.lock.release"), root.join("Gemfile.lock"))
+      if root.join("Gemfile.lock.release").exist?
+        FileUtils.cp(root.join("Gemfile.lock.release"), root.join("Gemfile.lock"))
+      else
+        # First time build of Gemfile.lock.release
+        update_gems = ["*"]
+        root.join("Gemfile.lock").delete
+      end
 
       if update_gems.any?
         cmd =


### PR DESCRIPTION
Additionally this PR fixes 2 issues with the `release:generate_lockfile` rake task that will need to be forward ported to master.

- Add support for first-time build of Gemfile.lock.release
- Fix bug where * was misinterpreted