### PR TITLE
Humanizing Chart data like Table does in Reports

### DIFF
--- a/app/models/miq_report/formatters/graph.rb
+++ b/app/models/miq_report/formatters/graph.rb
@@ -9,8 +9,30 @@ module MiqReport::Formatters::Graph
     end
   end
 
+  # Sets the boundary of staying with smaller unit versus going up.
+  # Example: with the value, say, 10, if the data is 9000 MB, we'd stay with MB, while we'd go to GB if it's 11000 MB.
+  UNIT_THRESHOLD = 10
+
   def to_chart(theme = nil, show_title = false, graph_options = nil)
     ManageIQ::Reporting::Formatter::ReportRenderer.render(ManageIQ::Reporting::Charting.format) do |e|
+      if col_formats
+        # NOTE: This code intentionally does not use number_to_human_size to create a human-readable
+        #   chart summary, because we want to match the unit of the column, regardless of the size.
+        #   This code chooses the unit first, then converts the size to that unit, as opposed to
+        #   number_to_human_size which chooses the most optimal unit for the size.
+        col_formats.each_with_index do |format, i|
+          next unless [:bytes_human_precision_2, :kilobytes_human, :megabytes_human, :megabytes_human_precision_2, :gigabytes_human, :gigabytes_human_precision_2].include?(format)
+
+          final_unit = 1
+          table.data.each do |d|
+            unit = [1.terabytes, 1.gigabytes, 1.megabytes, 1.kilobytes].detect { |u| d[i] / u >= UNIT_THRESHOLD }
+            final_unit = unit if unit > final_unit
+          end
+          table.data.each do |d|
+            d[i] /= final_unit
+          end
+        end
+      end
       e.options.mri           = self
       e.options.show_title    = show_title
       e.options.graph_options = graph_options unless graph_options.nil?

--- a/spec/models/miq_report/formatters/graph_spec.rb
+++ b/spec/models/miq_report/formatters/graph_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe MiqReport::Formatters::Graph do
+  describe '#to_chart' do
+    let(:table_data1) do
+      [{"id" => 102, "name" => "region2", "created_on" => "2023-03-15 10:11:12.000000", "size" => 3_333_333},
+       {"id" => 101, "name" => "region1", "created_on" => "2023-03-15 01:23:45.000000", "size" => 44_444_444},
+       {"id" => 103, "name" => "region3", "created_on" => "2023-03-15 12:34:56.000000", "size" => 555_555_555}]
+    end
+    let(:table_data2) do
+      [{"id" => 201, "name" => "region1", "created_on" => "2023-03-15 10:11:12.000000", "size" => 1_111_111},
+       {"id" => 202, "name" => "region2", "created_on" => "2023-03-15 12:34:56.000000", "size" => 222_222}]
+    end
+    let(:table_data3) do
+      [{"id" => 301, "name" => "region1", "created_on" => "2023-03-15 10:11:12.000000", "size" => 11_111_111},
+       {"id" => 302, "name" => "region2", "created_on" => "2023-03-15 12:34:56.000000", "size" => 222_222}]
+    end
+    let(:col_names) do
+      ["name", "size", "created_on"]
+    end
+    let(:col_formats) do
+      [nil, :megabytes_human, :date]
+    end
+    let(:miq_report) do
+      FactoryBot.create(:miq_report).tap do |report|
+        report.col_formats = col_formats
+        report.col_order = col_names
+        report.sortby = ["size"]
+        report.order = "Descending"
+        report.graph = {:type => 'Donut', :mode => "values", :column => "CloudVolume-size", :count => 10, :other => true}
+      end
+    end
+
+    it "finds the right unit and humanizes data that are in similar range" do
+      miq_report.table = Ruport::Data::Table.new(:data => table_data1, :column_names => col_names)
+      miq_report.to_chart(nil, true, MiqReport.graph_options({}))
+      chart = miq_report.chart
+
+      expect(chart[:data][:columns][0][1]).to eq(529) # 555555555/1024/1024
+      expect(chart[:data][:columns][1][1]).to eq(42)  #  44444444/1024/1024
+    end
+
+    it "finds the right unit and humanizes data with smaller unit" do
+      miq_report.table = Ruport::Data::Table.new(:data => table_data2, :column_names => col_names)
+      miq_report.to_chart(nil, true, MiqReport.graph_options({}))
+      chart = miq_report.chart
+
+      expect(chart[:data][:columns][0][1]).to eq(1085) # 1111111/1024
+      expect(chart[:data][:columns][1][1]).to eq(217)  #  222222/1024
+    end
+
+    it "finds the right unit and humanizes data with bigger unit" do
+      miq_report.table = Ruport::Data::Table.new(:data => table_data3, :column_names => col_names)
+      miq_report.to_chart(nil, true, MiqReport.graph_options({}))
+      chart = miq_report.chart
+
+      expect(chart[:data][:columns][0][1]).to eq(10) # 11111111/1024/1024
+      expect(chart[:data][:columns][1][1]).to eq(0)  #   222222/1024/1024
+    end
+  end
+end


### PR DESCRIPTION
This PR would address at least a part of [issue #21823](https://github.com/ManageIQ/manageiq/issues/21823). In a Report with a (pie/donut) chart, the Table part does a nice job of humanizing the big numbers. However, the Chart doesn't know how to do it, and it just goes with what's passed in. Therefore, we need to do some humanizing before passing the data to Chart.

The linked issue above shows a donut chart that shows a number in MB, while the table shows breakdowns in GB (each cell could be showing in different units, though). And when the number is really big, it could be like;

![image](https://user-images.githubusercontent.com/1767126/225976097-f77469bd-7940-4f02-abcc-b6fe8ed60f02.png)

So, this PR seeks the "right" unit for the data that has `Suffix Bytes (B, KB, MB, GB)` format setting and converts the individual data before getting passed to Chart component, so it'd look like;

![image](https://user-images.githubusercontent.com/1767126/225976741-1fcccddd-8641-4bdb-8f8b-864a299b84f0.png)
