### PR TITLE
Default back to miq_queue as the messaging_type

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -863,7 +863,7 @@
   :level_remote_console: info
   :secret_filter: []
 :messaging:
-  :type: kafka
+  :type: miq_queue
 :notifications:
   :history:
     :purge_window_size: 1000
@@ -1105,7 +1105,6 @@
           :queue_timeout: 120.minutes
           :dequeue_method: sql
       :event_handler:
-        :dequeue_method: miq_messaging
         :nice_delta: 7
       :generic_worker:
         :count: 2

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Metric::CiMixin::Capture do
           end
 
           context "with syndication enabled" do
-            before { stub_settings_merge(:performance => {:syndicate_metrics => true}) }
+            before { stub_settings_merge(:performance => {:syndicate_metrics => true}, :messaging => {:type => "kafka"}) }
 
             it "verifies that hole in the data is logged, corrupted data is logged and no other warnings are logged" do
               # Hole in the data is logged


### PR DESCRIPTION
We are postponing the requirement for kafka to be configured until a future version, thus we have to default back to MiqQueue for messaging