### PR TITLE
Extract MiqExpression#expression_prep from preprocess_for_sql

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -241,6 +241,43 @@ RSpec.describe MiqExpression do
     end
   end
 
+  describe "#preprocess_for_sql" do
+    let(:sql_field)  { {"=" => {"field" => "Vm-name", "value" => "foo"}.freeze}.freeze }
+    let(:ruby_field) { {"=" => {"field" => "Vm-platform", "value" => "bar"}.freeze}.freeze }
+
+    context "mode: :sql" do
+      it "(sql AND ruby) => (sql)" do
+        expect(sql_reduced_exp("AND" => [sql_field, ruby_field.clone])).to eq("AND" => [sql_field])
+      end
+
+      it "(ruby AND ruby) => ()" do
+        expect(sql_reduced_exp("AND" => [ruby_field.clone, ruby_field.clone])).to be_nil
+      end
+
+      it "(sql OR sql) => (sql OR sql)" do
+        expect(sql_reduced_exp("OR" => [sql_field, sql_field])).to eq("OR" => [sql_field, sql_field])
+      end
+
+      it "(sql OR ruby) => ()" do
+        expect(sql_reduced_exp("OR" => [sql_field, ruby_field])).to be_nil
+      end
+
+      it "(ruby OR ruby) => ()" do
+        expect(sql_reduced_exp("OR" => [ruby_field.clone, ruby_field.clone].deep_clone)).to be_nil
+      end
+
+      it "!(sql OR ruby) => (!(sql) AND !(ruby)) => !(sql)" do
+        expect(sql_reduced_exp("NOT" => {"OR" => [sql_field, ruby_field.clone]})).to be_nil
+        # TODO: eq("NOT" => sql_field)
+      end
+
+      it "!(sql AND ruby) => (!(sql) OR !(ruby)) => nil" do
+        expect(sql_reduced_exp("NOT" => {"AND" => [sql_field, ruby_field.clone]})).to eq("NOT" => {"AND" => [sql_field]})
+        # TODO:  be_nil
+      end
+    end
+  end
+
   describe "#to_sql" do
     it "returns nil if SQL generation for that expression is not supported" do
       sql, * = MiqExpression.new("=" => {"field" => "Service-custom_1", "value" => ""}).to_sql
@@ -402,6 +439,7 @@ RSpec.describe MiqExpression do
       expect(sql).to eq("(\"vms\".\"name\" LIKE 'foo%' AND \"vms\".\"name\" LIKE '%bar')")
     end
 
+    # these overlap the preprocessor tests
     it "generates the SQL for an AND expression where only one is supported by SQL" do
       exp1 = {"STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}}
       exp2 = {"ENDS WITH" => {"field" => "Vm-platform", "value" => "bar"}}
@@ -3428,5 +3466,13 @@ RSpec.describe MiqExpression do
       result = described_class.miq_adv_search_lists(Vm, :exp_available_fields, :include_id_columns => true)
       expect(result.map(&:first)).to include("VM and Instance : Id")
     end
+  end
+
+  private
+
+  def sql_reduced_exp(input)
+    mexp = MiqExpression.new(input)
+    pexp = mexp.preprocess_exp!(mexp.exp.deep_clone)
+    mexp.preprocess_for_sql(pexp).first
   end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -222,21 +222,21 @@ RSpec.describe MiqExpression do
     end
   end
 
-  describe "#preprocess_for_sql" do
+  describe "#preprocess_exp!" do
     it "convert size value in units to integer for comparasing operators on integer field" do
       expession_hash = {"=" => {"field" => "Vm-allocated_disk_storage", "value" => "5.megabytes"}}
       expession = MiqExpression.new(expession_hash)
-      exp, _ = expession.preprocess_for_sql(expession_hash)
+      exp, _ = expession.preprocess_exp!(expession_hash)
       expect(exp.values.first["value"]).to eq("5.megabyte".to_i_with_method)
 
       expession_hash = {">" => {"field" => "Vm-allocated_disk_storage", "value" => "5.kilobytes"}}
       expession = MiqExpression.new(expession_hash)
-      exp, _ = expession.preprocess_for_sql(expession_hash)
+      exp, _ = expession.preprocess_exp!(expession_hash)
       expect(exp.values.first["value"]).to eq("5.kilobytes".to_i_with_method)
 
       expession_hash = {"<" => {"field" => "Vm-allocated_disk_storage", "value" => "2.terabytes"}}
       expession = MiqExpression.new(expession_hash)
-      exp, _ = expession.preprocess_for_sql(expession_hash)
+      exp, _ = expession.preprocess_exp!(expession_hash)
       expect(exp.values.first["value"]).to eq(2.terabytes.to_i_with_method)
     end
   end


### PR DESCRIPTION
extracted from https://github.com/ManageIQ/manageiq/pull/22347

depends:
- [x] #22355 

Expression_prep modifies the values and removes the :token
It will possibly do other things in the future like look up the `Field`
so we can reduce all of those calls

preprocess_for_sql is just focused on pruning/rearranging nodes so the
expression tree will be optimized for sql

From here, writing tests around preprocess_for_sql are easier because there are fewer side effects in the expression.


Other possible improvements:
- look up the Field so we can reduce all of those calls (and drop field cache)
- collapse nested AND, OR, NOT nodes.
- downcase all operators
