### PR TITLE
Log external authentication groups on failed login.

### DIFF
--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -582,7 +582,7 @@ RSpec.describe Authenticator::Httpd do
             expect(AuditEvent).to receive(:failure).with({
                                                            :event   => 'authorize',
                                                            :userid  => 'bob',
-                                                           :message => "Authentication failed for userid bob@example.com, unable to match user's group membership to an EVM role",
+                                                           :message => "Authentication failed for userid bob@example.com, unable to match user's group membership to an EVM role. The incoming groups are: bubble, trouble",
                                                          }).and_call_original
             authenticate
           end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe Authenticator::Ldap do
             expect(AuditEvent).to receive(:failure).with({
                                                            :event   => 'authorize',
                                                            :userid  => 'bob',
-                                                           :message => "Authentication failed for userid bob, unable to match user's group membership to an EVM role",
+                                                           :message => "Authentication failed for userid bob, unable to match user's group membership to an EVM role. The incoming groups are: bubble, trouble",
                                                          })
             authenticate
           end


### PR DESCRIPTION
@jrafanie @bdunne Please review.

From a diagnostic point of view, when group membership is the reason for failure, it's impossible to know why, but as soon as you see the incoming group names, it's easy to solve.  This moves that logging to info and audit from debug.  This also changes the debug to not print one-per-line which is overkill.