### PR TITLE
Raise an error on page load if dev and pending migrations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,8 @@ Vmdb::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
+  config.active_record.migration_error = :page_load
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
Fixes #22160

In development, it's easy to miss running a migration so this will hopefully prevent some user errors.

The UI will show:

![image](https://user-images.githubusercontent.com/19339/195188547-1df8291d-0114-4f43-8c88-6035462990b6.png)



You'll see this in the log on any UI or API call:

```
[----] F, [2022-10-11T15:58:29.779309 #96316:13fc4] FATAL -- :
ActiveRecord::PendingMigrationError (

Migrations are pending. To resolve this issue, run:

        bin/rails db:migrate RAILS_ENV=development

You have 1 pending migration:

20221010195912_update_placement_group_view_feature_identifier.rb

):

```