### PR TITLE
Make container class' event_stream_filters match event_where_clause for ems_events

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -39,6 +39,18 @@ class Container < ApplicationRecord
     end
   end
 
+  def ems_event_filter
+    {
+      "container_name"      => name,
+      "container_namespace" => container_project.name,
+      "ems_id"              => ext_management_system.id,
+    }
+  end
+
+  def miq_event_filter
+    {"ems_id" => ext_management_system.id}
+  end
+
   PERF_ROLLUP_CHILDREN = []
 
   def perf_rollup_parents(interval_name = nil)

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -78,6 +78,18 @@ class ContainerGroup < ApplicationRecord
     end
   end
 
+  def ems_event_filter
+    {
+      "container_group_name" => name,
+      "container_namespace"  => container_project.name,
+      "ems_id"               => ext_management_system.id
+    }
+  end
+
+  def miq_event_filter
+    {"ems_id" => ext_management_system.id}
+  end
+
   PERF_ROLLUP_CHILDREN = []
 
   def perf_rollup_parents(interval_name = nil)

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -71,6 +71,17 @@ class ContainerNode < ApplicationRecord
     end
   end
 
+  def ems_event_filter
+    {
+      "container_node_name" => name,
+      "ems_id"              => ext_management_system.id
+    }
+  end
+
+  def miq_event_filter
+    {"ems_id" => ext_management_system.id}
+  end
+
   # TODO: children will be container groups
   PERF_ROLLUP_CHILDREN = []
 

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -66,6 +66,17 @@ class ContainerProject < ApplicationRecord
     end
   end
 
+  def ems_event_filter
+    {
+      "container_namespace" => name,
+      "ems_id"              => ext_management_system.id
+    }
+  end
+
+  def miq_event_filter
+    {"ems_id" => ext_management_system.id}
+  end
+
   def perf_rollup_parents(_interval_name = nil)
     []
   end

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -37,6 +37,18 @@ class ContainerReplicator < ApplicationRecord
     end
   end
 
+  def ems_event_filter
+    {
+      "container_namespace"       => container_project.name,
+      "container_replicator_name" => name,
+      "ems_id"                    => ext_management_system.id
+    }
+  end
+
+  def miq_event_filter
+    {"ems_id" => ext_management_system.id}
+  end
+
   def perf_rollup_parents(_interval_name = nil)
     []
   end

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -41,10 +41,20 @@ RSpec.describe EventMixin do
   end
 
   context "event_stream_filters" do
+    # Note
+    # 1) BottleneckEvent is not including event mixin, event_where_clause references missing resource_type, resource_id on event streams
+    # 2) EmsCluster#event_where_clause does an OR:  ems_cluster_id OR (host_id in ? OR dest_host_id IN ?) OR (vm_or_template in ? OR dest_vm_or_template_id in ?) (for now we just do ems_cluster_id in ems_event_filter)
+    # 3) Host#event_where_clause does an OR: host_id OR dest_host_id... right now we only do host_id in ems_event_filter
+    # 4) VmOrTemplate#event_where_clause does an OR: vm_or_template_id OR dest_vm_or_template_id, we only do vm_or_template_id in ems_event_filter
     %w[
+      AvailabilityZone    availability_zone_id
       EmsCluster          ems_cluster_id
       ExtManagementSystem ems_id
       Host                host_id
+      PhysicalChassis     physical_chassis_id
+      PhysicalServer      physical_server_id
+      PhysicalStorage     physical_storage_id
+      PhysicalSwitch      physical_switch_id
       VmOrTemplate        vm_or_template_id
       Vm                  vm_or_template_id
     ].each_slice(2) do |klass, column|
@@ -53,6 +63,85 @@ RSpec.describe EventMixin do
         expect(obj.event_stream_filters["EmsEvent"]).to eq(column => obj.id)
         expect(obj.event_stream_filters.dig("MiqEvent", "target_id")).to eq(obj.id)
         expect(obj.event_stream_filters.dig("MiqEvent", "target_type")).to eq(obj.class.base_class.name)
+      end
+
+      it "#{klass} behaves like event_where_clause for ems_events" do
+        obj = FactoryBot.create(klass.tableize.singularize)
+        event = FactoryBot.create(:event_stream, column => obj.id)
+        FactoryBot.create(:event_stream)
+        expect(EventStream.where(obj.event_stream_filters["EmsEvent"]).to_a).to eq([event])
+        expect(EventStream.where(obj.event_where_clause(:ems_events)).to_a).to eq([event])
+      end
+
+      # # TODO: some classes don't have this implemented or don't have columns for this
+      # # Do we consolidate policy events and miq events?
+      # it "behaves like event_where_clause for #{klass} for policy_events" do
+      #   obj = FactoryBot.create(klass.tableize.singularize)
+      #   event = FactoryBot.create(:event_stream, :target => obj)
+      #   FactoryBot.create(:event_stream)
+      #   expect(EventStream.where(obj.event_stream_filters["MiqEvent"]).to_a).to eq([event])
+      #   pending("policy_events or miq events aren't implemented in all classes and are likely busted")
+      #   expect(EventStream.where(obj.event_where_clause(:policy_events)).to_a).to eq([event])
+      # end
+    end
+
+    context "custom behavior" do
+      it "Container uses container_namespace, container_name in ems events" do
+        ems     = FactoryBot.create(:ext_management_system)
+        project = FactoryBot.create(:container_project)
+        obj     = FactoryBot.create(:container, :container_project => project, :ext_management_system => ems)
+        event   = FactoryBot.create(:event_stream, :container_namespace => project.name, :ems_id => ems.id, :container_name => obj.name)
+        FactoryBot.create(:event_stream, :ems_id => ems.id)
+
+        expect(obj.event_stream_filters["EmsEvent"]).to eq("container_namespace" => project.name, "ems_id" => ems.id, "container_name" => obj.name)
+        expect(EventStream.where(obj.event_where_clause(:ems_events)).to_a).to eq([event])
+        expect(EventStream.where(obj.event_stream_filters["EmsEvent"]).to_a).to eq([event])
+      end
+
+      it "ContainerGroup uses container_namespace, container_group_name, and ems_id in ems events" do
+        ems     = FactoryBot.create(:ext_management_system)
+        project = FactoryBot.create(:container_project)
+        obj     = FactoryBot.create(:container_group, :container_project => project, :ext_management_system => ems)
+        event   = FactoryBot.create(:event_stream, :container_namespace => project.name, :ems_id => ems.id, :container_group_name => obj.name)
+        FactoryBot.create(:event_stream, :ems_id => ems.id)
+
+        expect(obj.event_stream_filters["EmsEvent"]).to eq("container_namespace" => project.name, "ems_id" => ems.id, "container_group_name" => obj.name)
+        expect(EventStream.where(obj.event_where_clause(:ems_events)).to_a).to eq([event])
+        expect(EventStream.where(obj.event_stream_filters["EmsEvent"]).to_a).to eq([event])
+      end
+
+      it "ContainerNode uses container_node_name and ems_id in ems events" do
+        ems   = FactoryBot.create(:ext_management_system)
+        obj   = FactoryBot.create(:container_node, :name => "test", :ext_management_system => ems)
+        event = FactoryBot.create(:event_stream, :container_node_name => obj.name, :ems_id => ems.id)
+        FactoryBot.create(:event_stream, :ems_id => ems.id)
+
+        expect(obj.event_stream_filters["EmsEvent"]).to eq("container_node_name" => obj.name, "ems_id" => ems.id)
+        expect(EventStream.where(obj.event_where_clause(:ems_events)).to_a).to eq([event])
+        expect(EventStream.where(obj.event_stream_filters["EmsEvent"]).to_a).to eq([event])
+      end
+
+      it "ContainerProject uses container_namespace(name) and ems_id in ems events" do
+        ems   = FactoryBot.create(:ext_management_system)
+        obj   = FactoryBot.create(:container_project, :ext_management_system => ems)
+        event = FactoryBot.create(:event_stream, :container_namespace => obj.name, :ems_id => ems.id)
+        FactoryBot.create(:event_stream, :ems_id => ems.id)
+
+        expect(obj.event_stream_filters["EmsEvent"]).to eq("container_namespace" => obj.name, "ems_id" => ems.id)
+        expect(EventStream.where(obj.event_where_clause(:ems_events)).to_a).to eq([event])
+        expect(EventStream.where(obj.event_stream_filters["EmsEvent"]).to_a).to eq([event])
+      end
+
+      it "ContainerReplicator uses container_namespace, container_replicator_name, and ems_id in ems events" do
+        ems      = FactoryBot.create(:ext_management_system)
+        project  = FactoryBot.create(:container_project)
+        obj      = FactoryBot.create(:container_replicator, :name => "test", :ext_management_system => ems, :container_project => project)
+        event    = FactoryBot.create(:event_stream, :container_namespace => project.name, :ems_id => ems.id, :container_replicator_name => obj.name)
+        FactoryBot.create(:event_stream, :ems_id => ems.id)
+
+        expect(obj.event_stream_filters["EmsEvent"]).to eq("container_namespace" => project.name, "container_replicator_name" => obj.name, "ems_id" => ems.id)
+        expect(EventStream.where(obj.event_where_clause(:ems_events)).to_a).to eq([event])
+        expect(EventStream.where(obj.event_stream_filters["EmsEvent"]).to_a).to eq([event])
       end
     end
   end


### PR DESCRIPTION
The Event Mixin implementation that these classes are overriding generates a condition on a single column based on the `ems_events` association foreign key.  `host_id` for Host, `ems_id` for ExtMangementSystem, etc.

This PR tries to add parity between the new `event_stream_filters` and `event_where_clause` where container classes have more complex AND conditions.

Note, the UI doesn't currently display timelines for containers, contain_groups, container_nodes, container_projects, and container_replicators but gets us closer to removing the `event_where_clause`.

Note 2, the tests describe how some of the current `event_where_clause`	values use OR conditions.  Currently, this isn't implemented as we'll have to figure out how to combine AND and ORs in the API and expose a generic interface for the UI to build API requests to match these ANDs and ORs.

Note 3, this is a followup to the bullet list of items in https://github.com/ManageIQ/manageiq/pull/22361
