### PR TITLE
Host validation

### DIFF
--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe AuthenticationMixin do
         it "(:save => true) updates status" do
           @host.authentications.first.update(:status => nil) # start unauthorized
           allow(@host).to receive(:verify_credentials).and_return(true)
-          @host.authentication_check(:save => true)
+          @host.authentication_check(:default, :save => true)
           expect(@host.authentication_type(:default).status).to eq("Valid")
           expect(MiqQueue.where(:class_name => "MiqEvent").where(:method_name => "raise_evm_event").count).to eq(1)
         end
@@ -500,7 +500,7 @@ RSpec.describe AuthenticationMixin do
         it "(:save => false) does not update status" do
           @host.authentications.first.update(:status => nil) # start unauthorized
           allow(@host).to receive(:missing_credentials?).and_return(false)
-          @host.authentication_check(:save => false)
+          @host.authentication_check(:default, :save => false)
           expect(@host.authentication_type(:default).status).to be_nil
           expect(MiqQueue.where(:class_name => "MiqEvent").where(:method_name => "raise_evm_event").count).to eq(0)
         end


### PR DESCRIPTION
part of of https://github.com/ManageIQ/manageiq-ui-classic/pull/8608

depends upon:

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/859

dependent of:

- [ ] https://github.com/ManageIQ/manageiq-api/pull/1202
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/839

In the ui (read: api), we need to test new credentials.
These are not the credentials stored in the host.

So we need to pass these new credentials over the wire to the
`ems_operations` worker to test. `validate_credentials?` pulls those credentials out and applies to the host (without `save`)

Updated host to call a default authentication method so different providers like vmware and openstack can choose different defaults for verify credentials

/cc @MelsHyrule 