### PR TITLE
AutoSDE events report and widgets

### DIFF
--- a/product/dashboard/widgets/chart_autosde_fixed_events_last_week.yaml
+++ b/product/dashboard/widgets/chart_autosde_fixed_events_last_week.yaml
@@ -1,0 +1,18 @@
+description: chart_autosde_events_last_week
+title: "AutoSDE Events Last Week: Fixed vs Not-Fixed"
+content_type: chart
+options:
+  :timezone_matters: false
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: AutoSDE Events Last Week
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval:
+      :value: "1"
+      :unit: hourly
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/report_autosde_events.yaml
+++ b/product/dashboard/widgets/report_autosde_events.yaml
@@ -1,0 +1,24 @@
+description: report_autosde_events
+title: AutoSDE Events Last Week
+content_type: report
+options:
+  :col_order:
+  - timestamp
+  - event_type
+  - physical_storage_name
+  - source
+  - message
+  :row_count: 10
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: AutoSDE Events Last Week
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval:
+      :value: "1"
+      :unit: hourly
+enabled: true
+read_only: true


### PR DESCRIPTION
** a new PR for a squashed and updated branch of PR [22072](https://github.com/ManageIQ/manageiq/pull/22072) ** 

- added a report and a report-widget to show a table of autosde events last week.
- added a pie graph chart-widget which displays fixed vs not-fixed events last week.

![image](https://user-images.githubusercontent.com/106743023/187384623-6c4d950f-a782-466a-af1b-2d6646eab905.png)


@agrare comment from [22072](https://github.com/ManageIQ/manageiq/pull/22072):
"Not related to this change but I think it'd be a nice enhancement on our side to allow these to be seeded from provider plugins"

this enhancement required the following change, which was merged into master: 
https://github.com/ManageIQ/manageiq-providers-autosde/pull/171