### PR TITLE
Fix event stream filtering so we can filter by ems event or miq event (policy)

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -22,10 +22,6 @@ class MiqEvent < EventStream
 
   CLASS_GROUP_LEVELS = [MiqPolicy::CONDITION_SUCCESS, MiqPolicy::CONDITION_FAILURE].collect { |level| level.downcase.to_sym }
 
-  def self.description
-    _("Management Events")
-  end
-
   def self.class_group_levels
     CLASS_GROUP_LEVELS
   end
@@ -34,13 +30,42 @@ class MiqEvent < EventStream
     _("Policy Events")
   end
 
-  def self.group_names_and_levels
-    hash = default_group_names_and_levels
-    hash[:group_names].merge!(MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys)
-    group_levels.each do |level|
-      hash[:group_levels][level] ||= level.to_s.capitalize
+  def self.group_name(group)
+    return if group.nil?
+
+    group_names_and_levels.dig(:group_names, group.to_sym) || DEFAULT_GROUP_NAME_STR
+  end
+
+  def self.group_and_level(event_type)
+    by_literal = partition_group_and_level_by_event_type
+    by_literal[event_type.to_s] || [DEFAULT_GROUP_NAME, DEFAULT_GROUP_LEVEL]
+  end
+
+  private_class_method def self.partition_group_and_level_by_event_type
+    return @literal_group_and_level_by_event_type if @literal_group_and_level_by_event_type
+
+    @literal_group_and_level_by_event_type = {}
+
+    # TODO: check if there's a more performant way to look up the miq_sets and miq_set_membership
+    @literal_group_and_level_by_event_type = MiqEventDefinition.all.each_with_object({}) do |ed, h|
+      group_name = ed.event_group_name || DEFAULT_GROUP_NAME
+      h[ed.name] = [group_name.to_sym, DEFAULT_GROUP_LEVEL]
     end
-    hash
+  end
+
+  def self.clear_event_groups_cache
+    @group_names_and_levels, @literal_group_and_level_by_event_type = nil
+  end
+
+  def self.group_names_and_levels
+    @group_names_and_levels ||= begin
+      hash = default_group_names_and_levels
+      hash[:group_names].merge!(MiqEventDefinitionSet.all.pluck(:name, :description).to_h.symbolize_keys)
+      group_levels.each do |level|
+        hash[:group_levels][level] ||= level.to_s.capitalize
+      end
+      hash
+    end
   end
 
   def self.raise_evm_event(target, raw_event, inputs = {}, options = {})

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -452,6 +452,13 @@ RSpec.describe EmsEvent do
     end
   end
 
+  it "group_names_and_levels" do
+    result = described_class.group_names_and_levels
+    expect(result.keys).to match_array(%i[description group_names group_levels])
+    expect(result[:description]).to eq("Management Events")
+    expect(result[:group_names].keys).to include(:other)
+  end
+
   context 'refresh target' do
     describe 'src_vm_or_dest_host_refresh_target' do
       let(:ems)   { FactoryBot.create(:ems_vmware) }

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -208,4 +208,51 @@ RSpec.describe MiqEvent do
       end
     end
   end
+
+  context "with seeded event definitions" do
+    let(:seeded) do
+      MiqEventDefinitionSet.seed
+      MiqEventDefinition.seed
+    end
+
+    context "group_and_level" do
+      it "defaults for non-existing event" do
+        expect(MiqEvent.group_and_level("something")).to eq([described_class::DEFAULT_GROUP_NAME, described_class::DEFAULT_GROUP_LEVEL])
+      end
+
+      it "vm_start (string)" do
+        seeded
+        expect(MiqEvent.group_and_level("vm_start")).to eq([:vm_operational, described_class::DEFAULT_GROUP_LEVEL])
+      end
+
+      it ":vm_start (symbol)" do
+        seeded
+        expect(MiqEvent.group_and_level(:vm_start)).to eq([:vm_operational, described_class::DEFAULT_GROUP_LEVEL])
+      end
+    end
+
+    context "group_name" do
+      it "uses defaults for non-existing group" do
+        expect(described_class.group_name(:non_existing)).to eq(described_class::DEFAULT_GROUP_NAME_STR)
+      end
+
+      it "vm_operational (string)" do
+        seeded
+        expect(described_class.group_name("vm_operational")).to eq("VM Operation")
+      end
+
+      it ":vm_operational (symbol)" do
+        seeded
+        expect(described_class.group_name(:vm_operational)).to eq("VM Operation")
+      end
+    end
+  end
+
+  it "group_names_and_levels" do
+    result = described_class.group_names_and_levels
+    expect(result.keys).to match_array(%i[description group_names group_levels])
+    expect(result[:description]).to eq("Policy Events")
+    expect(result[:group_names].keys).to include(:other)
+    expect(result[:group_levels].keys).to include(described_class::DEFAULT_GROUP_LEVEL)
+  end
 end

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe EventMixin do
     end
   end
 
+  context "event_stream_filters" do
+    %w[
+      EmsCluster          ems_cluster_id
+      ExtManagementSystem ems_id
+      Host                host_id
+      VmOrTemplate        vm_or_template_id
+      Vm                  vm_or_template_id
+    ].each_slice(2) do |klass, column|
+      it "#{klass} uses #{column} and target_id and target_type" do
+        obj = FactoryBot.create(klass.tableize.singularize)
+        expect(obj.event_stream_filters["EmsEvent"]).to eq(column => obj.id)
+        expect(obj.event_stream_filters.dig("MiqEvent", "target_id")).to eq(obj.id)
+        expect(obj.event_stream_filters.dig("MiqEvent", "target_type")).to eq(obj.class.base_class.name)
+      end
+    end
+  end
+
   context "Included in a test class with no events" do
     let(:test_class) do
       Class.new do

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -45,6 +45,7 @@ module EvmSpecHelper
 
     EmsEvent.clear_event_groups_cache if defined?(EmsEvent)
     EventStream.clear_event_groups_cache if defined?(EventStream)
+    MiqEvent.clear_event_groups_cache if defined?(MiqEvent)
 
     MiqWorker.my_guid = nil
 


### PR DESCRIPTION
Previously, the UI depended on `event_where_clause`.  We now have `EventStream.miq_event_filter` and `EventStream.ems_event_filter` that gets called through `EventStream.event_stream_filter` by the UI to determine the API criteria, in where format, to properly filter requests for specific Host, Vms, Ems, etc.

The UI PR utilizing this new code is https://github.com/ManageIQ/manageiq-ui-classic/pull/8642

For example:
host uses `host_id => host.id` for ems events and `target_id => host.id, :target_type => host.base_class` for miq events.

Additionally, we now have proper group and level support in miq event.

TODO:

- [x] Set default group level for policy events to `detail` once the UI displays that as an option
- [x] Drop `event_stream_filter` from the `EventMixin` once the UI calls `@record.ems_event_filter` for EmsEvents(management) and `@record.miq_event_filter` for MiqEvent(policy).

Future PR work:
- Review the `event_where_clause` for existing models and ensure we're choosing the right columns for the different classes.  This might be moved to a followup PR.  The core ones seem right but the container ones are more complicated and I need event data to verify them.
- Move the `EmsEvent` specific logic out of the base `EventStream` and into `EmsEvent` and `event_where_clause` callers can eventually go away and removed from core entirely.  Verify API `OPTIONS` still works.
- Determine if we need to make `MiqEventDefinition.all.each_with_object` more optimized in how it loads the associated `MiqEventDefinitionSet`. I couldn't get it be less queries by using includes.
- Add host_id, host_name and the same for vm and ems so the UI can reliably get these values without having to pull in the full object and it's columns.

In case you're wondering, I generated a table of the foreign keys and how I determined what should be the various event_filter columns.  Of note, I don't think policy events, as listed for the policy_events_foreign_key is really used.



class | ems_events_foreign_key | miq_events_foreign_key | policy_events_foreign_key | ems_event_filter_column | miq_event_filter_column | policy_event_filter_column
-- | -- | -- | -- | -- | -- | --
AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
Container |   |   |   | container_id | target_id | target_id
ContainerGroup |   |   |   | container_group_id | target_id | target_id
ContainerNode |   |   |   | container_node_id | target_id | target_id
ContainerProject |   |   |   | container_project_id | target_id | target_id
ContainerReplicator |   |   |   | container_replicator_id | target_id | target_id
EmsCluster |   | target_id | ems_cluster_id | ems_cluster_id | target_id | ems_cluster_id
ExtManagementSystem | ems_id | target_id | ems_id | ems_id | target_id | ems_id
Host | host_id | target_id | host_id | host_id | target_id | host_id
HostAggregate |   |   |   | host_aggregate_id | target_id | target_id
ManageIQ::Providers::Amazon::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::Amazon::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Amazon::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Amazon::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Amazon::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::Amazon::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::Amazon::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::Amazon::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Amazon::StorageManager::Ebs | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Amazon::StorageManager::S3 | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::AnsibleTower::AutomationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::AutomationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Autosde::StorageManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage |   |   |   | physical_storage_id | target_id | target_id
ManageIQ::Providers::Awx::AutomationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Azure::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Azure::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::Azure::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Azure::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Azure::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Azure::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::Azure::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::Azure::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::Azure::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::AzureStack::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::AzureStack::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::AzureStack::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::AzureStack::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::BaseManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis |   |   |   | physical_chassis_id | target_id | target_id
ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer |   |   |   | physical_server_id | target_id | target_id
ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerProfile |   |   |   | physical_server_profile_id | target_id | target_id
ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch |   |   |   | physical_switch_id | target_id | target_id
ManageIQ::Providers::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::ConfigurationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::EmbeddedAnsible::AutomationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::EmbeddedAutomationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::ExternalAutomationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Foreman::ConfigurationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Foreman::ProvisioningManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Google::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Google::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::Google::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Google::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Google::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Google::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::Google::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::Google::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::Google::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCic::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCic::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::IbmCic::CloudManager::AvailabilityZoneNull | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::IbmCic::CloudManager::HostAggregate |   |   |   | host_aggregate_id | target_id | target_id
ManageIQ::Providers::IbmCic::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmCic::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmCic::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCic::StorageManager::CinderManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCic::StorageManager::SwiftManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::IbmCloud::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::IbmCloud::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::VPC::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::VPC::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmCloud::VPC::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmCloud::VPC::StorageManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmPowerHmc::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmPowerHmc::InfraManager::Host | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmPowerHmc::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmPowerHmc::InfraManager::Vios | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmPowerVc::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmPowerVc::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::IbmPowerVc::CloudManager::AvailabilityZoneNull | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::IbmPowerVc::CloudManager::HostAggregate |   |   |   | host_aggregate_id | target_id | target_id
ManageIQ::Providers::IbmPowerVc::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmPowerVc::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::IbmPowerVc::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmPowerVc::StorageManager::SwiftManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::IbmTerraform::ConfigurationManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::InfraManager::Cluster |   | target_id | ems_cluster_id | cluster_id | target_id | ems_cluster_id
ManageIQ::Providers::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::InfraManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Kubernetes::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Kubernetes::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::Kubernetes::MonitoringManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Kubevirt::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Kubevirt::InfraManager::Cluster |   | target_id | ems_cluster_id | cluster_id | target_id | ems_cluster_id
ManageIQ::Providers::Kubevirt::InfraManager::Host | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::Kubevirt::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Kubevirt::InfraManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Lenovo::PhysicalInfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis |   |   |   | physical_chassis_id | target_id | target_id
ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer |   |   |   | physical_server_id | target_id | target_id
ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalStorage |   |   |   | physical_storage_id | target_id | target_id
ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch |   |   |   | physical_switch_id | target_id | target_id
ManageIQ::Providers::MonitoringManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Nsxt::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Nuage::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openshift::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openshift::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::Openshift::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::Openshift::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::Openshift::MonitoringManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openstack::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openstack::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::BaseTemplate | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::HostAggregate |   |   |   | host_aggregate_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Openstack::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openstack::InfraManager::Cluster |   | target_id | ems_cluster_id | cluster_id | target_id | ems_cluster_id
ManageIQ::Providers::Openstack::InfraManager::Host | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::Openstack::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Openstack::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openstack::StorageManager::CinderManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Openstack::StorageManager::SwiftManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::OracleCloud::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::OracleCloud::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::OracleCloud::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::OracleCloud::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::OracleCloud::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::OracleCloud::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::OracleCloud::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::OracleCloud::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::OracleCloud::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Ovirt::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Ovirt::InfraManager::Cluster |   | target_id | ems_cluster_id | cluster_id | target_id | ems_cluster_id
ManageIQ::Providers::Ovirt::InfraManager::Host | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::Ovirt::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Ovirt::InfraManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Ovirt::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::PhysicalInfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::ProvisioningManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Redfish::PhysicalInfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalChassis |   |   |   | physical_chassis_id | target_id | target_id
ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer |   |   |   | physical_server_id | target_id | target_id
ManageIQ::Providers::Redhat::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Redhat::InfraManager::Cluster |   | target_id | ems_cluster_id | cluster_id | target_id | ems_cluster_id
ManageIQ::Providers::Redhat::InfraManager::Host | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::Redhat::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Redhat::InfraManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Redhat::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::StorageManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Vmware::CloudManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone | availability_zone_id |   |   | availability_zone_id | target_id | target_id
ManageIQ::Providers::Vmware::CloudManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Vmware::CloudManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Vmware::ContainerManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Vmware::ContainerManager::Container |   |   |   | container_id | target_id | target_id
ManageIQ::Providers::Vmware::ContainerManager::ContainerGroup |   |   |   | container_group_id | target_id | target_id
ManageIQ::Providers::Vmware::ContainerManager::ContainerNode |   |   |   | container_node_id | target_id | target_id
ManageIQ::Providers::Vmware::InfraManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
ManageIQ::Providers::Vmware::InfraManager::Cluster |   | target_id | ems_cluster_id | cluster_id | target_id | ems_cluster_id
ManageIQ::Providers::Vmware::InfraManager::Host | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::Vmware::InfraManager::HostEsx | host_id | target_id | host_id | host_id | target_id | host_id
ManageIQ::Providers::Vmware::InfraManager::Template | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Vmware::InfraManager::Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
ManageIQ::Providers::Vmware::NetworkManager | ems_id | target_id | ems_id | ems_id | target_id | ems_id
MiqTemplate | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
PhysicalChassis |   |   |   | physical_chassis_id | target_id | target_id
PhysicalServer |   |   |   | physical_server_id | target_id | target_id
PhysicalServerProfile |   |   |   | physical_server_profile_id | target_id | target_id
PhysicalStorage |   |   |   | physical_storage_id | target_id | target_id
PhysicalSwitch |   |   |   | physical_switch_id | target_id | target_id
Vm | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
VmOrTemplate | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id
VmServer | vm_or_template_id | target_id | target_id | vm_or_template_id | target_id | target_id




