### PR TITLE
Add validations to prevent delete on read only models

### DIFF
--- a/app/models/advanced_setting.rb
+++ b/app/models/advanced_setting.rb
@@ -1,4 +1,6 @@
 class AdvancedSetting < ApplicationRecord
+  include_concern "ReadOnlyMixin"
+
   belongs_to :resource, :polymorphic => true
 
   def self.add_elements(parent, xml_node)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,5 +1,6 @@
 class Classification < ApplicationRecord
   acts_as_tree
+  include_concern "ReadOnlyMixin"
 
   belongs_to :tag
 

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,5 +1,7 @@
 class Condition < ApplicationRecord
   include UuidMixin
+  include_concern "ReadOnlyMixin"
+
   before_validation :default_name_to_guid, :on => :create
 
   validates :name, :description, :expression, :towhat, :presence => true

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -1,5 +1,7 @@
 class DialogField < ApplicationRecord
   include NewWithTypeStiMixin
+  include_concern "ReadOnlyMixin"
+
   attr_accessor :value
   attr_accessor :dialog
 

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -1,5 +1,6 @@
 class MiqAlert < ApplicationRecord
   include UuidMixin
+  include_concern "ReadOnlyMixin"
 
   SEVERITIES = [nil, "info", "warning", "error"]
 

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -1,6 +1,8 @@
 # TODO: Import/Export support
 
 class MiqPolicy < ApplicationRecord
+  include_concern "ReadOnlyMixin"
+
   TOWHAT_APPLIES_TO_CLASSES = %w(ContainerGroup
                                  ContainerImage
                                  ContainerNode

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -1,5 +1,6 @@
 class MiqPolicySet < ApplicationRecord
   acts_as_miq_set
+  include_concern "ReadOnlyMixin"
 
   before_validation :default_name_to_description, :on => :create
   before_destroy    :destroy_policy_tags

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -1,4 +1,6 @@
 class MiqUserRole < ApplicationRecord
+  include_concern "ReadOnlyMixin"
+
   DEFAULT_TENANT_ROLE_NAME = "EvmRole-tenant_administrator"
 
   has_many                :entitlements, :dependent => :restrict_with_exception
@@ -12,13 +14,6 @@ class MiqUserRole < ApplicationRecord
   serialize :settings
 
   default_value_for :read_only, false
-
-  before_destroy do |r|
-    if r.read_only
-      errors.add(:base, _("Read only roles cannot be deleted."))
-      throw :abort
-    end
-  end
 
   FIXTURE_PATH = File.join(FIXTURE_DIR, table_name)
   FIXTURE_YAML = "#{FIXTURE_PATH}.yml"

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -2,6 +2,8 @@
 #
 
 class MiqWidget < ApplicationRecord
+  include_concern "ReadOnlyMixin"
+
   default_value_for :enabled, true
   default_value_for :read_only, false
 

--- a/app/models/mixins/read_only_mixin.rb
+++ b/app/models/mixins/read_only_mixin.rb
@@ -1,0 +1,17 @@
+module ReadOnlyMixin
+  extend ActiveSupport::Concern
+
+  included do
+    before_destroy :reject_if_read_only
+  end
+
+  private
+
+  def reject_if_read_only
+    if read_only? && !EvmDatabase.seeding?
+      model_name = self.class.name.pluralize.underscore.tr('_', ' ').gsub('miq ', '')
+      errors.add(:base, _("Read only #{model_name} cannot be deleted."))
+      throw :abort
+    end
+  end
+end

--- a/spec/custom_matchers/be_deleted_spec.rb
+++ b/spec/custom_matchers/be_deleted_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "be_deleted" do
+  let(:model) { obj.class.name }
+  let(:obj) { FactoryBot.create(:user) }
+
+  it "detects deleted" do
+    obj.delete
+    expect(obj).to be_deleted
+  end
+
+  it "fails detecting not deleted" do
+    expect { expect(obj).to be_deleted }.to raise_error "expected #{model} to be deleted"
+  end
+
+  it "detects exist" do
+    expect(obj).not_to be_deleted
+  end
+
+  it "fails detecting exist" do
+    obj.delete
+    expect { expect(obj).not_to be_deleted }.to raise_error "expected #{model} to exist"
+  end
+end

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -218,4 +218,14 @@ RSpec.describe EvmDatabase do
       expect(handlers.first.subscription).not_to eq(handlers.last.subscription)
     end
   end
+
+  context "seeding?" do
+    it "detects seeding" do
+      expect(EvmDatabase.seeding?).to be(false)
+      EvmDatabase.with_seed do
+        expect(EvmDatabase.seeding?).to be(true)
+      end
+      expect(EvmDatabase.seeding?).to be(false)
+    end
+  end
 end

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -115,28 +115,28 @@ RSpec.describe BottleneckEvent do
     context "for a host_redhat resource" do
       let(:resource_name) { :host_redhat }
       it "deletes the future event" do
-        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect(bottleneck_event).to be_deleted
       end
     end
 
     context "for a host_vmware resource" do
       let(:resource_name) { :host_vmware }
       it "deletes the future event" do
-        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect(bottleneck_event).to be_deleted
       end
     end
 
     context "for a miq_enterprise resource" do
       let(:resource_name) { :miq_enterprise }
       it "deletes the future event" do
-        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect(bottleneck_event).to be_deleted
       end
     end
 
     context "for a ems_cluster_openstack resource" do
       let(:resource_name) { :ems_cluster_openstack }
       it "deletes the future event" do
-        expect { bottleneck_event.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+        expect(bottleneck_event).to be_deleted
       end
     end
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -431,7 +431,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Configur
         # Run most recent queue item (`GitRepository#broadcast_repo_dir_delete`)
         MiqQueue.get.deliver
 
-        expect { record.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect(record).to be_deleted
 
         expect(git_repo_dir).to_not exist
       end

--- a/spec/models/miq_dialog/seeding_spec.rb
+++ b/spec/models/miq_dialog/seeding_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe MiqDialog do
 
         described_class.seed
 
-        expect { dialog.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(dialog).to be_deleted
       end
     end
   end

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe MiqProductFeature do
 
       MiqProductFeature.seed_features
 
-      expect { deleted.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(deleted).to be_deleted
       expect(changed.reload.name).to eq("One")
       expect(unchanged.reload.updated_at).to be_within(0.1).of unchanged_orig_updated_at
     end

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe MiqProvisionRequest do
         end
 
         it "should not delete Approver" do
-          expect { approver.reload }.not_to raise_error
+          expect(approver).not_to be_deleted
         end
       end
 

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe MiqUserRole do
     it "does not destroy if 'read only' attribute for this role is true" do
       role.update(:read_only => true)
       expect { expect { role.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed) }.to_not(change { MiqUserRole.count })
-      expect(role.errors.full_messages[0]).to eq("Read only roles cannot be deleted.")
+      expect(role.errors.full_messages[0]).to eq("Read only user roles cannot be deleted.")
     end
   end
 

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe MiqWidget do
 
     it "allows deletion of widgets not in a set/dashboard" do
       widget.destroy!
-      expect { widget.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(widget).to be_deleted
     end
 
     it "prevents deletion of widgets in a set/dashboard" do

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -273,6 +273,7 @@ RSpec.describe MiqWidget do
     before do
       MiqReport.seed_report("Vendor and Guest OS")
       MiqWidget.sync_from_file(widget_path)
+      widget.update!(:read_only => false)
     end
 
     it "allows deletion of widgets not in a set/dashboard" do

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe MiqWorker do
 
           expect(miq_task.reload.active?).to be_falsey
           expect(miq_task.status_error?).to be_truthy
-          expect { message_linked_to_task.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(message_linked_to_task).to be_deleted
         end
 
         it "let's other handlers pick up tasks and messages not yet started" do

--- a/spec/models/mixins/read_only_mixin_spec.rb
+++ b/spec/models/mixins/read_only_mixin_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe ReadOnlyMixin do
+  let(:test_class) do
+    Class.new(ApplicationRecord) do
+      def self.name
+        "TestClass"
+      end
+      # any table with a read_only column
+      self.table_name = "classifications"
+      include ReadOnlyMixin
+    end
+  end
+
+  it "doesnt protect regular records" do
+    record = test_class.create(:read_only => false)
+    record.destroy!
+    expect(record).to be_deleted
+  end
+
+  it "protects without seeding" do
+    record = test_class.create(:read_only => true)
+    expect { record.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    expect(record).not_to be_deleted
+  end
+
+  it "deletes during seeding" do
+    record = test_class.create(:read_only => true)
+    EvmDatabase.with_seed do
+      record.destroy!
+    end
+    expect(record).to be_deleted
+  end
+end

--- a/spec/models/scan_item/seeding_spec.rb
+++ b/spec/models/scan_item/seeding_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ScanItem do
 
         described_class.seed
 
-        expect { scan_item.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(scan_item).to be_deleted
       end
     end
   end

--- a/spec/shared/support/custom_matchers/be_deleted.rb
+++ b/spec/shared/support/custom_matchers/be_deleted.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :be_deleted do
+  match do |object_instance|
+    klass = object_instance.class
+    expect(klass.exists?(:id => object_instance.id)).to be false
+  end
+
+  failure_message do |object_instance|
+    "expected #{object_instance.class.name} to be deleted"
+  end
+
+  failure_message_when_negated do |object_instance|
+    "expected #{object_instance.class.name} to exist"
+  end
+end


### PR DESCRIPTION
We currently have some logic in the API for checking read_only records.

This PR moves that logic into the model using `supports` so we can make those api controllers more consistent.

1. We need to update the api controllers to check `supports`, but this is pretty standard across all our api controllers.
2. A number of models will respond `supports?(:delete) == false` because we have not added `supports` to every model. If we mix this module into `ApplicationRecord` we will not be able to leverage `respond_to?(:supports?)` to come up with generic logic. Don't think this is a problem but putting it out there.
3. Added an entry for all `read_only` models. A few of these models may be better served with standard rails validations.


|    table_name     |   column_name||
|-------------------|------------|---|
| advanced_settings | read_only|
| classifications   | read_only|
| conditions        | read_only|
| dialog_fields     | read_only|
| host_storages     | read_only|means something else|
| miq_alerts        | read_only|
| miq_policies      | read_only|
| miq_sets          | read_only|
| miq_user_roles    | read_only|
| miq_widgets       | read_only|