### PR TITLE
Create MiqRegion for all tests

### DIFF
--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe ArPglogicalMigrationHelper do
 
   context "with a region seeded" do
     let!(:my_region) do
-      MiqRegion.seed
       MiqRegion.my_region
     end
 

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe ArRegion do
   end
 
   context "#miq_region" do
-    before { MiqRegion.seed }
-
     let!(:vm) { FactoryBot.create(:vm) }
 
     it "returns the MiqRegion record" do
@@ -26,12 +24,12 @@ RSpec.describe ArRegion do
 
   context "#region_description" do
     it "when the region exists" do
-      MiqRegion.seed
       vm = FactoryBot.create(:vm)
       expect(vm.region_description).to eq(MiqRegion.first.description)
     end
 
     it "when the region does not exist" do
+      MiqRegion.destroy_all
       vm = FactoryBot.create(:vm)
       expect(vm.region_description).to be_nil
     end

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -225,8 +225,6 @@ RSpec.describe Vmdb::Settings do
     end
 
     it "saving settings for Zone does not change saved Region or Server settings" do
-      MiqRegion.seed
-
       described_class.save!(miq_server.zone, :api => {:token_ttl => "2.hour"})
       miq_server.zone.reload
       expect(miq_server.zone.settings_changes.count).to eq 1
@@ -240,8 +238,6 @@ RSpec.describe Vmdb::Settings do
     end
 
     it "saving settings for Region does not change saved Zone or Server settings" do
-      MiqRegion.seed
-
       described_class.save!(miq_server.zone.miq_region, :api => {:token_ttl => "3.hour"})
       miq_server.zone.miq_region.reload
 
@@ -265,8 +261,6 @@ RSpec.describe Vmdb::Settings do
       let(:reset) { described_class::RESET_COMMAND }
 
       before do
-        MiqRegion.seed
-
         described_class.save!(
           MiqRegion.first,
           :api     => {
@@ -509,7 +503,6 @@ RSpec.describe Vmdb::Settings do
     end
 
     it "can load settings on each level from Region -> Zone -> Server hierarchy" do
-      MiqRegion.seed
       described_class.save!(server.zone.miq_region, :api => {:token_ttl => "3.hour"})
       described_class.save!(server.zone, :api => {:token_ttl => "4.hour"})
       described_class.save!(server, :api => {:token_ttl => "5.hour"})
@@ -525,8 +518,6 @@ RSpec.describe Vmdb::Settings do
     end
 
     it "applies settings from up the hierarchy: Region -> Zone -> Server" do
-      MiqRegion.seed
-
       described_class.save!(server.zone.miq_region, :api => {:token_ttl => "3.hour"})
       settings = Vmdb::Settings.for_resource(server)
       expect(settings.api.token_ttl).to eq "3.hour"

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -12,7 +12,6 @@ describe GenericMailer do
 
   context 'with a notifier within a region' do
     before do
-      MiqRegion.seed
       ServerRole.seed
       @miq_server.server_roles << ServerRole.where(:name => 'notifier')
       @miq_server.save!
@@ -37,8 +36,6 @@ describe GenericMailer do
   end
 
   context 'without a notifier within a region' do
-    before { MiqRegion.seed }
-
     it 'does not queue any mail notifications' do
       @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
       expect { GenericMailer.deliver_queue(:generic_notification, @args) }.not_to(change { MiqQueue.count })

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe AutomationRequest do
   let(:admin) { FactoryBot.create(:user, :role => "admin") }
   before do
-    MiqRegion.seed
     allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
     @zone        = FactoryBot.create(:zone, :name => "fred")
     @approver    = FactoryBot.create(:user_miq_request_approver)

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -2,10 +2,6 @@ require 'workers/event_catcher'
 
 RSpec.describe BlacklistedEvent do
   let(:total_blacklist_entry_count) { ExtManagementSystem.descendants.collect(&:default_blacklisted_event_names).flatten.count }
-  before do
-    MiqRegion.seed
-  end
-
   context '.seed' do
     it 'loads event filters' do
       described_class.seed

--- a/spec/models/chargeback_configured_system_spec.rb
+++ b/spec/models/chargeback_configured_system_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe ChargebackConfiguredSystem do
   end
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     ManageIQ::Showback::InputMeasure.seed

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe ChargebackContainerImage do
   let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     MiqEnterprise.seed

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe ChargebackContainerProject do
   end
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     MiqEnterprise.seed

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe ChargebackVm do
   end
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     EvmSpecHelper.local_miq_server

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe ChargebackVm do
   end
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     ManageIQ::Showback::InputMeasure.seed

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe CustomButton do
 
       context "when invoking for a particular VM" do
         before do
-          MiqRegion.seed
           @vm    = FactoryBot.create(:vm_vmware)
           @user2 = FactoryBot.create(:user_with_group)
           EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
@@ -327,7 +326,6 @@ RSpec.describe CustomButton do
     let(:custom_button)   { FactoryBot.create(:custom_button, :applies_to => vm.class, :resource_action => resource_action) }
 
     before do
-      MiqRegion.seed
       EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
     end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -513,7 +513,6 @@ RSpec.describe ExtManagementSystem do
 
   context "#pause!" do
     before do
-      MiqRegion.seed
       Zone.seed
     end
 
@@ -575,7 +574,6 @@ RSpec.describe ExtManagementSystem do
 
   context "#resume" do
     before do
-      MiqRegion.seed
       Zone.seed
     end
 
@@ -678,7 +676,6 @@ RSpec.describe ExtManagementSystem do
 
   context "changing zone" do
     before do
-      MiqRegion.seed
       Zone.seed
     end
 

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe FileDepotFtp do
   end
 
   context "#upload_file" do
-    let(:region_key) { "Current_region_unknown_#{zone_name_id}_#{server_name_id}.txt".gsub(/\s+/, "_") }
+    let(:region_key) { "Current_region_#{MiqRegion.my_region_number}_#{zone_name_id}_#{server_name_id}.txt".gsub(/\s+/, "_") }
     it 'uploads file to vsftpd with existing directory structure' do
       vsftpd = vsftpd_mock.new('uploads' => {zone_name_id => {server_name_id => {}}})
       expect(file_depot_ftp).to receive(:connect).and_return(vsftpd)

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -672,7 +672,6 @@ RSpec.describe Host do
     let(:host) { FactoryBot.create(:host_vmware, :ext_management_system => ems) }
 
     before do
-      MiqRegion.seed
       Zone.seed
     end
 

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
   end
 
   describe ".perf_capture_gap" do
-    before do
-      MiqRegion.seed
-    end
-
     let(:host) { FactoryBot.create(:host_vmware, :ext_management_system => ems, :perf_capture_enabled => true) }
     let!(:vm)   { FactoryBot.create(:vm_vmware, :ext_management_system => ems, :host => host) }
     let(:host2) do
@@ -123,10 +119,6 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
   end
 
   describe ".perf_capture_all_queue" do
-    before do
-      MiqRegion.seed
-    end
-
     let(:host) { FactoryBot.create(:host_vmware, :ext_management_system => ems, :perf_capture_enabled => true) }
     let(:vm)   { FactoryBot.create(:vm_vmware, :ext_management_system => ems, :host => host).tap { MiqQueue.delete_all } }
     let(:host2) do

--- a/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
@@ -1,10 +1,6 @@
 RSpec.describe ManageIQ::Providers::CloudManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
-  before do
-    MiqRegion.seed
-  end
-
   let(:miq_server) { EvmSpecHelper.local_miq_server }
   let(:ems)  { FactoryBot.create(:ems_openstack, :zone => miq_server.zone) }
 

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -1,11 +1,6 @@
 RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
   let(:job) { FactoryBot.create(:embedded_ansible_job) }
 
-  before do
-    region = MiqRegion.seed
-    allow(MiqRegion).to receive(:my_region).and_return(region)
-  end
-
   context "when embedded_ansible role is enabled" do
     before do
       EvmSpecHelper.assign_embedded_ansible_role

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::Provider do
   let(:miq_server) { FactoryBot.create(:miq_server) }
 
   before do
-    MiqRegion.seed
     Zone.seed
     EvmSpecHelper.assign_embedded_ansible_role(miq_server)
   end

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ManageIQ::Providers::InfraManager::MetricsCapture do
   let(:ems) { FactoryBot.create(:ems_vmware, :zone => miq_server.zone) }
 
   before do
-    MiqRegion.seed
     storages = FactoryBot.create_list(:storage_vmware, 2)
     storages.each_with_index { |st, i| st.perf_capture_enabled = i.even? }
     clusters = FactoryBot.create_list(:ems_cluster, 2, :ext_management_system => ems)

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe MeteringContainerImage do
   let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     ChargebackRate.seed

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe MeteringContainerProject do
   let(:ems_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems, :hosts => [host]) }
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     MiqEnterprise.seed

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe MeteringVm do
   let(:ems_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems, :hosts => [host]) }
 
   before do
-    MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
     MiqEnterprise.seed

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe Metric::Capture do
   include Spec::Support::MetricHelper
 
   before do
-    MiqRegion.seed
-
     @zone = EvmSpecHelper.local_miq_server.zone
   end
 

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Metric::CiMixin::Rollup do
   before do
-    MiqRegion.seed
-
     @zone = miq_server.zone
   end
 

--- a/spec/models/metric/finders_spec.rb
+++ b/spec/models/metric/finders_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Metric::Finders do
   before do
-    MiqRegion.seed
-
     @zone = EvmSpecHelper.local_miq_server.zone
   end
 

--- a/spec/models/metric_rollup/chargeback_helper_spec.rb
+++ b/spec/models/metric_rollup/chargeback_helper_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe MetricRollup do
     let(:ems) { FactoryBot.build(:ems_vmware) }
 
     before do
-      MiqRegion.seed
       MiqEnterprise.seed
     end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe Metric do
   include Spec::Support::MetricHelper
 
   before do
-    MiqRegion.seed
-
     @zone = EvmSpecHelper.local_miq_server.zone
   end
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -443,7 +443,6 @@ RSpec.describe MiqAction do
 
   context 'validate action email should have correct type' do
     before do
-      MiqRegion.seed
       ServerRole.seed
     end
 

--- a/spec/models/miq_compare_spec.rb
+++ b/spec/models/miq_compare_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe MiqCompare do
       host1 = FactoryBot.create(:host_vmware)
       host2 = FactoryBot.create(:host_vmware)
 
-      MiqRegion.seed
       MiqReport.seed_report("hosts")
 
       report = MiqReport.find_by(:name => "Hosts: Compare Template")

--- a/spec/models/miq_enterprise_spec.rb
+++ b/spec/models/miq_enterprise_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe MiqEnterprise do
 
   context "with all existing records" do
     it "#miq_regions" do
-      MiqRegion.seed
-
       expect(enterprise.miq_regions.size).to eq(1)
     end
 

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -190,10 +190,6 @@ RSpec.describe MiqProductFeature do
         end
 
         context "with tenants from remote region" do
-          before do
-            MiqRegion.seed
-          end
-
           def id_for_model_in_region(model, region)
             model.id_in_region(model.count + 1_000_000, region.region)
           end

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe MiqProvisionRequestTemplate do
 
   describe '#create_tasks_for_service' do
     before do
-      MiqRegion.seed
       allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Provision).to receive(:get_hostname).and_return('hostname')
       allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(double(:root => 'miq'))
     end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -363,7 +363,6 @@ RSpec.describe MiqQueue do
 
   context "#put" do
     before do
-      MiqRegion.seed
       Zone.seed
       miq_server
     end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe MiqRegion do
     ApplicationRecord.region_to_range(remote_region_number).first
   end
   context "after seeding" do
-    before do
-      MiqRegion.seed
-    end
-
     it "should increment naming sequence number after each call" do
       expect(MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming")).to eq(1)
       expect(MiqRegion.my_region.next_naming_sequence("namingtest$n{3}", "naming")).to eq(2)
@@ -48,6 +44,7 @@ RSpec.describe MiqRegion do
 
   context ".seed" do
     before do
+      MiqRegion.destroy_all
       @region_number = 99
       allow(MiqRegion).to receive_messages(:my_region_number => @region_number)
       MiqRegion.seed

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -1073,7 +1073,6 @@ RSpec.describe MiqReport do
     end
 
     before do
-      MiqRegion.seed
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed
       ChargebackRate.seed

--- a/spec/models/miq_request_task/post_install_callback_spec.rb
+++ b/spec/models/miq_request_task/post_install_callback_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe MiqRequestTask::PostInstallCallback do
   end
 
   context "#post_install_callback_url" do
-    before { MiqRegion.seed }
-
     it "without remote ui url" do
       expect(task.post_install_callback_url).to be_nil
     end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe MiqScheduleWorker::Runner do
           before do
             allow(@schedule_worker).to receive(:heartbeat)
 
-            @region = MiqRegion.seed
+            @region = MiqRegion.my_region
             allow(MiqRegion).to receive(:my_region).and_return(@region)
             @schedule_worker.instance_variable_set(:@active_roles, ["database_operations"])
 

--- a/spec/models/miq_server/at_startup_spec.rb
+++ b/spec/models/miq_server/at_startup_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe MiqServer, "::AtStartup" do
   end
 
   it ".log_under_management (private)" do
-    MiqRegion.seed
     ems = FactoryBot.create(:ems_infra)
     FactoryBot.create(:host_vmware, :ext_management_system => ems)
     FactoryBot.create(:vm_vmware, :ext_management_system => ems)
@@ -57,7 +56,6 @@ RSpec.describe MiqServer, "::AtStartup" do
   end
 
   it ".log_not_under_management (private)" do
-    MiqRegion.seed
     FactoryBot.create(:host_vmware)
     FactoryBot.create(:vm_vmware)
     expect($log).to receive(:info).with(/VMs: \[1\], Hosts: \[1\]/)

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe MiqServer do
       let(:log_end)                   { Time.zone.parse("2018-05-11 15:34:16 UTC") }
       let(:daily_log)                 { Rails.root.join("data", "user", "system", "evm_server_daily.zip").to_s }
       let(:log_depot)                 { FactoryBot.create(:file_depot) }
-      let!(:region)                   { MiqRegion.seed }
+      let(:region)                    { MiqRegion.my_region }
       let(:zone)                      { @miq_server.zone }
       before do
         require 'vmdb/util'

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe "Server Role Management" do
   context "After Setup," do
     before do
-      MiqRegion.seed
       ServerRole.seed
       @server_roles = ServerRole.all
       @miq_server   = EvmSpecHelper.local_miq_server

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe "Server Monitor" do
   context "After Setup," do
     before do
-      MiqRegion.seed
       ServerRole.seed
 
       # Do this manually, to avoid caching at the class level

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe MiqServer do
 
   context ".seed" do
     before do
-      MiqRegion.seed
       Zone.seed
     end
 
@@ -80,7 +79,6 @@ RSpec.describe MiqServer do
     end
 
     it "cannot assign to maintenance zone" do
-      MiqRegion.seed
       Zone.seed
 
       @miq_server.zone = Zone.maintenance_zone
@@ -399,8 +397,6 @@ RSpec.describe MiqServer do
   end
 
   context ".managed_resources" do
-    before { MiqRegion.seed }
-
     let(:ems) { FactoryBot.create(:ems_infra) }
     let!(:active_vm) { FactoryBot.create(:vm_infra, :ext_management_system => ems) }
     let!(:archived_vm) { FactoryBot.create(:vm_infra) }

--- a/spec/models/orchestration_stack_retire_task_spec.rb
+++ b/spec/models/orchestration_stack_retire_task_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe OrchestrationStackRetireTask do
 
   describe "deliver_to_automate" do
     before do
-      MiqRegion.seed
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
       miq_request.approve(approver, "why not??")
     end

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe ServerRole do
       CSV
 
       allow(File).to receive(:open).and_return(StringIO.new(@csv))
-      MiqRegion.seed
       ServerRole.seed
     end
 

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe ServiceRetireTask do
 
     context "with resource" do
       before do
-        MiqRegion.seed
         allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
         miq_request.approve(approver, reason)
       end
@@ -221,7 +220,6 @@ RSpec.describe ServiceRetireTask do
 
   describe "deliver_to_automate" do
     before do
-      MiqRegion.seed
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
       miq_request.approve(approver, reason)
     end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -933,6 +933,7 @@ RSpec.describe Tenant do
   end
 
   context "using more regions with factory" do
+    before { MiqRegion.destroy_all }
     let!(:other_region) { FactoryBot.create(:miq_region) }
 
     context "without MiqRegion.seed" do

--- a/spec/models/vim_performance_analysis_spec.rb
+++ b/spec/models/vim_performance_analysis_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe VimPerformanceAnalysis do
   end
 
   before do
-    MiqRegion.seed
     EvmSpecHelper.local_miq_server
   end
 

--- a/spec/models/vm_retire_task_spec.rb
+++ b/spec/models/vm_retire_task_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe VmRetireTask do
 
   describe "deliver_to_automate" do
     before do
-      MiqRegion.seed
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
       miq_request.approve(approver, "why not??")
     end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe Zone do
   include_examples "AggregationMixin", "ext_management_systems"
 
   context ".seed" do
-    before { MiqRegion.seed }
     include_examples ".seed called multiple times", 2
   end
 
@@ -211,7 +210,6 @@ RSpec.describe Zone do
   end
 
   it "removes queued items on destroy" do
-    MiqRegion.seed
     Zone.seed
     zone = FactoryBot.create(:zone)
     FactoryBot.create(:miq_queue, :zone => zone.name)
@@ -226,8 +224,6 @@ RSpec.describe Zone do
   end
 
   describe "#destroy" do
-    before { MiqRegion.seed }
-
     it "fails for a zone with servers when not podified" do
       zone = FactoryBot.create(:zone)
       zone.miq_servers.create!(:name => "my_server")
@@ -273,7 +269,6 @@ RSpec.describe Zone do
     end
 
     it ".destroy deletes the server in the zone" do
-      MiqRegion.seed
       zone = Zone.create!(:name => "my_zone", :description => "some zone")
       server = zone.miq_servers.first
       zone.destroy!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,15 @@ RSpec.configure do |config|
   #   EvmSpecHelper.log_ruby_object_usage
   # end
 
+  # everything requires a region
+  config.before(:suite) do
+    MiqRegion.seed
+  end
+
+  config.after(:suite) do
+    MiqRegion.delete_all
+  end
+
   config.before do
     EmsRefresh.try(:debug_failures=, true)
   end


### PR DESCRIPTION
More and more components of the system are requiring an `MiqRegion` to function. Also, this record in the database is pretty static and does not change.
(Only caveat: it has a `maintenance_zone_id` value)

The straw for me:

I just added a component in `MiqQueue` that depended upon a value cached in `MiqRegion`. Too many tests were failing because there was not a default region.

We did not need to delete all these `MiqRegion.seed` entries. I just wanted to delete more lines than I added

In the future, it is possible we will create the region outside the test suite and remove it from the `before(:suite)`/`after(:suite)` entries.

Also, most relations in `MiqRegion` are virtual relations. So caching the `zones` was necessary.

As a followup, we may want to use `MiqRegion.my_region.zones` instead of `Zone.in_my_region` throughout our code.
