### PR TITLE
Fix Ruby 3 issue with AnsiblePlaybookWorkflow

### DIFF
--- a/app/models/manageiq/providers/ansible_playbook_workflow.rb
+++ b/app/models/manageiq/providers/ansible_playbook_workflow.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::AnsiblePlaybookWorkflow < ManageIQ::Providers::Ansibl
     env_vars, extra_vars, playbook_path = options.values_at(:env_vars, :extra_vars, :playbook_path)
     kwargs = options.slice(:credentials, :hosts, :verbosity, :become_enabled)
 
-    Ansible::Runner.run_async(env_vars, extra_vars, playbook_path, kwargs)
+    Ansible::Runner.run_async(env_vars, extra_vars, playbook_path, **kwargs)
   end
 
   private


### PR DESCRIPTION
@bdunne Please review.  cc @jrafanie 

The tests were passing here prior to this fix because RSpec's `with` doesn't seem to match kwargs properly.  Instead I've changed the specs for now to just stub a little closer to the actual run and have a separate spec to test that the options are forwarded to Ansible::Runner properly.  It's not the best approach but it does show the error (`wrong number of arguments (given 4, expected 3)`) from before the fix:

```
  1) ManageIQ::Providers::AnsiblePlaybookWorkflow#execute forwards the options to Ansible::Runner parameters
     Failure/Error: queue_signal(*args, :deliver_on => deliver_on)

       #<ManageIQ::Providers::AnsiblePlaybookWorkflow id: 24000000002172, guid: "05b531bb-63aa-4543-a94b-004fb8e5ddd3", state: "running", status: "ok", message: "process initiated", name: "ManageIQ::Providers::AnsiblePlaybookWorkflow creat...", userid: "system", created_on: "2022-12-02 00:59:38.161013000 +0000", updated_on: "2022-12-02 00:59:38.190481000 +0000", target_id: nil, target_class: nil, type: "ManageIQ::Providers::AnsiblePlaybookWorkflow", agent_message: nil, started_on: nil, dispatch_status: "pending", sync_key: nil, miq_server_id: nil, zone: nil, options: {:playbook_path=>"/path/to/playbook", :role=>"embedded_ansible", :become_enabled=>false, :credentials=>[], :env_vars=>{"ENV"=>"VAR"}, :extra_vars=>{"arg1"=>"val1"}, :hosts=>["192.0.2.0", "192.0.2.1"], :timeout=>1 hour, :poll_interval=>1 second, :verbosity=>3}, context: {}, miq_task_id: 24000000002172> received :queue_signal with unexpected arguments
         expected: (:poll_runner, {:deliver_on=>nil})
              got: (:abort, "Failed to run ansible playbook: wrong number of arguments (given 4, expected 3)", "error", {:deliver_on=>nil})
       Diff:
       @@ -1,4 +1,7 @@
       -[:poll_runner, {:deliver_on=>nil}]
       +[:abort,
       + "Failed to run ansible playbook: wrong number of arguments (given 4, expected 3)",
       + "error",
       + {:deliver_on=>nil}]

     # ./app/models/manageiq/providers/ansible_runner_workflow.rb:80:in `route_signal'
     # ./app/models/manageiq/providers/ansible_runner_workflow.rb:54:in `rescue in execute'
     # ./app/models/manageiq/providers/ansible_runner_workflow.rb:39:in `execute'
     # ./app/models/job/state_machine.rb:52:in `signal'
     # ./spec/models/manageiq/providers/ansible_playbook_workflow_spec.rb:187:in `block (3 levels) in <main>'
     # /Users/jfrey/.gem/ruby/3.0.5/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 4, expected 3)
     #   ./lib/ansible/runner.rb:15:in `run_async'
```