### PR TITLE
Re-revert enforce Kafka changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -269,7 +269,7 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
-  gem "manageiq-appliance_console",     "~>7.2",             :require => false
+  gem "manageiq-appliance_console",     "~>8.0",             :require => false
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -863,7 +863,7 @@
   :level_remote_console: info
   :secret_filter: []
 :messaging:
-  :type: miq_queue
+  :type: kafka
 :notifications:
   :history:
     :purge_window_size: 1000
@@ -1105,6 +1105,7 @@
           :queue_timeout: 120.minutes
           :dequeue_method: sql
       :event_handler:
+        :dequeue_method: miq_messaging
         :nice_delta: 7
       :generic_worker:
         :count: 2

--- a/systemd/evmserverd.service
+++ b/systemd/evmserverd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=EVM server daemon
-After=memcached.service manageiq-db-ready.service
-Wants=memcached.service manageiq-db-ready.service
+After=memcached.service manageiq-db-ready.service manageiq-messaging-ready.service
+Wants=memcached.service manageiq-db-ready.service manageiq-messaging-ready.service
 
 [Service]
 WorkingDirectory=/var/www/miq/vmdb


### PR DESCRIPTION
Re-reverting the following PRs for the enablement of requiring Kafka, therefore only merge when ready to enforce Kafka:
- https://github.com/ManageIQ/manageiq/pull/22215
- https://github.com/ManageIQ/manageiq/pull/22206
- https://github.com/ManageIQ/manageiq/pull/22205

Ref:
- https://github.com/ManageIQ/manageiq/issues/22225

@miq-bot add_label enhancement
@miq-bot assign @agrare 
@miq-bot add_reviewer @kbrock 