### PR TITLE
[WIP] Batch collect gap metrics collection

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -204,7 +204,7 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
       #   we will require a create_rollup_task_for_cluster
       current_batch_size = parent ? targets.size : batch_size
       rollup = parent.present?
-      targets.each_slice(current_batch_size) do |targets_batch|
+      targets.sort.each_slice(current_batch_size) do |targets_batch|
         perf_capture_queue_target(targets_batch, interval, :start_time => start_time, :end_time => end_time, :rollup => rollup)
       end
     else # send individual messages

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -93,7 +93,7 @@ module Metric::CiMixin::Capture
     start_range = end_range = counters_by_mor = counter_values_by_mor_and_ts = target_ems = nil
     counters_data = {}
     _, t = Benchmark.realtime_block(:total_time) do
-      Benchmark.realtime_block(:capture_state) { VimPerformanceState.capture(metrics_capture.target) }
+      perf_capture_states(metrics_capture.target)
 
       interval_name_for_capture = interval_name == 'historical' ? 'hourly' : interval_name
       counters_by_mor, counter_values_by_mor_and_ts = metrics_capture.perf_collect_metrics(interval_name_for_capture, start_time, end_time)
@@ -166,6 +166,10 @@ module Metric::CiMixin::Capture
         task.save!
       end
     end
+  end
+
+  def perf_capture_states(targets)
+    Benchmark.realtime_block(:capture_state) { VimPerformanceState.capture(targets) }
   end
 
   def perf_capture_state

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -101,9 +101,6 @@ module Metric::CiMixin::Capture
 
     _log.info("#{log_header} Capture for #{metrics_capture.log_targets}#{log_time}...Complete - Timings: #{t.inspect}")
 
-    # ems lookup cache
-    target_ems = nil
-
     metrics_capture.targets.each do |target|
       counters       = counters_by_mor[target.ems_ref] || {}
       counter_values = counter_values_by_mor_and_ts[target.ems_ref] || {}
@@ -122,8 +119,8 @@ module Metric::CiMixin::Capture
           _log.warn("#{log_header} For #{target.log_target}#{log_time}, expected to get data as of [#{expected_start_range}], but got data as of [#{start_range}].")
 
           # Raise ems_performance_gap_detected alert event to enable notification.
-          target_ems ||= target.ext_management_system
-          MiqEvent.raise_evm_alert_event_queue(target_ems, "ems_performance_gap_detected",
+          # NOTE: using parent ext_management_system
+          MiqEvent.raise_evm_alert_event_queue(ext_management_system, "ems_performance_gap_detected",
                                                :resource_class       => target.class.name,
                                                :resource_id          => target.id,
                                                :expected_start_range => expected_start_range,

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -90,6 +90,7 @@ module Metric::CiMixin::Capture
 
     _log.info("#{log_header} Capture for #{metrics_capture.log_targets}#{log_time}...")
 
+    new_last_perf_capture_on = Time.new.utc
     start_range = end_range = counters_by_mor = counter_values_by_mor_and_ts = target_ems = nil
     counters_data = {}
     _, t = Benchmark.realtime_block(:total_time) do
@@ -112,7 +113,7 @@ module Metric::CiMixin::Capture
       if start_range.nil?
         _log.info("#{log_header} Skipping processing for #{target.log_target}#{log_time} as no metrics were captured.")
         # Set the last capture on to end_time to prevent forever queueing up the same collection range
-        target.update(:last_perf_capture_on => end_time || Time.now.utc) if interval_name == 'realtime'
+        target.update(:last_perf_capture_on => end_time || new_last_perf_capture_on) if interval_name == 'realtime'
       else
         expected_start_range = target.calculate_gap(interval_name, start_time)
         if expected_start_range && start_range > expected_start_range

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -25,6 +25,8 @@ module Metric::CiMixin::Processing
     _log.info("#{log_header} Processing for #{log_specific_targets(resources)}, for range [#{start_time} - #{end_time}]...Complete - Timings: #{t.inspect}")
   end
 
+  private
+
   def process_counter_values(counters_data, interval_name)
     counters_data.each_with_object({}) do |(resource, data), rt_rows|
       log_header = "[#{interval_name}]"
@@ -112,8 +114,6 @@ module Metric::CiMixin::Processing
       resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
     end
   end
-
-  private
 
   def transform_parameters_row_per_metric(_resources, interval_name, _start_time, _end_time, rt_rows)
     rt_rows.flat_map do |(ts, _resource), rt|

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -110,8 +110,11 @@ module Metric::CiMixin::Processing
 
   def rollup_to_parent_metrics(resources, interval_orig, start_time, end_time)
     # Raise <class>_perf_complete alert event if realtime so alerts can be evaluated.
+    # all resources are the same class and ems as each other
+    # NOTE: using parent ext_management_system
+    zone = ext_management_system.my_zone
     resources.each do |resource|
-      resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
+      resource.perf_rollup_to_parents(interval_orig, start_time, end_time, :zone => zone)
     end
   end
 

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -14,67 +14,66 @@ module Metric::CiMixin::Processing
     _log.info("#{log_header} Processing for #{log_specific_targets(resources)}, for range [#{start_time} - #{end_time}]...")
 
     _dummy, t = Benchmark.realtime_block(:total_time) do
-      # Take the raw metrics and create hashes out of them
-      rt_rows = {}
-
-      counters_data.each do |resource, data|
-        process_counter_values(resource, data, interval_name, rt_rows) ## rt_rows changes
-      end
-
+      rt_rows = process_counter_values(counters_data, interval_name)
       parameters = convert_metrics(resources, interval_name, start_time, end_time, rt_rows)
       write_metrics(parameters)
-      update_and_publish_metrics(interval_orig, start_time, end_time, resources, rt_rows)
+      update_last_perf_capture_on(resources, end_time)
+      raise_perf_complete_alerts(resources)
+      rollup_to_parent_metrics(resources, interval_orig, start_time, end_time)
+      publish_metrics(rt_rows) if syndicate_metrics?
     end
     _log.info("#{log_header} Processing for #{log_specific_targets(resources)}, for range [#{start_time} - #{end_time}]...Complete - Timings: #{t.inspect}")
   end
 
-  def process_counter_values(resource, data, interval_name, rt_rows)
-    log_header = "[#{interval_name}]"
+  def process_counter_values(counters_data, interval_name)
+    counters_data.each_with_object({}) do |(resource, data), rt_rows|
+      log_header = "[#{interval_name}]"
 
-    counters       = data[:counters]
-    counter_values = data[:counter_values]
+      counters       = data[:counters]
+      counter_values = data[:counter_values]
 
-    Benchmark.realtime_block(:process_counter_values) do
-      counter_values.each do |ts, cv|
-        ts = Metric::Helper.nearest_realtime_timestamp(ts) if interval_name == 'realtime'
+      Benchmark.realtime_block(:process_counter_values) do
+        counter_values.each do |ts, cv|
+          ts = Metric::Helper.nearest_realtime_timestamp(ts) if interval_name == 'realtime'
 
-        col_vals = {}
-        cv.each do |counter_id, value|
-          counter = counters[counter_id]
-          next if counter.nil? || counter[:capture_interval_name] != interval_name
+          col_vals = {}
+          cv.each do |counter_id, value|
+            counter = counters[counter_id]
+            next if counter.nil? || counter[:capture_interval_name] != interval_name
 
-          col = counter[:counter_key].to_sym
-          unless Metric.column_names_symbols.include?(col)
-            _log.debug("#{log_header} Column [#{col}] is not defined, skipping")
-            next
-          end
-
-          col_vals.store_path(col, counter[:instance], [value, counter])
-        end
-
-        col_vals.each do |col, values_by_instance|
-          # If there are multiple instances for a column, use the aggregate
-          #   instance, if available, otherwise roll it up ourselves.
-          value, counter = values_by_instance[""]
-          if value.nil?
-            value = 0
-            counter = nil
-            values_by_instance.each_value do |v, c|
-              value += v
-              counter = c
+            col = counter[:counter_key].to_sym
+            unless Metric.column_names_symbols.include?(col)
+              _log.debug("#{log_header} Column [#{col}] is not defined, skipping")
+              next
             end
+
+            col_vals.store_path(col, counter[:instance], [value, counter])
           end
 
-          # Create hashes for the rows
-          rt = (rt_rows[[ts, resource]] ||= {
-            :capture_interval_name => interval_name,
-            :capture_interval      => counter[:capture_interval],
-            :resource              => resource,
-            :resource_name         => resource.name,
-            :timestamp             => ts
-          })
-          rt[col], message = normalize_value(value, counter)
-          _log.warn("#{log_header} #{log_target} Timestamp: [#{ts}], Column [#{col}]: '#{message}'") if message
+          col_vals.each do |col, values_by_instance|
+            # If there are multiple instances for a column, use the aggregate
+            #   instance, if available, otherwise roll it up ourselves.
+            value, counter = values_by_instance[""]
+            if value.nil?
+              value = 0
+              counter = nil
+              values_by_instance.each_value do |v, c|
+                value += v
+                counter = c
+              end
+            end
+
+            # Create hashes for the rows
+            rt = (rt_rows[[ts, resource]] ||= {
+              :capture_interval_name => interval_name,
+              :capture_interval      => counter[:capture_interval],
+              :resource              => resource,
+              :resource_name         => resource.name,
+              :timestamp             => ts
+            })
+            rt[col], message = normalize_value(value, counter)
+            _log.warn("#{log_header} #{log_target} Timestamp: [#{ts}], Column [#{col}]: '#{message}'") if message
+          end
         end
       end
     end
@@ -95,21 +94,23 @@ module Metric::CiMixin::Processing
     ActiveMetrics::Base.connection.write_multiple(parameters)
   end
 
-  def update_and_publish_metrics(interval_orig, start_time, end_time, resources, rt_rows)
+  def update_last_perf_capture_on(resources, end_time)
     resources.each do |resource|
       resource.update_attribute(:last_perf_capture_on, end_time) if resource.last_perf_capture_on.nil? || resource.last_perf_capture_on.utc.iso8601 < end_time
     end
+  end
 
-    # Raise <class>_perf_complete alert event if realtime so alerts can be evaluated.
+  def raise_perf_complete_alerts(resources)
     resources.each do |resource|
       MiqEvent.raise_evm_alert_event_queue(resource, MiqEvent.event_name_for_target(resource, "perf_complete"))
     end
+  end
 
+  def rollup_to_parent_metrics(resources, interval_orig, start_time, end_time)
+    # Raise <class>_perf_complete alert event if realtime so alerts can be evaluated.
     resources.each do |resource|
       resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
     end
-
-    publish_metrics(rt_rows) if syndicate_metrics?
   end
 
   private

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
         expect(queue_timings).to eq(
           "realtime"   => {queue_object(vm) => [[]]},
-          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
+          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on.beginning_of_hour, Time.now.utc.beginning_of_day)}
         )
       end
     end
@@ -308,7 +308,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
         expect(queue_timings).to eq(
           "realtime"   => {queue_object(vm) => [[]]},
-          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
+          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on.beginning_of_hour, Time.now.utc.beginning_of_day)}
         )
 
         Timecop.travel(20.minutes)
@@ -316,7 +316,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
         expect(queue_timings).to eq(
           "realtime"   => {queue_object(vm) => [[]]},
-          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
+          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on.beginning_of_hour, Time.now.utc.beginning_of_day)}
         )
       end
     end


### PR DESCRIPTION
## Overview

When we detect that metrics capture has not been run for a while, or never run for that matter, we submit gap/historical metrics requests.

followup to https://github.com/ManageIQ/manageiq/issues/20071

## Problem

Since the number of queue entries are split out by day, we were possibly putting hundreds of requests onto the queue for only a dozen VMs.

## Solution

When a gap is detected for inventory items, send the gap collection request in batches. This is minimal since the work to handle batches of inventory items has already been implemented.

For a coordinator with a troublesome C&U installation, gaps are by far the biggest issue we've had in the past in terms of over extending our queue.

 Now, it is putting a dozen message for hundreds of vms.
The backend has already been changed to handle batching collection. This changes the coordinator to send the collection requests in batches

This PR is split up into many improvements. They build a little but are relatively independent:

testing:
- refactor perf_process to make profiling easier
- tests ignore batching and date ranges to make sporadic test failures less likely
- drop unused metrics test helpers
- use ids instead of objects for metrics to make test failures easier to read

performance:
- [x] #22191
- [x] https://github.com/ManageIQ/manageiq/pull/22287

enhancements:
- use same last_perf_capture_on for the batch to make batching easier in the future
- sort batches so ids are sent more consistently
- send historical gaps as batches of ids (but still batch by date)
  this has big performance improvement b/c 250 times fewer queue entries. (# vms * # days / 250)
