### PR TITLE
Dynamically build worker_cmdline for non-rails workers

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -510,7 +510,12 @@ class MiqWorker::Runner
   end
 
   def worker_cmdline
-    raise NotImplementedError, _("worker_cmdline must be implemented in a subclass")
+    # Attempt to find the plugin where the class lives then default to
+    # the application root
+    engine = Vmdb::Plugins.plugin_for_class(self.class) || Rails
+
+    worker_type = self.class.module_parent.name.split("::").last.underscore
+    engine.root.join("workers/#{worker_type}/worker").to_s
   end
 
   def skip_heartbeat?

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -47,6 +47,15 @@ module Vmdb
       details.transform_values { |v| v[:version] }
     end
 
+    def plugin_for_class(klass)
+      klass = klass.to_s unless klass.kind_of?(String)
+
+      klass_path, _klass_line = Object.const_source_location(klass)
+      return unless klass_path
+
+      paths.detect { |_engine, path| klass_path.start_with?(path) }&.first
+    end
+
     # Ansible content (roles) that come out-of-the-box, for use by both Automate
     #   and ansible-runner
     def ansible_content

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -11,6 +11,49 @@ RSpec.describe Vmdb::Plugins do
     )
   end
 
+  describe ".plugin_for_class" do
+    context "with a class in core" do
+      it "returns nil" do
+        expect(described_class.plugin_for_class(::MiqGenericWorker)).to be_nil
+      end
+    end
+
+    context "with a class in a plugin" do
+      it "returns the plugin" do
+        expect(described_class.plugin_for_class(::ApplicationController)).to eq(ManageIQ::UI::Classic::Engine)
+        expect(described_class.plugin_for_class(::Api::BaseController)).to eq(ManageIQ::Api::Engine)
+      end
+    end
+
+    context "with a nonexistent class" do
+      it "returns nil" do
+        expect(described_class.plugin_for_class("ThisClassDoesntExist")).to be_nil
+      end
+    end
+
+    context "with a string argument" do
+      it "returns the plugin" do
+        # Ensure the classes are referenced otherwise this test can fail
+        # sporadically
+        _ = ApplicationController
+        _ = Api::BaseController
+        expect(described_class.plugin_for_class("::ApplicationController")).to be(ManageIQ::UI::Classic::Engine)
+        expect(described_class.plugin_for_class("::Api::BaseController")).to eq(ManageIQ::Api::Engine)
+      end
+    end
+
+    context "with a symbol argument" do
+      it "returns the plugin" do
+        # Ensure the classes are referenced otherwise this test can fail
+        # sporadically
+        _ = ApplicationController
+        _ = Api::BaseController
+        expect(described_class.plugin_for_class(:ApplicationController)).to be(ManageIQ::UI::Classic::Engine)
+        expect(described_class.plugin_for_class(:'Api::BaseController')).to eq(ManageIQ::Api::Engine)
+      end
+    end
+  end
+
   it ".ansible_content" do
     ansible_content = described_class.ansible_content
 

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -152,5 +152,11 @@ RSpec.describe MiqWorker::Runner do
         )
       end
     end
+
+    describe ".worker_cmdline (private)" do
+      it "returns a path to the worker binary" do
+        expect(runner.send(:worker_cmdline)).to eq(Rails.root.join("workers/miq_generic_worker/worker").to_s)
+      end
+    end
   end
 end


### PR DESCRIPTION
Use the worker class to find the engine root and dynamically build the `worker_cmdline` for a non-rails worker

This will allow us to not have to define e.g. https://github.com/ManageIQ/manageiq-providers-vmware/blob/af07bd1/app/models/manageiq/providers/vmware/infra_manager/event_catcher/runner.rb#L114-L116 in every non-rails capable worker class

TODO:
- [x] Is there a better way to detect the engine for a class?
- [x] Specs for Vmdb::Plugins.plugin_for_class

Follow-up to: https://github.com/ManageIQ/manageiq/pull/22130#issuecomment-1303529123

Dependents:
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/889