### PR TITLE
Provide the now required response object to the smtp exception

### DIFF
--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -48,7 +48,7 @@ describe GenericMailer do
       # raises error when delivered
       msg = @args.merge(:to => 'me@bedrock.gov, you@bedrock.gov')
       notification = GenericMailer.generic_notification(msg)
-      allow(notification).to receive(:deliver_now).and_raise(Net::SMTPFatalError)
+      allow(notification).to receive(:deliver_now).and_raise(Net::SMTPFatalError.new("fake_response"))
 
       # send error msg first...
       expect(GenericMailer)


### PR DESCRIPTION
mail gem 2.8.0 added ruby 3.1 support[1] which added net-smtp as an explicit gem dependency because it had recently become an extracted gem.

Previously, we used the ruby stdlib version, which was using gem version 0.1.0 in ruby 2.7.0 and 0.2.1 in ruby 3.0.0.

Starting with net-smtp 0.2.2, the Net::SMTPError types now require a response object [2] and an optional message. :shrug:

[1] https://github.com/mikel/mail/pull/1472/files
[2] https://github.com/ruby/net-smtp/pull/26/files