### PR TITLE
Better regex

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -5,7 +5,7 @@ class MiqExpression::Field < MiqExpression::Target
 -
 (?:
   (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z0-9A-Z]+[:_\-.\/[:alnum:]]*)|
-  (?<column>[a-z]+(_[[:alnum:]]+)*)
+  (?<column>[[:alnum:]]+(?:_[[:alnum:]]+)*)?(?<pivot>__[[:alnum:]]+)?
 )
 /x
 

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,6 +1,6 @@
 class MiqExpression::Field < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
+(?<model_name>[[:upper:]][[:alnum:]]+(?:::[[:upper:]][[:alnum:]]+)*)
 (?!.*\b(managed|user_tag)\b)
 \.?(?<associations>[a-z][0-9a-z_\.]+)?
 -

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,7 +1,6 @@
 class MiqExpression::Field < MiqExpression::Target
   REGEX = /
 (?<model_name>[[:upper:]][[:alnum:]]+(?:::[[:upper:]][[:alnum:]]+)*)
-(?!.*\b(managed|user_tag)\b)
 \.?(?<associations>[a-z][0-9a-z_\.]+)?
 -
 (?:

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,12 +1,12 @@
 class MiqExpression::Field < MiqExpression::Target
-  REGEX = /
+  REGEX = /\A
 (?<model_name>[[:upper:]][[:alnum:]]+(?:::[[:upper:]][[:alnum:]]+)*)
 (?<associations>\.[a-z][0-9a-z_\.]+)?
 -
 (?:
   (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z0-9A-Z]+[:_\-.\/[:alnum:]]*)|
   (?<column>[[:alnum:]]+(?:_[[:alnum:]]+)*)?(?<pivot>__[[:alnum:]]+)?
-)
+)\z
 /x
 
   def self.parse(field)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,7 +1,7 @@
 class MiqExpression::Field < MiqExpression::Target
   REGEX = /
 (?<model_name>[[:upper:]][[:alnum:]]+(?:::[[:upper:]][[:alnum:]]+)*)
-\.?(?<associations>[a-z][0-9a-z_\.]+)?
+(?<associations>\.[a-z][0-9a-z_\.]+)?
 -
 (?:
   (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z0-9A-Z]+[:_\-.\/[:alnum:]]*)|

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -11,6 +11,7 @@ class MiqExpression::Target
   def self.parse_params(field)
     return unless field.kind_of?(String)
     match = self::REGEX.match(field) || return
+    return if match[:associations] =~ /(managed|user_tag)$/
     # convert matches to hash to format
     # {:model_name => 'User', :associations => ...}
     parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -20,7 +20,11 @@ class MiqExpression::Target
     rescue LoadError # issues for case sensitivity (e.g.: VM vs vm)
       parsed_params[:model_name] = nil
     end
-    parsed_params[:associations] = parsed_params[:associations].to_s.split(".")
+    parsed_params[:associations] = if parsed_params[:associations]
+                                     parsed_params[:associations][1..].split(".")
+                                   else
+                                     []
+                                   end
     parsed_params
   end
 


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/22325

We were having troubles matching a long string

`'WAA3T7ahBzdslege7z7ZLAImwBP4rRfhfRKz3wiBQEnZ4uvxcg9RLpMf4leoIU5yendrStHZds-'`

thanks to help from https://regex101.com/r/lVeEPu/1

went from very bad to 384 backtraces

- TODO: need to apply to other regular expressions in the MiqExpression::Target classes
- alternative to https://github.com/ManageIQ/manageiq/pull/22326