### PR TITLE
Update the locale test to ignore the exact year

### DIFF
--- a/spec/i18n/locale_contents_spec.rb
+++ b/spec/i18n/locale_contents_spec.rb
@@ -5,7 +5,7 @@ describe :locale_contents do
     locale_files.each do |locale_file|
       it locale_file.basename do
         yaml = YAML.load_file(locale_file)
-        expect(yaml.fetch_path(yaml.keys.first, "product", "copyright")).to start_with("Copyright (c) #{Time.zone.now.year} ManageIQ.")
+        expect(yaml.fetch_path(yaml.keys.first, "product", "copyright")).to match(/Copyright \(c\) \d{4} ManageIQ\./)
       end
     end
   end


### PR DESCRIPTION
Discussion: The locale copyright test always starts to fail on the first of a near year.  Is this test supposed to catch when we haven't updated the Copyright year or something else?

