### PR TITLE
Revert Merge pull request #22183 from agrare/bump_manageiq_appliance_console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -273,7 +273,7 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
-  gem "manageiq-appliance_console",     "~>8.0",  :require => false
+  gem "manageiq-appliance_console",     "~>7.1", ">=7.1.1",  :require => false
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues


### PR DESCRIPTION
This reverts PR https://github.com/ManageIQ/manageiq/pull/22183 which brought in this change to require kafka setup https://github.com/ManageIQ/manageiq-appliance_console/pull/195.

We are going to delay requiring kafka to be configured until a later major release

Related: https://github.com/ManageIQ/manageiq/pull/22205