### PR TITLE
Add a `EmsRefreshWorkflow#refresh_target` method

### DIFF
--- a/app/models/manageiq/providers/ems_refresh_workflow.rb
+++ b/app/models/manageiq/providers/ems_refresh_workflow.rb
@@ -32,9 +32,7 @@ class ManageIQ::Providers::EmsRefreshWorkflow < Job
   end
 
   def refresh
-    target = target_entity
-
-    task_ids = EmsRefresh.queue_refresh_task(target)
+    task_ids = EmsRefresh.queue_refresh_task(refresh_target)
     if task_ids.blank?
       process_error("Failed to queue refresh", "error")
       queue_signal(:error)
@@ -99,5 +97,9 @@ class ManageIQ::Providers::EmsRefreshWorkflow < Job
     end
 
     true
+  end
+
+  def refresh_target
+    target_entity
   end
 end


### PR DESCRIPTION
Allow provider subclasses to override the refresh_target method to control the refresh target.