### PR TITLE
Non rails worker settings

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -224,6 +224,8 @@ class MiqWorker < ApplicationRecord
               settings[k] = settings[k].to_i_with_method
             elsif settings[k] =~ /\A\d+(.\d+)?\z/ # case where int/float saved as string
               settings[k] = settings[k].to_i
+            elsif ManageIQ::Password.encrypted?(settings[k])
+              settings[k] = ManageIQ::Password.decrypt(settings[k])
             end
           end
         end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -224,9 +224,9 @@ class MiqWorker < ApplicationRecord
 
   # If not specified, provide the worker_settings cleaned up in fixnums, etc. instead of 1.seconds, 10.megabytes
   # and decrypt any values which are encrypted with ManageIQ::Password.
-  def self.normalize_settings!(settings)
+  def self.normalize_settings!(settings, recurse: false)
     settings.each_key do |k|
-      if settings[k].kind_of?(Hash)
+      if settings[k].kind_of?(Hash) && recurse
         normalize_settings!(settings[k])
       elsif settings[k].kind_of?(String)
         if settings[k].number_with_method?

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -495,7 +495,7 @@ class MiqWorker::Runner
 
     {
       :messaging => MiqQueue.messaging_client_options,
-      :settings  => worker.class.normalize_settings!(settings)
+      :settings  => worker.class.normalize_settings!(settings, :recurse => true)
     }
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -485,9 +485,17 @@ class MiqWorker::Runner
   private
 
   def worker_options
+    settings = {
+      :worker_settings => worker_settings
+    }
+
+    worker.class.worker_settings_paths.to_a.each do |settings_path|
+      settings.store_path(settings_path, Settings.to_hash.dig(*settings_path))
+    end
+
     {
       :messaging => MiqQueue.messaging_client_options,
-      :settings  => worker_settings.to_hash
+      :settings  => worker.class.normalize_settings!(settings)
     }
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -487,7 +487,7 @@ class MiqWorker::Runner
   def worker_options
     {
       :messaging => MiqQueue.messaging_client_options,
-      :settings  => Settings.to_hash
+      :settings  => worker_settings.to_hash
     }
   end
 


### PR DESCRIPTION
Pass in worker settings with strings like `"20.minutes"` converted to standard integers and encrypted `v2:{}` strings decrypted for non-rails workers.

Follow-up to https://github.com/ManageIQ/manageiq-providers-vmware/pull/836#discussion_r1013354546

As an example,
```
class ManageIQ::Providers::Vmware::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
  self.worker_settings_paths = [
    %i[http_proxy vmwarews],
    %i[log level_vim],
    %i[ems ems_vmware]
  ]
```

We'll get:
```
worker_options[:settings]
{:worker_settings=>{:count=>1, :cpu_request_percent=>5, :cpu_threshold_percent=>100, :gc_interval=>900, :heartbeat_freq=>10, :heartbeat_timeout=>120, :memory_request=>524288000, :memory_threshold=>2147483648, :nice_delta=>1, :parent_time_threshold=>180, :poll=>1, :poll_escalate_max=>30, :poll_method=>"normal", :starting_timeout=>600, :stopping_timeout=>600, :flooding_events_per_minute=>30, :flooding_monitor_enabled=>true, :ems_event_page_size=>100, :ems_event_thread_shutdown_timeout=>10, :ems_event_max_wait=>60, :rails_worker=>false}, :http_proxy=>{:vmwarews=>{:host=>nil, :password=>"password", :port=>2, :user=>nil}}, :log=>{:level_vim=>"debug"}, :ems=>{:ems_vmware=>{:blacklisted_event_names=>[], :event_handling=>{:event_groups=>{:addition=>{:critical=>nil}, :power=>{:critical=>nil}}}, :capture_batch_size=>250}}}
```

And specifically if we set a v2 encrypted password for the proxy:
```
worker_options[:settings][:http_proxy]
{:vmwarews=>{:host=>nil, :password=>"password", :port=>nil, :user=>nil}}
```

https://github.com/ManageIQ/manageiq/issues/21992