### PR TITLE
Fix additional regions added via settings

### DIFF
--- a/app/models/manageiq/providers/regions.rb
+++ b/app/models/manageiq/providers/regions.rb
@@ -21,7 +21,7 @@ module ManageIQ::Providers
       end
 
       def additional_regions
-        Settings.dig(:ems, ems_type, :additional_regions).to_h.stringify_keys
+        Settings.dig(:ems, ems_type, :additional_regions).to_hash.stringify_keys
       end
 
       def disabled_regions

--- a/app/models/manageiq/providers/regions.rb
+++ b/app/models/manageiq/providers/regions.rb
@@ -29,7 +29,7 @@ module ManageIQ::Providers
       end
 
       def ems_type
-        vendor = module_parent.name.sub("ManageIQ::Providers::", "").sub("::", "_").downcase
+        vendor = module_parent.name.sub("ManageIQ::Providers::", "").sub("::", "_").underscore
 
         "ems_#{vendor}".to_sym
       end

--- a/spec/models/manageiq/providers/regions_spec.rb
+++ b/spec/models/manageiq/providers/regions_spec.rb
@@ -1,9 +1,22 @@
-RSpec.describe ManageIQ::Providers::Regions do
+RSpec.describe ManageIQ::Providers::Regions, :providers_common => true do
   describe ".regions" do
     ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
       context klass.description do
         it "returns regions" do
           expect(klass.module_parent::Regions.regions.count).not_to be_zero
+        end
+
+        context "with additional_regions" do
+          let(:ems_settings_name) { klass.module_parent::Regions.send(:ems_type) }
+          before do
+            stub_settings_merge(
+              :ems => {ems_settings_name => {:additional_regions => {:foo => {:name => :my_special_region, :description => "My Special Region"}}}}
+            )
+          end
+
+          it "includes the additional region" do
+            expect(klass.module_parent::Regions.regions).to include("foo" => {:name => :my_special_region, :description => "My Special Region"})
+          end
         end
       end
     end
@@ -15,6 +28,19 @@ RSpec.describe ManageIQ::Providers::Regions do
         it "returns regions" do
           expect(klass.module_parent::Regions.all.count).not_to be_zero
         end
+
+        context "with additional_regions" do
+          let(:ems_settings_name) { klass.module_parent::Regions.send(:ems_type) }
+          before do
+            stub_settings_merge(
+              :ems => {ems_settings_name => {:additional_regions => {:foo => {:name => :my_special_region, :description => "My Special Region"}}}}
+            )
+          end
+
+          it "includes the additional region" do
+            expect(klass.module_parent::Regions.all).to include({:name => :my_special_region, :description => "My Special Region"})
+          end
+        end
       end
     end
   end
@@ -24,6 +50,19 @@ RSpec.describe ManageIQ::Providers::Regions do
       context klass.description do
         it "returns regions" do
           expect(klass.module_parent::Regions.all.count).not_to be_zero
+        end
+
+        context "with additional_regions" do
+          let(:ems_settings_name) { klass.module_parent::Regions.send(:ems_type) }
+          before do
+            stub_settings_merge(
+              :ems => {ems_settings_name => {:additional_regions => {:foo => {:name => :my_special_region, :description => "My Special Region"}}}}
+            )
+          end
+
+          it "includes the additional region" do
+            expect(klass.module_parent::Regions.names).to include("foo")
+          end
         end
       end
     end

--- a/spec/models/manageiq/providers/regions_spec.rb
+++ b/spec/models/manageiq/providers/regions_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ManageIQ::Providers::Regions do
+  describe ".regions" do
+    ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
+      context klass.description do
+        it "returns regions" do
+          expect(klass.module_parent::Regions.regions.count).not_to be_zero
+        end
+      end
+    end
+  end
+
+  describe ".all" do
+    ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
+      context klass.description do
+        it "returns regions" do
+          expect(klass.module_parent::Regions.all.count).not_to be_zero
+        end
+      end
+    end
+  end
+
+  describe ".names" do
+    ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
+      context klass.description do
+        it "returns regions" do
+          expect(klass.module_parent::Regions.all.count).not_to be_zero
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When additional settings are added via the advanced settings page the values returned are `Config::Options` not a simple hash.  We use `to_h` to convert to a hash but that only converts the top-level object and not the values:
```
>> Settings.ems.ems_azure.additional_regions.to_h
=> 
{:norwayeast=>#<Config::Options description="Norway East", name="norwayeast">,
 :norwaywest=>#<Config::Options description="Norway West", name="norwaywest">}
>> Settings.ems.ems_azure.additional_regions.to_hash
=> 
{:norwayeast=>{:description=>"Norway East", :name=>"norwayeast"},
 :norwaywest=>{:description=>"Norway West", :name=>"norwaywest"}}
```

This leads to an issue with the API parsing the regions:
```
[----] F, [2023-02-22T11:18:07.530788 #420348:62c8c] FATAL -- development: Error caught: [NoMethodError] undefined method `slice' for #<Config::Options description="Norway East", name="norwayeast">
/home/grare/adam/.gem/ruby/3.0.0/gems/config-2.2.3/lib/config/options.rb:186:in `method_missing'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-api-194ae2d0659c/app/controllers/api/providers_controller.rb:160:in `block (2 levels) in providers_options'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-api-194ae2d0659c/app/controllers/api/providers_controller.rb:160:in `map' 
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-api-194ae2d0659c/app/controllers/api/providers_controller.rb:160:in `block in providers_options'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-api-194ae2d0659c/app/controllers/api/providers_controller.rb:158:in `map' 
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-api-194ae2d0659c/app/controllers/api/providers_controller.rb:158:in `providers_options'
/home/grare/adam/.gem/ruby/3.0.0/bundler/gems/manageiq-api-194ae2d0659c/app/controllers/api/providers_controller.rb:91:in `options'
```