### PR TITLE
Fix workers not restarting when auth/endpoints are changed.

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -191,8 +191,8 @@ class ExtManagementSystem < ApplicationRecord
         authentications_changed ||= authentications_to_delete.delete_all > 0
 
         ems.assign_attributes(params)
-        ems.endpoints       = endpoints.map(&method(:assign_nested_endpoint))
-        ems.authentications = authentications.map(&method(:assign_nested_authentication))
+        ems.endpoints       = endpoints.map       { |ep| assign_nested_endpoint(ep) }
+        ems.authentications = authentications.map { |auth| assign_nested_authentication(auth) }
 
         endpoint_changes = ems.endpoints.select(&:changed?).to_h do |ep|
           [ep.role.to_sym, ep.changes]

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -194,12 +194,12 @@ class ExtManagementSystem < ApplicationRecord
         endpoints_changed       ||= ems.endpoints.any?(&:changed?)
         authentications_changed ||= ems.authentications.any?(&:changed?)
 
-        after_update_endpoints      if endpoints_changed
-        after_update_authentication if authentications_changed
-
         ems.provider.save! if ems.provider.present? && ems.provider.changed?
         ems.save!
       end
+
+      after_update_endpoints      if endpoints_changed
+      after_update_authentication if authentications_changed
     end
   end
 
@@ -891,14 +891,14 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def stop_event_monitor_queue_on_change
-    if event_monitor_class && !new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
+    if event_monitor_class && !new_record?
       _log.info("EMS: [#{name}], Hostname or IP address has changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")
       stop_event_monitor_queue
     end
   end
 
   def stop_event_monitor_queue_on_credential_change
-    if event_monitor_class && !new_record? && default_authentication&.changed?
+    if event_monitor_class && !new_record?
       _log.info("EMS: [#{name}], Credentials have changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")
       stop_event_monitor_queue
     end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -194,12 +194,12 @@ class ExtManagementSystem < ApplicationRecord
         endpoints_changed       ||= ems.endpoints.any?(&:changed?)
         authentications_changed ||= ems.authentications.any?(&:changed?)
 
+        after_update_endpoints      if endpoints_changed
+        after_update_authentication if authentications_changed
+
         ems.provider.save! if ems.provider.present? && ems.provider.changed?
         ems.save!
       end
-
-      after_update_endpoints      if endpoints_changed
-      after_update_authentication if authentications_changed
     end
   end
 
@@ -891,14 +891,14 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def stop_event_monitor_queue_on_change
-    if event_monitor_class && !self.new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
+    if event_monitor_class && !new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
       _log.info("EMS: [#{name}], Hostname or IP address has changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")
       stop_event_monitor_queue
     end
   end
 
   def stop_event_monitor_queue_on_credential_change
-    if event_monitor_class && !self.new_record? && self.credentials_changed?
+    if event_monitor_class && !new_record? && default_authentication&.changed?
       _log.info("EMS: [#{name}], Credentials have changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")
       stop_event_monitor_queue
     end
@@ -955,14 +955,14 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def stop_refresh_worker_queue_on_change
-    if refresh_worker_class && !self.new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
+    if refresh_worker_class && !new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
       _log.info("EMS: [#{name}], Hostname or IP address has changed, stopping Refresh Worker.  It will be restarted by the WorkerMonitor.")
       stop_refresh_worker_queue
     end
   end
 
   def stop_refresh_worker_queue_on_credential_change
-    if refresh_worker_class && !self.new_record? && self.credentials_changed?
+    if refresh_worker_class && !new_record? && default_authentication&.changed?
       _log.info("EMS: [#{name}], Credentials have changed, stopping Refresh Worker.  It will be restarted by the WorkerMonitor.")
       stop_refresh_worker_queue
     end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -76,8 +76,8 @@ module ManageIQ::Providers
       MiqSystem.open_browser(browser_url)
     end
 
-    def stop_event_monitor_queue_on_credential_change
-      if event_monitor_class && !new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
+    def stop_event_monitor_queue_on_credential_change(changes)
+      if event_monitor_class && !new_record? && changes["default"]&.keys&.include_any?("hostname", "ipaddress")
         _log.info("EMS: [#{name}], Credentials have changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")
         stop_event_monitor_queue
         network_manager.stop_event_monitor_queue if respond_to?(:network_manager) && network_manager

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -77,7 +77,7 @@ module ManageIQ::Providers
     end
 
     def stop_event_monitor_queue_on_credential_change
-      if event_monitor_class && !self.new_record? && self.credentials_changed?
+      if event_monitor_class && !new_record? && default_endpoint.changed.include_any?("hostname", "ipaddress")
         _log.info("EMS: [#{name}], Credentials have changed, stopping Event Monitor.  It will be restarted by the WorkerMonitor.")
         stop_event_monitor_queue
         network_manager.stop_event_monitor_queue if respond_to?(:network_manager) && network_manager

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -243,17 +243,17 @@ module AuthenticationMixin
       cred.auth_key        = value[:auth_key]
       cred.service_account = value[:service_account].presence
 
-      changes = {type => cred.changes} if cred.changed?
+      changes = [type.to_sym, cred.changes] if cred.changed?
 
       cred.save if options[:save] && id
 
       changes
-    end.compact
+    end.compact.to_h
 
     return if authentication_changes.blank? || !options[:save]
 
     # Invoke callback
-    after_update_authentication if respond_to?(:after_update_authentication)
+    after_update_authentication(authentication_changes) if respond_to?(:after_update_authentication)
   end
 
   def authentication_type(type)

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -183,8 +183,6 @@ module AuthenticationMixin
 
     options.reverse_merge!(:save => true)
 
-    @orig_credentials ||= auth_user_pwd || "none"
-
     # Invoke before callback
     before_update_authentication if self.respond_to?(:before_update_authentication) && options[:save]
 
@@ -250,13 +248,6 @@ module AuthenticationMixin
 
     # Invoke callback
     after_update_authentication if self.respond_to?(:after_update_authentication) && options[:save]
-    @orig_credentials = nil if options[:save]
-  end
-
-  def credentials_changed?
-    @orig_credentials ||= auth_user_pwd || "none"
-    new_credentials = auth_user_pwd || "none"
-    @orig_credentials != new_credentials
   end
 
   def authentication_type(type)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -851,7 +851,7 @@ RSpec.describe ExtManagementSystem do
     let(:default_authentication) { {"authtype" => "default", "userid" => ems.default_authentication.userid, "password" => ems.default_authentication.password} }
 
     context "with no changes" do
-      it "doesn't call endpoints or authentications changed callbaks" do
+      it "doesn't call endpoints or authentications changed callbacks" do
         expect(ems).not_to receive(:after_update_endpoints)
         expect(ems).not_to receive(:after_update_authentication)
 
@@ -921,6 +921,12 @@ RSpec.describe ExtManagementSystem do
 
         ems.edit_with_params(params, endpoints, authentications)
       end
+
+      it "stops the event monitor" do
+        expect(ems).to receive(:stop_event_monitor_queue)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
     end
 
     context "adding an authentication" do
@@ -972,6 +978,12 @@ RSpec.describe ExtManagementSystem do
       it "calls after_update_authentication" do
         expect(ems).to receive(:after_update_authentication)
         expect(ems).not_to receive(:after_update_endpoints)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+
+      it "stops the event monitor" do
+        expect(ems).to receive(:stop_event_monitor_queue)
 
         ems.edit_with_params(params, endpoints, authentications)
       end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -833,6 +833,151 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
+  describe "#edit_with_params" do
+    let(:zone) { EvmSpecHelper.local_miq_server.zone }
+    let(:ems)  do
+      FactoryBot.create(:ext_management_system, :with_authentication, :zone => zone).tap do |ems|
+        # assign_nested_authentication automatically sets the name to "#{self.class.name} #{name}"
+        # set it here to prevent spurious authentication record changes
+        ems.default_authentication.update!(:name => "#{ems.class.name} #{ems.name}")
+      end
+    end
+
+    let(:params)          { {"name" => ems.name, "zone" => ems.zone} }
+    let(:endpoints)       { [default_endpoint] }
+    let(:authentications) { [default_authentication] }
+
+    let(:default_endpoint)       { {"role" => "default", "hostname" => ems.default_endpoint.hostname, "ipaddress" => ems.default_endpoint.ipaddress} }
+    let(:default_authentication) { {"authtype" => "default", "userid" => ems.default_authentication.userid, "password" => ems.default_authentication.password} }
+
+    context "with no changes" do
+      it "doesn't call endpoints or authentications changed callbaks" do
+        expect(ems).not_to receive(:after_update_endpoints)
+        expect(ems).not_to receive(:after_update_authentication)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+
+    context "changing an ext_management_system record attribute" do
+      let(:params) { {:name => "new-name", :zone => ems.zone} }
+
+      it "changes the name" do
+        ems.edit_with_params(params, endpoints, authentications)
+        expect(ems.reload.name).to eq("new-name")
+      end
+    end
+
+    context "adding an endpoint" do
+      let(:endpoints) { [default_endpoint, {"role" => "metrics", "hostname" => "metrics"}] }
+
+      it "creates the new endpoint" do
+        ems.edit_with_params(params, endpoints, authentications)
+
+        ems.reload
+
+        expect(ems.endpoints.pluck(:role)).to match_array(["default", "metrics"])
+      end
+
+      it "calls after_update_endpoints" do
+        expect(ems).to receive(:after_update_endpoints)
+        expect(ems).not_to receive(:after_update_authentication)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+
+    context "deleting an endpoint" do
+      before { ems.endpoints.create!(:role => "metrics", :hostname => "metrics") }
+
+      it "deletes the unused endpoint" do
+        ems.edit_with_params(params, endpoints, authentications)
+
+        ems.reload
+        expect(ems.endpoints.pluck(:role)).to match_array(["default"])
+      end
+
+      it "calls after_update_endpoints" do
+        expect(ems).to receive(:after_update_endpoints)
+        expect(ems).not_to receive(:after_update_authentication)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+
+    context "updating an endpoint" do
+      let(:default_endpoint) { {"role" => "default", "hostname" => "new-hostname", "ipaddress" => ems.default_endpoint.ipaddress} }
+
+      it "updates the default hostname" do
+        ems.edit_with_params(params, endpoints, authentications)
+
+        ems.reload
+        expect(ems.default_endpoint.hostname).to eq("new-hostname")
+      end
+
+      it "calls after_update_endpoints" do
+        expect(ems).to receive(:after_update_endpoints)
+        expect(ems).not_to receive(:after_update_authentication)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+
+    context "adding an authentication" do
+      let(:authentications) { [default_authentication, {:authtype => "metrics", :auth_key => "secret"}] }
+
+      it "creates the authentication" do
+        ems.edit_with_params(params, endpoints, authentications)
+
+        ems.reload
+        expect(ems.authentications.pluck(:authtype)).to match_array(["default", "metrics"])
+      end
+
+      it "calls after_update_authentication" do
+        expect(ems).to receive(:after_update_authentication)
+        expect(ems).not_to receive(:after_update_endpoints)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+
+    context "deleting an authentication" do
+      before { ems.authentications.create!(:authtype => "metrics", :auth_key => "secret") }
+
+      it "deletes the authentication" do
+        ems.edit_with_params(params, endpoints, authentications)
+
+        ems.reload
+        expect(ems.authentications.pluck(:authtype)).to match_array(["default"])
+      end
+
+      it "calls after_update_authentication" do
+        expect(ems).to receive(:after_update_authentication)
+        expect(ems).not_to receive(:after_update_endpoints)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+
+    context "updating an authentication" do
+      let(:default_authentication) { {"authtype" => "default", "userid" => ems.default_authentication.userid, "password" => "more-secret"} }
+
+      it "updates the password" do
+        ems.edit_with_params(params, endpoints, authentications)
+
+        ems.reload
+        expect(ems.default_authentication.password).to eq("more-secret")
+      end
+
+      it "calls after_update_authentication" do
+        expect(ems).to receive(:after_update_authentication)
+        expect(ems).not_to receive(:after_update_endpoints)
+
+        ems.edit_with_params(params, endpoints, authentications)
+      end
+    end
+  end
+
   context "virtual column :supports_block_storage (direct supports)" do
     it "returns false if block storage is not supported" do
       ems = FactoryBot.create(:ext_management_system)


### PR DESCRIPTION
When changes are made to the endpoints or authentications workers which run with an open connection like event catchers and streaming refresh workers have to be restarted.

This was done via `after_update_authentication` called from `update_authentication`.  The issue is that this method is no longer called when providers are updated via the API with DDF parameters.

We also have some `before_save :stop_event_monitor_queue_on_change, :stop_refresh_worker_queue_on_change` but these aren't invoked because auth/endpoint changes aren't part of the `ext_management_system` record.

Ref https://github.com/ManageIQ/manageiq-providers-openshift/issues/235#issuecomment-1337854350

TODO
- [x] Specs for edit_with_params
- [ ] Handle child managers' workers

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/841
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/479
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/832
- [ ] https://github.com/ManageIQ/manageiq-providers-nuage/pull/283

Cross-Repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/720