### PR TITLE
Prevent deletion of widgets currently in a dashboard

### DIFF
--- a/app/models/miq_widget_set/set_data.rb
+++ b/app/models/miq_widget_set/set_data.rb
@@ -19,6 +19,10 @@ module MiqWidgetSet::SetData
       MiqWidget.where(:id => widget_ids)
     end
 
+    def has_widget_id_member?(widget_id)
+      widget_ids.include?(widget_id)
+    end
+
     private
 
     def init_set_data


### PR DESCRIPTION
Previously, you could delete a widget that was in widget sets / dashboards.

This would then cause us to fail validation when trying to update this dashboard because it checks for orphaned widgets in the set_data.

## Before - delete two widgets in a dashboard
![26b85280-489e-11ed-9951-755eecd69d13](https://user-images.githubusercontent.com/19339/195182810-6c187894-3efc-4e5a-b472-b0294461d2b1.png)
![654e0d00-489e-11ed-8261-f14c72760e47](https://user-images.githubusercontent.com/19339/195182817-6e267e2c-7b66-40be-8495-09a59167cfe3.png)
![6f700b80-489e-11ed-85be-e2af5eabbc89](https://user-images.githubusercontent.com/19339/195182828-5de4f15f-f849-486f-a45d-e44ea2163e5d.png)

### Before - now try to edit the dashboard
![e3121880-489e-11ed-96e3-f781062582d1](https://user-images.githubusercontent.com/19339/195182839-61c100ea-8d3c-4901-8ef9-b58203b1c415.png)

### After - you cannot delete a widget that is currently in a dashboard
![image](https://user-images.githubusercontent.com/19339/195183336-25006f4a-7ba1-4e48-890c-c945f00db531.png)

