### PR TITLE
[WIP] Copy appliance configuration files in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     rm -rf /var/cache/dnf
 
 ## Copy/link the appliance files again so that we get ssl
+RUN cp -Rv /opt/manageiq/manageiq-appliance/COPY/* /
 RUN source /etc/default/evm && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf
 


### PR DESCRIPTION
The appliance COPY directory includes required httpd configuration files.

Fixes #22105 

Depends on:
- https://github.com/ManageIQ/manageiq-rpm_build/pull/323