### PR TITLE
Make MIQ widgets pluggable

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -32,7 +32,6 @@ class MiqWidget < ApplicationRecord
   include YAMLImportExportMixin
   acts_as_miq_set_member
 
-  WIDGET_DIR =  File.expand_path(File.join(Rails.root, "product/dashboard/widgets"))
   WIDGET_REPORT_SOURCE = "Generated for widget".freeze
 
   before_destroy :destroy_schedule
@@ -458,7 +457,7 @@ class MiqWidget < ApplicationRecord
   end
 
   def self.sync_from_dir
-    Dir.glob(File.join(WIDGET_DIR, "*.yaml")).sort.each { |f| sync_from_file(f) }
+    Vmdb::Plugins.miq_widgets_content.sort.each { |f| sync_from_file(f) }
   end
 
   def self.sync_from_file(filename)
@@ -554,13 +553,6 @@ class MiqWidget < ApplicationRecord
 
   def self.seed
     sync_from_dir
-  end
-
-  def self.seed_widget(pattern)
-    files = Dir.glob(File.join(WIDGET_DIR, "*#{pattern}*"))
-    files.collect do |f|
-      sync_from_file(f)
-    end
   end
 
   def save_with_shortcuts(shortcuts)  # [[<shortcut.id>, <widget_shortcut.description>], ...]

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -80,6 +80,10 @@ module Vmdb
       end
     end
 
+    def miq_widgets_content
+      @miq_widgets_content ||= Dir.glob(Rails.root.join("product/dashboard/widgets", "*")) + flat_map { |engine| content_directories(engine, "dashboard/widgets") }
+    end
+
     def provider_plugins
       @provider_plugins ||= select { |engine| engine.name.start_with?("ManageIQ::Providers::") }
     end

--- a/spec/lib/task_helpers/exports/widgets_spec.rb
+++ b/spec/lib/task_helpers/exports/widgets_spec.rb
@@ -3,11 +3,13 @@ RSpec.describe TaskHelpers::Exports::Widgets do
     Dir.mktmpdir('miq_exp_dir')
   end
 
+  let(:widget_path) { Rails.root.join("product/dashboard/widgets/chart_vendor_and_guest_os.yaml") }
+
   before do
     EvmSpecHelper.local_miq_server
 
     MiqReport.seed_report("Vendor and Guest OS")
-    MiqWidget.seed_widget("chart_vendor_and_guest_os")
+    MiqWidget.sync_from_file(widget_path)
     MiqWidget.sync_from_hash(YAML.safe_load("
     description: Test Widget
     title: Test Widget

--- a/spec/models/miq_widget/chart_content_spec.rb
+++ b/spec/models/miq_widget/chart_content_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe "Widget Chart Content" do
   let(:widget) { MiqWidget.find_by(:description => "chart_vendor_and_guest_os") }
+  let(:widget_path) { Rails.root.join("product/dashboard/widgets/chart_vendor_and_guest_os.yaml") }
+
   before do
     EvmSpecHelper.local_miq_server
 
     MiqReport.seed_report("Vendor and Guest OS")
-    MiqWidget.seed_widget("chart_vendor_and_guest_os")
+    MiqWidget.sync_from_file(widget_path)
 
     @role  = FactoryBot.create(:miq_user_role)
     @group = FactoryBot.create(:miq_group, :miq_user_role => @role)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -684,10 +684,11 @@ RSpec.describe MiqWidget do
 
   context "multiple groups" do
     let(:widget) { MiqWidget.find_by(:description => "chart_vendor_and_guest_os") }
+    let(:widget_path) { Rails.root.join("product/dashboard/widgets/chart_vendor_and_guest_os.yaml") }
 
     before do
       MiqReport.seed_report("Vendor and Guest OS")
-      MiqWidget.seed_widget("chart_vendor_and_guest_os")
+      MiqWidget.sync_from_file(widget_path)
 
       # tests are written for timezone_matters = true
       widget.options[:timezone_matters] = true if widget.options


### PR DESCRIPTION
- allows widgets to be seeded from providers in addition to core
- widgets in provider are seeded from i.e. `<manageiq-provider>/content/dashboard/widgets`

@miq-bot assign @agrare 
@miq-bot add_label enhancement