### PR TITLE
fix no superclass method conditions=

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -99,7 +99,7 @@ class MiqReport < ApplicationRecord
 
   def conditions=(exp)
     exp = MiqExpression.new(exp) if exp && !exp.kind_of?(MiqExpression)
-    super
+    _write_attribute("conditions", exp)
   end
 
   # NOTE: this can by dynamically manipulated


### PR DESCRIPTION
This showed up for someone, and while I can't reproduce, this no longer
relies upon a super. The use of super is a little suspect since it is this
class that should have defined that method.
