### PR TITLE
Remove ANSIBLE_STDOUT_CALLBACK env var

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -308,10 +308,7 @@ module Ansible
       end
 
       def runner_env
-        {
-          "ANSIBLE_STDOUT_CALLBACK" => "json",
-          "PYTHONPATH"              => python_path
-        }.delete_nils
+        {"PYTHONPATH" => python_path}.delete_nils
       end
 
       def credentials_info(credentials, base_dir)

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -101,16 +101,6 @@ RSpec.describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
     end
 
-    it "sets ANSIBLE_STDOUT_CALLBACK to json" do
-      expect(AwesomeSpawn).to receive(:run) do |command, options|
-        expect(command).to eq("ansible-runner")
-
-        expect(options[:env]["ANSIBLE_STDOUT_CALLBACK"]).to eq("json")
-      end.and_return(result)
-
-      described_class.run(env_vars, extra_vars, playbook)
-    end
-
     it "sets PYTHONPATH correctly with python3 awx modules only installed" do
       expect(described_class).to receive(:ansible_python_path).and_return("")
       expect(File).to receive(:exist?).with(py3_awx_modules_path).and_return(true)


### PR DESCRIPTION
This ENV var is not necessary and causes problems with output with newer ansible-runner versions such as 2.2.1.

This env var was added in #21382, in order to remove the need for the ansible.cfg. However, walking further back to when the ansible.cfg was added leads us to #17564, which was added in order to support running ansible-playbook (_not ansible-runner_). This variable allows ansible core to return JSON, which was honored by ansible-playbook. ansible-runner takes care of wrapping the output properly for us, so we don't need it, and setting it causes us to lose the "normal" STDOUT we'd otherwise get from ansible-runner.

ansible-runner 1.4.7 seemingly ignores this value (or perhaps overrides it for its own purposes), so we don't need to set it.  For the future versions of ansible-runner, it causes the problems above, so this commit removes it altogether.

@agrare Please review.