### PR TITLE
Remove redundant audit log mirroring

### DIFF
--- a/lib/vmdb/loggers/audit_logger.rb
+++ b/lib/vmdb/loggers/audit_logger.rb
@@ -1,15 +1,11 @@
 module Vmdb::Loggers
   class AuditLogger < ManageIQ::Loggers::Base
     def success(msg)
-      msg = "<AuditSuccess> #{msg}"
-      info(msg)
-      $log.info(msg) if $log
+      info("<AuditSuccess> #{msg}")
     end
 
     def failure(msg)
-      msg = "<AuditFailure> #{msg}"
-      warn(msg)
-      $log.warn(msg) if $log
+      warn("<AuditFailure> #{msg}")
     end
   end
 end


### PR DESCRIPTION
With container and appliance logging, we log to either STDOUT or syslog by default respectively.  Therefore, we already have this logged and do not need mirroring.