### PR TITLE
Physical infr button classes

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -55,6 +55,11 @@ class CustomButton < ApplicationRecord
     Tenant,
     User,
     Vm,
+    PhysicalChassis,
+    PhysicalServer,
+    PhysicalStorage,
+    PhysicalRack,
+    PhysicalSwitch,
   ].freeze
 
   def self.buttons_for(other, applies_to_id = nil)

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -59,7 +59,6 @@ class CustomButton < ApplicationRecord
     PhysicalServer,
     PhysicalStorage,
     PhysicalRack,
-    PhysicalSwitch,
   ].freeze
 
   def self.buttons_for(other, applies_to_id = nil)

--- a/app/models/physical_chassis.rb
+++ b/app/models/physical_chassis.rb
@@ -2,6 +2,7 @@ class PhysicalChassis < ApplicationRecord
   include SupportsFeatureMixin
   include EventMixin
   include EmsRefreshMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/physical_rack.rb
+++ b/app/models/physical_rack.rb
@@ -1,6 +1,7 @@
 class PhysicalRack < ApplicationRecord
   include SupportsFeatureMixin
   include EmsRefreshMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -9,6 +9,8 @@ class PhysicalServer < ApplicationRecord
   include ProviderObjectMixin
   include ComplianceMixin
   include EmsRefreshMixin
+  include CustomActionsMixin
+
 
   include_concern 'Operations'
 

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -2,7 +2,6 @@ class PhysicalSwitch < Switch
   include SupportsFeatureMixin
   include EventMixin
   include EmsRefreshMixin
-  include CustomActionsMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_switches,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -2,6 +2,7 @@ class PhysicalSwitch < Switch
   include SupportsFeatureMixin
   include EventMixin
   include EmsRefreshMixin
+  include CustomActionsMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_switches,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"


### PR DESCRIPTION
This comes from the need to enable custom buttons on the physical infrastructure objects such as, Physical Server, Physical Rack, Physical Chassis, Physical Storage and Physical Switch.

To enable custom button creation without manually performing api calls, the described classes were added to custom_button's `BUTTON_CLASSES`. *NOTE*: PhysicalSwitch was not added, as it is available under Switch.

Also, CustomActionsMixin was added to these classes, so that custom actions may be triggered from the custom buttons on these objects.

**_Refers to:_**
  -  [ManageIQ/manageiq-providers-cisco_intersight/issues/76](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/issues/76)

**_Depends on:_**: 
  - [ManageIQ/manageiq-ui-classis/pull/8548](https://github.com/ManageIQ/manageiq-ui-classic/pull/8545)
  - [ManageIQ/manageiq-api/pull/1189](https://github.com/ManageIQ/manageiq-api/pull/1189)