### PR TITLE
Fix deprecated `Module#parent` calls in provider generator and Refresher

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -264,7 +264,7 @@ module ManageIQ
       end
 
       def refresher_type
-        self.class.parent.short_token
+        self.class.module_parent.short_token
       end
 
       def full_refresh?(ems)

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher/runner.rb
@@ -34,7 +34,7 @@ class <%= class_name %>::<%= manager_type %>::EventCatcher::Runner < ManageIQ::P
 
   def event_monitor_handle
     @event_monitor_handle ||= begin
-      self.class.parent::Stream.new(
+      self.class.module_parent::Stream.new(
         @ems,
         :poll_sleep => worker_settings[:poll]
       )


### PR DESCRIPTION
There are a couple of stragglers left still calling `self.class.parent`