### PR TITLE
set a valid Storage.store_type

### DIFF
--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :storage do
+    store_type { "NTFS" }
     sequence(:name) { |n| "storage_#{seq_padded_for_sorting(n)}" }
   end
 


### PR DESCRIPTION
By default, a storage should be valid for smart state Sure, it also needs an ems and others, but we definitely need a good store_type value

This is a followup to the recent supports change #22258 / 28fa0a6d27

fixes in ui-classic

```
rspec ./spec/helpers/application_helper/buttons/storage_scan_spec.rb:23 # ApplicationHelper::Button::StorageScan#disabled? when EMS has valid credentials behaves like an enabled button is expected to be truthy
```

/cc @jeffibm @agrare 