### PR TITLE
Add github action PR for locale:update_all

### DIFF
--- a/.github/workflows/locale_update_all.yaml
+++ b/.github/workflows/locale_update_all.yaml
@@ -1,0 +1,60 @@
+name: "Locale Update All"
+
+on:
+  schedule:
+  - cron: '0 0 1,15 * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  locale_update_all:
+    if: github.repository_owner == 'ManageIQ'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: manageiq/postgresql:13
+        env:
+          POSTGRESQL_USER: root
+          POSTGRESQL_PASSWORD: smartvm
+          POSTGRESQL_DATABASE: vmdb_i18n
+        options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
+        ports:
+        - 5432:5432
+    env:
+      PGHOST: localhost
+      PGPASSWORD: smartvm
+      RAILS_ENV: i18n
+      SKIP_TEST_RESET: true
+      SKIP_DATABASE_SETUP: true
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up system
+      run: bin/before_install
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.0"
+        bundler-cache: true
+      timeout-minutes: 30
+    - name: Prepare dependencies
+      run: bin/setup
+    - name: Setup database
+      run: bundle exec rake evm:db:reset
+    - name: Run locale:update_all
+      run: bundle exec rake locale:update_all
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        add-paths: |
+          locale/manageiq.pot
+          locale/en/manageiq.po
+        commit-message: Update English Translations ${{github.event.repository.updated_at}}
+        branch: update_english_translations
+        author: ManageIQ Bot <bot@manageiq.org>
+        committer: ManageIQ Bot <bot@manageiq.org>
+        delete-branch: true
+        labels: internationalization
+        push-to-fork: miq-bot/manageiq
+        title: Update English Translations ${{github.event.repository.updated_at}}
+        body: Update the English Translations in the manageiq.po and manageiq.pot files.
+        token: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/locale_update_all.yaml
+++ b/.github/workflows/locale_update_all.yaml
@@ -57,4 +57,4 @@ jobs:
         push-to-fork: miq-bot/manageiq
         title: Update English Translations ${{github.event.repository.updated_at}}
         body: Update the English Translations in the manageiq.po and manageiq.pot files.
-        token: ${{ secrets.DEPLOY_TOKEN }}
+        token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
This will require setting the DEPLOY_TOKEN for opening a PR as the bot.

This will provie ad-hoc generation and scheduled on the 1st and 15th of each month.

The goal is to replace manually created pull requests like https://github.com/ManageIQ/manageiq/pull/22216

The results looks like this when hacked to run on my fork:
https://github.com/jrafanie/manageiq/pull/8