### PR TITLE
Add PhysicalServer remote console supports feature

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -19,6 +19,8 @@ class PhysicalServer < ApplicationRecord
     nil       => "Unknown",
   }.freeze
 
+  supports_not :console
+
   validates :vendor, :inclusion =>{:in => VENDOR_TYPES}
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_servers,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"

--- a/app/models/physical_server/operations.rb
+++ b/app/models/physical_server/operations.rb
@@ -6,6 +6,25 @@ module PhysicalServer::Operations
   include_concern 'ConfigPattern'
   include_concern 'Lifecycle'
 
+  def remote_console_acquire_resource_queue(userid)
+    task_opts = {
+      :action => "Acquiring remote console file or url from a physical server with uuid #{ems_ref} for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'remote_console_acquire_resource',
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [userid, MiqServer.my_server.id]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
   private
 
   def change_state(verb)


### PR DESCRIPTION
Remote consoles are supported for only some physical-infrastructure managers so we have to have a supports feature check to control if we should display the console button on the UI.

Dependents:
* https://github.com/ManageIQ/manageiq-providers-lenovo/pull/379

https://github.com/ManageIQ/manageiq/issues/22210