### PR TITLE
Allow large numbers as parameters to not blow up

### DIFF
--- a/config/initializers/postgres_bigints.rb
+++ b/config/initializers/postgres_bigints.rb
@@ -1,0 +1,8 @@
+# Rails has a protection to not lookup values by a large number.
+# A lookup/comparison with a large number (bigger than bigint)
+# needs to cast the db column to a double/numeric.
+# and that casting skips the index and forces a table scan
+#
+# https://discuss.rubyonrails.org/t/cve-2022-44566-possible-denial-of-service-vulnerability-in-activerecords-postgresql-adapter/82119
+#
+ActiveRecord::Base.raise_int_wider_than_64bit = false


### PR DESCRIPTION
Rails 6.1.7.1 (and 7.0.4.1) no longer allow larger numbers to go through and raise an exception.

This was causing specs to fail in manageiq-ui-classic:

```
rspec spec/controllers/application_controller_spec.rb:321

expected no Exception, got IntegerOutOf64BitRange
```

Some side notes:

Many of these fields should probably just be int or bigints. In that case, keeping the default behavior would work fine.

- `memory_mb`, since it gets converted from megs to bytes and aggregated, was converted to make the aggregation and comparison easier ( https://github.com/ManageIQ/manageq/pull/15554 )
- binary_blobs size, part_size are precision 20
miq_servers#memory_{usage,size} {unique,porportional}_set_size} along with a bunch others) are precision 20
miq_workers (same as above)
container_quota_items  quota_{desired,enforced,observed}   precision of 30 (!?!)
