### PR TITLE
Add a way for worker subclasses to handle settings changes

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -11,8 +11,9 @@ module MiqServer::ConfigurationManagement
 
     Vmdb::Settings.reload!
 
-    reset_server_caches
-    worker_manager.notify_workers_of_config_change(Time.now.utc)
+    sync_assigned_roles
+
+    worker_manager.reload_worker_settings
   end
 
   def servers_for_settings_reload
@@ -35,11 +36,5 @@ module MiqServer::ConfigurationManagement
     end
 
     save
-  end
-
-  def reset_server_caches
-    worker_manager.sync_config
-    sync_assigned_roles
-    worker_manager.reset_queue_messages
   end
 end

--- a/app/models/miq_server/worker_management/monitor/settings.rb
+++ b/app/models/miq_server/worker_management/monitor/settings.rb
@@ -6,6 +6,13 @@ module MiqServer::WorkerManagement::Monitor::Settings
     attr_reader :worker_monitor_settings
   end
 
+  def reload_worker_settings
+    sync_config
+    reset_queue_messages
+    notify_workers_of_config_change(Time.now.utc)
+    MiqWorkerType.worker_classes.each(&:reload_worker_settings)
+  end
+
   def sync_config
     sync_worker_monitor_settings
     sync_child_worker_settings

--- a/app/models/miq_server/worker_management/monitor/settings.rb
+++ b/app/models/miq_server/worker_management/monitor/settings.rb
@@ -20,11 +20,14 @@ module MiqServer::WorkerManagement::Monitor::Settings
   end
 
   def sync_child_worker_settings
-    @child_worker_settings = {}
+    child_worker_settings = {}
     MiqWorkerType.worker_classes.each do |worker_class|
-      @child_worker_settings[worker_class.settings_name] = worker_class.worker_settings
+      child_worker_settings[worker_class.settings_name] = worker_class.worker_settings
+      child_worker_settings[worker_class.settings_name].merge!(get_additional_settings(worker_class.worker_settings_paths)) unless worker_class.worker_settings_paths.empty?
+      check_settings_diff(child_worker_settings[worker_class.settings_name], worker_class) unless worker_class.rails_worker?
     end
-    @child_worker_settings
+
+    @child_worker_settings = child_worker_settings
   end
 
   def sync_worker_monitor_settings
@@ -57,5 +60,24 @@ module MiqServer::WorkerManagement::Monitor::Settings
 
   def get_memory_threshold(worker)
     @child_worker_settings[worker.class.settings_name][:memory_threshold]
+  end
+
+  def get_additional_settings(worker_settings_paths)
+    additional_settings = {}
+    worker_settings_paths.to_a.each do |settings_path|
+      additional_settings.store_path(settings_path, Settings.to_hash.dig(*settings_path))
+    end
+
+    additional_settings
+  end
+
+  private
+
+  def check_settings_diff(new_settings, worker_class)
+    return if @child_worker_settings.nil?
+
+    old_settings = @child_worker_settings[worker_class.settings_name]
+
+    worker_class.restart_workers if Vmdb::Settings::HashDiffer.changes(new_settings, old_settings).any?
   end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -257,6 +257,10 @@ class MiqWorker < ApplicationRecord
     fetch_worker_settings_from_server(MiqServer.my_server, options)
   end
 
+  def self.reload_worker_settings
+    # By default worker settings are reloaded periodically by the worker runner
+  end
+
   def self.start_workers
     return unless self.has_required_role?
     workers.times { start_worker }


### PR DESCRIPTION
Continuing off of https://github.com/ManageIQ/manageiq/pull/22196

> Non-rails workers get their settings via STDIN on startup. This means there is no easy way to "reload" the worker settings after startup. As settings don't change that frequently we can just restart the worker if settings have changed.
> 
> TODO:
> 
>  - [X] Use Vmdb::Settings.changes or diff_to_deltas and compare with worker_settings_paths to see if any settings that the worker cares about changed

Ref:
- https://github.com/ManageIQ/manageiq/issues/21992

@miq-bot assign @agrare 
@miq-bot add_labels enhancement, core/workers, core