### PR TITLE
Move provider cloud network factories out of core

### DIFF
--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -3,28 +3,4 @@ FactoryBot.define do
     sequence(:name)    { |n| "cloud_network_#{seq_padded_for_sorting(n)}" }
     sequence(:ems_ref) { |n| "ems_ref_#{seq_padded_for_sorting(n)}" }
   end
-
-  factory :cloud_network_openstack, :class  => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork",
-                                    :parent => :cloud_network
-  factory :cloud_network_private_openstack,
-          :class  => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private",
-          :parent => :cloud_network_openstack
-  factory :cloud_network_public_openstack,
-          :class  => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public",
-          :parent => :cloud_network_openstack
-  factory :cloud_network_amazon, :class  => "ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork",
-                                 :parent => :cloud_network
-  factory :cloud_network_azure, :class  => "ManageIQ::Providers::Azure::NetworkManager::CloudNetwork",
-                                :parent => :cloud_network
-  factory :cloud_network_google, :class  => "ManageIQ::Providers::Google::NetworkManager::CloudNetwork",
-                                 :parent => :cloud_network
-  factory :cloud_network_vmware_vdc,
-          :class  => "ManageIQ::Providers::Vmware::NetworkManager::CloudNetwork::OrgVdcNet",
-          :parent => :cloud_network
-  factory :cloud_network_vmware_vapp,
-          :class  => "ManageIQ::Providers::Vmware::NetworkManager::CloudNetwork::VappNet",
-          :parent => :cloud_network
-  factory :cloud_network_nsxt,
-          :class  => "ManageIQ::Providers::Nsxt::NetworkManager::CloudNetwork",
-          :parent => :cloud_network
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -287,13 +287,6 @@ FactoryBot.define do
     authtype { "default" }
   end
 
-  factory :ems_amazon_with_cloud_networks,
-          :parent => :ems_amazon do
-    after(:create) do |x|
-      2.times { x.cloud_networks << FactoryBot.create(:cloud_network_amazon) }
-    end
-  end
-
   factory :ems_azure,
           :aliases => ["manageiq/providers/azure/cloud_manager"],
           :class   => "ManageIQ::Providers::Azure::CloudManager",


### PR DESCRIPTION
- part of the effort to move provider-specific code out of the core ManageIQ repository and to their respective plugins

Depends on:
- [x] https://github.com/ManageIQ/manageiq-api/pull/1180
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8436
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/823
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/790
- [ ] https://github.com/ManageIQ/manageiq-providers-google/pull/235
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/819
- [ ] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/76
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/519

Ref:
- https://github.com/ManageIQ/manageiq/issues/19440

@miq-bot add_labels refactoring, test
@miq-bot assign @agrare 