### PR TITLE
Metrics C&U: Introduce batches

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -17,6 +17,10 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
     ems.zone.name
   end
 
+  def targets
+    Array(target)
+  end
+
   # Queue Capturing all metrics for an ems
   def perf_capture_all_queue
     perf_capture_health_check
@@ -97,6 +101,15 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
   def perf_capture_queue_targets_hosts(targets, interval, start_time:, end_time:)
     targets.group_by(&:ems_cluster).each do |ems_cluster, hosts|
       perf_capture_queue_targets(hosts, interval, :start_time => start_time, :end_time => end_time, :parent => ems_cluster)
+    end
+  end
+
+  # private, but called by ci_mixin/capture.rb
+  def log_targets
+    if targets.size == 1
+      "[#{targets.first.class.name}], [#{targets.first.id}], [#{targets.first.name}]"
+    else
+      "[#{targets.map { |obj| obj.class.name }.uniq.join(", ")}], [#{targets.size} targets]"
     end
   end
 
@@ -185,6 +198,11 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
   end
 
   def perf_capture_queue_target(target, interval_name, start_time:, end_time:, task_id: nil)
+    if target.kind_of?(Array)
+      target_ids = target.map(&:id) if target.size > 1
+      target = target.first
+    end
+
     # cb is the task used to group cluster realtime metrics
     cb = {:class_name => target.class.name, :instance_id => target.id, :method_name => :perf_capture_callback, :args => [[task_id]]} if task_id
 
@@ -199,7 +217,7 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
       :zone        => my_zone,
       :state       => ['ready', 'dequeue'],
     }
-    queue_item[:args] = [start_time, end_time] if start_time
+    queue_item[:args] = [start_time, end_time, target_ids] if start_time || target_ids.present?
 
     # reason for setting MiqQueue#miq_task_id is to initializes MiqTask.started_on column when message delivered.
     MiqQueue.create_with(:miq_task_id => task_id, :miq_callback => cb).put_or_update(queue_item) do |msg, qi|

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -35,7 +35,7 @@ module Metric::CiMixin::Capture
     end
 
     metrics_capture = perf_capture_object
-    start_time, end_time = fix_capture_start_end_time(interval_name, start_time, end_time)
+    start_time, end_time = fix_capture_start_end_time(interval_name, start_time, end_time, metrics_capture.target)
     start_range, end_range, counters_data = just_perf_capture(interval_name, start_time, end_time, metrics_capture)
 
     perf_process(interval_name, start_range, end_range, counters_data) if start_range
@@ -43,15 +43,17 @@ module Metric::CiMixin::Capture
 
   # Determine the start_time for capturing if not provided
   # interval_name == realtime is the only one that passes no start_time/end_time
-  def fix_capture_start_end_time(interval_name, start_time, end_time)
+  def fix_capture_start_end_time(interval_name, start_time, end_time, target)
     start_time ||=
       case interval_name
       when "historical" # Vm or Host
         Metric::Capture.historical_start_time
       when "hourly" # Storage (value is ignored)
-        last_perf_capture_on || 4.hours.ago.utc
+        4.hours.ago.utc
       else # "realtime" for Vm or Host
-        [last_perf_capture_on, 4.hours.ago.utc].compact.max
+        # pick the oldest last_perf_capture_on, but make sure it is within 4 hours
+        # if there is none, then choose 4 hours ago
+        [Array(target).map(&:last_perf_capture_on).compact.min, 4.hours.ago.utc].compact.max
       end
     [start_time&.utc, end_time&.utc]
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -22,7 +22,7 @@ module Metric::CiMixin::Capture
     perf_capture('historical', *args)
   end
 
-  def perf_capture(interval_name, start_time = nil, end_time = nil, target_ids = nil)
+  def perf_capture(interval_name, start_time = nil, end_time = nil, target_ids = nil, rollup = false)
     unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
       raise ArgumentError, _("invalid interval_name '%{name}'") % {:name => interval_name}
     end
@@ -39,6 +39,8 @@ module Metric::CiMixin::Capture
     start_range, end_range, counters_data = just_perf_capture(interval_name, start_time, end_time, metrics_capture)
 
     perf_process(interval_name, start_range, end_range, counters_data) if start_range
+    # rollup host metrics for the cluster
+    ems_cluster.perf_rollup_range_queue(start_time, end_time, interval_name) if rollup
   end
 
   # Determine the start_time for capturing if not provided

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -22,7 +22,7 @@ module Metric::CiMixin::Capture
     perf_capture('historical', *args)
   end
 
-  def perf_capture(interval_name, start_time = nil, end_time = nil)
+  def perf_capture(interval_name, start_time = nil, end_time = nil, target_ids = nil)
     unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
       raise ArgumentError, _("invalid interval_name '%{name}'") % {:name => interval_name}
     end
@@ -34,7 +34,7 @@ module Metric::CiMixin::Capture
       return
     end
 
-    metrics_capture = perf_capture_object
+    metrics_capture = perf_capture_object(target_ids ? self.class.where(:id => target_ids).to_a : self)
     start_time, end_time = fix_capture_start_end_time(interval_name, start_time, end_time, metrics_capture.target)
     start_range, end_range, counters_data = just_perf_capture(interval_name, start_time, end_time, metrics_capture)
 
@@ -86,7 +86,7 @@ module Metric::CiMixin::Capture
     log_time << ", start_time: [#{start_time}]" unless start_time.nil?
     log_time << ", end_time: [#{end_time}]" unless end_time.nil?
 
-    _log.info("#{log_header} Capture for #{log_target}#{log_time}...")
+    _log.info("#{log_header} Capture for #{metrics_capture.log_targets}#{log_time}...")
 
     start_range = end_range = counters_by_mor = counter_values_by_mor_and_ts = target_ems = nil
     counters_data = {}
@@ -97,12 +97,12 @@ module Metric::CiMixin::Capture
       counters_by_mor, counter_values_by_mor_and_ts = metrics_capture.perf_collect_metrics(interval_name_for_capture, start_time, end_time)
     end
 
-    _log.info("#{log_header} Capture for #{log_target}#{log_time}...Complete - Timings: #{t.inspect}")
+    _log.info("#{log_header} Capture for #{metrics_capture.log_targets}#{log_time}...Complete - Timings: #{t.inspect}")
 
     # ems lookup cache
     target_ems = nil
 
-    Array(metrics_capture.target).each do |target|
+    metrics_capture.targets.each do |target|
       counters       = counters_by_mor[target.ems_ref] || {}
       counter_values = counter_values_by_mor_and_ts[target.ems_ref] || {}
 

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -37,9 +37,9 @@ module Spec
       end
 
       # sorry, stole from the code - not really testing
-      def arg_day_range(start_time, end_time, threshold = 1.day)
-        (start_time.utc..end_time.utc).step_value(threshold).each_cons(2).collect do |s_time, e_time|
-          [s_time, e_time]
+      def arg_day_range(start_time, end_time)
+        (start_time.utc..end_time.utc).step_value(1.day).each_cons(2).collect do |s_time, e_time|
+          [s_time, e_time, nil, false]
         end
       end
 


### PR DESCRIPTION
Part of #20071 (dependencies listed there)

also merge
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/834

metrics perf_capture and callback handle multiple targets

# Flow

perf_capture logic lives in MetricsCapture and obtainable via perf_capture_object method
It is ems specific and queues all work for an ems

```
generic worker:
  scheduler

ems_metrics_coordinator worker:
  => perf_capture_timer => perf_capture_queue => perf_capture_targets => perf_capture_target

ems_collector worker:
  => perf_capture_{realtime,historical}
  => perf_capture_callback (for Host nodes)

ems_metrics_processor worker:
  => perf_rollup_range
  => perf_rollup_range to derive cluster metrics
```

Read: The scheduler calls perf_capture_timer (via the queue)
      perf_capture_timer runs on the ems_metrics_coordiantor worker
      perf_capture_timer calls perf_capture_queue which calls ...

# Before

- perf_capture_targets calls perf_capture_target for each object/timeframe
- message queued for each object/timeframe
- host callback also called for each object/timeframe
- Task used for host callback synchronization to then add rollup when all are done.

# After

- perf_capture_targets calls perf_capture_target with a list of targets
- each ems can override behavior to best meet their needs.
- message queued per 250 objects (Vm and Storage)
- message has same ems, timefame, and type (Host, Vm, or Storage)
- message has same cluster (Host) -- no 250 limit
- host callback called for each cluster (with list of host ids)


# Implementation Details

- Still calling Capture#perf_capture on instance of Vm/Host even though passing target_ids. (instance is one of the targets)
- Wanted to support single target and not move too many objects around.
- The instance_id needs to be sent in the target_ids. (instance_id only used to get correct ems/MetricsCapture subclass)

# Performance

|         ms |        bytes |       objects | query |    qry ms |     rows |`comments`
|        ---:|          ---:|           ---:|   ---:|       ---:|      ---:| ---
|   13,536.0 |  68,468,583* |    10,935,195 | 4,062 |  10,199.5 |      820 |`perf_capture-before`
|    5,045.4 |  50,056,647* |     7,306,457 |    56 |   4,784.2 |      820 |`perf_capture-after`
|        56% |              |               |   99% |       53% |          |
|  701,835.6 | 467,283,634* | 1,180,566,804 |50,855 | 298,696.7 |   12,103 |`capture-before`
|  606,988.0 | 727,409,742* | 1,154,128,824 |38,897 | 236,385.4 |    9,692 |`capture-after`
|        14% |              |               |   24% |       21% |      20% | delta

