### PR TITLE
[WIP] Generically restart provider workers on endpoint or credential changes

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -694,6 +694,11 @@ class ExtManagementSystem < ApplicationRecord
     task.id
   end
 
+  def self.ems_worker_types
+    MiqWorkerType.worker_class_names.select { |klass_name| klass_name.start_with?(name) }.map(&:constantize)
+  end
+  delegate :ems_worker_types, :to => :class
+
   def ems_workers
     MiqWorker.find_alive.where(:queue_name => queue_name)
   end

--- a/app/models/manageiq/providers/base_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher.rb
@@ -20,4 +20,8 @@ class ManageIQ::Providers::BaseManager::EventCatcher < MiqWorker
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_EVENT_CATCHERS
   end
+
+  def self.restart_on_change?
+    true
+  end
 end

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -26,4 +26,8 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_REFRESH_WORKERS
   end
+
+  def self.restart_on_change?
+    module_parent.supports?(:streaming_refresh)
+  end
 end

--- a/app/models/mixins/provider_worker_mixin.rb
+++ b/app/models/mixins/provider_worker_mixin.rb
@@ -21,5 +21,9 @@ module ProviderWorkerMixin
     def service_base_name
       "manageiq-providers-#{minimal_class_name.underscore.tr("/", "_")}"
     end
+
+    def restart_on_change?
+      false
+    end
   end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -131,6 +131,36 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
+  describe ".ems_worker_types" do
+    let(:ems_infra) { FactoryBot.create(:ems_vmware) }
+
+    before do
+      MiqWorkerType.create!(
+        [
+          {:worker_type => "MiqGenericWorker"},
+          {:worker_type => "ManageIQ::Providers::BaseManager::EventCatcher"},
+          {:worker_type => "ManageIQ::Providers::BaseManager::RefreshWorker"},
+          {:worker_type => "ManageIQ::Providers::Amazon::CloudManager::RefreshWorker"},
+        ]
+      )
+    end
+
+    it "returns all workers for a provider type" do
+      expect(ManageIQ::Providers::BaseManager.ems_worker_types)
+        .to include(ManageIQ::Providers::BaseManager::EventCatcher, ManageIQ::Providers::BaseManager::RefreshWorker)
+    end
+
+    it "doesn't return non-provider workers" do
+      expect(ManageIQ::Providers::BaseManager.ems_worker_types)
+        .not_to include(MiqGenericWorker)
+    end
+
+    it "doesn't return workers for other providers" do
+      expect(ManageIQ::Providers::BaseManager.ems_worker_types)
+        .not_to include(ManageIQ::Providers::Amazon::CloudManager::RefreshWorker)
+    end
+  end
+
   it "does access database when unchanged model is saved" do
     r = FactoryBot.create(:ems_vmware)
     expect { r.valid? }.to make_database_queries(:count => 3)


### PR DESCRIPTION
Currently the event monitor is the only worker type which is restarted when either the endpoint or the credentials are changed.  Now that we do streaming refresh for a number of providers the refresh worker also must be restarted.

Still VERY WIP

Ref: https://github.com/ManageIQ/manageiq-providers-openshift/issues/235#issuecomment-1334222927