### PR TITLE
Implement cloud snapshot collector, list page, create & delete methods

### DIFF
--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -3,6 +3,8 @@ class CloudVolumeSnapshot < ApplicationRecord
   include ProviderObjectMixin
   include SupportsFeatureMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
+  include EmsRefreshMixin
 
   acts_as_miq_taggable
 
@@ -10,6 +12,10 @@ class CloudVolumeSnapshot < ApplicationRecord
   belongs_to :cloud_tenant
   belongs_to :cloud_volume
   has_many   :based_volumes, :class_name => 'CloudVolume'
+
+  supports_not :create
+  supports_not :delete
+  supports_not :update
 
   virtual_total :total_based_volumes, :based_volumes
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -154,6 +154,7 @@ class ExtManagementSystem < ApplicationRecord
   supports_not :cloud_subnet_create
   supports_not :cloud_tenant_mapping
   supports_not :cloud_volume_create
+  supports_not :cloud_volume_snapshots_create
   supports_not :storage_service_create
   supports_not :console
   supports_not :create_iso_datastore
@@ -302,6 +303,8 @@ class ExtManagementSystem < ApplicationRecord
   supports_attribute :feature => :cloud_subnet_create
   supports_attribute :feature => :cloud_volume
   supports_attribute :feature => :cloud_volume_create
+  supports_attribute :feature => :cloud_volume_snapshots
+  supports_attribute :feature => :cloud_volume_snapshots_create
   supports_attribute :supports_cloud_database_create, :child_model => "CloudDatabase"
   supports_attribute :supports_create_flavor, :child_model => "Flavor"
   supports_attribute :supports_create_floating_ip, :child_model => "FloatingIp"

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -154,7 +154,6 @@ class ExtManagementSystem < ApplicationRecord
   supports_not :cloud_subnet_create
   supports_not :cloud_tenant_mapping
   supports_not :cloud_volume_create
-  supports_not :cloud_volume_snapshots_create
   supports_not :storage_service_create
   supports_not :console
   supports_not :create_iso_datastore
@@ -304,7 +303,6 @@ class ExtManagementSystem < ApplicationRecord
   supports_attribute :feature => :cloud_volume
   supports_attribute :feature => :cloud_volume_create
   supports_attribute :feature => :cloud_volume_snapshots
-  supports_attribute :feature => :cloud_volume_snapshots_create
   supports_attribute :supports_cloud_database_create, :child_model => "CloudDatabase"
   supports_attribute :supports_create_flavor, :child_model => "Flavor"
   supports_attribute :supports_create_floating_ip, :child_model => "FloatingIp"

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -7,6 +7,7 @@ module ManageIQ::Providers
     supports_not :cloud_object_store_container_create
     supports_not :cloud_volume
     supports_not :cloud_volume_create
+    supports_not :cloud_volume_snapshots
     supports_not :object_storage
     supports_not :smartstate_analysis
     supports_not :storage_services

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -971,8 +971,13 @@
       :description: Edit Tags of Snapshots
       :feature_type: control
       :identifier: cloud_volume_snapshot_tag
+  - :name: Modify
+    :description: Modify Volume Snapshots
+    :feature_type: admin
+    :identifier: cloud_volume_snapshot_admin
+    :children:
     - :name: Remove
-      :description: Remove Snapshot
+      :description: Remove a Volume Snapshot
       :feature_type: admin
       :identifier: cloud_volume_snapshot_delete
 


### PR DESCRIPTION
We have developed an integration with a new resource type - "cloud volume snapshot" on the Autosde side. Now, we can provide a list of snapshots from the attached physical storage, create a new one based on a particular volume object and delete it - by using the Autosde rest endpoint (The Autosde GEM is already updated with these new features).
Following these new features, I have added to our (MIQ Autosde provider) collector and refresher to pull snapshots from Autosde and show them in the right place - Cloud Volume Snapshots. I also added the counter component to the provider dashboard.

List page:
![image](https://user-images.githubusercontent.com/33315712/218869146-daaa2529-3fdd-45e9-ac3c-2570896271a0.png)

Snapshot summary page:
![image](https://user-images.githubusercontent.com/33315712/218869307-c048bcaf-2d0c-4440-b424-dc4d41eac5da.png)

Dashboard:
![image](https://user-images.githubusercontent.com/33315712/218869365-be4953bf-936c-4728-bc7c-b682b6fb9078.png)

Create snapshot from cloud volume:
1.
![image](https://user-images.githubusercontent.com/33315712/220778117-7cc9327c-6ec9-4429-a310-8ddc7453c976.png)
2.
![image](https://user-images.githubusercontent.com/33315712/220781667-0899679b-7972-42c8-9dcd-87a2ffca9968.png)

Delete button exists as well at the snapshots page

# related PRs:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8647
- https://github.com/ManageIQ/manageiq-providers-autosde/pull/210
- https://github.com/ManageIQ/manageiq-api/pull/1205