### PR TITLE
Don't automatically create messaging.yml for development

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -33,10 +33,9 @@ module ManageIQ
 
     def self.ensure_config_files
       config_files = {
-        "certs/v2_key.dev"           => "certs/v2_key",
-        "config/cable.yml.sample"    => "config/cable.yml",
-        "config/database.pg.yml"     => "config/database.yml",
-        "config/messaging.kafka.yml" => "config/messaging.yml",
+        "certs/v2_key.dev"        => "certs/v2_key",
+        "config/cable.yml.sample" => "config/cable.yml",
+        "config/database.pg.yml"  => "config/database.yml"
       }
 
       config_files.each do |source, dest|


### PR DESCRIPTION
If the messaging.yml file isn't present we assume that messaging/kafka isn't configured for use and fall back to MiqQueue.

By creating this file with defaults for developers it puts us in a situation where some functionality will fail if a kafka broker isn't present on the developer's system.