### PR TITLE
[OPARIN] Drop autosde_openapi_client gem to 1.1.32

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -460,7 +460,7 @@ GEM
       oauth
       rest-client (>= 1.6.5)
     ast (2.4.2)
-    autosde_openapi_client (1.1.34)
+    autosde_openapi_client (1.1.32)
       typhoeus (~> 1.0, >= 1.0.1)
     awesome_spawn (1.5.0)
     aws-eventstream (1.2.0)


### PR DESCRIPTION
Autosde 1.1.33 introduced a breaking change and 1.1.33 and 1.1.34 have been yanked.

Ref: https://github.com/ManageIQ/manageiq-providers-autosde/pull/158#issuecomment-1236278605