### PR TITLE
Fix `ChargebackVm.extra_resources_without_rollups` hard-coding SCVMM VMs

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -99,6 +99,10 @@ class ChargebackVm < Chargeback
 
   def self.extra_resources_without_rollups(region)
     # support VM types for which we do not collect metrics yet (also when we are including metrics in calculations)
+    #
+    # NOTE since this scope is used later on as part of other queries this has to be an
+    # ActiveRecord::Relation not an array.  The SupportsFeatureMixin.supporting method
+    # checks instance-level supports which returns an array thus cannot be used here.
     scope = @options.include_metrics? ? Vm.where.not(:type => Vm.types_supporting(:capture)) : vms(region)
     scope = scope.eager_load(:hardware, :taggings, :tags, :host, :ems_cluster, :storage, :ext_management_system,
                              :tenant)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -98,8 +98,8 @@ class ChargebackVm < Chargeback
   end
 
   def self.extra_resources_without_rollups(region)
-    # support hyper-v for which we do not collect metrics yet (also when we are including metrics in calculations)
-    scope = @options.include_metrics? ? ManageIQ::Providers::Microsoft::InfraManager::Vm : vms(region)
+    # support VM types for which we do not collect metrics yet (also when we are including metrics in calculations)
+    scope = @options.include_metrics? ? Vm.where.not(:type => Vm.types_supporting(:capture)) : vms(region)
     scope = scope.eager_load(:hardware, :taggings, :tags, :host, :ems_cluster, :storage, :ext_management_system,
                              :tenant)
 

--- a/app/models/metric/ci_mixin.rb
+++ b/app/models/metric/ci_mixin.rb
@@ -20,12 +20,7 @@ module Metric::CiMixin
       virtual_column vcol, :type => :float, :uses => :vim_performance_operating_ranges
     end
 
-    supports :capture do
-      metrics_capture_klass = "#{self.class.module_parent.name}::MetricsCapture".safe_constantize
-      unless metrics_capture_klass&.method_defined?(:perf_collect_metrics)
-        _('This provider does not support metrics collection')
-      end
-    end
+    supports_not :capture
   end
 
   def has_perf_data?

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/vm.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/vm.rb
@@ -1,4 +1,6 @@
 class <%= class_name %>::<%= manager_type %>::Vm < ManageIQ::Providers::<%= manager_type %>::Vm
+  supports :capture
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.find_vm(ems_ref)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe ChargebackVm do
   include Spec::Support::ChargebackHelper
+  include Spec::Support::SupportsHelper
 
   let(:admin) { FactoryBot.create(:user_admin) }
   let(:base_options) do
@@ -1520,11 +1521,12 @@ RSpec.describe ChargebackVm do
     let(:cpu_cost) { cores * count_hourly_rate * 24 }
     let(:disk_cost) { disk_gb * count_hourly_rate * 24 }
 
-    context 'for SCVMM (hyper-v)' do
+    context 'for VMs not supporting metrics capture' do
       let!(:vm1) do
-        vm = FactoryBot.create(:vm_microsoft, :hardware => hardware, :created_on => report_run_time - 1.day)
-        vm.tag_with(@tag.name, :ns => '*')
-        vm
+        FactoryBot.create(:vm_infra, :hardware => hardware, :created_on => report_run_time - 1.day).tap do |vm|
+          vm.tag_with(@tag.name, :ns => '*')
+          stub_supports_not(vm, :capture)
+        end
       end
 
       let(:options) { base_options.merge(:interval => 'daily') }


### PR DESCRIPTION
The `.extra_resources_without_rollups` method is checking for `@options.include_metrics` and adding in SCVMM type VMs because they do not support metrics.  This a. hard-codes a plugin class and b. ignores other types which do not support metrics capture.

I suspect at the time SCVMM was the only VM provider which didn't support metrics, but that assumption is no longer true.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/803
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/529
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/90
- [x] https://github.com/ManageIQ/manageiq-providers-dummy_provider/pull/51
- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/241
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/442
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/27
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/480
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/834
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/83
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/627
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/130
- [x] https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/86
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/846