### PR TITLE
update codeql tool

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,10 +29,10 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
```
This version of the CodeQL Action was deprecated on January 18th, 2023, and is no longer
updated or supported. For better performance, improved security, and new features, upgrade
to v2. For more information, see https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
```

I `s/v1/v2/g` per instructions on [blog] -- there were only 2 tasks for codeql and it seemed reasonable.

[blog]: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

---

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js
16: github/codeql-action/init@v1, github/codeql-action/analyze@v1. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
```

I was not able to find any `nodejs` or `using:` or any of our code. Guessing that was from the v1 containers and will resolve itself after the other fix. If nothing else, this should resolve the first issue