### PR TITLE
`physical_storage` model: added a `has many` relation to `event_stream` with cascade on delete

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -28,6 +28,7 @@ class PhysicalStorage < ApplicationRecord
   has_many :canister_computer_systems, :through => :canisters, :source => :computer_system
   has_many :guest_devices, :through => :hardware
   has_many :wwpn_candidates, :dependent => :destroy
+  has_many :event_streams, :dependent => :nullify
 
   supports :timeline
 


### PR DESCRIPTION
events related to a storage system will be deleted from `EventStream` db when the system is deleted.

manual test:

1. before fix:
1.1 storage system storwize-svc-sim is connected but has no related event:
![image](https://user-images.githubusercontent.com/106743023/186362531-ba1765b9-4d74-4488-bea1-e9b687072a76.png)

![image](https://user-images.githubusercontent.com/106743023/186362997-c6a8242a-879b-4bf2-bf65-1d2b6cd387f0.png)

1.2 a test event is created for that system in AutoSDE backend and appears in `EventStream` db:
![image](https://user-images.githubusercontent.com/106743023/186363239-fe407d38-4b94-4b88-8c3f-42823069e003.png)

1.3 storage test was deleted but event persists in `EventStream` db (though auto-deleted from backend db):
![image](https://user-images.githubusercontent.com/106743023/186364009-b959da00-c45e-4ed2-bcc7-0a5aa1911aff.png)
![image](https://user-images.githubusercontent.com/106743023/186364271-07e88f5d-51c0-4103-b2f4-87579f6046e6.png)

persisting event was manually deleted from `EventStream` db 

2. same routine after fix:
2.1 storage and related event re-added:
![image](https://user-images.githubusercontent.com/106743023/186368918-012e1df3-9af7-4599-ab4b-016338b0f6f4.png)

2.2 storage removed:
![image](https://user-images.githubusercontent.com/106743023/186369246-4ac74936-368c-4394-b63a-78aecb63802c.png)

2.3 event no longer appears in EventStream db:
![image](https://user-images.githubusercontent.com/106743023/186370445-63192330-6c61-42cd-bc7d-d3649f01872b.png)


this was tested also in a scenario in which the storage system is deleted directly through the backend endpoint, and the event was successfully auto-deleted from `EventStream` db as well.

