### PR TITLE
Update inventory_refresh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "gettext_i18n_rails",               "~>1.7.2"
 gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
-gem "inventory_refresh",                "~>1.0",             :require => false
+gem "inventory_refresh",                "~>2.0",             :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false

--- a/spec/models/manageiq/providers/inventory/persister/finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/finders_spec.rb
@@ -58,22 +58,6 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
     end.to(raise_error(expected_error))
   end
 
-  it "checks that we recognize first argument vs passed kwargs" do
-    # This passes nicely
-    lazy_vm = persister.vms.lazy_find({:name => "name"}, :ref => :by_name)
-    expect(lazy_vm.reference.full_reference).to eq(:name => "name")
-
-    # TODO(lsmola) But this fails, since it takes the whole hash as 1st arg, it should correctly raise invalid format
-    expected_error = "Finder has missing keys for index :manager_ref, missing indexes are: [:ems_ref]"
-    expect do
-      persister.vms.lazy_find(:name => "name", :ref => :by_name)
-    end.to(raise_error(expected_error))
-
-    # TODO(lsmola) And this doesn't fail, but the :key is silently ignored, it should also raise invalid format
-    lazy_vm = persister.vms.lazy_find(:ems_ref => "ems_ref_1", :key => :name)
-    expect(lazy_vm.reference.full_reference).to eq(:ems_ref => "ems_ref_1", :key => :name)
-  end
-
   it "checks passing more keys to index passes just fine" do
     # There is not need to force exact match as long as all keys of the index are passed
     vm_lazy_1 = persister.vms.lazy_find({:name => "name", :uid_ems => "uid_ems", :ems_ref => "ems_ref"}, {:ref => :by_uid_ems_and_name})


### PR DESCRIPTION
Update inventory_refresh to v2.0

I had wanted to remove `InventoryRefresh::InventoryCollection#find` in v2.0 but that is proving to be more complicated as it is used internally as well and I don't want to hold up what has already been done in the master branch for ruby 3.

Cross-repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/707