### PR TITLE
Call after_failover hook on successful failover, rely on manageiq-db-ready to restart services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "manageiq-api-client",              "~>0.3.6",           :require => false
 gem "manageiq-loggers",                 "~>1.0",             :require => false
 gem "manageiq-messaging",               "~>1.0", ">=1.1.0",  :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
-gem "manageiq-postgres_ha_admin",       "~>3.1", ">=3.1.4",  :require => false
+gem "manageiq-postgres_ha_admin",       "~>3.2",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false
 gem "memoist",                          "~>0.16.0",          :require => false
 gem "money",                            "~>6.13.5",          :require => false

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -193,7 +193,6 @@ class EvmDatabase
       ActiveRecord::Base.establish_connection(Rails.application.config.database_configuration[Rails.env])
 
       raise_server_event("db_failover_executed")
-      LinuxAdmin::Service.new("evmserverd").restart
     end
 
     monitor.add_handler(rails_handler)


### PR DESCRIPTION
After some discussion, I'll be changing the code implemented here https://github.com/ManageIQ/manageiq/pull/22115 and utilized here:
https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/36

* Let after_failover hook only handle successful failover
* We can add after_failed_failover hook if needed or just log errors for now
* Let manageiq-db-ready handle the monitoring of the DB after we change the configuration and let it start evmserverd
* Bump to 3.2 ha admin for https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/36

I've tested https://github.com/ManageIQ/manageiq/pull/22116 along with https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/36 in the following scenarios:
* Failover to standby
* Failover with no standby (evmserverd exits with error, failover monitor skips failover and logs an error, manageiq-db-ready waits for the configured database to be accessible and restarts evmserverd when old db comes back up)
* Failback (failover from old standby back to primary) (primary was reintroduced as a standby before we fail back)