### PR TITLE
added `StorageService` to `EmsRefresh.get_target_objects`

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -84,7 +84,7 @@ module EmsRefresh
       target_class = target_class.to_s.constantize unless target_class.kind_of?(Class)
 
       if ManageIQ::Providers::Inventory.persister_class_for(target_class).blank? &&
-         [VmOrTemplate, Host, PhysicalServer, PhysicalStorage, CloudVolume, ExtManagementSystem, InventoryRefresh::Target].none? { |k| target_class <= k }
+         [VmOrTemplate, Host, PhysicalServer, PhysicalStorage, CloudVolume, ExtManagementSystem, StorageService, InventoryRefresh::Target].none? { |k| target_class <= k }
         _log.warn("Unknown target type: [#{target_class}].")
         next
       end


### PR DESCRIPTION
added `StorageService` to `EmsRefresh.get_target_objects`.
before that, a post-service_delete targeted refresh didn't even reach `ManageIQ::Providers::Autosde::Inventory::Collector::TargetCollection`.

- [ ] https://github.com/ManageIQ/manageiq-providers-autosde/pull/220