### PR TITLE
Add `Job#signal_start` to simplify starting jobs

### DIFF
--- a/app/models/job/state_machine.rb
+++ b/app/models/job/state_machine.rb
@@ -41,6 +41,10 @@ module Job::StateMachine
     signal(:abort, *args)
   end
 
+  def signal_start(*args)
+    signal(:start, *args)
+  end
+
   def signal(signal, *args)
     signal = :abort_job if signal == :abort
     if transit_state(signal)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -21,9 +21,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < Manage
     kwargs[:timeout]   = vars[:execution_ttl].to_i.minutes
     kwargs[:verbosity] = vars[:verbosity].to_i if vars[:verbosity].present?
 
-    workflow.create_job({}, extra_vars, playbook_vars, vars[:hosts], credentials, **kwargs).tap do |job|
-      job.signal(:start)
-    end
+    workflow.create_job({}, extra_vars, playbook_vars, vars[:hosts], credentials, **kwargs).tap(&:signal_start)
   end
 
   private

--- a/app/models/service/resource_linking.rb
+++ b/app/models/service/resource_linking.rb
@@ -18,9 +18,7 @@ module Service::ResourceLinking
 
     _log.info("NAME [#{options[:name]}] for user #{evm_owner.userid}")
 
-    Service::LinkingWorkflow.create_job(options).tap do |job|
-      job.signal(:start)
-    end
+    Service::LinkingWorkflow.create_job(options).tap(&:signal_start)
   rescue => err
     _log.log_backtrace(err)
     raise

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -38,7 +38,7 @@ class ServiceOrchestration < Service
 
     @deploy_stack_job = ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner.create_job(job_options)
     update(:options => options.merge(:deploy_stack_job_id => @deploy_stack_job.id))
-    @deploy_stack_job.signal(:start)
+    @deploy_stack_job.signal_start
 
     wait_on_orchestration_stack
     orchestration_stack

--- a/spec/models/service/resource_linking_spec.rb
+++ b/spec/models/service/resource_linking_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Service do
       expect(Service::LinkingWorkflow).to receive(:create_job) do |args|
         expect(args).to match(hash_including(:target_class => provider.class.name, :target_id => provider.id))
         expect(args).to match(hash_including(:uid_ems_array => array_including(uid_ems_array)))
-      end.and_return(double(:signal => :start))
+      end.and_return(double(:signal_start => nil))
       service.add_provider_vms(provider, uid_ems_array)
     end
   end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe ServiceOrchestration do
   describe '#deploy_orchestration_stack' do
     it 'calls OrchestrationTemplateRunner' do
       job = double(:job, :id => 1, :orchestration_stack => FactoryBot.create(:orchestration_stack))
-      allow(job).to receive(:signal).with(:start)
+      allow(job).to receive(:signal_start)
       allow(service_with_dialog_options).to receive(:wait_on_orchestration_stack)
       allow(ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner).to receive(:create_job) do |options|
         expect(options).to include(
@@ -207,7 +207,7 @@ RSpec.describe ServiceOrchestration do
 
     it 'raises runtime error when job finishes with pre-existing stack' do
       job = double(:job, :id => 1, :status => 'error', :orchestration_stack => nil)
-      allow(job).to receive(:signal).with(:start)
+      allow(job).to receive(:signal_start)
       allow(ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner).to receive(:create_job).and_return(job)
       expect { service_with_dialog_options.deploy_orchestration_stack }.to raise_error(RuntimeError, /Orchestration template runner finished with error/)
     end


### PR DESCRIPTION
In a large number of the cases where we call `JobClass.create_job()` we immediately `.tap { |job| job.signal(:start) }`.

This can be made simpler if we just `.tap(&:signal_start)` but this method didn't exist.