### PR TITLE
Remove 'placement_group' from advanced settings

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -243,7 +243,6 @@ class VmOrTemplate < ApplicationRecord
     'entitled_processors' => [:entitled_processors,  :float],
     'processor_type'      => [:processor_share_type, :string],
     'pin_policy'          => [:processor_pin_policy, :string],
-    'placement_group'     => [:placement_group,      :string],
     'software_licenses'   => [:software_licenses,    :string],
   }
   REQUIRED_ADVANCED_SETTINGS.each do |k, (m, t)|


### PR DESCRIPTION
Now that there is a dedicated PlacementGroup model there's no need to also have an entry in advanced settings. Further, this prevents active record calls from finding a Vm's associated PlacementGroup.