### PR TITLE
Properly parse MiqExpression::CountField

### DIFF
--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -26,6 +26,13 @@ class MiqExpression::CountField < MiqExpression::Target
     :integer
   end
 
+  def attribute_supported_by_sql?
+    reflection_supported_by_sql?
+  rescue ArgumentError
+    # the association chain is not legal, so no, it is not supported by sql
+    false
+  end
+
   private
 
   def tag_values

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -36,6 +36,10 @@ class MiqExpression::Target
     @column = column
   end
 
+  def sub_type
+    column_type
+  end
+
   def date?
     column_type == :date
   end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -252,6 +252,11 @@ RSpec.describe MiqExpression do
       expect(sql).to be_nil
     end
 
+    it "does not raise error for SQL generation if expression has a count in it" do
+      sql, _ = MiqExpression.new("AND" => [{"=" => {"field" => "Vm-name", "value" => "foo"}}, {"=" => {"count" => "Vm.snapshots", "value" => "1"}}]).to_sql
+      expect(sql).to eq("(\"vms\".\"name\" = 'foo')")
+    end
+
     it "generates the SQL for an = expression if SQL generation for expression supported and 'token' key present in expression's Hash" do
       sql, * = MiqExpression.new("=" => {"field" => "Vm-name", "value" => "foo"}, :token => 1).to_sql
       expect(sql).to eq("\"vms\".\"name\" = 'foo'")
@@ -1717,6 +1722,12 @@ RSpec.describe MiqExpression do
       actual = described_class.new("AND" => [{"=" => {"field" => "Vm-name", "value" => "foo"}},
                                              {"=" => {"field" => "Vm-vendor", "value" => "bar"}}]).to_ruby
       expected = "(<value ref=vm, type=string>/virtual/name</value> == \"foo\" and <value ref=vm, type=string>/virtual/vendor</value> == \"bar\")"
+      expect(actual).to eq(expected)
+    end
+
+    it "generates the ruby for an OR with a count" do
+      actual = described_class.new("OR" => [{"=" => {"field" => "Vm-name", "value" => "foo"}}, {"=" => {"count" => "Vm.snapshots", "value" => "1"}}]).to_ruby
+      expected = "(<value ref=vm, type=string>/virtual/name</value> == \"foo\" or <count ref=vm>/virtual/snapshots</count> == 1)"
       expect(actual).to eq(expected)
     end
 


### PR DESCRIPTION
extracted from #22347

Before
======

When we are parsing fields in a model, if we hit a count field, then it throws an error.

After
=====

the model can answer the question if it is supported by sql

In the future, we should probably add sql support for the count fields, but that is a future endeavor

