### PR TITLE
Handle subscribing to a topic before creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "manageiq-api-client",              "~>0.3.6",           :require => false
 gem "manageiq-loggers",                 "~>1.0",             :require => false
-gem "manageiq-messaging",               "~>1.0", ">=1.1.0",  :require => false
+gem "manageiq-messaging",               "~>1.0", ">=1.2.0",  :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.2",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false


### PR DESCRIPTION
Kafka topics are auto-created on first post but if we subscribe before the first publish the queue worker subscribe thread will throw an exception and get restarted.

https://github.com/ManageIQ/manageiq-messaging/pull/75 added an option to handle that exception and sleeps for a bit to prevent hammering the broker and filling the logs with exceptions.  The option defaults to true so all we have to do is pull in the latest version of the gem.

Part of: https://github.com/ManageIQ/manageiq/issues/22132