### PR TITLE
Disable syndication of inventory/events/metrics by default now that we use kafka internally

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -110,12 +110,12 @@
   :history:
     :keep_events: 6.months
     :purge_window_size: 1000
-  :syndicate_events: true
+  :syndicate_events: false
 :ems_refresh:
   :debug_trace: false
   :capture_vm_created_on_date: false
   :full_refresh_threshold: 100
-  :syndicate_inventory: true
+  :syndicate_inventory: false
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours
 :event_handling:
@@ -895,7 +895,7 @@
   :host_overhead:
     :memory: 2.01.percent
     :cpu: 0.15.percent
-  :syndicate_metrics: true
+  :syndicate_metrics: false
   :targets:
     :archived_for: 8.hours
   :vim_cache_ttl: 1.hour


### PR DESCRIPTION
Previously we defaulted to true for syndication of events, inventory, and metrics but we would only publish if miq_messaging/kafka was configured, the expectation being if you went through the effort of setting up kafka it was for the explicit purpose of syndication.

Now that we use kafka internally this assumption is no longer true and this can lead to a lot of "wasted" traffic on kafka.