### PR TITLE
added ems_storage provider link for the monitoring page

### DIFF
--- a/lib/manageiq/reporting/formatter/timeline.rb
+++ b/lib/manageiq/reporting/formatter/timeline.rb
@@ -100,10 +100,12 @@ module ManageIQ
               e_title = rec[:name]
             when "EventStream"
               ems_cloud = false
+              ems_storage = false
               if rec[:ems_id] && ExtManagementSystem.exists?(rec[:ems_id])
                 ems = ExtManagementSystem.find(rec[:ems_id])
                 ems_cloud =  true if ems.kind_of?(EmsCloud)
                 ems_container = true if ems.kind_of?(::ManageIQ::Providers::ContainerManager)
+                ems_storage = true if ems.kind_of?(::ManageIQ::Providers::StorageManager)
               end
               if !ems_cloud
                 e_title = if rec[:vm_name] # Create the title using VM name
@@ -164,6 +166,7 @@ module ManageIQ
 
           flags = {:ems_cloud     => ems_cloud,
                    :ems_container => ems_container,
+                   :ems_storage   => ems_storage,
                    :time_zone     => tz}
           tl_message = TimelineMessage.new(row, rec, flags, mri.db)
           event_data = {}

--- a/lib/manageiq/reporting/formatter/timeline_message.rb
+++ b/lib/manageiq/reporting/formatter/timeline_message.rb
@@ -110,6 +110,8 @@ module ManageIQ
               "<a href=/ems_container/#{provider_id}>#{text}</a>"
             elsif ems_mw
               "<a href=/ems_middleware/#{provider_id}>#{text}</a>"
+            elsif ems_storage
+              "<a href=/ems_storage/#{provider_id}>#{text}</a>"
             else
               "<a href=/ems_infra/#{provider_id}>#{text}</a>"
             end
@@ -147,6 +149,10 @@ module ManageIQ
 
         def ems_mw
           @flags[:ems_mw]
+        end
+
+        def ems_storage
+          @flags[:ems_storage]
         end
       end
     end


### PR DESCRIPTION
I have fixed a minor bug in the monitoring page that we have implemented recently for physical storage providers.
It has redirected to the "ems_infra" page which is incorrect, now it redirects to the right page "ems_storage".

Screenshot:
![image](https://user-images.githubusercontent.com/33315712/186693618-7d25c775-475c-4a5b-9aa1-354eff16f536.png)
