### PR TITLE
Helper method for MiqQueue.deliver and delivered duo

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -486,6 +486,14 @@ class MiqQueue < ApplicationRecord
     return status, message, result
   end
 
+  # @return status
+  def deliver_and_process(requester = nil, &block)
+    status, message, result = deliver(requester, &block)
+    delivered(status, message, result) unless status == STATUS_RETRY
+
+    status
+  end
+
   def dispatch_method(obj, args)
     Timeout.timeout(msg_timeout) do
       args = activate_miq_task(args)

--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -50,8 +50,7 @@ module Vmdb
         if q
           puts "\e[33;1m\n** Delivering #{MiqQueue.format_full_log_msg(q)}\n\e[0;m"
           q.update!(:state => MiqQueue::STATE_DEQUEUE, :handler => MiqServer.my_server)
-          status, message, result = q.deliver
-          q.delivered(status, message, result) unless status == MiqQueue::STATUS_RETRY
+          q.deliver_and_process
         else
           break_on_complete ? break : sleep(1.second)
         end

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe AsyncDeleteMixin do
       expect_any_instance_of(@obj.class).to receive(:destroy).once
 
       queue_message = MiqQueue.where(cond).first
-      status, message, result = queue_message.deliver
-      queue_message.delivered(status, message, result)
+      queue_message.deliver_and_process
       expect(queue_message.state).to eq("ok")
     end
   end
@@ -59,8 +58,7 @@ RSpec.describe AsyncDeleteMixin do
 
       queue_messages = MiqQueue.where(cond)
       queue_messages.each do |queue_message|
-        status, message, result = queue_message.deliver
-        queue_message.delivered(status, message, result)
+        queue_message.deliver_and_process
         expect(queue_message.state).to eq("ok")
       end
       expect(@obj.class.count).to eq(count - ids.length)
@@ -76,8 +74,7 @@ RSpec.describe AsyncDeleteMixin do
       expect_any_instance_of(@obj.class).to receive(:delete).once
 
       queue_message = MiqQueue.where(cond).first
-      status, message, result = queue_message.deliver
-      queue_message.delivered(status, message, result)
+      queue_message.deliver_and_process
       expect(queue_message.state).to eq("ok")
     end
   end
@@ -93,8 +90,7 @@ RSpec.describe AsyncDeleteMixin do
 
       queue_messages = MiqQueue.where(cond)
       queue_messages.each do |queue_message|
-        status, message, result = queue_message.deliver
-        queue_message.delivered(status, message, result)
+        queue_message.deliver_and_process
         expect(queue_message.state).to eq("ok")
       end
       expect(@obj.class.count).to eq(count - ids.length)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -724,9 +724,7 @@ RSpec.describe ExtManagementSystem do
       ems.orchestrate_destroy
 
       # Simulate another process delivering the worker kill message
-      queue_message = MiqQueue.order(:id).first
-      status, message, result = queue_message.deliver
-      queue_message.delivered(status, message, result)
+      MiqQueue.order(:id).first.deliver_and_process
 
       expect(ExtManagementSystem.count).to eq(0)
       expect(worker.class.exists?(worker.id)).to eq(false)
@@ -810,8 +808,7 @@ RSpec.describe ExtManagementSystem do
     end
 
     def deliver_queue_message(queue_message = MiqQueue.order(:id).first)
-      status, message, result = queue_message.deliver
-      queue_message.delivered(status, message, result)
+      queue_message.deliver_and_process
     end
   end
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -147,8 +147,7 @@ RSpec.describe Host do
 
         MiqQueue.delete_all
         @host.start
-        status, message, result = MiqQueue.first.deliver
-        MiqQueue.first.delivered(status, message, result)
+        MiqQueue.first.deliver_and_process
       end
 
       it "policy prevented" do

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe Job do
       context "after queue message is processed" do
         before do
           @msg = MiqQueue.get(:role => "smartstate", :zone => @zone.name)
-          status, message, result = @msg.deliver
-          @msg.delivered(status, message, result)
+          @msg.deliver_and_process
 
           @job.reload
         end
@@ -69,8 +68,7 @@ RSpec.describe Job do
         Job.check_jobs_for_timeout
 
         @msg = MiqQueue.get(:role => "smartstate", :zone => @zone.name)
-        status, message, result = @msg.deliver
-        @msg.delivered(status, message, result)
+        @msg.deliver_and_process
 
         @job.reload
       end
@@ -98,8 +96,7 @@ RSpec.describe Job do
         Job.check_jobs_for_timeout
 
         @msg = MiqQueue.get(:role => "smartstate", :zone => @zone.name)
-        status, message, result = @msg.deliver
-        @msg.delivered(status, message, result)
+        @msg.deliver_and_process
 
         @job.reload
       end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
         allow(MiqTask).to receive(:wait_for_taskid) do
           request = MiqQueue.find_by(:class_name => described_class.name)
           request.update(:state => MiqQueue::STATE_DEQUEUE)
-          request.delivered(*request.deliver)
+          request.deliver_and_process
         end
       end
 

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -95,8 +95,7 @@ RSpec.describe Metric::CiMixin::Rollup do
             expect(m.miq_callback[:method_name]).to eq(:perf_capture_callback)
             expect(m.miq_callback[:args].first.sort).to eq(task_ids.sort)
 
-            status, message, result = m.deliver
-            m.delivered(status, message, result)
+            m.deliver_and_process
           end
         end
 

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -555,8 +555,7 @@ RSpec.describe MiqAlert do
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => MiqServer.my_zone
       )
-      status, message, result = msg.deliver
-      msg.delivered(status, message, result)
+      msg.deliver_and_process
     end
   end
 

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -491,8 +491,7 @@ RSpec.describe MiqWidget do
     it "finished task should not be timed out" do
       @widget.queue_generate_content
       q = MiqQueue.first
-      status, message, result = q.deliver
-      q.delivered(status, message, result)
+      q.deliver_and_process
 
       task = MiqTask.first
       expect(task.status).to eq(MiqTask::STATUS_OK)
@@ -508,8 +507,7 @@ RSpec.describe MiqWidget do
     it "finished task should not be re-used" do
       @widget.queue_generate_content
       q = MiqQueue.first
-      status, message, result = q.deliver
-      q.delivered(status, message, result)
+      q.deliver_and_process
 
       task = MiqTask.first
       expect(task.pct_complete).to eq(100)
@@ -519,8 +517,7 @@ RSpec.describe MiqWidget do
 
       @widget.create_initial_content_for_user(new_user)
       q = MiqQueue.first
-      status, message, result = q.deliver
-      q.delivered(status, message, result)
+      q.deliver_and_process
 
       task.reload
       expect(task.state).to eq(MiqTask::STATE_FINISHED)

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe AuthenticationMixin do
               Host.authentication_check_schedule
               allow_any_instance_of(Host).to receive(:verify_credentials).and_raise
               msg = MiqQueue.find_by(queue_conditions)
-              msg.delivered(*msg.deliver)
+              msg.deliver_and_process
 
               # attempt 2, 3, 4, 5 should requeue, 6 should NOT
               2.upto(6) do |counter|
@@ -226,7 +226,7 @@ RSpec.describe AuthenticationMixin do
                   expect(msg.args.last).to eq(:attempt => counter)
                   expect(msg.deliver_on).to be_within(0.01).of(time + minutes)
 
-                  msg.delivered(*msg.deliver)
+                  msg.deliver_and_process
                 else
                   expect(MiqQueue).not_to exist(queue_conditions)
                 end

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe "VM Retirement Management" do
 
         allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'success', MiqAeEngine::MiqAeWorkspaceRuntime.new])
         vm_with_owner.retirement_check
-        status, message, result = MiqQueue.first.deliver
-        MiqQueue.first.delivered(status, message, result)
+        MiqQueue.first.deliver_and_process
 
         vm_with_owner.reload
         expect(vm_with_owner.retirement_last_warn).not_to be_nil
@@ -44,8 +43,7 @@ RSpec.describe "VM Retirement Management" do
         expect(vm_with_owner.retirement_last_warn).to be_nil
         allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'success', MiqAeEngine::MiqAeWorkspaceRuntime.new])
         vm_with_owner_no_group.retirement_check
-        status, message, result = MiqQueue.first.deliver
-        MiqQueue.first.delivered(status, message, result)
+        MiqQueue.first.deliver_and_process
 
         expect(vm_with_owner_no_group.retirement_last_warn).not_to be_nil
         # the next test is only nil because we're not creating a true super admin in these specs
@@ -65,8 +63,7 @@ RSpec.describe "VM Retirement Management" do
 
         allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'success', MiqAeEngine::MiqAeWorkspaceRuntime.new])
         vm_with_owner.retirement_check
-        status, message, result = MiqQueue.first.deliver
-        MiqQueue.first.delivered(status, message, result)
+        MiqQueue.first.deliver_and_process
 
         vm_with_owner.reload
         expect(vm_with_owner.retirement_last_warn).not_to be_nil
@@ -193,8 +190,7 @@ RSpec.describe "VM Retirement Management" do
 
       allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'success', ws])
       Vm.make_retire_request(@vm.id, user, :initiated_by => 'system')
-      status, message, result = MiqQueue.first.deliver
-      MiqQueue.first.delivered(status, message, result)
+      MiqQueue.first.deliver_and_process
     end
 
     it "with user as initiated_by" do
@@ -209,9 +205,7 @@ RSpec.describe "VM Retirement Management" do
       expect(q).to receive(:_log).and_return(log_stub).at_least(:once)
       expect(log_stub).to receive(:error).with(/Validation failed: VmRetireRequest: Initiated by is not included in the list/)
       expect(log_stub).to receive(:log_backtrace)
-      status, message, result = q.deliver
-
-      q.delivered(status, message, result)
+      q.deliver_and_process
     end
 
     it "with user as initiated_by, with unknown vm.id" do
@@ -227,8 +221,7 @@ RSpec.describe "VM Retirement Management" do
       expect(q).to receive(:_log).and_return(log_stub).at_least(:once)
       expect(log_stub).to receive(:error).with(/Validation failed: VmRetireRequest: Initiated by is not included in the list/)
       expect(log_stub).to receive(:log_backtrace)
-      status, message, result = q.deliver
-      q.delivered(status, message, result)
+      q.deliver_and_process
     end
 
     it "policy prevents" do

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe VmScan do
         vm.scan
 
         job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
-        job_item.delivered(*job_item.deliver)
+        job_item.deliver_and_process
 
         # Allow the use of allow(job) and expect(job) instead of having to use
         # [allow/expect]_any_instance_of(VmScan) due to some signals being
@@ -40,13 +40,13 @@ RSpec.describe VmScan do
 
           # check_policy raises an miq_event, deliver the raise_evm_job_event
           job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
-          job_item.delivered(*job_item.deliver)
+          job_item.deliver_and_process
 
           expect(job).to receive(:before_scan)
 
           # Then deliver the signal from that event
           queue_item = MiqQueue.find_by(:class_name => job.class.name, :method_name => "signal")
-          queue_item.delivered(*queue_item.deliver)
+          queue_item.deliver_and_process
         end
       end
 
@@ -144,7 +144,7 @@ RSpec.describe VmScan do
         before do
           @vm.scan
           job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
-          job_item.delivered(*job_item.deliver)
+          job_item.deliver_and_process
 
           @job = Job.first
         end
@@ -177,7 +177,7 @@ RSpec.describe VmScan do
         before do
           @vm2.scan
           job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
-          job_item.delivered(*job_item.deliver)
+          job_item.deliver_and_process
 
           @job = Job.first
         end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -185,8 +185,7 @@ RSpec.describe Vm do
 
       allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
       @vm.start
-      status, message, result = MiqQueue.first.deliver
-      MiqQueue.first.delivered(status, message, result)
+      MiqQueue.first.deliver_and_process
     end
 
     it "policy prevented" do
@@ -220,8 +219,7 @@ RSpec.describe Vm do
 
       allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
       @vm.scan
-      status, message, result = MiqQueue.first.deliver
-      MiqQueue.first.delivered(status, message, result)
+      MiqQueue.first.deliver_and_process
     end
 
     it "policy prevented" do


### PR DESCRIPTION
All queue processing follows the same pattern:

```ruby
status, message, result = queue_message.deliver
queue_message.delivered(status, message, result) unless status == MiqQueue::STATUS_RETRY

# optional:
if status == MiqQueue::STATUS_TIMEOUT
```

just calling `delivered` at the end of `deliver`

UPDATE:

not changing this for the core code, but adding `process_and_update` for tests