### PR TITLE
Add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 [![License](http://img.shields.io/badge/license-APACHE2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Translate](https://img.shields.io/badge/translate-transifex-blue.svg)](https://www.transifex.com/manageiq/manageiq/dashboard/)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4282/badge)](https://bestpractices.coreinfrastructure.org/projects/4282)
 [![Open Source Helpers](https://www.codetriage.com/manageiq/manageiq/badges/users.svg)](https://www.codetriage.com/manageiq/manageiq)
+
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4282/badge)](https://bestpractices.coreinfrastructure.org/projects/4282)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ManageIQ/manageiq/badge)](https://api.securityscorecards.dev/projects/github.com/ManageIQ/manageiq)
 
 [![Build history for master branch](https://buildstats.info/github/chart/ManageIQ/manageiq?branch=master&buildCount=50&includeBuildsFromPullRequest=false&showstats=false)](https://github.com/ManageIQ/manageiq/actions?query=branch%3Amaster)
 


### PR DESCRIPTION
See https://securityscorecards.dev/. Since ManageIQ is one of the
top-1000 project that OpenSSF pre-scans [[ref]], we can reference the badge
directly and do not need to run the scanner ourselves.

[skip ci]

[ref]: https://github.com/ossf/scorecard/blob/main/cron/internal/data/projects.csv

@jrafanie Please review.