### PR TITLE
Consolidate Condition.subst_matches?

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -88,6 +88,7 @@ class Condition < ApplicationRecord
   def self.do_eval(expr)
     !!eval(expr)
   end
+  private_class_method :do_eval
 
   def self.subst(expr, rec)
     findexp = /<find>(.+?)<\/find>/im
@@ -105,6 +106,7 @@ class Condition < ApplicationRecord
 
     expr
   end
+  private_class_method :subst
 
   def self._subst(rec, opts, tag, mode)
     ohash, ref, _object = options2hash(opts, rec)
@@ -127,6 +129,7 @@ class Condition < ApplicationRecord
     end
     value
   end
+  private_class_method :_subst
 
   def self.collect_children(ref, methods)
     method = methods.shift
@@ -140,6 +143,7 @@ class Condition < ApplicationRecord
     end
     result
   end
+  private_class_method :collect_children
 
   def self._subst_find(rec, expr)
     MiqPolicy.logger.debug("MIQ(condition-_subst_find): Find Expression before substitution: [#{expr}]")

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -74,14 +74,7 @@ class Condition < ApplicationRecord
              when "object"
                expression.to_ruby
              end
-
-      MiqPolicy.logger.debug("MIQ(condition-eval): Name: #{name}, Expression before substitution: [#{expr.gsub(/\n/, " ")}]")
-
-      subst(expr, rec)
-
-      MiqPolicy.logger.debug("MIQ(condition-eval): Name: #{name}, Expression after substitution: [#{expr.gsub(/\n/, " ")}]")
-      result = do_eval(expr)
-      MiqPolicy.logger.info("MIQ(condition-eval): Name: #{name}, Expression evaluation result: [#{result}]")
+      result = subst_matches?(expr, rec)
     end
     result
   end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -462,12 +462,7 @@ class MiqExpression
 
   def evaluate(obj, tz = nil)
     ruby_exp = to_ruby(tz)
-    _log.debug("Expression before substitution: #{ruby_exp}")
-    subst_expr = Condition.subst(ruby_exp, obj)
-    _log.debug("Expression after substitution: #{subst_expr}")
-    result = Condition.do_eval(subst_expr)
-    _log.debug("Expression evaluation result: [#{result}]")
-    result
+    Condition.subst_matches?(ruby_exp, obj)
   end
 
   def self.evaluate_atoms(exp, obj)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1701,58 +1701,6 @@ RSpec.describe MiqExpression do
       expect(filter.to_ruby).to eq('<value ref=vm, type=integer>/virtual/used_disk_storage</value> >= 1048576000')
     end
 
-    context "integration" do
-      it "should escape strings" do
-        filter = YAML.load '--- !ruby/object:MiqExpression
-        exp:
-          INCLUDES:
-            field: Vm.registry_items-data
-            value: $foo
-        '
-        expect(filter.to_ruby).to eq("<value ref=vm, type=text>/virtual/registry_items/data</value> =~ /\\$foo/")
-
-        data = {"registry_items.data" => "C:\\Documents and Users\\O'Neill, April\\", "/virtual/registry_items/data" => "C:\\Documents and Users\\O'Neill, April\\"}
-        expect(Condition.subst(filter.to_ruby, data)).to eq("\"C:\\\\Documents and Users\\\\O'Neill, April\\\\\" =~ /\\$foo/")
-      end
-
-      context "when context_type is 'hash'" do
-        let(:data) do
-          {
-            "name"                            => "VM_1",
-            "guest_applications.version"      => "3.1.2.7193",
-            "guest_applications.release"      => nil,
-            "guest_applications.vendor"       => "VMware, Inc.", "id" => 9,
-            "guest_applications.name"         => "VMware Tools",
-            "guest_applications.package_name" => nil
-          }
-        end
-
-        it "should test context hash with EQUAL" do
-          filter = YAML.load '--- !ruby/object:MiqExpression
-          exp:
-            "=":
-              field: Vm.guest_applications-name
-              value: VMware Tools
-          context_type: hash
-          '
-          expect(filter.to_ruby).to eq("<value type=string>guest_applications.name</value> == \"VMware Tools\"")
-          expect(Condition.subst(filter.to_ruby, data)).to eq("\"VMware Tools\" == \"VMware Tools\"")
-        end
-
-        it "should test context hash with REGULAR EXPRESSION MATCHES" do
-          filter = YAML.load '--- !ruby/object:MiqExpression
-          exp:
-            REGULAR EXPRESSION MATCHES:
-              field: Vm.guest_applications-vendor
-              value: /^[^.]*ware.*$/
-          context_type: hash
-          '
-          expect(filter.to_ruby).to eq("<value type=string>guest_applications.vendor</value> =~ /^[^.]*ware.*$/")
-          expect(Condition.subst(filter.to_ruby, data)).to eq('"VMware, Inc." =~ /^[^.]*ware.*$/')
-        end
-      end
-    end
-
     it "generates the ruby for a STARTS WITH expression" do
       actual = described_class.new("STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
       expected = "<value ref=vm, type=string>/virtual/name</value> =~ /^foo/"


### PR DESCRIPTION
Consolidating the implementation of `MiqExpression#evaluate` / `Condition#subst_matches?` to make the callers more consistent and hide some of the implementations.

Also removed some of the logging as we were taking quite a hit.

I'm working on MiqExpression optimizations and saw this distraction so pulled out a PR