### PR TITLE
manageiq-messaging-ready systemd support

### DIFF
--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MiqWorker::SystemdCommon do
     it "every worker has a matching systemd target and service file", :providers_common => true do
       expected_units = (Vmdb::Plugins.systemd_units + Rails.root.join("systemd").glob("*.*")).map(&:basename).map(&:to_s)
 
-      expected_units -= %w[manageiq-db-ready.service evmserverd.service manageiq.target]
+      expected_units -= %w[manageiq-db-ready.service manageiq-messaging-ready.service evmserverd.service manageiq.target]
 
       found_units = MiqWorkerType.worker_classes.flat_map do |worker_class|
         service_base_name = worker_class.service_base_name

--- a/systemd/evmserverd.service
+++ b/systemd/evmserverd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=EVM server daemon
-After=memcached.service manageiq-db-ready.service
-Wants=memcached.service manageiq-db-ready.service
+After=memcached.service manageiq-db-ready.service manageiq-messaging-ready.service
+Wants=memcached.service manageiq-db-ready.service manageiq-messaging-ready.service
 
 [Service]
 WorkingDirectory=/var/www/miq/vmdb

--- a/systemd/evmserverd.service
+++ b/systemd/evmserverd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=EVM server daemon
-After=memcached.service manageiq-db-ready.service manageiq-messaging-ready.service
-Wants=memcached.service manageiq-db-ready.service manageiq-messaging-ready.service
+After=memcached.service manageiq-db-ready.service
+Wants=memcached.service manageiq-db-ready.service
 
 [Service]
 WorkingDirectory=/var/www/miq/vmdb

--- a/systemd/manageiq-messaging-ready.service
+++ b/systemd/manageiq-messaging-ready.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ManageIQ Messaging Ready
+After=network.target
+Before=evmserverd.service
+ConditionPathExists=/var/www/miq/vmdb/config/messaging.yml
+
+[Service]
+ExecStart=/usr/bin/manageiq-messaging-ready
+EnvironmentFile=/etc/default/manageiq*.properties
+TimeoutStartSec=infinity
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- systemd file needed for the addition of `manageiq-messaging-ready` script

Depends on:
- [x] https://github.com/ManageIQ/manageiq-appliance/pull/368

Ref:
- https://github.com/ManageIQ/manageiq/issues/22132

@miq-bot add_label enhancement
@miq-bot assign @agrare 
