### PR TITLE
Introduce Zone#maintenance?

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -218,7 +218,7 @@ class ExtManagementSystem < ApplicationRecord
 
   # validation - Zone cannot be maintenance_zone when enabled == true
   def validate_zone_not_maintenance_when_ems_enabled?
-    if enabled? && zone.present? && zone == Zone.maintenance_zone
+    if enabled? && zone&.maintenance?
       errors.add(:zone, N_("cannot be the maintenance zone when provider is active"))
     end
   end
@@ -329,7 +329,7 @@ class ExtManagementSystem < ApplicationRecord
   #                            we need to specify original zone for children explicitly
   def pause!(orig_zone = nil)
     previous_zone = orig_zone || zone
-    if previous_zone == Zone.maintenance_zone
+    if previous_zone.maintenance?
       _log.warn("Trying to pause paused EMS [#{name}] id [#{id}]. Skipping.")
       return
     end
@@ -364,7 +364,7 @@ class ExtManagementSystem < ApplicationRecord
     _log.info("Resuming EMS [#{name}] id [#{id}].")
 
     new_zone = if zone_before_pause.nil?
-                 zone == Zone.maintenance_zone ? Zone.default_zone : zone
+                 zone.maintenance? ? Zone.default_zone : zone
                else
                  zone_before_pause
                end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1273,7 +1273,7 @@ class Host < ApplicationRecord
   end
 
   def validate_task(task)
-    if ext_management_system&.zone == Zone.maintenance_zone
+    if ext_management_system&.zone&.maintenance?
       task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_ERROR, "#{ext_management_system.name} is paused")
       return false
     end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -140,7 +140,7 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
-    if options[:zone].present? && options[:zone] == Zone.maintenance_zone&.name
+    if Zone.maintenance?(options[:zone])
       _log.debug("MiqQueue#put skipped: #{options.inspect}")
       return
     end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -57,7 +57,7 @@ class MiqServer < ApplicationRecord
   RESTART_EXIT_STATUS = 123
 
   def validate_zone_not_maintenance?
-    errors.add(:zone, N_('cannot be maintenance zone')) if zone == Zone.maintenance_zone
+    errors.add(:zone, N_('cannot be maintenance zone')) if zone&.maintenance?
   end
 
   def hostname

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -202,7 +202,7 @@ module ProcessTasksMixin
 
     # default: validate retirement and maintenance zone, can be overridden
     def validate_task(task, instance, options)
-      if instance.try(:ext_management_system)&.zone == Zone.maintenance_zone
+      if instance.try(:ext_management_system)&.zone&.maintenance?
         task.error("#{instance.ext_management_system.name} is paused")
         return false
       end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -164,11 +164,12 @@ RSpec.describe Zone do
     expect(described_class.new.settings).to be_kind_of(Hash)
   end
 
-  context "maintenance zone" do
-    before { MiqRegion.seed }
+  context "#maintenance_zone" do
+    before { described_class.seed }
+
+    let(:zone) { FactoryBot.create(:zone) }
 
     it "is seeded with relation to region" do
-      described_class.seed
       expect(Zone.maintenance_zone).to have_attributes(
         :name => a_string_starting_with("__maintenance__")
       )
@@ -177,13 +178,25 @@ RSpec.describe Zone do
     end
 
     it "is not visible" do
-      described_class.seed
       expect(described_class.maintenance_zone.visible).to eq(false)
     end
 
     it "cannot be destroyed" do
-      described_class.seed
       expect { described_class.maintenance_zone.destroy! }.to raise_error(RuntimeError)
+    end
+
+    it "properly detects" do
+      expect(zone.maintenance?).to eq(false)
+      expect(described_class.maintenance_zone.maintenance?).to eq(true)
+      expect(described_class.maintenance?(zone)).to eq(false)
+      expect(described_class.maintenance?(described_class.maintenance_zone)).to eq(true)
+      expect(described_class.maintenance?(zone.name)).to eq(false)
+      expect(described_class.maintenance?(described_class.maintenance_zone.name)).to eq(true)
+    end
+
+    it "is cached" do
+      described_class.maintenance_zone
+      expect { described_class.maintenance_zone }.to_not make_database_queries
     end
   end
 


### PR DESCRIPTION
When I was profiling, I noticed that it was looking up the maintenance `Zone` when inserting an `MiqQueue` record.

This is probably a moot point as this will only happen.

1. But I did like how `Zone#maintenance?` read.
2. And I wondered if we wanted to `/^__maintenance__/.match?(zone.name)` instead of the `MiqRegion.my_region.maintenance_zone == zone`?
3. And I did find an issue with the cached `Zone#maintenance_zone` in one case.

There were a reasonable number of tests on the `maintenance_zone` concept.