### PR TITLE
Extract active role syncing out of worker management

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -171,6 +171,10 @@ class MiqServer < ApplicationRecord
     ::Settings.server.server_log_frequency.to_i_with_method
   end
 
+  def server_role_monitor_frequency
+    ::Settings.server.server_role_monitor_frequency.to_i_with_method
+  end
+
   def worker_dequeue_frequency
     ::Settings.server.worker_dequeue_frequency.to_i_with_method
   end
@@ -206,6 +210,7 @@ class MiqServer < ApplicationRecord
     end if threshold_exceeded?(:server_monitor_frequency, now)
 
     Benchmark.realtime_block(:log_active_servers)      { log_active_servers }                     if threshold_exceeded?(:server_log_frequency, now)
+    Benchmark.realtime_block(:role_monitor)            { monitor_active_roles }                   if threshold_exceeded?(:server_role_monitor_frequency, now)
     Benchmark.realtime_block(:worker_monitor)          { worker_manager.monitor_workers }         if threshold_exceeded?(:worker_monitor_frequency, now)
     Benchmark.realtime_block(:worker_dequeue)          { worker_manager.populate_queue_messages } if threshold_exceeded?(:worker_dequeue_frequency, now)
     monitor_myself

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -971,6 +971,7 @@
   :server_log_frequency: 5.minutes
   :server_log_timings_threshold: 1.second
   :server_monitor_frequency: 60.seconds
+  :server_role_monitor_frequency: 15.seconds
   :session_store: cache
   :startup_timeout: 300
   :stop_poll: 10.seconds


### PR DESCRIPTION
Part of the worker_management sync_monitor loop is to sync_active_roles for the server, then notify workers of the change.

This seems like the wrong place for this since we have a RoleManagement module already, and most of the worker_management code has to call up to RoleManagement which to me indicates that it is in the wrong spot to begin with.