### PR TITLE
Perf capture - better VimPerformanceState lookups

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -51,7 +51,7 @@ module Metric::CiMixin::Capture
       when "hourly" # Storage (value is ignored)
         last_perf_capture_on || 4.hours.ago.utc
       else # "realtime" for Vm or Host
-        [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].compact.max
+        [last_perf_capture_on, 4.hours.ago.utc].compact.max
       end
     [start_time&.utc, end_time&.utc]
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -7,6 +7,7 @@ module Metric::CiMixin::Capture
     end
   end
 
+  # delegate currently only used on Ems
   delegate :perf_collect_metrics, :to => :perf_capture_object
 
   def perf_capture_realtime(*args)
@@ -33,25 +34,26 @@ module Metric::CiMixin::Capture
       return
     end
 
+    metrics_capture = perf_capture_object
     start_time, end_time = fix_capture_start_end_time(interval_name, start_time, end_time)
-    start_range, end_range, counters_data = just_perf_capture(interval_name, start_time, end_time)
+    start_range, end_range, counters_data = just_perf_capture(interval_name, start_time, end_time, metrics_capture)
 
     perf_process(interval_name, start_range, end_range, counters_data) if start_range
   end
 
+  # Determine the start_time for capturing if not provided
+  # interval_name == realtime is the only one that passes no start_time/end_time
   def fix_capture_start_end_time(interval_name, start_time, end_time)
-    start_time = start_time.utc unless start_time.nil?
-    end_time = end_time.utc unless end_time.nil?
-
-    # Determine the start_time for capturing if not provided
-    if interval_name == 'historical'
-      start_time ||= Metric::Capture.historical_start_time
-    elsif interval_name == "hourly"
-      start_time ||= last_perf_capture_on || 4.hours.ago.utc
-    else # interval_name == realtime
-      start_time ||= [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].compact.max
-    end
-    [start_time, end_time]
+    start_time ||=
+      case interval_name
+      when "historical" # Vm or Host
+        Metric::Capture.historical_start_time
+      when "hourly" # Storage (value is ignored)
+        last_perf_capture_on || 4.hours.ago.utc
+      else # "realtime" for Vm or Host
+        [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].compact.max
+      end
+    [start_time&.utc, end_time&.utc]
   end
 
   # Determine the expected start time, so we can detect gaps or missing data
@@ -76,7 +78,7 @@ module Metric::CiMixin::Capture
     end
   end
 
-  def just_perf_capture(interval_name, start_time = nil, end_time = nil)
+  def just_perf_capture(interval_name, start_time, end_time, metrics_capture)
     log_header = "[#{interval_name}]"
     log_time = ''
     log_time << ", start_time: [#{start_time}]" unless start_time.nil?
@@ -84,48 +86,51 @@ module Metric::CiMixin::Capture
 
     _log.info("#{log_header} Capture for #{log_target}#{log_time}...")
 
-    start_range = end_range = counters = counter_values = counters_data = nil
+    start_range = end_range = counters_by_mor = counter_values_by_mor_and_ts = target_ems = nil
+    counters_data = {}
     _, t = Benchmark.realtime_block(:total_time) do
-      Benchmark.realtime_block(:capture_state) { perf_capture_state }
+      Benchmark.realtime_block(:capture_state) { VimPerformanceState.capture(metrics_capture.target) }
 
       interval_name_for_capture = interval_name == 'historical' ? 'hourly' : interval_name
-      counters_by_mor, counter_values_by_mor_and_ts = perf_collect_metrics(interval_name_for_capture, start_time, end_time)
-
-      counters       = counters_by_mor[ems_ref] || {}
-      counter_values = counter_values_by_mor_and_ts[ems_ref] || {}
-
-      ts = counter_values.keys.sort
-      start_range = ts.first
-      end_range   = ts.last
+      counters_by_mor, counter_values_by_mor_and_ts = metrics_capture.perf_collect_metrics(interval_name_for_capture, start_time, end_time)
     end
 
     _log.info("#{log_header} Capture for #{log_target}#{log_time}...Complete - Timings: #{t.inspect}")
 
-    if start_range.nil?
-      _log.info("#{log_header} Skipping processing for #{log_target}#{log_time} as no metrics were captured.")
-      # Set the last capture on to end_time to prevent forever queueing up the same collection range
-      update(:last_perf_capture_on => end_time || Time.now.utc) if interval_name == 'realtime'
-    else
-      expected_start_range = calculate_gap(interval_name, start_time)
-      if expected_start_range && start_range > expected_start_range
-        _log.warn("#{log_header} For #{log_target}#{log_time}, expected to get data as of [#{expected_start_range}], but got data as of [#{start_range}].")
+    # ems lookup cache
+    target_ems = nil
 
-        # Raise ems_performance_gap_detected alert event to enable notification.
-        MiqEvent.raise_evm_alert_event_queue(ext_management_system, "ems_performance_gap_detected",
-                                             :resource_class       => self.class.name,
-                                             :resource_id          => id,
-                                             :expected_start_range => expected_start_range,
-                                             :start_range          => start_range
-                                            )
-      end
+    Array(metrics_capture.target).each do |target|
+      counters       = counters_by_mor[target.ems_ref] || {}
+      counter_values = counter_values_by_mor_and_ts[target.ems_ref] || {}
 
-      # Convert to format allowing to send multiple resources at once
-      counters_data = {
-        self => {
+      ts = counter_values.keys.sort
+      start_range = ts.first
+      end_range   = ts.last
+
+      if start_range.nil?
+        _log.info("#{log_header} Skipping processing for #{target.log_target}#{log_time} as no metrics were captured.")
+        # Set the last capture on to end_time to prevent forever queueing up the same collection range
+        target.update(:last_perf_capture_on => end_time || Time.now.utc) if interval_name == 'realtime'
+      else
+        expected_start_range = target.calculate_gap(interval_name, start_time)
+        if expected_start_range && start_range > expected_start_range
+          _log.warn("#{log_header} For #{target.log_target}#{log_time}, expected to get data as of [#{expected_start_range}], but got data as of [#{start_range}].")
+
+          # Raise ems_performance_gap_detected alert event to enable notification.
+          target_ems ||= target.ext_management_system
+          MiqEvent.raise_evm_alert_event_queue(target_ems, "ems_performance_gap_detected",
+                                               :resource_class       => target.class.name,
+                                               :resource_id          => target.id,
+                                               :expected_start_range => expected_start_range,
+                                               :start_range          => start_range)
+        end
+
+        counters_data[target] = {
           :counters       => counters,
           :counter_values => counter_values
         }
-      }
+      end
     end
 
     [start_range, end_range, counters_data]

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -18,82 +18,98 @@ module Metric::CiMixin::Processing
       rt_rows = {}
 
       counters_data.each do |resource, data|
-        counters       = data[:counters]
-        counter_values = data[:counter_values]
-
-        Benchmark.realtime_block(:process_counter_values) do
-          counter_values.each do |ts, cv|
-            ts = Metric::Helper.nearest_realtime_timestamp(ts) if interval_name == 'realtime'
-
-            col_vals = {}
-            cv.each do |counter_id, value|
-              counter = counters[counter_id]
-              next if counter.nil? || counter[:capture_interval_name] != interval_name
-
-              col = counter[:counter_key].to_sym
-              unless Metric.column_names_symbols.include?(col)
-                _log.debug("#{log_header} Column [#{col}] is not defined, skipping")
-                next
-              end
-
-              col_vals.store_path(col, counter[:instance], [value, counter])
-            end
-
-            col_vals.each do |col, values_by_instance|
-              # If there are multiple instances for a column, use the aggregate
-              #   instance, if available, otherwise roll it up ourselves.
-              value, counter = values_by_instance[""]
-              if value.nil?
-                value = 0
-                counter = nil
-                values_by_instance.each_value do |v, c|
-                  value += v
-                  counter = c
-                end
-              end
-
-              # Create hashes for the rows
-              rt = (rt_rows[[ts, resource]] ||= {
-                :capture_interval_name => interval_name,
-                :capture_interval      => counter[:capture_interval],
-                :resource              => resource,
-                :resource_name         => resource.name,
-                :timestamp             => ts
-              })
-              rt[col], message = normalize_value(value, counter)
-              _log.warn("#{log_header} #{log_target} Timestamp: [#{ts}], Column [#{col}]: '#{message}'") if message
-            end
-          end
-        end
+        process_counter_values(resource, data, interval_name, rt_rows) ## rt_rows changes
       end
 
-      parameters = if ActiveMetrics::Base.connection_config[:adapter] == "miq_postgres"
-                     # We can just pass original data to PG, with metrics grouped by timestamps, since that is how
-                     # we store to PG now. It will spare quite some memory and time to not convert it to row_per_metric
-                     # and than back to original format.
-                     transform_parameters_row_with_all_metrics(resources, interval_name, start_time, end_time, rt_rows)
-                   else
-                     transform_parameters_row_per_metric(resources, interval_name, start_time, end_time, rt_rows)
-                   end
-
-      ActiveMetrics::Base.connection.write_multiple(parameters)
-
-      resources.each do |resource|
-        resource.update_attribute(:last_perf_capture_on, end_time) if resource.last_perf_capture_on.nil? || resource.last_perf_capture_on.utc.iso8601 < end_time
-      end
-
-      # Raise <class>_perf_complete alert event if realtime so alerts can be evaluated.
-      resources.each do |resource|
-        MiqEvent.raise_evm_alert_event_queue(resource, MiqEvent.event_name_for_target(resource, "perf_complete"))
-      end
-
-      resources.each do |resource|
-        resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
-      end
-
-      publish_metrics(rt_rows) if syndicate_metrics?
+      parameters = convert_metrics(resources, interval_name, start_time, end_time, rt_rows)
+      write_metrics(parameters)
+      update_and_publish_metrics(interval_orig, start_time, end_time, resources, rt_rows)
     end
     _log.info("#{log_header} Processing for #{log_specific_targets(resources)}, for range [#{start_time} - #{end_time}]...Complete - Timings: #{t.inspect}")
+  end
+
+  def process_counter_values(resource, data, interval_name, rt_rows)
+    log_header = "[#{interval_name}]"
+
+    counters       = data[:counters]
+    counter_values = data[:counter_values]
+
+    Benchmark.realtime_block(:process_counter_values) do
+      counter_values.each do |ts, cv|
+        ts = Metric::Helper.nearest_realtime_timestamp(ts) if interval_name == 'realtime'
+
+        col_vals = {}
+        cv.each do |counter_id, value|
+          counter = counters[counter_id]
+          next if counter.nil? || counter[:capture_interval_name] != interval_name
+
+          col = counter[:counter_key].to_sym
+          unless Metric.column_names_symbols.include?(col)
+            _log.debug("#{log_header} Column [#{col}] is not defined, skipping")
+            next
+          end
+
+          col_vals.store_path(col, counter[:instance], [value, counter])
+        end
+
+        col_vals.each do |col, values_by_instance|
+          # If there are multiple instances for a column, use the aggregate
+          #   instance, if available, otherwise roll it up ourselves.
+          value, counter = values_by_instance[""]
+          if value.nil?
+            value = 0
+            counter = nil
+            values_by_instance.each_value do |v, c|
+              value += v
+              counter = c
+            end
+          end
+
+          # Create hashes for the rows
+          rt = (rt_rows[[ts, resource]] ||= {
+            :capture_interval_name => interval_name,
+            :capture_interval      => counter[:capture_interval],
+            :resource              => resource,
+            :resource_name         => resource.name,
+            :timestamp             => ts
+          })
+          rt[col], message = normalize_value(value, counter)
+          _log.warn("#{log_header} #{log_target} Timestamp: [#{ts}], Column [#{col}]: '#{message}'") if message
+        end
+      end
+    end
+  end
+
+  def convert_metrics(resources, interval_name, start_time, end_time, rt_rows)
+    if ActiveMetrics::Base.connection_config[:adapter] == "miq_postgres"
+      # We can just pass original data to PG, with metrics grouped by timestamps, since that is how
+      # we store to PG now. It will spare quite some memory and time to not convert it to row_per_metric
+      # and than back to original format.
+      transform_parameters_row_with_all_metrics(resources, interval_name, start_time, end_time, rt_rows)
+    else
+      transform_parameters_row_per_metric(resources, interval_name, start_time, end_time, rt_rows)
+    end
+  end
+
+  def write_metrics(parameters)
+    ActiveMetrics::Base.connection.write_multiple(parameters)
+  end
+
+  def update_and_publish_metrics(interval_orig, start_time, end_time, resources, rt_rows)
+    resources.each do |resource|
+      resource.update_attribute(:last_perf_capture_on, end_time) if resource.last_perf_capture_on.nil? || resource.last_perf_capture_on.utc.iso8601 < end_time
+    end
+
+    # Raise <class>_perf_complete alert event if realtime so alerts can be evaluated.
+    resources.each do |resource|
+      MiqEvent.raise_evm_alert_event_queue(resource, MiqEvent.event_name_for_target(resource, "perf_complete"))
+    end
+
+    resources.each do |resource|
+      resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
+    end
+
+    publish_metrics(rt_rows) if syndicate_metrics?
   end
 
   private

--- a/app/models/metric/ci_mixin/state_finders.rb
+++ b/app/models/metric/ci_mixin/state_finders.rb
@@ -18,18 +18,14 @@ module Metric::CiMixin::StateFinders
           state = vim_performance_states.detect { |s| s.timestamp == t }
         end
       else
-        state = vim_performance_states.find_by(:timestamp => ts)
+        state = @states_by_ts[Metric::Helper.nearest_hourly_timestamp(Time.now.utc)]
+        state ||= vim_performance_states.find_by(:timestamp => ts)
       end
-      # TODO: index perf_capture_state to avoid fetching it everytime for a missing ts and hour
       state ||= perf_capture_state
-      @states_by_ts[ts] = state
+      @states_by_ts[state.timestamp.utc.iso8601] = state
     end
 
     state
-  end
-
-  def preload_vim_performance_state_for_ts(conditions = {})
-    @states_by_ts = vim_performance_states.where(conditions).index_by(&:timestamp)
   end
 
   def preload_vim_performance_state_for_ts_iso8601(conditions = {})


### PR DESCRIPTION
part of #20071
extracted from #22175

This is prepping us to allow collection requests and collection execution to handle multiple targets.

`capture`: determines how to partition the work. Puts work onto queue.
`perf_capture`: handles the actual requests. Pulls work off of the queue.

## `capture` Changes

- move the host targets and cluster rollup logic into a separate method. 
- move the host gap / historical capture into a separate method

## `perf_capture` Changes

- `just_perf_capture` now supports multiple targets.
- `fix_capture_start_end` rubocop fixes - uses a `case` statement.
- `VimPerformanceState#capture` now supports multiple objects
- `VimPerformanceState` caching now properly works. (performance numbers below)
- `fix_capture_start_end` `CHANGED/FIXED` to limit `"realtime"` to 4 hours
- `perf_process` split into multiple methods (no other change)

## Performance impact

|        ms |       bytes |    objects |query |   qry ms |     rows |`comments`
|       ---:|         ---:|        ---:|  ---:|      ---:|      ---:| ---
|  18,966.9 | 44,165,289* | 32,711,827 |1,675 |  6,538.2 |      445 |`capture-before`
|  18,789.9 | 62,526,021* | 32,590,959 |1,455 |  6,047.2 |      335 |`capture-after`
|           |             |            | 13%  |      8%  |      25% | delta

There is are more comments in that particular commit. But the high level is when creating a new `VimPerformanceState`, it no longer queries for the latest state.
