### PR TITLE
Identify RHCOS as 'linux_coreos' operating system

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -20,7 +20,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_chrome",    %w[chromeos]],
     ["linux_chromium",  %w[chromiumos]],
     ["linux_suse",      %w[suse sles]],
-    ["linux_coreos",    %w[coreos]],
+    ["linux_coreos",    %w[coreos rhcos]],
     ["linux_redhat",    %w[redhat rhel]],
     ["linux_fedora",    %w[fedora]],
     ["linux_gentoo",    %w[gentoo]],

--- a/spec/models/operating_system_spec.rb
+++ b/spec/models/operating_system_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe OperatingSystem do
       "coreos-cloud"               => "linux_coreos",
       "linux debian"               => "linux_debian",
       "redhat coreos"              => "linux_coreos",
+      "rhcos-4.11.2"               => "linux_coreos",
     }.each do |image, expected|
       it "normalizes #{image}" do
         expect(described_class.normalize_os_name(image)).to eq(expected)


### PR DESCRIPTION
RHCOS is the acronym for `Red Hat Enterprise Linux CoreOS`.
It is often found in image names.