### PR TITLE
Allow pg 10-13, disallow 9 and below, warn on 14+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -273,7 +273,7 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
-  gem "manageiq-appliance_console",     "~>7.1", ">=7.1.1",  :require => false
+  gem "manageiq-appliance_console",     "~>7.2",             :require => false
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues

--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -5,14 +5,13 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   end
 
   def check_version
-    msg = "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (13 required)"
+    msg = "The version of PostgreSQL being connected to (#{postgresql_version}) is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (130000 / 13 required)"
 
-    if postgresql_version < 100000
+    if postgresql_version < 10_00_00
       raise msg
     end
 
-    if postgresql_version < 130000 || postgresql_version >= 140000
-      raise msg if Rails.env.production? && !ENV["UNSAFE_PG_VERSION"]
+    if postgresql_version >= 14_00_00
       $stderr.puts msg
     end
   end

--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -5,13 +5,13 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   end
 
   def check_version
-    msg = "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (10 required)"
+    msg = "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (13 required)"
 
-    if postgresql_version < 90500
+    if postgresql_version < 100000
       raise msg
     end
 
-    if postgresql_version < 100000 || postgresql_version >= 130000
+    if postgresql_version < 130000 || postgresql_version >= 140000
       raise msg if Rails.env.production? && !ENV["UNSAFE_PG_VERSION"]
       $stderr.puts msg
     end


### PR DESCRIPTION
- [x] Manually test pg 13 appliance HA
- [x] Manually test pg 13 podified
- [x] Manually test pg 13 logical replication (locally) (rake development:replication:setup and teardown

This pull request now is very lenient as we allow pg 10-13 to accommodate 10 to 13 migrations.  It disallows 9 and lower but only warns on 14+.

Therefore there is only one dependency:
- [x] Update appliance_console to allow either repmgr10 or repmgr13: https://github.com/ManageIQ/manageiq-appliance_console/pull/192

Follow up work:
- [ ] Manually test pg 13 appliance logical replication
- [ ] Document out how users upgrade from appliances/podified with pg 10 to pg 13
- [ ] Update tests to use pg 13 image and do cross repo. See https://github.com/ManageIQ/manageiq/blob/1d140d7d3b4ebea9dcee7826fdfdb764b154dcd2/.github/workflows/ci.yaml#L26

