### PR TITLE
Fix rails_worker not defaulting to true in child classes

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -64,7 +64,10 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.rails_worker?
-    @rails_worker.kind_of?(Proc) ? @rails_worker.call : @rails_worker
+    return @rails_worker.call if @rails_worker.kind_of?(Proc)
+    return @rails_worker unless @rails_worker.nil?
+
+    true
   end
 
   def self.scalable?
@@ -90,7 +93,6 @@ class MiqWorker < ApplicationRecord
   class_attribute :default_queue_name, :required_roles, :maximum_workers_count, :include_stopping_workers_on_synchronize
   self.include_stopping_workers_on_synchronize = false
   self.required_roles = []
-  self.rails_worker = true
 
   def self.server_scope
     return current_scope if current_scope && current_scope.where_values_hash.include?('miq_server_id')

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -131,6 +131,22 @@ RSpec.describe MiqWorker do
     end
   end
 
+  describe ".rails_worker?" do
+    it "defaults to true" do
+      expect(described_class.rails_worker?).to be_truthy
+    end
+
+    it "can be set to false" do
+      described_class.rails_worker = false
+      expect(described_class.rails_worker?).to be_falsey
+    end
+
+    it "can be set to a lambda" do
+      described_class.rails_worker = -> { false }
+      expect(described_class.rails_worker?).to be_falsey
+    end
+  end
+
   describe ".worker_settings" do
     let(:settings) do
       {

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -40,6 +40,7 @@ module EvmSpecHelper
     clear_instance_variable(MiqProductFeature, :@feature_cache) if defined?(MiqProductFeature)
     clear_instance_variable(MiqProductFeature, :@obj_cache) if defined?(MiqProductFeature)
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
+    clear_instance_variable(MiqWorker, :@rails_worker) if defined?(MiqWorker)
     clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
 
     MiqWorker.my_guid = nil


### PR DESCRIPTION
The `rails_worker` property is a class instance variable not a class attribute so `self.rails_worker = true` in the `MiqWorker` base class was not being inherited by the child classes.

Introduced by https://github.com/ManageIQ/manageiq/pull/22114