### PR TITLE
Fix call_automate_event argument error during provisioning

### DIFF
--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -45,7 +45,7 @@ module MiqProvisionMixin
     update_attribute(:options, options.merge(:vm_notes => notes))
   end
 
-  def call_automate_event(*args)
+  def call_automate_event(*args, **kwargs)
     super
   rescue MiqAeException::Error
     # Allow the state machine to complete.


### PR DESCRIPTION
Fix Argument Error when calling `call_automate_event` through the MiqProvisionMixin on ruby3, we are passing through the `*args` but not the `*kwargs`.

This means when we call `call_automate_event(event_name, :synchronous => true)` we get an argument number error:

```
[----] I, [2022-10-05T14:37:12.045574 #209228:9704]  INFO -- evm: MIQ(MiqQueue#deliver) Message id: [154], Delivering...
[----] E, [2022-10-05T14:37:12.047307 #209228:9704] ERROR -- evm: MIQ(MiqQueue#deliver) Message id: [154], Error: [wrong number of arguments (given 2, expected 1)]
[----] E, [2022-10-05T14:37:12.047578 #209228:9704] ERROR -- evm: [ArgumentError]: wrong number of arguments (given 2, expected 1)  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2022-10-05T14:37:12.047734 #209228:9704] ERROR -- evm: /home/grare/adam/src/manageiq/manageiq/app/models/miq_request.rb:220:in `call_automate_event'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/miq_provision_mixin.rb:49:in `call_automate_event'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request.rb:232:in `automate_event_failed?'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request.rb:455:in `create_request_tasks'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_queue.rb:492:in `block in dispatch_method'
```