### PR TITLE
Perf capture minor changes for testing

### DIFF
--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         Metric::Capture.perf_capture_gap(7.days.ago.utc, 5.days.ago.utc, nil, ems.id)
         expect(queue_timings).to eq(
           "historical" => {
-            vm    => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            vm2   => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            host  => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            host2 => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            host3 => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(vm)    => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(vm2)   => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(host)  => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(host2) => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(host3) => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
           }
         )
       end
@@ -63,11 +63,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         expect(MiqQueue.where("class_name like '%Vm'").count).to eq(2)
         expect(queue_timings).to eq(
           "historical" => {
-            vm    => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            vm2   => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            host  => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            host2 => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
-            host3 => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(vm)    => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(vm2)   => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(host)  => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(host2) => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
+            queue_object(host3) => arg_day_range(7.days.ago.utc, 5.days.ago.utc),
           }
         )
       end
@@ -167,21 +167,21 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
         expect(queue_timings).to eq(
           "realtime"   => {
-            host  => [[]],
-            host2 => [[]],
-            host3 => [[]],
-            vm    => [[]],
-            vm2   => [[]]
+            queue_object(host)  => [[]],
+            queue_object(host2) => [[]],
+            queue_object(host3) => [[]],
+            queue_object(vm)    => [[]],
+            queue_object(vm2)   => [[]]
           },
           "historical" => {
-            host  => arg_day_range(bod - 7.days, bod + 1.day),
-            host2 => arg_day_range(bod - 7.days, bod + 1.day),
-            host3 => arg_day_range(bod - 7.days, bod + 1.day),
-            vm    => arg_day_range(bod - 7.days, bod + 1.day),
-            vm2   => arg_day_range(bod - 7.days, bod + 1.day)
+            queue_object(host)  => arg_day_range(bod - 7.days, bod + 1.day),
+            queue_object(host2) => arg_day_range(bod - 7.days, bod + 1.day),
+            queue_object(host3) => arg_day_range(bod - 7.days, bod + 1.day),
+            queue_object(vm)    => arg_day_range(bod - 7.days, bod + 1.day),
+            queue_object(vm2)   => arg_day_range(bod - 7.days, bod + 1.day)
           },
           "hourly"     => {
-            storage => [[]]
+            queue_object(storage) => [[]]
           }
         )
       end
@@ -212,8 +212,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
           bod = Time.now.utc.beginning_of_day
 
           expect(queue_timings).to eq(
-            "realtime"   => vms.each_with_object({}) { |k, h| h[k] = [[]] },
-            "historical" => vms.each_with_object({}) { |k, h| h[k] = arg_day_range(bod - 7.days, bod + 1.day) }
+            "realtime"   => vms.each_with_object({}) { |k, h| h[queue_object(k)] = [[]] },
+            "historical" => vms.each_with_object({}) { |k, h| h[queue_object(k)] = arg_day_range(bod - 7.days, bod + 1.day) }
           )
         end
       end
@@ -239,14 +239,14 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture("realtime")
 
         expect(queue_timings).to eq(
-          "realtime" => {vm => [[]]}
+          "realtime" => {queue_object(vm) => [[]]}
         )
 
         Timecop.travel(20.minutes)
         trigger_capture("realtime")
 
         expect(queue_timings).to eq(
-          "realtime" => {vm => [[]]}
+          "realtime" => {queue_object(vm) => [[]]}
         )
       end
     end
@@ -261,8 +261,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture("realtime")
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[]]},
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
+          "realtime"   => {queue_object(vm) => [[]]},
+          "historical" => {queue_object(vm) => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
         )
       end
     end
@@ -277,8 +277,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture("realtime", last_perf_capture_on)
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[]]},
-          "historical" => {vm => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
+          "realtime"   => {queue_object(vm) => [[]]},
+          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
         )
       end
     end
@@ -291,7 +291,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture("realtime", last_perf_capture_on)
 
         expect(queue_timings).to eq(
-          "realtime" => {vm => [[]]}
+          "realtime" => {queue_object(vm) => [[]]}
         )
       end
     end
@@ -307,16 +307,16 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture("realtime", last_perf_capture_on)
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[]]},
-          "historical" => {vm => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
+          "realtime"   => {queue_object(vm) => [[]]},
+          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
         )
 
         Timecop.travel(20.minutes)
         trigger_capture("realtime")
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[]]},
-          "historical" => {vm => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
+          "realtime"   => {queue_object(vm) => [[]]},
+          "historical" => {queue_object(vm) => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
         )
       end
     end
@@ -331,7 +331,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture("historical", :start_time => 4.days.ago.utc, :end_time => 2.days.ago.utc)
 
         expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(4.days.ago.utc, 2.days.ago.utc)}
+          "historical" => {queue_object(vm) => arg_day_range(4.days.ago.utc, 2.days.ago.utc)}
         )
       end
     end
@@ -346,7 +346,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         last_perf_capture_on = (2.days + 5.hours + 23.minutes).ago
         trigger_capture("historical", last_perf_capture_on, :start_time => 4.days.ago.utc, :end_time => 2.days.ago.utc)
         expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(4.days.ago.utc, 2.days.ago.utc)}
+          "historical" => {queue_object(vm) => arg_day_range(4.days.ago.utc, 2.days.ago.utc)}
         )
       end
     end

--- a/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe ManageIQ::Providers::ContainerManager::MetricsCapture do
 
             expect(queue_timings).to include(
               "realtime" => {
-                container_node  => [[]],
-                container_group => [[]],
-                container       => [[]],
-                container_image => [[]]
+                queue_object(container_node)  => [[]],
+                queue_object(container_group) => [[]],
+                queue_object(container)       => [[]],
+                queue_object(container_image) => [[]]
               }
             )
           end

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -1,23 +1,6 @@
 module Spec
   module Support
     module MetricHelper
-      # given (enabled) capture_targets, compare with suggested queue entries
-      def metric_targets(expected_targets)
-        expected_targets.flat_map do |t|
-          # Storage is hourly only
-          # Non-storage historical is expecting 7 days back, plus partial day = 8
-          t.kind_of?(Storage) ? [[t, "hourly"]] : [[t, "realtime"]] + [[t, "historical"]] * 8
-        end
-      end
-
-      # @return [Array<Array<Object, String>>] List of object and interval names in miq queue
-      def queue_intervals(items = MiqQueue.where(:method_name => %w[perf_capture_hourly perf_capture_realtime perf_capture_historical]))
-        items.map do |q|
-          interval_name = q.method_name.sub("perf_capture_", "")
-          [Object.const_get(q.class_name).find(q.instance_id), interval_name]
-        end
-      end
-
       # method_name => {target => [timing1, timing2] }
       # for each capture type, what objects are submitted and what are their time frames
       #

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -20,27 +20,40 @@ module Spec
 
       # method_name => {target => [timing1, timing2] }
       # for each capture type, what objects are submitted and what are their time frames
+      #
+      # The objects can be added as a batch or invididually. Additionally dates can be
+      # split up into multiple date ranges.
+      # This method undoes the batching and splitting to make testing more consistent
+      #
       # @return [Hash{String => Hash{Object => Array<Array>}} ]
+      #         {"Vm:1" => [[start_time1, finish_time1], [start_time2, finish_time2]]}
       def queue_timings(items = MiqQueue.where(:method_name => %w[perf_capture_hourly perf_capture_realtime perf_capture_historical]))
         messages = {}
         items.each do |q|
-          obj = q.instance_id ? Object.const_get(q.class_name).find(q.instance_id) : q.class_name.constantize
+          klass = q.class_name.constantize
+          # If the third argument contains a list of object ids
+          # we denormalize to one message per object_id
+          date_first, date_end, ids, *_ = q.args
+          ids = q.instance_id if ids.blank?
+          objs = ids.blank? ? [klass] : klass.where(:id => ids)
 
-          interval_name = q.method_name.sub("perf_capture_", "")
+          objs.each do |obj|
+            interval_name = q.method_name.sub("perf_capture_", "")
 
-          messages[interval_name] ||= {}
-          (messages[interval_name][obj] ||= []) << q.args
+            # historical captures have a date range, while realtime captures do not.
+            messages[interval_name] ||= {}
+            (messages[interval_name][obj] ||= []) << (date_first ? [date_first, date_end] : [])
+          end
         end
-        messages["historical"]&.transform_values!(&:sort!)
+        # there can be multiple messages for a large date range
+        # this will combine multiple consecutive date ranges into larger ones
+        messages["historical"]&.transform_values! { |v| combine_consecutive(v) }
 
         messages
       end
 
-      # sorry, stole from the code - not really testing
       def arg_day_range(start_time, end_time)
-        (start_time.utc..end_time.utc).step_value(1.day).each_cons(2).collect do |s_time, e_time|
-          [s_time, e_time, nil, false]
-        end
+        [[start_time, end_time]]
       end
 
       def stub_performance_settings(hash)
@@ -58,6 +71,23 @@ module Spec
             }
           }
         }
+      end
+
+      private
+
+      def combine_consecutive(array)
+        prev_first, prev_end = array.sort!.shift
+        array.each_with_object([]) do |(cur_first, cur_end), ac|
+          # It can overlap or abut, we want to join both of those
+          #   prev=1-1-2000T0..23:59, cur=1-2-2000T0..23:59
+          #   prev=1-1-2000T0..24:00, cur=1-2-2000T0..24:00
+          if cur_first <= (prev_end + 1.second)
+            prev_end = cur_end
+          else
+            ac << [prev_first, prev_end]
+            prev_first, prev_end = cur_first, cur_end
+          end
+        end << [prev_first, prev_end]
       end
     end
   end


### PR DESCRIPTION
pulled out of https://github.com/ManageIQ/manageiq/pull/22221

~~Mostly~~ test changes to allow the actual messages to not pay so much attention to the packaging of the collection and more attention to what is collected and the time spans.

Changes:

- ~~remove zone lookup for ems in rollup~~
- ~~remove zone lookup for gap detection alerting~~
- ~~send full 250 records to ems (was limiting vmware to 20)~~
- ~~sort batches so ids are sent more consistently~~
