### PR TITLE
Update containerized non rails workers status to started

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -49,7 +49,7 @@ class MiqServer::WorkerManagement
     wait_for_started_workers
   end
 
-  def sync_starting_workers!(_starting)
+  def sync_starting_workers
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 

--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -20,8 +20,17 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
     sync_deployment_settings
   end
 
-  # TODO: Synchronize worker records and status as they are starting up
-  def sync_starting_workers!(_starting)
+  def sync_starting_workers!(starting)
+    starting.each do |worker|
+      next if worker.class.rails_worker?
+
+      worker_pod = find_pod(worker[:system_uid])
+      container_status = worker_pod.status.containerStatuses.find { |container| container.name == worker.worker_deployment_name }
+      if worker_pod.status.phase == "Running" && container_status.ready && container_status.started
+        worker.update!(:status => "started")
+        starting.delete(worker)
+      end
+    end
   end
 
   def enough_resource_to_start_worker?(_worker_class)
@@ -229,5 +238,9 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
   def delete_pod(pod)
     current_pods.delete(pod.metadata.name)
+  end
+
+  def find_pod(pod_name)
+    orchestrator.get_pods.find { |pod| pod.metadata[:name] == pod_name }
   end
 end

--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -20,17 +20,20 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
     sync_deployment_settings
   end
 
-  def sync_starting_workers!(starting)
+  def sync_starting_workers
+    starting = MiqWorker.find_all_starting.to_a
     starting.each do |worker|
       next if worker.class.rails_worker?
 
-      worker_pod = find_pod(worker[:system_uid])
+      worker_pod = get_pod(worker[:system_uid])
       container_status = worker_pod.status.containerStatuses.find { |container| container.name == worker.worker_deployment_name }
       if worker_pod.status.phase == "Running" && container_status.ready && container_status.started
         worker.update!(:status => "started")
         starting.delete(worker)
       end
     end
+
+    starting
   end
 
   def enough_resource_to_start_worker?(_worker_class)
@@ -240,7 +243,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
     current_pods.delete(pod.metadata.name)
   end
 
-  def find_pod(pod_name)
+  def get_pod(pod_name)
     orchestrator.get_pods.find { |pod| pod.metadata[:name] == pod_name }
   end
 end

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -23,6 +23,8 @@ module MiqServer::WorkerManagement::Monitor
     # Sync the workers after sync'ing the child worker settings
     sync_workers
 
+    sync_starting_workers
+
     MiqWorker.status_update_all
 
     cleanup_failed_workers

--- a/app/models/miq_server/worker_management/monitor/start.rb
+++ b/app/models/miq_server/worker_management/monitor/start.rb
@@ -10,8 +10,7 @@ module MiqServer::WorkerManagement::Monitor::Start
     entered_wait_for_started_loop = Time.now.utc
     wait_for_started_timeout      = @worker_monitor_settings[:wait_for_started_timeout] || 10.minutes
     loop do
-      starting = MiqWorker.find_starting.find_all { |w| MiqWorkerType.worker_class_names.include?(w.class.name) }.to_a
-      sync_starting_workers!(starting)
+      starting = sync_starting_workers
       if starting.empty?
         _log.info("All workers have been started")
         break

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -4,7 +4,8 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
     self.miq_processes = Sys::ProcTable.ps.select { |proc| proc.ppid == my_server.pid }
   end
 
-  def sync_starting_workers!(_starting)
+  def sync_starting_workers
+    MiqWorker.find_all_starting.to_a
   end
 
   def monitor_workers

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -4,7 +4,8 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     self.miq_services_by_guid = miq_services.index_by { |w| w[:name].match(/^.+@(?<guid>.+)\.service$/).named_captures["guid"] }
   end
 
-  def sync_starting_workers!(starting)
+  def sync_starting_workers
+    starting = MiqWorker.find_all_starting.to_a
     sync_from_system
     starting.each do |worker|
       next if worker.class.rails_worker?
@@ -15,6 +16,8 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
         starting.delete(worker)
       end
     end
+
+    starting
   end
 
   def cleanup_failed_workers

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -113,6 +113,10 @@ class MiqWorker < ApplicationRecord
     server_scope.where(:status => STATUSES_STARTING)
   end
 
+  def self.find_all_starting
+    find_starting.where(:type => MiqWorkerType.worker_class_names)
+  end
+
   def self.find_current_or_starting
     server_scope.where(:status => STATUSES_CURRENT_OR_STARTING)
   end


### PR DESCRIPTION
- use `ContainerOrchestrator` object to check pod and container status and update non rails worker accordingly

Ref:
- https://github.com/ManageIQ/manageiq/issues/21992

@miq-bot add_label enhancement
@miq-bot assign @agrare 