### PR TITLE
Avoid catastrophic backtracking in MiqExpression::Field.parse

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -9,7 +9,7 @@ class MiqExpression::Field < MiqExpression::Target
   (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z0-9A-Z]+[:_\-.\/[:alnum:]]*)|
   (?<column>[a-z]+(_[[:alnum:]]+)*)
 )
-/x
+/x.freeze
 
   def self.parse(field)
     parsed_params = parse_params(field) || return

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,8 +1,9 @@
 class MiqExpression::Field < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
+\A
+(?<model_name>(?>[[:upper:]][[:alnum:]]+(?:::[[:upper:]][[:alnum:]]+)*))
 (?!.*\b(managed|user_tag)\b)
-\.?(?<associations>[a-z][0-9a-z_\.]+)?
+(?:\.(?<associations>[a-z][0-9a-z_\.]+))?
 -
 (?:
   (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z0-9A-Z]+[:_\-.\/[:alnum:]]*)|

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -10,10 +10,10 @@ class MiqExpression::Target
   # {:model_name => Host<ApplicationRecord> , :associations => ['vms']<Array>, :column_name => 'host_name' <String>}
   def self.parse_params(field)
     return unless field.kind_of?(String)
-    match = self::REGEX.match(field) || return
-    # convert matches to hash to format
-    # {:model_name => 'User', :associations => ...}
-    parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]
+
+    parsed_params = match(field)
+    return if parsed_params.nil?
+
     begin
       parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize
     rescue LoadError # issues for case sensitivity (e.g.: VM vs vm)
@@ -21,6 +21,10 @@ class MiqExpression::Target
     end
     parsed_params[:associations] = parsed_params[:associations].to_s.split(".")
     parsed_params
+  end
+
+  def self.match(field)
+    self::REGEX.match(field)&.named_captures&.symbolize_keys
   end
 
   attr_reader :column

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe MiqExpression::Field do
                                                               :associations => %w(win32_services),
                                                               :column       => 'dependencies')
     end
+
+    # This test is here because of the complexity of the MiqExpression::Field::REGEX.
+    # If the regex is removed or greatly simplified, then this test can also be removed.
+    it "avoids catastrophic backtracking" do
+      expect(Benchmark.realtime { MiqExpression::Field.parse("XXXXXXXXXXXXXXXXXXXXXXXXX-") }).to be < 1.second
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
Fixes #22325

@jrafanie @kbrock Please review. I don't love this change, but I think it solves the problem at hand.

~~What I noticed was that the "before dash" part of the regex would match quickly up to the dash, then find nothing after. So, what it would do is backtrack to see if the tailing characters were part of the association (I think because the \.? and the association itself are separated).  While I could have probably fixed the regex there, I realized that the `-` is a) a hard requirement, and b) there are no `-` before it.  Therefore it's clearner to split the string on `-` and process them separately.  Eventually maybe we can drop the regex entirely and do normal String manipulations in the future.~~

As discussed, we redid this PR to focus on the existing Regex, with some of the solutions in #22328 and also some others I found here, and also kept the refactoring to a method which makes is easier to fix other problems later.

cc @evertmulder 