### PR TITLE
[OPARIN] Bump ibm_power_hmc and manageiq-postgres_has_admin gems

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -183,11 +183,11 @@ GIT
 
 GIT
   remote: https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc
-  revision: a26ab688968be245d7ed3faeb399d0bf1bf68c41
+  revision: fd7a425afd12aea3b4f162b29bd2bb0aa88c9622
   branch: oparin
   specs:
     manageiq-providers-ibm_power_hmc (0.1.0)
-      ibm_power_hmc (~> 0.12.0)
+      ibm_power_hmc (~> 0.12.2)
 
 GIT
   remote: https://github.com/ManageIQ/manageiq-providers-ibm_power_vc
@@ -772,7 +772,7 @@ GEM
       concurrent-ruby (~> 1.0)
       http (~> 4.4.0)
       jwt (~> 2.2.1)
-    ibm_power_hmc (0.12.0)
+    ibm_power_hmc (0.12.2)
       rest-client (~> 2.1)
     ibm_vpc (0.4.0)
       concurrent-ruby (~> 1.0)
@@ -865,7 +865,7 @@ GEM
       rdkafka (~> 0.8)
       stomp (~> 1.4.4)
     manageiq-password (1.1.0)
-    manageiq-postgres_ha_admin (3.1.4)
+    manageiq-postgres_ha_admin (3.2.0)
       activesupport (>= 5.0, < 7.0)
       awesome_spawn (~> 1.4)
       manageiq-password (< 2)
@@ -1324,7 +1324,7 @@ DEPENDENCIES
   manageiq-loggers (~> 1.0)
   manageiq-messaging (~> 1.0, >= 1.1.0)
   manageiq-password (~> 1.0)
-  manageiq-postgres_ha_admin (~> 3.1, >= 3.1.4)
+  manageiq-postgres_ha_admin (~> 3.2)
   manageiq-providers-amazon!
   manageiq-providers-ansible_tower!
   manageiq-providers-autosde!


### PR DESCRIPTION
- ibm_power_hmc bumped to 0.12.2 due to backport of https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/76
- manageiq-postgres_ha_admin bumped to 3.2 due to backport of https://github.com/ManageIQ/manageiq/pull/22116

@jrafanie @agrare  Please review