### PR TITLE
Bump qpid_proton to 0.37.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,7 +197,7 @@ group :red_hat_virtualization, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.30.0",          :require => false
+  gem "qpid_proton",                    "~>0.37.0",          :require => false
 end
 
 group :systemd, :optional => true do


### PR DESCRIPTION
Update the version of the qpid_proton gem to match the qpid_proton C
library

Depends on:
- [x] https://github.com/ManageIQ/manageiq-appliance-build/pull/559

Related:
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/830
* https://github.com/ManageIQ/manageiq-providers-nuage/pull/281