### PR TITLE
Add virtual delegates for frequently used event stream API columns

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -30,6 +30,10 @@ class EventStream < ApplicationRecord
   belongs_to :physical_chassis, :inverse_of => :event_streams
   belongs_to :physical_switch, :inverse_of => :event_streams
 
+  virtual_delegate :name, :to => :ext_management_system, :prefix => true, :allow_nil => true, :type => :string
+  virtual_delegate :name, :to => :host,                  :prefix => true, :allow_nil => true, :type => :string
+  virtual_delegate :name, :to => :vm_or_template,        :prefix => true, :allow_nil => true, :type => :string
+
   virtual_column :group,       :type => :string
   virtual_column :group_level, :type => :string
   virtual_column :group_name,  :type => :string


### PR DESCRIPTION
See client UI code in: 
https://github.com/ManageIQ/manageiq-ui-classic/pull/8562
https://github.com/ManageIQ/manageiq-ui-classic/pull/8642

This is a followup to https://github.com/ManageIQ/manageiq/pull/22361

Previously, the UI needed to run an API request including the `vm`, `host`, and
`ext management system` and all of their data because sometimes the event
stream didn't have a `vm`, `host` or `ems` so the UI code would need to add
conditional logic as `vm.name`, `host.name` and `ext_mangement_system.name`
would be empty for some entries and exist for others. See [1].

We can add virtual delegates to always return a name or null if the relationship
doesn't exist or the name is null.  This saves us lots of data if we're only
using a single column from each relationship.

For a specific API call with proper timestamp filtering so we only return tens
of thousands of event_streams:

"name": "event_streams",
"count": 299925,
"subcount": 1000,
"subquery_count": 39487,
"pages": 40,

Before:

```
http://localhost:3000/api/event_streams?limit=5000&offset=0&expand=resources&attributes=group,group_level,group_name,id,event_type,ems_id,type,timestamp,created_on,host,source,message,vm,ext_management_system&filter[]=ems_id=2&filter[]=type=EmsEvent&filter[]=group=[configuration,other]&filter[]=group_level=[warning,detail,critical]&filter[]=timestamp%3E2022-10-01T22:19:39.148Z&filter[]=timestamp%3C2022-10-5T22:19:39.148Z

20.07 s
2.59 MB
```

After:

```
http://localhost:3000/api/event_streams?limit=5000&offset=0&expand=resources&attributes=group,group_level,group_name,id,event_type,ems_id,type,timestamp,created_on,host_name,source,message,vm_or_template_name,ext_management_system_name&filter[]=ems_id=2&filter[]=type=EmsEvent&filter[]=group=[configuration,other]&filter[]=group_level=[warning,detail,critical]&filter[]=timestamp%3E2022-10-01T22:19:39.148Z&filter[]=timestamp%3C2022-10-5T22:19:39.148Z

(replacing ext_management_system, host, and vm with ext_management_system_name,
host_name, and vm_or_template_name)

15.89 s
391 KB
```

[1] If you use association.method format: vm_or_template.name,
ext_management_system.name, host.name, you are missing sections if they're nil,
leading to client code needing to have conditional logic:

```
{
    "href": "http://localhost:3000/api/event_streams/20409",
    "id": "20409",
    "event_type": "INVALID_URI",
    "ems_id": "2",
    "type": "EmsEvent",
    "timestamp": "2022-10-03T13:05:31Z",
    "created_on": "2022-10-03T12:35:09Z",
    "source": "IBM_POWER_HMC",
    "message": null,
    "group": "other",
    "group_level": "detail",
    "group_name": "Other",
    "vm_or_template": {
        "name": "vm1"
    },
    "ext_management_system": {
        "name": "ems1"
    }
},
{
    "href": "http://localhost:3000/api/event_streams/20410",
    "id": "20410",
    "event_type": "INVALID_URI",
    "ems_id": "2",
    "type": "EmsEvent",
    "timestamp": "2022-10-03T13:05:51Z",
    "created_on": "2022-10-03T12:35:24Z",
    "source": "IBM_POWER_HMC",
    "message": null,
    "group": "other",
    "group_level": "detail",
    "group_name": "Other",
    "ext_management_system": {
        "name": "ems1"
    }
},
```

If you use virtual columns, it's flat and easy to use:

```
{
    "href": "http://localhost:3000/api/event_streams/20409",
    "id": "20409",
    "event_type": "INVALID_URI",
    "ems_id": "2",
    "type": "EmsEvent",
    "timestamp": "2022-10-03T13:05:31Z",
    "created_on": "2022-10-03T12:35:09Z",
    "host_name": null,
    "source": "IBM_POWER_HMC",
    "message": null,
    "group": "other",
    "group_level": "detail",
    "group_name": "Other",
    "vm_or_template_name": "vm1",
    "ext_management_system_name": "ems1"
},
{
    "href": "http://localhost:3000/api/event_streams/20410",
    "id": "20410",
    "event_type": "INVALID_URI",
    "ems_id": "2",
    "type": "EmsEvent",
    "timestamp": "2022-10-03T13:05:51Z",
    "created_on": "2022-10-03T12:35:24Z",
    "host_name": null,
    "source": "IBM_POWER_HMC",
    "message": null,
    "group": "other",
    "group_level": "detail",
    "group_name": "Other",
    "vm_or_template_name": null,
    "ext_management_system_name": "ems1"
},
```