### PR TITLE
Don't leave trailing hyphen in deployment name

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -108,7 +108,7 @@ class MiqWorker
     def worker_deployment_name
       @worker_deployment_name ||= begin
         deployment_name = abbreviated_class_name.dup.chomp("Worker").sub("Manager", "").sub(/^Miq/, "")
-        deployment_name << "-#{Array(ems_id).map { |id| ApplicationRecord.split_id(id).last }.join("-")}" if respond_to?(:ems_id)
+        deployment_name << "-#{Array(ems_id).map { |id| ApplicationRecord.split_id(id).last }.join("-")}" if respond_to?(:ems_id) && ems_id.present?
         "#{deployment_prefix}#{deployment_name.underscore.dasherize.tr("/", "-")}"
       end
     end

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -108,7 +108,7 @@ class MiqWorker
     def worker_deployment_name
       @worker_deployment_name ||= begin
         deployment_name = abbreviated_class_name.dup.chomp("Worker").sub("Manager", "").sub(/^Miq/, "")
-        deployment_name << "-#{Array(ems_id).map { |id| ApplicationRecord.split_id(id).last }.join("-")}" if respond_to?(:ems_id) && ems_id.present?
+        deployment_name << "-#{ApplicationRecord.split_id(ems_id).last}" if respond_to?(:ems_id) && ems_id.present?
         "#{deployment_prefix}#{deployment_name.underscore.dasherize.tr("/", "-")}"
       end
     end

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -113,6 +113,30 @@ RSpec.describe MiqWorker::ContainerCommon do
         expect(klass.constantize.new.worker_deployment_name.length).to be <= 60
       end
     end
+
+    context "ems_id" do
+      let(:subject) { ManageIQ::Providers::BaseManager::EventCatcher.new }
+
+      it "is appended" do
+        subject.queue_name = "ems_1"
+        expect(subject.worker_deployment_name[-2..]).to eq("-1")
+      end
+
+      it "isn't appended for nil queue_name" do
+        subject.queue_name = nil
+        expect(subject.worker_deployment_name[-7..]).to eq("catcher")
+      end
+
+      it "isn't appended for blank queue_name" do
+        subject.queue_name = " "
+        expect(subject.worker_deployment_name[-7..]).to eq("catcher")
+      end
+
+      it "isn't appended for invalid queue_name prefix" do
+        subject.queue_name = "notems_1"
+        expect(subject.worker_deployment_name[-7..]).to eq("catcher")
+      end
+    end
   end
 
   describe "#scale_deployment" do


### PR DESCRIPTION
* If the `ems_id` is `nil`, empty, or not in the expected format, it can return `nil`
causing us to leave the deployment name with a trailing hyphen.  Now, we only
append the hyphen and `ems_id` if it's present.

* `ems_id` cannot be an array, simplifying this logic of `ems_id` returning nil or an fixnum

`ems_id` comes from `ems_id_from_queue_name` which as of [1] can only ever return an
integer or nil from `parse_ems_id`.

[1] https://github.com/ManageIQ/manageiq/pull/20345

Related, we need to fix the foreman provider to not return an array from [queue_name_for_ems](https://github.com/ManageIQ/manageiq-providers-foreman/blob/052f424eedabef20ba768f3ec1f45ea2a343d0a9/app/models/manageiq/providers/foreman/configuration_manager/refresh_worker.rb#L13-L17)