### PR TITLE
Miq expression removes sql only fields for filters

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -155,8 +155,14 @@ class MiqExpression
     clause
   end
 
-  def to_ruby(tz = nil)
-    # TODO: we cache the ruby expression regardless if the tz is different
+  def to_ruby(timezone = nil)
+    timezone ||= "UTC".freeze
+    cached_args = timezone
+    # clear out the cache if the args changed
+    if @chached_args != cached_args
+      @ruby = nil
+      @chached_args = cached_args
+    end
     if @ruby
       @ruby.dup
     elsif valid?

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -563,8 +563,8 @@ class MiqExpression
     }
   end
 
-  def lenient_evaluate(obj, tz = nil)
-    ruby_exp = to_ruby(tz)
+  def lenient_evaluate(obj, timezone = nil, prune_sql: false)
+    ruby_exp = to_ruby(timezone, :prune_sql => prune_sql)
     ruby_exp.nil? || Condition.subst_matches?(ruby_exp, obj)
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -247,33 +247,102 @@ RSpec.describe MiqExpression do
 
     context "mode: :sql" do
       it "(sql AND ruby) => (sql)" do
-        expect(sql_reduced_exp("AND" => [sql_field, ruby_field.clone])).to eq("AND" => [sql_field])
+        expect(sql_pruned_exp("AND" => [sql_field, ruby_field.clone])).to eq("AND" => [sql_field])
       end
 
       it "(ruby AND ruby) => ()" do
-        expect(sql_reduced_exp("AND" => [ruby_field.clone, ruby_field.clone])).to be_nil
+        expect(sql_pruned_exp("AND" => [ruby_field.clone, ruby_field.clone])).to be_nil
       end
 
       it "(sql OR sql) => (sql OR sql)" do
-        expect(sql_reduced_exp("OR" => [sql_field, sql_field])).to eq("OR" => [sql_field, sql_field])
+        expect(sql_pruned_exp("OR" => [sql_field, sql_field])).to eq("OR" => [sql_field, sql_field])
       end
 
       it "(sql OR ruby) => ()" do
-        expect(sql_reduced_exp("OR" => [sql_field, ruby_field])).to be_nil
+        expect(sql_pruned_exp("OR" => [sql_field, ruby_field])).to be_nil
       end
 
       it "(ruby OR ruby) => ()" do
-        expect(sql_reduced_exp("OR" => [ruby_field.clone, ruby_field.clone].deep_clone)).to be_nil
+        expect(sql_pruned_exp("OR" => [ruby_field.clone, ruby_field.clone].deep_clone)).to be_nil
       end
 
       it "!(sql OR ruby) => (!(sql) AND !(ruby)) => !(sql)" do
-        expect(sql_reduced_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to be_nil
+        expect(sql_pruned_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to be_nil
         # TODO: eq("NOT" => sql_field)
       end
 
       it "!(sql AND ruby) => (!(sql) OR !(ruby)) => nil" do
-        expect(sql_reduced_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => {"AND" => [sql_field]})
+        expect(sql_pruned_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => {"AND" => [sql_field]})
         # TODO:  be_nil
+      end
+    end
+  end
+
+  describe "#prune_exp" do
+    let(:sql_field)  { {"=" => {"field" => "Vm-name", "value" => "foo"}.freeze}.freeze }
+    let(:ruby_field) { {"=" => {"field" => "Vm-platform", "value" => "bar"}.freeze}.freeze }
+
+    context "mode: ruby" do
+      it "(sql) => ()" do
+        expect(ruby_pruned_exp(sql_field.clone)).to be_nil
+      end
+
+      it "(ruby) => (ruby)" do
+        expect(ruby_pruned_exp(ruby_field.clone)).to eq(ruby_field)
+      end
+
+      it "(sql and sql) => ()" do
+        expect(ruby_pruned_exp("AND" => [sql_field.clone, sql_field.clone])).to be_nil
+      end
+
+      it "(sql and ruby) => (ruby)" do
+        expect(ruby_pruned_exp("AND" => [sql_field.clone, ruby_field.clone])).to eq(ruby_field)
+      end
+
+      it "(ruby or ruby) => (ruby or ruby)" do
+        expect(ruby_pruned_exp("OR" => [ruby_field.clone, ruby_field.clone])).to eq("OR" => [ruby_field, ruby_field])
+      end
+
+      it "(sql or sql) => ()" do
+        expect(ruby_pruned_exp("OR" => [sql_field.clone, sql_field.clone])).to be_nil
+      end
+
+      it "(sql or ruby) => (sql or ruby)" do
+        expect(ruby_pruned_exp("OR" => [ruby_field.clone, sql_field.clone])).to eq("OR" => [ruby_field, sql_field])
+      end
+
+      it "(ruby or ruby) => (ruby or ruby)" do
+        expect(ruby_pruned_exp("OR" => [ruby_field.clone, ruby_field.clone])).to eq("OR" => [ruby_field, ruby_field])
+      end
+
+      it "(sql AND sql) or ruby => keep all expressions" do
+        expect(ruby_pruned_exp("OR" => [{"AND" => [sql_field.clone, sql_field.clone]}, ruby_field.clone])).to eq("OR" => [{"AND" => [sql_field, sql_field]}, ruby_field])
+      end
+
+      # ensuring that the OR/AND is treating each sub expression independently
+      # it was getting this wrong
+      it "(sql or sql) and ruby => ruby" do
+        expect(ruby_pruned_exp("AND" => [{"OR" => [sql_field.clone, sql_field.clone]}, ruby_field.clone])).to eq(ruby_field)
+      end
+
+      it "ruby and (sql or sql) => ruby" do
+        expect(ruby_pruned_exp("AND" => [ruby_field.clone, {"OR" => [sql_field.clone, sql_field.clone]}])).to eq(ruby_field)
+      end
+
+      it "!(ruby) => keep all expressions" do
+        exp1 = {"=" => {"field" => "Vm-platform", "value" => "foo"}}
+        ruby = MiqExpression.new("NOT" => exp1).to_ruby(:prune_sql => true)
+        expect(ruby).to eq("!(<value ref=vm, type=string>/virtual/platform</value> == \"foo\")")
+      end
+
+      it "!(sql OR ruby) => (!(sql) AND !(ruby)) => !(ruby)" do
+        expect(ruby_pruned_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to eq("NOT" => {"OR" => [sql_field, ruby_field.clone]})
+        # TODO: eq("NOT" => ruby_field)
+      end
+
+      it "!(sql AND ruby) => (!(sql) OR !(ruby)) => !(sql AND ruby)" do
+        expect(ruby_pruned_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => ruby_field)
+        # TODO:  eq("NOT" => {"AND" => [sql_field, ruby_field]})
       end
     end
   end
@@ -1034,6 +1103,13 @@ RSpec.describe MiqExpression do
           result = Vm.where(filter.to_sql(timezone).first)
           expect(result).to contain_exactly(vm2, vm3)
         end
+      end
+    end
+
+    context "caching" do
+      it "clears caching if prune_sql value changes" do
+        exp = MiqExpression.new({"=" => {"field" => "Vm-name", "value" => "foo"}})
+        expect(exp.to_ruby(:prune_sql => true)).not_to eq(exp.to_ruby(:prune_sql => false))
       end
     end
   end
@@ -3472,9 +3548,15 @@ RSpec.describe MiqExpression do
 
   private
 
-  def sql_reduced_exp(input)
+  def sql_pruned_exp(input)
     mexp = MiqExpression.new(input)
     pexp = mexp.preprocess_exp!(mexp.exp.deep_clone)
     mexp.preprocess_for_sql(pexp).first
+  end
+
+  def ruby_pruned_exp(input)
+    mexp = MiqExpression.new(input)
+    pexp = mexp.preprocess_exp!(mexp.exp.deep_clone)
+    mexp.prune_exp(pexp, MiqExpression::MODE_RUBY).first
   end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -267,13 +267,11 @@ RSpec.describe MiqExpression do
       end
 
       it "!(sql OR ruby) => (!(sql) AND !(ruby)) => !(sql)" do
-        expect(sql_pruned_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to be_nil
-        # TODO: eq("NOT" => sql_field)
+        expect(sql_pruned_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to eq("NOT" => sql_field)
       end
 
       it "!(sql AND ruby) => (!(sql) OR !(ruby)) => nil" do
-        expect(sql_pruned_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => sql_field)
-        # TODO:  be_nil
+        expect(sql_pruned_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to be_nil
       end
     end
 
@@ -331,13 +329,11 @@ RSpec.describe MiqExpression do
       end
 
       it "!(sql OR ruby) => (!(sql) AND !(ruby)) => !(ruby)" do
-        expect(ruby_pruned_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to eq("NOT" => {"OR" => [sql_field, ruby_field.clone]})
-        # TODO: eq("NOT" => ruby_field)
+        expect(ruby_pruned_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to eq("NOT" => ruby_field)
       end
 
       it "!(sql AND ruby) => (!(sql) OR !(ruby)) => !(sql AND ruby)" do
-        expect(ruby_pruned_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => ruby_field)
-        # TODO:  eq("NOT" => {"AND" => [sql_field, ruby_field]})
+        expect(ruby_pruned_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => {"AND" => [sql_field, ruby_field]})
       end
     end
   end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2502,7 +2502,7 @@ RSpec.describe Rbac::Filterer do
     it "supports limits in ruby with limits on scopes" do
       filter = MiqExpression.new("=" => {"field" => "Vm-location", "value" => "b"})
       # force this filter to be evaluated in ruby
-      expect(filter).to receive(:sql_supports_atom?).and_return(false)
+      expect(filter).to receive(:sql_supports_atom?).at_least(:once).and_return(false)
 
       FactoryBot.create_list(:vm_vmware, 3, :location => "a")
       FactoryBot.create_list(:vm_vmware, 3, :location => "b")


### PR DESCRIPTION
- [x] #22355 
- [x] #22356 

commits:

- added some comments around `MiqExpression`.
- added `prune_exp` to reduce the expression for a particular mode/language.
- using `prune_exp` for sql (was `preprocess_for_sql`)
- `Rbac#filter` now uses `prune_exp` to remove unnecessary sql from ruby.
- fix bugs around Demorgan's law (i.e.: `!(a || b) == !a && !b`)

code   | all(ms)  | records(ms) |do_eval(ms) | subst(ms) | comments
-------|-----:|--------:|-------:|------:|------
master | 2289 | 815     |    144 | 1294  |
after  | 1225 | 769     |     37 |  285  |
delta  |  46% | n/a     |    74% |  78%  |

Dates (via #22358) are on master and were a big win.
Since most of the fields were removed from the ruby expression processing, the whole processing time is approaching the record retrieval timing.

Wish I could have cached `@ruby` as something other than `true`, but since `YAML.parse` stores `@ruby==nil` as the uninitialized value, I need to store a value other than `nil` for a computed `nil` result.

NOTE: the expression was specifically picked because a lot of the fields were sql friendly. less sql friendly expressions will have less gain.