### PR TITLE
consolidate supported storage types

### DIFF
--- a/app/models/manageiq/providers/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/infra_manager/metrics_capture.rb
@@ -78,7 +78,7 @@ class ManageIQ::Providers::InfraManager::MetricsCapture < ManageIQ::Providers::B
   # @return [Array<Storage>] supported storages
   # hosts preloaded storages and tags
   def capture_storage_targets(hosts)
-    hosts.flat_map(&:storages).uniq.select { |s| s.storage_type_supported_for_ssa? & s.perf_capture_enabled? }
+    hosts.flat_map(&:storages).uniq.select { |s| s.supports?(:smartstate_analysis) & s.perf_capture_enabled? }
   end
 
   # @param [ExtManagementSystem] ems

--- a/app/models/manageiq/providers/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/infra_manager/metrics_capture.rb
@@ -78,7 +78,7 @@ class ManageIQ::Providers::InfraManager::MetricsCapture < ManageIQ::Providers::B
   # @return [Array<Storage>] supported storages
   # hosts preloaded storages and tags
   def capture_storage_targets(hosts)
-    hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) & s.perf_capture_enabled? }
+    hosts.flat_map(&:storages).uniq.select { |s| s.storage_type_supported_for_ssa? & s.perf_capture_enabled? }
   end
 
   # @param [ExtManagementSystem] ems

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -343,7 +343,7 @@ class Storage < ApplicationRecord
   end
 
   def scan(userid = "system", _role = "ems_operations")
-    unless SUPPORTED_STORAGE_TYPES.include?(store_type.upcase)
+    unless storage_type_supported_for_ssa?
       raise(MiqException::MiqUnsupportedStorage,
             _("Action not supported for Datastore type [%{store_type}], [%{name}] with id: [%{id}]") %
               {:store_type => store_type, :name => name, :id => id})
@@ -815,9 +815,8 @@ class Storage < ApplicationRecord
     with_relationship_type("vm_scan_storage_affinity") { parents }
   end
 
-  # @param [String, Storage] store_type upcased version of the storage type
-  def self.supports?(store_type)
-    Storage::SUPPORTED_STORAGE_TYPES.include?(store_type)
+  def storage_type_supported_for_ssa?
+    SUPPORTED_STORAGE_TYPES.include?(store_type.upcase)
   end
 
   def self.display_name(number = 1)

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -67,7 +67,7 @@ class Storage < ApplicationRecord
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
 
-  SUPPORTED_STORAGE_TYPES = %w( VMFS NFS NFS41 FCP ISCSI GLUSTERFS )
+  SUPPORTED_STORAGE_TYPES = %w[VSAN VMFS NAS NFS NFS41 ISCSI DIR FCP CSVFS NTFS GLUSTERFS].freeze
 
   supports :smartstate_analysis do
     if !ext_management_system&.class&.supports?(:smartstate_analysis)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1143,14 +1143,10 @@ class VmOrTemplate < ApplicationRecord
     # Return location for RHEV-M VMs
     return rhevm_config_path if vendor.to_s.downcase == 'redhat'
 
-    case storage.store_type
-    when "VMFS"  then "[#{storage.name}] #{location}"
-    when "VSAN"  then "[#{storage.name}] #{location}"
-    when "NFS"   then "[#{storage.name}] #{location}"
-    when "NFS41" then "[#{storage.name}] #{location}"
-    when "NTFS"  then "[#{storage.name}] #{location}"
-    when "CSVFS" then "[#{storage.name}] #{location}"
-    when "NAS"   then File.join(storage.name, location)
+    if storage.store_type == "NAS"
+      File.join(storage.name, location)
+    elsif storage.storage_type_supported_for_ssa?
+      "[#{storage.name}] #{location}"
     else
       _log.warn("VM [#{name}] storage type [#{storage.store_type}] not supported")
       @path = location

--- a/app/models/vm_scan/dispatcher.rb
+++ b/app/models/vm_scan/dispatcher.rb
@@ -252,8 +252,8 @@ class VmScan
           queue_signal(job, {:args => [:abort, msg, "error"]})
           return []
         else
-          unless @vm.storage.storage_type_supported_for_ssa?
-            msg = "Vm storage type [#{@vm.storage.store_type}] unsupported [#{job.target_id}], aborting job [#{job.guid}]."
+          unless @vm.storage.supports?(:smartstate_analysis)
+            msg = @vm.storage.unsupported_reason(:smartstate_analysis)
             queue_signal(job, {:args => [:abort, msg, "error"]})
             return []
           end

--- a/app/models/vm_scan/dispatcher.rb
+++ b/app/models/vm_scan/dispatcher.rb
@@ -252,7 +252,7 @@ class VmScan
           queue_signal(job, {:args => [:abort, msg, "error"]})
           return []
         else
-          unless %w[VSAN VMFS NAS NFS NFS41 ISCSI DIR FCP CSVFS NTFS GLUSTERFS].include?(@vm.storage.store_type)
+          unless @vm.storage.storage_type_supported_for_ssa?
             msg = "Vm storage type [#{@vm.storage.store_type}] unsupported [#{job.target_id}], aborting job [#{job.guid}]."
             queue_signal(job, {:args => [:abort, msg, "error"]})
             return []

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ManageIQ::Providers::InfraManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
   let(:miq_server) { EvmSpecHelper.local_miq_server }
-  let(:ems) { FactoryBot.create(:ems_vmware, :zone => miq_server.zone) }
+  let(:ems) { FactoryBot.create(:ems_vmware_with_authentication, :zone => miq_server.zone) }
 
   before do
     storages = FactoryBot.create_list(:storage_vmware, 2)

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -506,4 +506,16 @@ RSpec.describe Storage do
       expect(storage.tenant_identity.current_tenant).to eq(Tenant.root_tenant)
     end
   end
+
+  describe "#storage_type_supported_for_ssa?" do
+    it "detects bad storage type" do
+      storage = FactoryBot.build(:storage, :store_type => "XYZ")
+      expect(storage.storage_type_supported_for_ssa?).to eq(false)
+    end
+
+    it "detects good storage type" do
+      storage = FactoryBot.build(:storage, :store_type => "NFS")
+      expect(storage.storage_type_supported_for_ssa?).to eq(true)
+    end
+  end
 end

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -395,13 +395,26 @@ RSpec.describe Storage do
   end
 
   context "#supports?(:smartstate_analysis)" do
-    it "returns true for VMware Storage when queried whether it supports smartstate analysis" do
-      storage = FactoryBot.create(:storage, :ext_management_system => FactoryBot.create(:ems_vmware_with_authentication))
+    it "supports smartstate if the ems supports smartstate analysis" do
+      ems = FactoryBot.create(:ems_vmware_with_authentication)
+      expect(ems.supports?(:smartstate_analysis)).to eq(true)
+      storage = FactoryBot.create(:storage_nfs, :ext_management_system => ems)
+
       expect(storage.supports?(:smartstate_analysis)).to eq(true)
     end
 
-    it "returns false for non-vmware Storage when queried whether it supports smartstate analysis" do
-      storage = FactoryBot.create(:storage, :ext_management_system => FactoryBot.create(:ems_microsoft_with_authentication))
+    it "doesn't support smartstate for an unknown store_type" do
+      ems = FactoryBot.create(:ems_vmware_with_authentication)
+      storage = FactoryBot.create(:storage_unknown, :ext_management_system => ems)
+
+      expect(storage.supports?(:smartstate_analysis)).to eq(false)
+    end
+
+    it "doesn't support smartstate for an ems that doesn't support smartstate analysis" do
+      ems = FactoryBot.create(:ems_microsoft_with_authentication)
+      expect(ems.supports?(:smartstate_analysis)).not_to eq(true)
+      storage = FactoryBot.create(:storage_nfs, :ext_management_system => ems)
+
       expect(storage.supports?(:smartstate_analysis)).to_not eq(true)
     end
   end

--- a/spec/models/vm_scan/dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/vm_scan/dispatcher_vm_storage2proxies_spec.rb
@@ -83,12 +83,13 @@ RSpec.describe "VmScanDispatcherVmStorage2Proxies" do
 
             context "a vm template and invalid VC authentication" do
               before do
-                allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:missing_credentials? => true)
-                allow(@vm).to receive_messages(:template? => true)
+                @vm.template = true
+                @hosts.each { |host| host.authentications.destroy_all }
                 @ems1 = FactoryBot.create(:ems_vmware, :name => "Ems1")
                 @vm.ext_management_system = @ems1
                 @vm.save
               end
+
               it "Vm#storage2active_proxies will return an empty list" do
                 expect(@vm.storage2active_proxies).to be_empty
               end
@@ -96,7 +97,7 @@ RSpec.describe "VmScanDispatcherVmStorage2Proxies" do
 
             context "a vm and invalid host authentication" do
               before do
-                allow_any_instance_of(Host).to receive_messages(:missing_credentials? => true)
+                @hosts.each { |host| host.authentications.destroy_all }
                 allow(@vm).to receive_messages(:template? => false)
               end
               it "Vm#storage2active_proxies will return an empty list" do

--- a/spec/support/job_proxy_dispatcher_helper.rb
+++ b/spec/support/job_proxy_dispatcher_helper.rb
@@ -5,16 +5,13 @@ module Spec
         options = {:hosts => 2, :storages => 2, :vms => 3, :repo_vms => 3, :container_providers => [1, 2], :zone => FactoryBot.create(:zone)}.merge(options)
 
         proxies = []
-        storages = []
-        options[:storages].times do |i|
-          storage = FactoryBot.create(:storage, :name => "test_storage_#{i}", :store_type => "VMFS")
-          storages << storage
-        end
 
-        ems = FactoryBot.create(:ems_vmware, :name => "ems1", :zone => options[:zone])
+        ems = FactoryBot.create(:ems_vmware, :name => "ems1", :zone => options[:zone], :authtype => :default)
+        storages = FactoryBot.create_list(:storage, options[:storages], :store_type => "VMFS", :ext_management_system => ems)
+
         hosts = []
         options[:hosts].times do |i|
-          host = FactoryBot.create(:host, :name => "test_host_#{i}", :hostname => "test_host_#{i}")
+          host = FactoryBot.create(:host_with_authentication, :name => "test_host_#{i}", :hostname => "test_host_#{i}")
           max = i > storages.length ? storages.length : i
           host.storages = storages[0..max]
           host.ext_management_system = ems
@@ -32,30 +29,19 @@ module Spec
           vms << vm
         end
 
-        repo_vms = []
-
-        repo_storage = FactoryBot.create(:storage, :name => "test_repo_storage", :store_type => "VMFS")
-        repo_storage.hosts = []
-        repo_storage.save
-
-        options[:repo_vms].times do |i|
-          vm = FactoryBot.create(:vm_vmware, :name => "test_repo_vm_#{i}", :location => "abc/abc.vmx")
-          vm.storage = repo_storage
-          vm.host = nil
-          vm.save
-          repo_vms << vm
-        end
+        repo_storage = FactoryBot.create(:storage, :name => "test_repo_storage", :store_type => "VMFS", :hosts => [], :ext_management_system => ems)
+        repo_vms = FactoryBot.create_list(:vm_vmware, options[:repo_vms], :location => "abc/abc.vmx", :ext_management_system => ems, :host => nil, :storage => repo_storage)
 
         container_providers = []
         options[:container_providers].each_with_index do |images_count, i|
-          ems_openshift = FactoryBot.create(:ems_openshift, :name => "test_container_provider_#{i}", :zone => options[:zone])
+          ems_openshift = FactoryBot.create(:ems_openshift, :name => "test_container_provider_#{i}", :zone => options[:zone], :authtype => :default)
           container_providers << ems_openshift
           container_image_classes = ContainerImage.descendants.append(ContainerImage)
           images_count.times do |idx|
             container_image_classes.each do |cic|
               FactoryBot.create(:container_image,
                                  :name   => "test_container_images_#{idx}",
-                                 :ems_id => ems_openshift.id,
+                                 :ext_management_system => ems_openshift,
                                  :type   => cic.name)
             end
           end


### PR DESCRIPTION
needed for:

- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8548

I only need the first change, which is low risk. The second one is a clean up that may not be necessary or deemed too risky.

Change:

1. Rename method `supports?` to `storage_type_supported_for_ssa?`
   I introduced a conflict with `SupportsFeatureMixin` in #9447
2. Make the list of supported `storage_type` values consistent.
   The method above was used in metrics capture [Storage.scan] and [capture_storage_targets]
   Similar but different lists are found in [vm_scan], and [Vm.path].

@agrare Regarding the second item:
- Is there a reason why those 3 lists of supported `storage_type` values should be different?
- What is the best way to determine the proper list? (I chose to include all)


|storage_type| [Storage.scan] | [Vm.path] | [vm_scan] |
|------------|--------------|---------|---------|
|VSAN        |              | y       | y       |
|VMFS        |         y    | y       | y       |
|NAS         |              | y       | y       |
|NFS         |         y    | y       | y       |
|NFS41       |         y    | y       | y       |
|ISCSI       |         y    |         | y       |
|DIR         |              |         | y       |
|FCP         |         y    |         | y       |
|CSVFS       |              | y       | y       |
|NTFS        |              | y       | y       |
|GLUSTERFS   |         y    |         | y       |

[Storage.scan]: https://github.com/ManageIQ/manageiq/blob/master/app/models/storage.rb#L345
[vm_scan]: https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_scan/dispatcher.rb#L255
[Vm.path]: https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L1137

[capture_storage_targets]: https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/infra_manager/metrics_capture.rb#L80

/cc @nasark 