### PR TITLE
Drop scvmm/hyperv references since it was dropped in #22279

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -631,7 +631,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def self.ems_infra_discovery_types
-    @ems_infra_discovery_types ||= %w(virtualcenter scvmm rhevm openstack_infra)
+    @ems_infra_discovery_types ||= %w(virtualcenter rhevm openstack_infra)
   end
 
   def self.ems_physical_infra_discovery_types

--- a/lib/manageiq/network_discovery/discovery.rb
+++ b/lib/manageiq/network_discovery/discovery.rb
@@ -5,9 +5,6 @@ module ManageIQ
     module Discovery
       PROVIDERS_BY_TYPE = {
         :ipmi            => "ManageIQ::Util::IPMI::Discovery",
-        :msvirtualserver => "ManageIQ::Providers::Microsoft::Discovery",
-        :mswin           => "ManageIQ::Providers::Microsoft::Discovery",
-        :scvmm           => "ManageIQ::Providers::Microsoft::Discovery",
         :openstack_infra => "ManageIQ::Providers::Openstack::Discovery",
         :ovirt           => "ManageIQ::Providers::Ovirt::Discovery",
         :rhevm           => "ManageIQ::Providers::Redhat::Discovery",

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe ExtManagementSystem do
   end
 
   it ".ems_infra_discovery_types" do
-    expected_types = %w(scvmm rhevm virtualcenter openstack_infra)
+    expected_types = %w(rhevm virtualcenter openstack_infra)
 
     expect(described_class.ems_infra_discovery_types).to match_array(expected_types)
   end


### PR DESCRIPTION
See: https://github.com/ManageIQ/manageiq/pull/22279

Related PRs:
https://github.com/ManageIQ/manageiq/pull/22413 (this one)
https://github.com/ManageIQ/manageiq-smartstate/pull/172
https://github.com/ManageIQ/manageiq-gems-pending/issues/556