### PR TITLE
force latest version of rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.3.1",         :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>6.1.6", ">=6.1.6.1"
+gem "rails",                            "~>6.1.7", ">=6.1.7.1"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false


### PR DESCRIPTION
followup to #22321

Force us to using the latest version.

after https://github.com/ManageIQ/manageiq-ui-classic/pull/8613 - we do have the option to roll back 22321 - but we still want to force the latest version of rails