### PR TITLE
Heartbeat for non-rails workers

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -121,7 +121,7 @@ class MiqWorker::Runner
     # Using exec here rather than fork+exec so that we can continue to use the
     # standard systemd service Type=notify and not have to use Type=forking which
     # can limit other systemd options available to the service.
-    Bundler.unbundled_exec(worker_cmdline)
+    Bundler.unbundled_exec(worker_env, worker_cmdline)
   end
 
   def recover_from_temporary_failure
@@ -488,6 +488,14 @@ class MiqWorker::Runner
     {
       :messaging => MiqQueue.messaging_client_options,
       :settings  => Settings.to_hash
+    }
+  end
+
+  def worker_env
+    {
+      "APP_ROOT"              => Rails.root.to_s,
+      "GUID"                  => @worker.guid,
+      "WORKER_HEARTBEAT_FILE" => @worker.heartbeat_file
     }
   end
 


### PR DESCRIPTION
Non-rails workers do not have access to their miq_workers database record or the MiqWorker class which has helpful values specifically for heartbeating.  We also can't simply set these in the run_single_worker process' ENV because Bundler.with_clean_env doesn't reload ENV vars after startup.

Make sure to pass these options to the child non-rails worker on startup.

Follow-up:
* Check heartbeat for workers in "starting" status (non-rails can't set their record to "started")

Required for:
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/836