### PR TITLE
Inject override_gem into bundler.d for a generated plugin to prevent immediate failures after creating a plugin

### DIFF
--- a/lib/generators/manageiq/plugin/plugin_generator.rb
+++ b/lib/generators/manageiq/plugin/plugin_generator.rb
@@ -85,6 +85,16 @@ module ManageIQ
         end
       GEMFILE
       inject_into_file Rails.root.join('Gemfile'), "\n#{data}\n", :after => "### providers\n"
+
+      bundler_d_dir       = Rails.root.join("bundler.d")
+      plugin_overrides_rb = bundler_d_dir.glob("*.rb").first || bundler_d_dir.join("plugins.rb")
+
+      data = "override_gem \"#{plugin_name}\", :path => \"#{destination_root}\"\n"
+      if plugin_overrides_rb.exist?
+        inject_into_file plugin_overrides_rb, data
+      else
+        plugin_overrides_rb.write(data)
+      end
     end
 
     private


### PR DESCRIPTION
When generating a plugin or provider we inject the gem dependency into the core `Gemfile` automatically for the user, but we do not add any reference to the local plugin to the `bundler.d` overrides, and since no generated plugin exists in `github.com:ManageIQ/` yet running `rails c` and `bundle install` always fails until the developer adds the new plugin to their overrides.

This change will detect if an overrides file already exists otherwise it will create one.

Example Gemfile diff:
```
+
+group :awesome_cloud, :manageiq_default do
+  manageiq_plugin "manageiq-providers-awesome_cloud" # TODO: Sort alphabetically...
+end
+
```

Example failure without bundler.d changes:
```
$ rails c
The git source https://github.com/ManageIQ/manageiq-providers-awesome_cloud is not yet checked out. Please run `bundle install` before trying to start your application
$ bundle update
Fetching https://github.com/ManageIQ/manageiq-providers-awesome_cloud
Username for 'https://github.com': 
Password for 'https://github.com': 
remote: Repository not found.
```

Example bundler.d override with these changes:
```
$ cat bundler.d/plugins.rb 
override_gem "manageiq-providers-awesome_cloud", :path => "/home/grare/adam/src/manageiq/manageiq/plugins/manageiq-providers-awesome_cloud"
```