### PR TITLE
add customizable disk_size to vm post-provision

### DIFF
--- a/app/models/manageiq/providers/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/infra_manager/provision_workflow.rb
@@ -5,8 +5,17 @@ class ManageIQ::Providers::InfraManager::ProvisionWorkflow < ::MiqProvisionVirtW
       :cpu_limit      => vm.cpu_limit,
       :memory_limit   => vm.memory_limit,
       :cpu_reserve    => vm.cpu_reserve,
-      :memory_reserve => vm.memory_reserve
+      :memory_reserve => vm.memory_reserve,
     }.merge!(get_cpu_values_hash(vm))
+
+    # TODO: short-term fix to only enable :allocated_disk_storage in machines that have a single hard disk
+    #   in the long-term it should be able to deal with multiple hard disks
+    virtual_disk_array = vm.hardware.disks.where(:device_type => "disk")
+    if virtual_disk_array.length == 1
+      default_size = (vm.hardware.disks.find_by(:device_type => "disk").size / 1.gigabyte).to_s
+      update_values.update({:allocated_disk_storage => default_size})
+    end
+
     set_or_default_field_values(update_values)
   end
 

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe MiqProvisionWorkflow do
                                             :host => @host)
           @hardware    = FactoryBot.create(:hardware, :vm_or_template => @vm_template, :guest_os => "winxppro",
                                             :memory_mb => 512,
-                                            :cpu_sockets => 2)
+                                            :cpu_sockets => 2,
+                                            :disks => FactoryBot.create(:disks, [:device_type => "disk", :size => 16 * (1024**3)]))
           @switch      = FactoryBot.create(:switch, :name => 'vSwitch0', :ports => 32, :hosts => [@host])
           @lan         = FactoryBot.create(:lan, :name => "VM Network", :switch => @switch)
           @ethernet    = FactoryBot.create(:guest_device, :hardware => @hardware, :lan => @lan,


### PR DESCRIPTION
add the field to `set_or_default_hardware_field_values`, so that it would show the default template disk size

![image](https://user-images.githubusercontent.com/106743023/204128420-8d87eadb-76d8-4fcc-98c5-5798bdfda701.png)


related PRs:
providers-vmware: https://github.com/ManageIQ/manageiq-providers-vmware/pull/839

ui-classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/8547
