### PR TITLE
Rolling back changes to original MemoryStore

### DIFF
--- a/lib/manageiq/session/memory_store_adapter.rb
+++ b/lib/manageiq/session/memory_store_adapter.rb
@@ -1,12 +1,29 @@
 # Be sure to restart your server when you modify this file.
+# Port of old CGI::Session::MemoryStore to Rails 3
 module ActionDispatch
   module Session
     # In-memory session storage class.
-    class MemoryStore < ActionDispatch::Session::CacheStore
-      # typically points to the config.cache_store.
-      # this points to a memory store instead
-      def initialize(app, options)
-        super(app, options.reverse_merge(:cache => ActiveSupport::Cache::MemoryStore.new))
+    #
+    # Implements session storage as a global in-memory hash.  Session
+    # data will only persist for as long as the ruby interpreter
+    # instance does.
+    class MemoryStore < AbstractStore
+      GLOBAL_HASH_TABLE = {} #:nodoc:
+
+      def find_session(_req, session_id)
+        session_id ||= generate_sid
+        session = GLOBAL_HASH_TABLE[session_id] || {}
+        [session_id, session]
+      end
+
+      def write_session(_req, session_id, session_data, _options = nil)
+        GLOBAL_HASH_TABLE[session_id] = session_data
+        session_id
+      end
+
+      def delete_session(_req, session_id, _options)
+        GLOBAL_HASH_TABLE.delete(session_id)
+        generate_sid
       end
     end
   end


### PR DESCRIPTION
We did remove a number of monkey patches in #20610 f9e68c593a53 that added delete_sessions to each store.

But rolled back the implementation of MemoryStore. The one based upon CacheStore had strange session_ids so using the one based upon AbstractStore works better for now Since it is only used for test, it makes the most sense.

Did remove the `private` declaration for the find/delete methods
