### PR TITLE
Set auth_uri/token_uri in google_credential

### DIFF
--- a/lib/ansible/runner/credential/google_credential.rb
+++ b/lib/ansible/runner/credential/google_credential.rb
@@ -25,11 +25,19 @@ module Ansible
 
       def write_gce_credentials_file
         json_data = {
-          :type         => "service_account",
-          :private_key  => auth.auth_key || "",
-          :client_email => auth.userid || "",
-          :project_id   => auth.project || ""
+          :type                        => "service_account",
+          :private_key                 => auth.auth_key || "",
+          :client_email                => auth.userid || "",
+          :project_id                  => auth.project || "",
+          :auth_uri                    => "https://accounts.google.com/o/oauth2/auth",
+          :token_uri                   => "https://oauth2.googleapis.com/token",
+          :auth_provider_x509_cert_url => "https://www.googleapis.com/oauth2/v1/certs"
         }
+
+        if auth.userid.present?
+          client_x509_cert_url = "https://www.googleapis.com/robot/v1/metadata/x509/#{CGI.escape(auth.userid)}"
+          json_data[:client_x509_cert_url] = client_x509_cert_url
+        end
 
         File.write(gce_credentials_file, json_data.to_json)
         File.chmod(0o0600, gce_credentials_file)

--- a/spec/lib/ansible/runner/credential/google_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/google_credential_spec.rb
@@ -71,10 +71,14 @@ RSpec.describe Ansible::Runner::GoogleCredential do
 
         actual_data   = JSON.parse(File.read(File.join(@base_dir, "gce_credentials")))
         expected_data = {
-          "type"         => "service_account",
-          "private_key"  => "key_data",
-          "client_email" => "manageiq@gmail.com",
-          "project_id"   => "google_project",
+          "type"                        => "service_account",
+          "private_key"                 => "key_data",
+          "client_email"                => "manageiq@gmail.com",
+          "project_id"                  => "google_project",
+          "auth_uri"                    => "https://accounts.google.com/o/oauth2/auth",
+          "token_uri"                   => "https://oauth2.googleapis.com/token",
+          "auth_provider_x509_cert_url" => "https://www.googleapis.com/oauth2/v1/certs",
+          "client_x509_cert_url"        => "https://www.googleapis.com/robot/v1/metadata/x509/manageiq%40gmail.com"
         }
 
         expect(expected_data).to eq(actual_data)
@@ -86,10 +90,13 @@ RSpec.describe Ansible::Runner::GoogleCredential do
 
         actual_data   = JSON.parse(File.read(File.join(@base_dir, "gce_credentials")))
         expected_data = {
-          "type"         => "service_account",
-          "private_key"  => "",
-          "client_email" => "",
-          "project_id"   => "",
+          "type"                        => "service_account",
+          "private_key"                 => "",
+          "client_email"                => "",
+          "project_id"                  => "",
+          "auth_uri"                    => "https://accounts.google.com/o/oauth2/auth",
+          "token_uri"                   => "https://oauth2.googleapis.com/token",
+          "auth_provider_x509_cert_url" => "https://www.googleapis.com/oauth2/v1/certs"
         }
 
         expect(expected_data).to eq(actual_data)
@@ -101,10 +108,14 @@ RSpec.describe Ansible::Runner::GoogleCredential do
 
         actual_data   = JSON.parse(File.read(File.join(@base_dir, "gce_credentials")))
         expected_data = {
-          "type"         => "service_account",
-          "private_key"  => "key_data",
-          "client_email" => "manageiq@gmail.com",
-          "project_id"   => "",
+          "type"                        => "service_account",
+          "private_key"                 => "key_data",
+          "client_email"                => "manageiq@gmail.com",
+          "project_id"                  => "",
+          "auth_uri"                    => "https://accounts.google.com/o/oauth2/auth",
+          "token_uri"                   => "https://oauth2.googleapis.com/token",
+          "auth_provider_x509_cert_url" => "https://www.googleapis.com/oauth2/v1/certs",
+          "client_x509_cert_url"        => "https://www.googleapis.com/robot/v1/metadata/x509/manageiq%40gmail.com"
         }
 
         expect(expected_data).to eq(actual_data)


### PR DESCRIPTION
Set the auth and token URIs in the Ansible Runner Google Credential.