### PR TITLE
Fix code scanning issue with IO.open

### DIFF
--- a/lib/pid_file.rb
+++ b/lib/pid_file.rb
@@ -15,7 +15,7 @@ class PidFile
 
   def pid
     return nil unless File.file?(@fname)
-    data = IO.read(@fname).strip
+    data = File.read(@fname).strip
     return nil if data.empty? || !/\d+/.match(data)
     data.to_i
   end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/security/code-scanning/37

> Use of Kernel.open or IO.read or similar sinks with a non-constant value
>
> If Kernel.open is given a file name that starts with a | character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to IO.read, IO.write, IO.binread, IO.binwrite, IO.foreach, IO.readlines and URI.open.
>
> Use File.open instead of Kernel.open, as the former does not have this vulnerability. Similarly, use the methods from the File class instead of the IO class e.g. File.read instead of IO.read.

@jrafanie Please review.  A user can't control this entrypoint, but a fix is a fix.