### PR TITLE
Bump manageiq-appliance_console to 8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -273,7 +273,7 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
-  gem "manageiq-appliance_console",     "~>7.1", ">=7.1.1",  :require => false
+  gem "manageiq-appliance_console",     "~>8.0",  :require => false
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues


### PR DESCRIPTION
Bring in changes to require setting up messaging and simplifying working with messaging.yml

Depends on:
- [x] merge and release of https://github.com/ManageIQ/manageiq-appliance_console/pull/199