### PR TITLE
Reduce filtering for pagination in Rbac.search

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -187,16 +187,16 @@ module Rbac
     # @param  options filtering options
     # @option options :targets       [nil|Array<Numeric|Object>|scope] Objects to be filtered
     #   - an nil entry uses the optional where_clause
-    #   - Array<Numeric> list if ids. :class is required. results are returned as ids
-    #   - Array<Object> list of objects. results are returned as objects
+    #   - Array<Numeric> list of ids. :class is required.
+    #   - Array<Object> list of objects.
     # @option options :named_scope   [Symbol|Array<String,Integer>] support for using named scope in search
     #     Example one scope without args:     :named_scope => :in_my_region
     #     Example one scope with args:        :named_scope => [[:in_region, 1]]
     #     Example more scopes without args:   :named_scope => [:in_my_region, :active]
     #     Example more scopes some with args: :named_scope => [[:in_region, 1], :active, [:with_manager, "X"]]
     # @option options :conditions    [Hash|String|Array<String>]
-    # @option options :where_clause  []
-    # @option options :sub_filter
+    # @option options :where_clause  [] same as conditions. used in one place. would like to remove
+    # @option options :sub_filter    [Nil|Array<String>] ui advanced search filter
     # @option options :include_for_find [Array<Symbol>, Hash{Symbol => Symbol,Hash,Array}] models included but not in query
     # @option options :references   [Array<Symbol>], models used by select and where. If not passed, uses include_for_find instead
     # @option options :filter       [MiqExpression] (optional)
@@ -209,23 +209,18 @@ module Rbac
     # @option options :order        [Numeric] (default: no order)
     # @option options :limit        [Numeric] (default: no limit)
     # @option options :offset       [Numeric] (default: no offset)
-    # @option options :apply_limit_in_sql [Boolean]
-    # @option options :ext_options
     # @option options :skip_count   [Boolean] (default: false)
+    #
     # @return [Array<Array<Object>,Hash>] list of object and the associated search options
     #   Array<Object> list of object in the same order as input targets if possible
     # @option attrs :auth_count [Numeric]
     # @option attrs :user_filters
-    # @option attrs apply_limit_in_sql
-    # @option attrs target_ids_for_paging
+    # @option attrs :apply_limit_in_sql [Boolean] true if this limit was applied in sql
+    # @option attrs :target_ids_for_paging [Array[Numeric]] the list of target ids (only if we can't apply limits in sql)
     def search(options = {})
       if options.key?(:targets) && options[:targets].kind_of?(Array) && options[:targets].empty?
         return [], {:auth_count => 0}
       end
-      # => empty inputs - normal find with optional where_clause
-      # => list if ids - :class is required for this format.
-      # => list of objects
-      # results are returned in the same format as the targets. for empty targets, the default result format is a list of ids.
       targets           = options[:targets]
       scope             = options[:named_scope]
 
@@ -296,6 +291,27 @@ module Rbac
       scope = include_references(scope, klass, references, exp_includes)
       scope = scope.limit(limit).offset(offset) if attrs[:apply_limit_in_sql]
 
+      #      SELECT col1, (SELECT "abc") AS virtual_col
+      #        FROM model
+      #       LIMIT 20
+      #
+      # virtual attribute (implemented as subqueries) are calculated for every row in whole table
+      # read: 1,000 row table, limit 20 records will run subquery 1,000 times
+      #
+      # we use an inline_view (inner and outer view)
+      #
+      #      SELECT col1, (SELECT "abc") AS virtual_col1
+      #        FROM (
+      #          SELECT col1
+      #            FROM model
+      #           LIMIT 20
+      #        ) AS model
+      #
+      #   inner view has limiter, outer view only sees $limit (i.e.: 20) rows:
+      #     1. Virtual attributes in outer view only performs <20 subqueries
+      #     2. SQL COUNT on the outer view only sees <20 rows.
+      #        Hence auth_count calculated from inner_scope.
+      #
       if inline_view?(options, scope)
         inner_scope = scope.except(:select, :includes, :references)
         scope.includes_values.each { |hash| inner_scope = add_joins(klass, inner_scope, hash) }
@@ -316,6 +332,10 @@ module Rbac
         auth_count ||= attrs[:apply_limit_in_sql] && limit ? targets.except(:offset, :limit, :order).count(:all) : targets.length
       end
 
+      # if we have a sub expression that requires ruby, then run it in ruby
+      # (some of the filtering may have happened in sql)
+      #
+      # NOTE: if supported_by_sql is false then apply_limit_in_sql is also false
       if search_filter && targets && (!exp_attrs || !exp_attrs[:supported_by_sql])
         rejects     = targets.reject { |obj| matches_search_filters?(obj, search_filter, tz) }
         auth_count -= rejects.length unless options[:skip_counts]
@@ -454,6 +474,9 @@ module Rbac
       nil
     end
 
+    # pluck_ids is here to show where sql queries could work in calc_filtered_ids.
+    # So once calc_filtered_ids uses pluck_ids for all, then that filter
+    # can converted across to a 100% sql friendly query
     def pluck_ids(targets)
       targets.pluck(:id) if targets
     end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -782,6 +782,8 @@ RSpec.describe MiqExpression do
           _vm2 = FactoryBot.create(:vm, :memory_reserve => 0)
           name_of_attribute = "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}example"
           filter = MiqExpression.new("<" => {"field" => "VmOrTemplate-memory_reserve", "value" => name_of_attribute})
+          # This is basically calling Rbac.filtered_object
+          # Leaving this as search to exercise the :skip_count methods
           result = Rbac.search(:targets => Vm, :filter => filter).first.first
           expect(filter.to_sql.last).to eq(:supported_by_sql => false)
           expect(result).to eq(vm1)


### PR DESCRIPTION
Before
===

When an MiqExpression filters by a ruby field, we need to download
all records and filter the data in ruby.

We were running the MiqExpression on every record and then throwing away
the records that were outside the current page.

The optimization
===

Lets be clear, the best optimization would have been to convert the ruby
virtual attribute into sql. Then we don't need to download all the records
and filter them. But if we have to stay in the ruby world...

We only need to filter enough data until we have the data to fill the current page.
That way we can avoid filtering records that are 5 pages later. This is our angle.

In the case of timelines, this is quite a significant amount of extra data.

When does this optimization apply?
===

The ui-classic list view displays the total count (auth_count) [ref](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1326-L1336)
We still need to filter every record to get the total count, so this can not be used.
no `skip_count` means no optimization.

If we are displaying every record, then we need to filter every record.
no pagination means no optimization.

If we have no MiqExpression, then we are not filtering by miq expression
and don't need to optimize it.
no miq_expression means no optimization

If the MiqExpression is only using sql columns, then the filtering and
pagination happens in the database. So we are only downloading the correct
number of records and we don't even need to filter in ruby. Typically these
return a scope anyway.
no ruby miq_expression means no optimization.

So... the API is a good example of a query that can leverage this optimization.
And do note, the last 2 are not optimized because they are already fast.

After
===

- We use `lazy` to only filter the rows when they are read.
- We use `to_a` to filter all records if we are counting. This avoids running the enumeration/filtering twice.
- We use `to_a` to convert any lazy enumeration to an array, so the external interface does not change.

Risks
===

- We just changed our pagination from `[offset...limit]` to `drop(offset).take(limit)`. Possibly
- We just added yet another type that the targets variable can be. array of id, array of objects, scope, named scope, class, and now lazy enumeration.

@miq-bot cross-repo-tests manageiq-ui-classic