### PR TITLE
Use `unbundled_exec` when starting provider workers

### DIFF
--- a/lib/workers/bin/provider_worker
+++ b/lib/workers/bin/provider_worker
@@ -56,4 +56,4 @@ $stdout.puts "Starting #{worker_type} with PID: #{Process.pid} and args: #{args}
 # Using exec here rather than fork+exec so that we can continue to use the
 # standard systemd service Type=notify and not have to use Type=forking which
 # can limit other systemd options available to the service.
-Kernel.exec(args)
+Bundler.unbundled_exec(args)


### PR DESCRIPTION
When starting a provider worker we have to clean the bundler environment
variables to prevent pure-ruby workers from inheriting the ManageIQ
rails app's bundler environment.