### PR TITLE
Cleanup sync_starting_workers method

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -49,6 +49,10 @@ class MiqServer::WorkerManagement
     wait_for_started_workers
   end
 
+  def sync_starting_workers!(_starting)
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
   def start_drb_server
     require 'drb'
     require 'drb/acl'

--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -21,7 +21,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
   end
 
   # TODO: Synchronize worker records and status as they are starting up
-  def sync_starting_workers!
+  def sync_starting_workers!(_starting)
   end
 
   def enough_resource_to_start_worker?(_worker_class)

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -4,7 +4,7 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
     self.miq_processes = Sys::ProcTable.ps.select { |proc| proc.ppid == my_server.pid }
   end
 
-  def sync_starting_workers!
+  def sync_starting_workers!(_starting)
   end
 
   def monitor_workers


### PR DESCRIPTION
The `starting` parameter was missed from the empty method definitions in https://github.com/ManageIQ/manageiq/pull/22298

@miq-bot assign @agrare 
@miq-bot add_label bug