### PR TITLE
Store all messaging options in the messaging.yml file

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -62,7 +62,6 @@ class MiqQueue < ApplicationRecord
     return if opts.nil?
 
     opts.transform_values! { |v| v.kind_of?(String) ? ManageIQ::Password.try_decrypt(v) : v }
-    opts.merge(:encoding => "json", :protocol => messaging_protocol)
   end
 
   def self.columns_for_requeue
@@ -664,16 +663,6 @@ class MiqQueue < ApplicationRecord
   end
 
   private_class_method :optional_values
-
-  def self.messaging_protocol
-    case messaging_type
-    when "artemis"
-      :Stomp
-    when "kafka"
-      :Kafka
-    end
-  end
-  private_class_method :messaging_protocol
 
   private_class_method def self.messaging_options_from_env
     return unless ENV["MESSAGING_HOSTNAME"] && ENV["MESSAGING_PORT"] && ENV["MESSAGING_USERNAME"] && ENV["MESSAGING_PASSWORD"]

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -672,6 +672,8 @@ class MiqQueue < ApplicationRecord
       :port     => ENV["MESSAGING_PORT"].to_i,
       :username => ENV["MESSAGING_USERNAME"],
       :password => ENV["MESSAGING_PASSWORD"],
+      :protocol => ENV.fetch("MESSAGING_PROTOCOL", "Kafka"),
+      :encoding => ENV.fetch("MESSAGING_ENCODING", "json")
     }
   end
 
@@ -679,7 +681,7 @@ class MiqQueue < ApplicationRecord
   private_class_method def self.messaging_options_from_file
     return unless MESSAGING_CONFIG_FILE.file?
 
-    YAML.load_file(MESSAGING_CONFIG_FILE)[Rails.env].symbolize_keys.tap { |h| h[:host] = h.delete(:hostname) }
+    YAML.load_file(MESSAGING_CONFIG_FILE)[Rails.env].symbolize_keys
   end
 
   def destroy_potentially_stale_record

--- a/config/messaging.artemis.yml
+++ b/config/messaging.artemis.yml
@@ -1,6 +1,6 @@
 ---
 base: &base
-  hostname: localhost
+  host: localhost
   port: 61616
   protocol: Stomp
   encoding: json

--- a/config/messaging.artemis.yml
+++ b/config/messaging.artemis.yml
@@ -2,6 +2,8 @@
 base: &base
   hostname: localhost
   port: 61616
+  protocol: Stomp
+  encoding: json
   username: admin
   password: smartvm
 

--- a/config/messaging.kafka.yml
+++ b/config/messaging.kafka.yml
@@ -1,6 +1,6 @@
 ---
 base: &base
-  hostname: localhost
+  host: localhost
   port: 9092
   protocol: Kafka
   encoding: json

--- a/config/messaging.kafka.yml
+++ b/config/messaging.kafka.yml
@@ -4,9 +4,8 @@ base: &base
   port: 9092
   protocol: Kafka
   encoding: json
-  sasl.mechanism: PLAIN
-  sasl.username: admin
-  sasl.password: smartvm
+  username: admin
+  password: smartvm
 
 development:
   <<: *base

--- a/config/messaging.kafka.yml
+++ b/config/messaging.kafka.yml
@@ -2,8 +2,11 @@
 base: &base
   hostname: localhost
   port: 9092
-  username: admin
-  password: smartvm
+  protocol: Kafka
+  encoding: json
+  sasl.mechanism: PLAIN
+  sasl.username: admin
+  sasl.password: smartvm
 
 development:
   <<: *base


### PR DESCRIPTION
For the messaging configuration we were storing most options in the template `config/messaging.{kafka,artemis}.yml` files but confusingly merging some other options after reading these files.

Simplify this by simply storing all options in the respective yml files.

Related:
* https://github.com/ManageIQ/manageiq-appliance_console/pull/197
* https://github.com/ManageIQ/manageiq-appliance/pull/370
* https://github.com/ManageIQ/manageiq-messaging/pull/76

Depends:
* https://github.com/ManageIQ/manageiq/pull/22167