### PR TITLE
Since we only cache valid? _to_ruby, don't check it again

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -156,10 +156,15 @@ class MiqExpression
   end
 
   def to_ruby(tz = nil)
-    return "" unless valid?
-    tz ||= "UTC"
-    @ruby ||= self.class._to_ruby(exp.deep_clone, context_type, tz)
-    @ruby.dup
+    # TODO: we cache the ruby expression regardless if the tz is different
+    if @ruby
+      @ruby.dup
+    elsif valid?
+      @ruby ||= self.class._to_ruby(exp.deep_clone, context_type, tz || "UTC".freeze)
+      @ruby.dup
+    else
+      ""
+    end
   end
 
   def self._to_ruby(exp, context_type, tz)


### PR DESCRIPTION
For this api request with 10k event_streams, we save 3 seconds by avoiding calling valid? on previously valid? `@ruby` objects.

initial(cold, no prior requests): ~46 => ~41 seconds
subsequent(previously requested): ~42 => ~39 seconds

```
http://localhost:3000/api/event_streams?limit=100&offset=0&expand=resources&attributes=group,group_level,group_name,id,event_type,message,ems_id,type,timestamp,created_on,host.name,source,ems_id,ext_management_system.name&filter[]=type=EmsEvent&filter[]=group=other&filter[]=group_level=detail
```

Extracted from PR: #22304 commit https://github.com/ManageIQ/manageiq/pull/22304/commits/c3423c8c4afb79766a9f479c401953067c194b97 "When caching _to_ruby, also cache valid?" with the following change: "don't cache empty strings in `@ruby`.