### PR TITLE
Add a Settings.messaging config section

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -33,7 +33,7 @@ class MiqQueue < ApplicationRecord
   PRIORITY_DIR    = [:higher, :lower]
 
   def self.messaging_type
-    ENV.fetch("MESSAGING_TYPE", nil) || Settings.messaging_type
+    ENV.fetch("MESSAGING_TYPE", nil) || Settings.messaging.type
   end
 
   def self.messaging_client(client_ref)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -862,7 +862,8 @@
   :level_policy: info
   :level_remote_console: info
   :secret_filter: []
-:messaging_type: kafka
+:messaging:
+  :type: kafka
 :notifications:
   :history:
     :purge_window_size: 1000

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe EmsEvent do
       end
 
       context "messaging_type: artemis" do
-        before { stub_settings_merge(:messaging_type => 'artemis') }
+        before { stub_settings_merge(:messaging => {:type => 'artemis'}) }
 
         it "Adds event to Artemis queue" do
           messaging_client = double("ManageIQ::Messaging")
@@ -141,7 +141,7 @@ RSpec.describe EmsEvent do
       end
 
       context "messaging_type: kafka" do
-        before { stub_settings_merge(:messaging_type => 'kafka') }
+        before { stub_settings_merge(:messaging => {:type => 'kafka'}) }
 
         it "Adds event to Kafka topic" do
           messaging_client = double("ManageIQ::Messaging")
@@ -161,7 +161,7 @@ RSpec.describe EmsEvent do
       end
 
       context "messaging_type: miq_queue" do
-        before { stub_settings_merge(:messaging_type => 'miq_queue') }
+        before { stub_settings_merge(:messaging => {:type => 'miq_queue'}) }
 
         it "Adds event to MiqQueue" do
           expected_queue_payload = {

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
     let(:persister) { Spec::Support::EmsRefreshHelper::TestPersister.new(ems) }
 
     before do
-      stub_settings_merge(:ems_refresh => {:syndicate_inventory => true}, :prototype => {:messaging_type => 'kafka'})
+      stub_settings_merge(:ems_refresh => {:syndicate_inventory => true}, :messaging => {:type => 'kafka'})
       allow(MiqQueue).to receive(:messaging_client).and_return(messaging_client)
     end
 


### PR DESCRIPTION
Move the :messaging_type setting under a top-level :messaging section allowing for other options to be added in the future

Ref: https://github.com/ManageIQ/manageiq/pull/21997#discussion_r924820785