### PR TITLE
Remove old brakeman patch/Repatch for engine support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -283,7 +283,7 @@ group :development do
 end
 
 group :test do
-  gem "brakeman",                       "~>5.0",             :require => false
+  gem "brakeman",                       "~>5.4",             :require => false
   gem "bundler-audit",                                       :require => false
   gem "capybara",                       "~>2.5.0",           :require => false
   gem "db-query-matchers",              "~>0.10.0"

--- a/lib/extensions/brakeman_excludes_patch.rb
+++ b/lib/extensions/brakeman_excludes_patch.rb
@@ -1,22 +1,28 @@
 module BrakemanExcludesPatch
-  # Original code can be found here:
-  # https://github.com/presidentbeef/brakeman/blob/5a1eb49216b7087243f5ed0f17c90ea8ca696df1/lib/brakeman/app_tree.rb#L204-L216
+  # Override the default Brakeman in_engine_paths? method to account for running
+  # brakeman from within an engine.
   #
-  # Brakeman silently excludes the vendor directory as of 5.0 by default, see:
-  # https://github.com/presidentbeef/brakeman/commit/89e40fef82a2144aaec5f6203959df39aed22c17
-  # This exclusion occurs AFTER inclusion paths via configuration such as engine paths.
-  # The patch below overrides this behavior and only excludes vendor/ files that aren't opted-in via engine paths.
-  def reject_global_excludes(paths)
-    paths.reject do |path|
-      relative_path = path.relative
-
-      # Add last check for engine_paths
-      if @skip_vendor and relative_path.include? 'vendor/' and @engine_paths.none? { |p| path.absolute.include?(p) }
-        true
+  # When brakeman is run from within an engine, the list of engine paths will
+  # include the engine's root directory. In CI, the vendor directory would then be a
+  # child of an engine. The original code would then check "does this path include
+  # an engine", and it always will because the engine is the parent of the vendor
+  # directory.
+  #
+  # For example, if we are running brakeman from /path/to/manageiq-ui-classic,
+  # @engine_paths will include "/path/to/manageiq-ui-classic", and the vendor
+  # directory will be /path/to/manageiq-ui-classic/vendor. The original code would
+  # then check if "/path/to/manageiq-ui-classic/vendor/some/file" includes
+  # "/path/to/manageiq-ui-classic", and of course it always will.
+  #
+  # This patch takes care of that case, by honoring all engine paths _except_
+  # ENGINE_ROOT itself. As this method is only called on paths that already include
+  # "vendor/" we can safely ignore any file under ENGINE_ROOT/vendor.
+  def in_engine_paths?(path)
+    @engine_paths.any? do |p|
+      if defined?(ENGINE_ROOT) && p == ENGINE_ROOT
+        false # Ignore anything in the ENGINE_ROOT/vendor directory
       else
-        Brakeman::AppTree::EXCLUDED_PATHS.any? do |excluded|
-          relative_path.include? excluded
-        end
+        path.absolute.include?(p)
       end
     end
   end

--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -9,9 +9,8 @@ namespace :test do
       require "vmdb/plugins"
       require "brakeman"
 
-      # Brakeman 5.0+ excludes files in the vendor directory even if they're included
-      # via engine paths.  We patch it below so that requested engine paths are not excluded.
-      require 'brakeman/app_tree'
+      # Brakeman's engine_paths check does not work properly with engines
+      require "brakeman/app_tree"
       require Rails.root.join('lib/extensions/brakeman_excludes_patch')
       Brakeman::AppTree.prepend(BrakemanExcludesPatch)
 


### PR DESCRIPTION
We no longer need the old brakeman patch, because it was upstreamed and released in brakeman v5.3.0.

However, that patch doesn't support running brakeman from a Rails engine itself. Thus, this commit introduces a new patch to support that case.

@jrafanie Please review.

When run within core:

```
== Overview ==

Controllers: 260
Models: 2018
Templates: 821
Errors: 0
Security Warnings: 1

== Warning Types ==

Command Injection: 1

== Warnings ==

Confidence: Medium
Category: Command Injection
Check: Execute
Message: Possible command injection
Code: `_("My Filter: ") #{schedule.miq_search.description}`
File: ../../.gem/ruby/3.0.5/bundler/gems/manageiq-ui-classic-5e1326250acf/app/helpers/settings_schedule_helper.rb
Line: 51
```

When run within ui-classic

```
== Overview ==

Controllers: 260
Models: 2018
Templates: 821
Errors: 0
Security Warnings: 1

== Warning Types ==

Command Injection: 1

== Warnings ==

Confidence: Medium
Category: Command Injection
Check: Execute
Message: Possible command injection
Code: `_("My Filter: ") #{schedule.miq_search.description}`
File: ../manageiq-ui-classic/app/helpers/settings_schedule_helper.rb
Line: 51
```