### PR TITLE
Host factory

### DIFF
--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     power_state         { "on" }
 
     transient do
+      authtype { nil }
       storage_count { nil }
     end
 
@@ -18,29 +19,24 @@ FactoryBot.define do
 
     after :create do |host, ev|
       host.storages = create_list :storage, ev.storage_count if ev.storage_count
+      Array(ev.authtype).each { |a| host.authentications << FactoryBot.create(:authentication, :authtype => a, :resource => host) } if ev.authtype
     end
   end
 
   factory :host_with_ref, :parent => :host, :traits => [:with_ref]
 
   factory :host_with_authentication, :parent => :host do
-    after(:create) do |x|
-      x.authentications = [FactoryBot.build(:authentication, :resource => x)]
-    end
+    authtype { "default" }
   end
 
   factory :host_vmware_esx_with_authentication, :parent => :host_vmware_esx do
-    after(:create) do |x|
-      x.authentications = [FactoryBot.build(:authentication, :resource => x)]
-    end
+    authtype { "default" }
   end
 
   factory :host_with_ipmi, :parent => :host do
     ipmi_address { "127.0.0.1" }
     mac_address  { "aa:bb:cc:dd:ee:ff" }
-    after(:create) do |x|
-      x.authentications = [FactoryBot.build(:authentication_ipmi, :resource => x)]
-    end
+    authtype     { "ipmi" }
   end
 
   # Type specific subclasses

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -11,14 +11,17 @@ FactoryBot.define do
       storage_count { nil }
     end
 
+    trait :with_ref do
+      ems_ref_type { "HostSystem" }
+      sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
+    end
+
     after :create do |host, ev|
       host.storages = create_list :storage, ev.storage_count if ev.storage_count
     end
   end
 
-  factory :host_with_ref, :parent => :host do
-    sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
-  end
+  factory :host_with_ref, :parent => :host, :traits => [:with_ref]
 
   factory :host_with_authentication, :parent => :host do
     after(:create) do |x|
@@ -49,13 +52,11 @@ FactoryBot.define do
     vmm_product  { "ESX" }
   end
 
-  factory :host_redhat, :parent => :host, :class => "ManageIQ::Providers::Redhat::InfraManager::Host" do
-    sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
+  factory :host_redhat, :parent => :host, :class => "ManageIQ::Providers::Redhat::InfraManager::Host", :traits => [:with_ref] do
     vmm_vendor { "redhat" }
   end
 
-  factory :host_ovirt, :parent => :host, :class => "ManageIQ::Providers::Ovirt::InfraManager::Host" do
-    sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
+  factory :host_ovirt, :parent => :host, :class => "ManageIQ::Providers::Ovirt::InfraManager::Host", :traits => [:with_ref] do
     vmm_vendor { "ovirt" }
   end
 

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -6,6 +6,14 @@ FactoryBot.define do
     ipaddress           { "127.0.0.1" }
     user_assigned_os    { "linux_generic" }
     power_state         { "on" }
+
+    transient do
+      storage_count { nil }
+    end
+
+    after :create do |host, ev|
+      host.storages = create_list :storage, ev.storage_count if ev.storage_count
+    end
   end
 
   factory :host_with_ref, :parent => :host do
@@ -67,25 +75,5 @@ FactoryBot.define do
                                                      :class  => "ManageIQ::Providers::Openstack::InfraManager::Host" do
     name        { "host1 (NovaCompute)" }
     maintenance { true }
-  end
-
-  trait :storage do
-    transient do
-      storage_count { 1 }
-    end
-
-    after :create do |h, evaluator|
-      h.storages = create_list :storage, evaluator.storage_count
-    end
-  end
-
-  trait :storage_redhat do
-    transient do
-      storage_count { 1 }
-    end
-
-    after :create do |h, evaluator|
-      h.storages = create_list :storage_redhat, evaluator.storage_count
-    end
   end
 end

--- a/spec/factories/small_environment.rb
+++ b/spec/factories/small_environment.rb
@@ -2,23 +2,16 @@ FactoryBot.define do
   factory :small_environment, :parent => :zone do
     sequence(:name)         { |n| "small_environment_#{seq_padded_for_sorting(n)}" }
     sequence(:description)  { |n| "Small Environment #{seq_padded_for_sorting(n)}" }
-    ext_management_systems  { [FactoryBot.create(:ems_small_environment)] }
 
-    # Hackery: Due to ntp reload occurring on save, we need to add the servers after saving the zone.
     after(:create) do |z|
+      # Hackery: Due to ntp reload occurring on save,
+      #          we need to add the servers after saving the zone.
       EvmSpecHelper.local_miq_server(:is_master => true, :zone => z)
+      FactoryBot.create_list(:ems_vmware, 1, :zone => z) do |ems|
+        FactoryBot.create(:host, :with_ref, :vmm_product => "Workstation", :ext_management_system => ems) do |host|
+          FactoryBot.create_list(:vm_with_ref, 2, :ext_management_system => ems, :host => host)
+        end
+      end
     end
-  end
-
-  factory :ems_small_environment, :parent => :ems_vmware do
-    hosts        { [FactoryBot.create(:host_small_environment)] }
-    after(:create) do |x|
-      x.hosts.each { |h| h.vms.each { |v| v.update_attribute(:ems_id, x.id) } }
-    end
-  end
-
-  factory :host_small_environment, :parent => :host_with_ref do
-    vmm_product  { "Workstation" }
-    vms          { [FactoryBot.create(:vm_with_ref, :name => "vmtest1"), FactoryBot.create(:vm_with_ref, :name => "vmtest2")] }
   end
 end

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ResourcePool do
   include_examples "MiqPolicyMixin"
 
   describe "AggregationMixin methods" do
-    let(:host) { FactoryBot.create(:host, :storage) }
+    let(:host) { FactoryBot.create(:host, :storage_count => 1) }
     let(:rp) { FactoryBot.create(:resource_pool) }
     let(:vm) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 2048)) }
     let(:vm2) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 1024)) }


### PR DESCRIPTION
commits:

- drop host factory traits that are invalid (traits need to be in an actual factory)
- make host ems_ref a common trait (DRY)
- reduce small_environment_factory (leverage ems_ref)
- make host authentication closer to ems authentication 