### PR TITLE
Only print "Delivering" before running queue message

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -51,12 +51,11 @@ module Vmdb
                   .first
         end
         if q
-          puts "\e[33;1m\n** Delivering #{MiqQueue.format_full_log_msg(q)}\n\e[0;m"
           begin
             q.update!(:state => MiqQueue::STATE_DEQUEUE, :handler => MiqServer.my_server)
           rescue ActiveRecord::StaleObjectError
-            puts "\e[33;1m\n** Skipping delivery since it is being processed by another simulator\n\e[0;m"
           else
+            puts "\e[33;1m\n** Delivering #{MiqQueue.format_full_log_msg(q)}\n\e[0;m"
             q.deliver_and_process
           end
         else


### PR DESCRIPTION
When dequeuing a queue message we update the record to put it in dequeue.  If another worker has already dequeued this message a StaleObjectError will be raised.

Only print "Delivering..." after we know that we are responsible for this queue message.

Follow-up to https://github.com/ManageIQ/manageiq/pull/22342