### PR TITLE
Handle `nil` additional_regions

### DIFF
--- a/app/models/manageiq/providers/regions.rb
+++ b/app/models/manageiq/providers/regions.rb
@@ -21,7 +21,7 @@ module ManageIQ::Providers
       end
 
       def additional_regions
-        Settings.dig(:ems, ems_type, :additional_regions).to_hash.stringify_keys
+        Settings.dig(:ems, ems_type, :additional_regions)&.to_hash&.stringify_keys || {}
       end
 
       def disabled_regions


### PR DESCRIPTION
Amazon has a spec test checking that `nil` additional_regions are
handled which is causing that repo to fail specs