### PR TITLE
Add caching of event_groups and pre-partition the event types

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -36,8 +36,9 @@ class EventStream < ApplicationRecord
 
   after_commit :emit_notifications, :on => :create
 
-  DEFAULT_GROUP_NAME  = :other
-  DEFAULT_GROUP_LEVEL = :detail
+  DEFAULT_GROUP_NAME     = :other
+  DEFAULT_GROUP_NAME_STR = N_("Other")
+  DEFAULT_GROUP_LEVEL    = :detail
 
   def self.description
     raise NotImplementedError, "Description must be implemented in a subclass"
@@ -59,57 +60,75 @@ class EventStream < ApplicationRecord
 
   # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def self.event_groups
-    core_event_groups = ::Settings.event_handling.event_groups.to_hash
-    Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
-      provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
-      next unless provider_event_groups
-      DeepMerge.deep_merge!(
-        provider_event_groups.to_hash, event_groups,
-        :preserve_unmergeables => false,
-        :overwrite_arrays      => false
-      )
+    @event_groups ||= begin # TODO: this cache needs to be busted whenever settings are changed (and also in test)
+      core_event_groups = ::Settings.event_handling.event_groups.to_hash
+      Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
+        provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
+        next unless provider_event_groups
+
+        DeepMerge.deep_merge!(
+          provider_event_groups.to_hash, event_groups,
+          :preserve_unmergeables => false,
+          :overwrite_arrays      => false
+        )
+      end
     end
+  end
+
+  private_class_method def self.partition_group_and_level_by_event_type
+    # TODO: this cache needs to be busted whenever settings are changed (and also in test)
+    return @literal_group_and_level_by_event_type, @regex_group_and_level_by_event_type if @literal_group_and_level_by_event_type
+
+    @literal_group_and_level_by_event_type = {}
+    @regex_group_and_level_by_event_type = {}
+
+    event_groups.each do |group_name, group_contents|
+      group_contents.each do |group_level, event_types|
+        next if group_level == :name
+
+        event_types.each do |event_type|
+          if event_type.starts_with?("/")
+            @regex_group_and_level_by_event_type[Regexp.new(event_type[1..-2])] ||= [group_name, group_level]
+          else
+            @literal_group_and_level_by_event_type[event_type] ||= [group_name, group_level]
+          end
+        end
+      end
+    end
+
+    return @literal_group_and_level_by_event_type, @regex_group_and_level_by_event_type
+  end
+
+  def self.clear_event_groups_cache
+    @event_groups = @literal_group_and_level_by_event_type = @regex_group_and_level_by_event_type = nil
   end
 
   # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def self.group_and_level(event_type)
-    level = DEFAULT_GROUP_LEVEL # the level is detail as default
-    egroups = event_groups
-
-    group = egroups.detect do |_, value|
-      group_levels
-        .detect { |lvl| value[lvl]&.any? { |typ| !typ.starts_with?("/") && typ == event_type } }
-        .tap { |level_found| level = level_found || level }
-    end&.first
-
-    group ||= egroups.detect do |_, value|
-      group_levels
-        .detect { |lvl| value[lvl]&.any? { |typ| typ.starts_with?("/") && Regexp.new(typ[1..-2]).match?(event_type) } }
-        .tap { |level_found| level = level_found || level }
-    end&.first
-
-    group ||= DEFAULT_GROUP_NAME
-    return group, level
+    by_literal, by_regex = partition_group_and_level_by_event_type
+    by_literal[event_type] ||
+      by_regex.detect { |regex, _| regex.match?(event_type) }&.last ||
+      [DEFAULT_GROUP_NAME, DEFAULT_GROUP_LEVEL]
   end
 
   def self.group_name(group)
     return if group.nil?
-    group = event_groups[group.to_sym]
-    group.nil? ? DEFAULT_GROUP_NAME.to_s.capitalize : group[:name]
+
+    event_groups.dig(group.to_sym, :name) || DEFAULT_GROUP_NAME_STR
   end
 
   # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def group
-    return @group unless @group.nil?
-    @group, @group_level = self.class.group_and_level(event_type)
-    @group
+    group_and_level.first
   end
 
   # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def group_level
-    return @group_level unless @group_level.nil?
-    @group, @group_level = self.class.group_and_level(event_type)
-    @group_level
+    group_and_level.last
+  end
+
+  private def group_and_level
+    @group_and_level ||= self.class.group_and_level(event_type)
   end
 
   # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.

--- a/lib/vmdb/settings/activator.rb
+++ b/lib/vmdb/settings/activator.rb
@@ -25,6 +25,11 @@ module Vmdb
         Vmdb::Loggers.apply_config(data)
       end
 
+      def event_handling(_data)
+        EmsEvent.clear_event_groups_cache
+        EventStream.clear_event_groups_cache
+      end
+
       def session(data)
         Session.timeout(data.timeout)
         Session.interval(data.interval)

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -43,6 +43,9 @@ module EvmSpecHelper
     clear_instance_variable(MiqWorker, :@rails_worker) if defined?(MiqWorker)
     clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
 
+    EmsEvent.clear_event_groups_cache if defined?(EmsEvent)
+    EventStream.clear_event_groups_cache if defined?(EventStream)
+
     MiqWorker.my_guid = nil
 
     # Clear the thread local variable to prevent test contamination


### PR DESCRIPTION
Based on #22304 

The way this works is we take the resolved set of event_groups and cache
that. This should not change unless the settings change.

After that, instead of always walking the event_groups during lookup, we
walk them once and partition it into one lookup table for String literals
and another lookup table for Regexes, and cache those. Later, when we
want to find the group_and_level we go to those lookup tables instead.

This drops the old lookup code from O(N) + a lot of allocated objects to
O(1 String) + O(N Regex) (note that there are many Strings and very few
Regex).

@jrafanie Please review
cc @kbrock @MelsHyrule 

~~WIP: I still need to bust the caches when Settings changes~~ DONE

---

Before: The following example code took forever (I canceled it and never let it complete)
After: The group, group_name, and group_level lookups are sub-millisecond

```
# With 300k event records

# Baseline query to determine query, instantiation, and Array conversion overhead
irb(main):001:0> Benchmark.ms { EmsEvent.all.to_a; nil }
  EmsEvent Load (711.7ms)  SELECT "event_streams".* FROM "event_streams" WHERE "event_streams"."type" = $1  [["type", "EmsEvent"]]
  EmsEvent Inst Including Associations (6830.4ms - 297116rows)
=> 14751.755999983288

irb(main):002:0> Benchmark.ms { EmsEvent.all.each { |e| [e.group, e.group_name, e.group_level] }; nil }
  EmsEvent Load (756.9ms)  SELECT "event_streams".* FROM "event_streams" WHERE "event_streams"."type" = $1  [["type", "EmsEvent"]]
  EmsEvent Inst Including Associations (6682.2ms - 297116rows)
=> 15410.467999987304
```

---

Future PR - After this we have basically lookup tables by `event_type -> [group, group_level]`, so if we want to query by group or group_level we can just invert that.  I believe it shouldn't be too difficult to make it a scope, and that would allow filtering in SQL.