### PR TITLE
Move ems event specifics for event_groups and friends to EmsEvent

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -33,6 +33,62 @@ class EmsEvent < EventStream
     end
   end
 
+  def self.event_groups
+    @event_groups ||= begin
+      core_event_groups = ::Settings.event_handling.event_groups.to_hash
+      Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
+        provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
+        next unless provider_event_groups
+
+        DeepMerge.deep_merge!(
+          provider_event_groups.to_hash, event_groups,
+          :preserve_unmergeables => false,
+          :overwrite_arrays      => false
+        )
+      end
+    end
+  end
+
+  private_class_method def self.partition_group_and_level_by_event_type
+    return @literal_group_and_level_by_event_type, @regex_group_and_level_by_event_type if @literal_group_and_level_by_event_type
+
+    @literal_group_and_level_by_event_type = {}
+    @regex_group_and_level_by_event_type = {}
+
+    event_groups.each do |group_name, group_contents|
+      group_contents.each do |group_level, event_types|
+        next if group_level == :name
+
+        event_types.each do |event_type|
+          if event_type.starts_with?("/")
+            @regex_group_and_level_by_event_type[Regexp.new(event_type[1..-2])] ||= [group_name, group_level]
+          else
+            @literal_group_and_level_by_event_type[event_type] ||= [group_name, group_level]
+          end
+        end
+      end
+    end
+
+    return @literal_group_and_level_by_event_type, @regex_group_and_level_by_event_type
+  end
+
+  def self.clear_event_groups_cache
+    @event_groups = @literal_group_and_level_by_event_type = @regex_group_and_level_by_event_type = nil
+  end
+
+  def self.group_and_level(event_type)
+    by_literal, by_regex = partition_group_and_level_by_event_type
+    by_literal[event_type] ||
+      by_regex.detect { |regex, _| regex.match?(event_type) }&.last ||
+      [DEFAULT_GROUP_NAME, DEFAULT_GROUP_LEVEL]
+  end
+
+  def self.group_name(group)
+    return if group.nil?
+
+    event_groups.dig(group.to_sym, :name) || DEFAULT_GROUP_NAME_STR
+  end
+
   def handle_event
     EmsEventHelper.new(self).handle
   rescue => err

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -82,6 +82,16 @@ class EventStream < ApplicationRecord
     @group_name ||= self.class.group_name(group)
   end
 
+  def self.group_and_level(event_type)
+    # Given a specific event_type, return the group and level for it
+    raise NotImplementedError, "group_and_level must be implemented in a subclass"
+  end
+
+  def self.group_name(group)
+    # Return the name for a specific event group
+    raise NotImplementedError, "group_name must be implemented in a subclass"
+  end
+
   def self.timeline_classes
     EventStream.subclasses.select { |e| e.respond_to?(:group_names_and_levels) }
   end

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -49,7 +49,7 @@ class EventStream < ApplicationRecord
   end
 
   def self.clear_event_groups_cache
-    # subclasses can implement their own cache clearing
+    descendants.each { |c| c.clear_event_groups_cache if c.respond_to?(:clear_event_groups_cache) }
   end
 
   def self.group_levels

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -48,6 +48,10 @@ class EventStream < ApplicationRecord
     []
   end
 
+  def self.clear_event_groups_cache
+    # subclasses can implement their own cache clearing
+  end
+
   def self.group_levels
     class_group_levels + [DEFAULT_GROUP_LEVEL]
   end
@@ -58,70 +62,14 @@ class EventStream < ApplicationRecord
     _log.log_backtrace(err)
   end
 
-  # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def self.event_groups
-    @event_groups ||= begin
-      core_event_groups = ::Settings.event_handling.event_groups.to_hash
-      Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
-        provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
-        next unless provider_event_groups
-
-        DeepMerge.deep_merge!(
-          provider_event_groups.to_hash, event_groups,
-          :preserve_unmergeables => false,
-          :overwrite_arrays      => false
-        )
-      end
-    end
+    raise NotImplementedError, "event_groups must be implemented in a subclass"
   end
 
-  private_class_method def self.partition_group_and_level_by_event_type
-    return @literal_group_and_level_by_event_type, @regex_group_and_level_by_event_type if @literal_group_and_level_by_event_type
-
-    @literal_group_and_level_by_event_type = {}
-    @regex_group_and_level_by_event_type = {}
-
-    event_groups.each do |group_name, group_contents|
-      group_contents.each do |group_level, event_types|
-        next if group_level == :name
-
-        event_types.each do |event_type|
-          if event_type.starts_with?("/")
-            @regex_group_and_level_by_event_type[Regexp.new(event_type[1..-2])] ||= [group_name, group_level]
-          else
-            @literal_group_and_level_by_event_type[event_type] ||= [group_name, group_level]
-          end
-        end
-      end
-    end
-
-    return @literal_group_and_level_by_event_type, @regex_group_and_level_by_event_type
-  end
-
-  def self.clear_event_groups_cache
-    @event_groups = @literal_group_and_level_by_event_type = @regex_group_and_level_by_event_type = nil
-  end
-
-  # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
-  def self.group_and_level(event_type)
-    by_literal, by_regex = partition_group_and_level_by_event_type
-    by_literal[event_type] ||
-      by_regex.detect { |regex, _| regex.match?(event_type) }&.last ||
-      [DEFAULT_GROUP_NAME, DEFAULT_GROUP_LEVEL]
-  end
-
-  def self.group_name(group)
-    return if group.nil?
-
-    event_groups.dig(group.to_sym, :name) || DEFAULT_GROUP_NAME_STR
-  end
-
-  # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def group
     group_and_level.first
   end
 
-  # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def group_level
     group_and_level.last
   end
@@ -130,7 +78,6 @@ class EventStream < ApplicationRecord
     @group_and_level ||= self.class.group_and_level(event_type)
   end
 
-  # TODO: Consider moving since this is EmsEvent specific. group, group_level and group_name exposed as a virtual columns for reports/api.
   def group_name
     @group_name ||= self.class.group_name(group)
   end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -309,7 +309,9 @@ RSpec.describe EmsEvent do
     end
   end
 
-  describe ".event_groups (no stubbing)" do
+  # NOTE: Do not use Settings stubs here (e.g. stub_settings_merge), as this test is meant to
+  # test the actual Settings across all providers.
+  describe ".event_groups (actual Settings)" do
     described_class.event_groups.each do |group_name, group_data|
       described_class.group_levels.each do |level|
         group_data[level]&.each do |typ|

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -309,6 +309,29 @@ RSpec.describe EmsEvent do
     end
   end
 
+  describe ".event_groups (no stubbing)" do
+    described_class.event_groups.each do |group_name, group_data|
+      described_class.group_levels.each do |level|
+        group_data[level]&.each do |typ|
+          it ":#{group_name}/:#{level}/#{typ} is string or regex", :providers_common => true do
+            expect(typ.kind_of?(Regexp) || typ.kind_of?(String)).to eq(true)
+          end
+
+          if typ.kind_of?(Regexp)
+            it ":#{group_name}/:#{level}/#{typ} is usable in SQL queries", :providers_common => true do
+              expect { described_class.where("event_type ~ ?", typ.source).to_a }
+                .to_not raise_error
+            end
+
+            it ":#{group_name}/:#{level}/#{typ} only uses case insensitivity option", :providers_common => true do
+              expect(typ.options & (Regexp::EXTENDED | Regexp::MULTILINE)).to eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+
   context '.event_groups' do
     before(:each) do
       stub_settings_merge(

--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -1,27 +1,4 @@
 RSpec.describe EventStream do
-  describe ".event_groups" do
-    EventStream.event_groups.each do |group_name, group_data|
-      (EmsEvent.group_levels + MiqEvent.group_levels).each do |level|
-        group_data[level]&.each do |typ|
-          it ":#{group_name}/:#{level}/#{typ} is string or regex", :providers_common => true do
-            expect(typ.kind_of?(Regexp) || typ.kind_of?(String)).to eq(true)
-          end
-
-          if typ.kind_of?(Regexp)
-            it ":#{group_name}/:#{level}/#{typ} is usable in SQL queries", :providers_common => true do
-              expect { EventStream.where("event_type ~ ?", typ.source).to_a }
-                .to_not raise_error
-            end
-
-            it ":#{group_name}/:#{level}/#{typ} only uses case insensitivity option", :providers_common => true do
-              expect(typ.options & (Regexp::EXTENDED | Regexp::MULTILINE)).to eq(0)
-            end
-          end
-        end
-      end
-    end
-  end
-
   context "description" do
     it "raises NotImplementedError, for subclasses to implement" do
       expect { described_class.description }.to raise_error(NotImplementedError)

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -44,7 +44,6 @@ module EvmSpecHelper
     clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
 
     EmsEvent.clear_event_groups_cache if defined?(EmsEvent)
-    EventStream.clear_event_groups_cache if defined?(EventStream)
     MiqEvent.clear_event_groups_cache if defined?(MiqEvent)
 
     MiqWorker.my_guid = nil

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -43,8 +43,7 @@ module EvmSpecHelper
     clear_instance_variable(MiqWorker, :@rails_worker) if defined?(MiqWorker)
     clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
 
-    EmsEvent.clear_event_groups_cache if defined?(EmsEvent)
-    MiqEvent.clear_event_groups_cache if defined?(MiqEvent)
+    EventStream.clear_event_groups_cache if defined?(EventStream)
 
     MiqWorker.my_guid = nil
 


### PR DESCRIPTION
Depends on / Built on top of: 

- [x] https://github.com/ManageIQ/manageiq/pull/22361

This PR just moves the management event logic from the base class into EmsEvent where it belongs and removes the todos.

