### PR TITLE
Add audit_events purging

### DIFF
--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -3,6 +3,8 @@ class AuditEvent < ApplicationRecord
   validates :status, :inclusion => { :in => %w(success failure) }
   validates :severity, :inclusion => { :in => %w(fatal error warn info debug) }
 
+  include_concern 'Purging'
+
   def self.generate(attrs)
     attrs = {
       :severity => "info",

--- a/app/models/audit_event/purging.rb
+++ b/app/models/audit_event/purging.rb
@@ -1,0 +1,24 @@
+class AuditEvent < ApplicationRecord
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_mode_and_value
+        [:scope, purge_date]
+      end
+
+      def purge_date
+        ::Settings.audit_events.history.keep_events.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.audit_events.history.purge_window_size
+      end
+
+      def purge_scope(older_than = nil)
+        where(arel_table[:created_on].lt(older_than))
+      end
+    end
+  end
+end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -101,6 +101,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "DriftState", :method_name => "purge_timer", :zone => nil)
   end
 
+  def audit_event_purge_timer
+    queue_work(:class_name => "AuditEvent", :method_name => "purge_timer", :zone => nil)
+  end
+
   def event_stream_purge_timer
     queue_work(:class_name => "EventStream", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -238,6 +238,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:binary_blob_purge_timer)
     end
 
+    # Schedule - Purging of audit events
+    scheduler.schedule_every(
+      :audit_event_purge_timer,
+      worker_settings[:audit_events_purge_interval]
+    ) do
+      enqueue(:audit_event_purge_timer)
+    end
+
     # Schedule - Purging of notifications
     scheduler.schedule_every(
       :notification_purge_timer,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,8 @@
 ---
+:audit_events:
+  :history:
+    :keep_events: 6.months
+    :purge_window_size: 1000
 :authentication:
   :basedn:
   :bind_dn:
@@ -1122,6 +1126,7 @@
         :heartbeat_thread_shutdown_timeout: 10.seconds
     :schedule_worker:
       :audit_managed_resources: 1.days
+      :audit_events_purge_interval: 1.day
       :container_entities_purge_interval: 1.day
       :binary_blob_purge_interval: 1.hour
       :authentication_check_interval: 1.hour

--- a/spec/models/audit_event/purging_spec.rb
+++ b/spec/models/audit_event/purging_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe AuditEvent do
+  context "::Purging" do
+    context ".purge_queue" do
+      before do
+        EvmSpecHelper.local_miq_server
+      end
+      let(:purge_time) { (Time.zone.now + 10).round }
+
+      it "submits to the queue" do
+        expect(described_class).to receive(:purge_date).and_return(purge_time)
+        described_class.purge_timer
+
+        q = MiqQueue.all
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
+          :class_name  => described_class.name,
+          :method_name => "purge_by_scope",
+          :args        => [purge_time]
+        )
+      end
+    end
+
+    context ".purge" do
+      let(:created_on) { 6.months.ago }
+
+      before do
+        defaults = {:event => "login", :status => "success", :severity => "info", :message => "all good"}
+        @old_audit_event        = FactoryBot.create(:audit_event, defaults.merge(:created_on => created_on - 1.day))
+        @purge_date_audit_event = FactoryBot.create(:audit_event, defaults.merge(:created_on => created_on - 1.second))
+        @new_audit_event        = FactoryBot.create(:audit_event, defaults.merge(:created_on => created_on + 1.day))
+      end
+
+      def assert_unpurged_ids(unpurged_ids)
+        expect(described_class.order(:id).pluck(:id)).to eq(Array(unpurged_ids).sort)
+      end
+
+      it "purge_date and older" do
+        described_class.purge(created_on)
+        assert_unpurged_ids(@new_audit_event.id)
+        expect(described_class.count).to eq(1)
+      end
+
+      it "with a window" do
+        described_class.purge(created_on, 1)
+        assert_unpurged_ids(@new_audit_event.id)
+        expect(described_class.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, the table would grow unbounded, now like many other purgers, we delete audit_events older than 6 months. This value is exposed so you can change it if you'd like to retain more or less history.

Fixes #20956

Note, we can discuss dropping this table entirely later.  It doesn't get cut for all audit activity and logging might be enough.  This PR just ensures the existing table doesn't grow without end.