### PR TITLE
Don't run a manager_refresh if using streaming

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -3,6 +3,8 @@ class EmsEvent
     extend ActiveSupport::Concern
 
     def manager_refresh(sync: false)
+      return if ext_management_system&.supports?(:streaming_refresh)
+
       refresh_targets = manager_refresh_targets
 
       return if refresh_targets.blank?


### PR DESCRIPTION
If using streaming refresh don't run a refresh with manager_refresh_targets.

Previously providers using streaming refresh would have allow_targeted_refresh not set so ext_management_system.class::EventTargetParser wouldn't be called.

Related https://github.com/ManageIQ/manageiq-providers-vmware/pull/833

cc @jrafanie 