### PR TITLE
Better ansible runner detection

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "1d1f63511c528d6d28a292a8b3ff2a91b5e0c4104112fb06631a00ca89f03e2f",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "lib/ansible/runner.rb",
+      "line": 409,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`python#{version} -c 'import site; print(\":\".join(site.getsitepackages()))'`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Ansible::Runner",
+        "method": "ansible_python_paths_raw"
+      },
+      "user_input": "version",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "This method is safe because it verifies that the version is in the form #.#."
+    }
+  ],
+  "updated": "2023-03-20 10:30:55 -0400",
+  "brakeman_version": "5.4.1"
+}

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -387,34 +387,17 @@ module Ansible
         res
       end
 
-      def python_path
-        if python3_modules_path.present?
-          python3_modules_path
-        else
-          python2_modules_path
-        end
-      end
-
-      PYTHON2_MODULE_PATHS = %w[
-        /var/lib/manageiq/venv/lib/python2.7/site-packages
-      ].freeze
-      def python2_modules_path
-        @python2_modules_path ||= begin
-          determine_existing_python_paths_for(*PYTHON2_MODULE_PATHS).join(File::PATH_SEPARATOR)
-        end
-      end
-
-      PYTHON3_MODULE_PATHS = %w[
+      PYTHON_MODULE_PATHS = %w[
         /var/lib/awx/venv/ansible/lib/python3.6/site-packages
         /var/lib/manageiq/venv/lib/python3.6/site-packages
         /var/lib/manageiq/venv/lib/python3.8/site-packages
         /usr/local/lib/python3.8/site-packages
       ].freeze
-      def python3_modules_path
-        @python3_modules_path ||= begin
-          paths = [*PYTHON3_MODULE_PATHS, ansible_python_path.presence].compact
-          determine_existing_python_paths_for(*paths).join(File::PATH_SEPARATOR)
-        end
+      def python_path
+        @python_path ||=
+          [*PYTHON_MODULE_PATHS, ansible_python_path.presence]
+            .select { |path| path && File.exist?(path) }
+            .join(File::PATH_SEPARATOR)
       end
 
       def ansible_python_path
@@ -422,10 +405,6 @@ module Ansible
           path = `ansible --version 2>/dev/null`.split("\n").grep(/ansible python module location/).first.to_s.split(" = ").last.to_s
           path.present? ? File.dirname(path) : path
         end
-      end
-
-      def determine_existing_python_paths_for(*paths)
-        paths.select { |path| File.exist?(path) }
       end
     end
   end

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -388,7 +388,6 @@ module Ansible
       end
 
       PYTHON_MODULE_PATHS = %w[
-        /var/lib/awx/venv/ansible/lib/python3.6/site-packages
         /var/lib/manageiq/venv/lib/python3.6/site-packages
         /var/lib/manageiq/venv/lib/python3.8/site-packages
         /usr/local/lib/python3.8/site-packages

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -5,20 +5,18 @@ RSpec.describe Ansible::Runner do
   let(:tags)       { "tag" }
   let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", "0") }
 
-  let(:python2_modules_path) { "/var/lib/manageiq/venv/lib/python2.7/site-packages" }
-  let(:python3_modules_path) { "/usr/lib64/python3.6/site-packages" }
+  let(:python_modules_path) { "/usr/lib64/python3.8/site-packages" }
   let(:py3_awx_modules_path) { "/var/lib/awx/venv/ansible/lib/python3.6/site-packages" }
 
   after do
-    Ansible::Runner.instance_variable_set(:@python2_modules_path, nil)
-    Ansible::Runner.instance_variable_set(:@python3_modules_path, nil)
+    Ansible::Runner.instance_variable_set(:@python_path, nil)
     Ansible::Runner.instance_variable_set(:@ansible_python_path, nil)
   end
 
   describe ".run" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(python3_modules_path)
+      allow(described_class).to receive(:ansible_python_path).and_return(python_modules_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -114,23 +112,9 @@ RSpec.describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
     end
 
-    it "sets PYTHONPATH correctly with python2 modules installed" do
-      expect(described_class).to receive(:ansible_python_path).and_return("")
-      expect(File).to receive(:exist?).with(py3_awx_modules_path).and_return(false)
-      expect(File).to receive(:exist?).with(python2_modules_path).and_return(true)
-
-      expect(AwesomeSpawn).to receive(:run) do |command, options|
-        expect(command).to eq("ansible-runner")
-
-        expect(options[:env]["PYTHONPATH"]).to eq(python2_modules_path)
-      end.and_return(result)
-
-      described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
-    end
-
     it "assigns multiple path values if they exist" do
-      expect(described_class).to receive(:ansible_python_path).and_return(python3_modules_path)
-      expect(File).to receive(:exist?).with(python3_modules_path).and_return(true)
+      expect(described_class).to receive(:ansible_python_path).and_return(python_modules_path)
+      expect(File).to receive(:exist?).with(python_modules_path).and_return(true)
       expect(File).to receive(:exist?).with(py3_awx_modules_path).and_return(true)
 
       expect(AwesomeSpawn).to receive(:run) do |command, options|
@@ -175,7 +159,7 @@ RSpec.describe Ansible::Runner do
   describe ".run_async" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(python3_modules_path)
+      allow(described_class).to receive(:ansible_python_path).and_return(python_modules_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -226,7 +210,7 @@ RSpec.describe Ansible::Runner do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(python3_modules_path)
+      allow(described_class).to receive(:ansible_python_path).and_return(python_modules_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -285,7 +269,7 @@ RSpec.describe Ansible::Runner do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(python3_modules_path)
+      allow(described_class).to receive(:ansible_python_path).and_return(python_modules_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -5,18 +5,13 @@ RSpec.describe Ansible::Runner do
   let(:tags)       { "tag" }
   let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", "0") }
 
-  let(:ansible_python_path)   { "/usr/lib64/python3.9/site-packages" }
-  let(:python38_modules_path) { "/var/lib/manageiq/venv/lib/python3.8/site-packages" }
-
-  after do
-    Ansible::Runner.instance_variable_set(:@python_path, nil)
-    Ansible::Runner.instance_variable_set(:@ansible_python_path, nil)
-  end
+  let(:manageiq_venv_path)  { "/var/lib/manageiq/venv/python3.8/site-packages" }
+  let(:ansible_python_path) { "/usr/local/lib64/python3.8/site-packages:/usr/local/lib/python3.8/site-packages:/usr/lib64/python3.8/site-packages:/usr/lib/python3.8/site-packages" }
 
   describe ".run" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(ansible_python_path)
+      allow(described_class).to receive(:python_path).and_return(ansible_python_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -99,15 +94,17 @@ RSpec.describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
     end
 
-    it "assigns multiple path values if they exist" do
-      expect(described_class).to receive(:ansible_python_path).and_return(ansible_python_path)
-      expect(File).to receive(:exist?).with(ansible_python_path).and_return(true)
-      expect(File).to receive(:exist?).with(python38_modules_path).and_return(true)
+    it "sets PYTHON_PATH correctly" do
+      # Undo stubbing of python_path in this particular test
+      expect(described_class).to receive(:python_path).and_call_original
+
+      expect(described_class).to receive(:manageiq_venv_path).and_return(manageiq_venv_path)
+      stub_ansible_raw(ansible_exists: true)
 
       expect(AwesomeSpawn).to receive(:run) do |command, options|
         expect(command).to eq("ansible-runner")
 
-        expected_path = [python38_modules_path, ansible_python_path].join(File::PATH_SEPARATOR)
+        expected_path = [manageiq_venv_path, ansible_python_path].join(File::PATH_SEPARATOR)
         expect(options[:env]["PYTHONPATH"]).to eq(expected_path)
       end.and_return(result)
 
@@ -146,7 +143,7 @@ RSpec.describe Ansible::Runner do
   describe ".run_async" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(ansible_python_path)
+      allow(described_class).to receive(:python_path).and_return(ansible_python_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -197,7 +194,7 @@ RSpec.describe Ansible::Runner do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(ansible_python_path)
+      allow(described_class).to receive(:python_path).and_return(ansible_python_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -256,7 +253,7 @@ RSpec.describe Ansible::Runner do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
     before do
-      allow(described_class).to receive(:ansible_python_path).and_return(ansible_python_path)
+      allow(described_class).to receive(:python_path).and_return(ansible_python_path)
 
       allow(described_class).to receive(:wait_for).and_yield
       allow(File).to receive(:exist?).and_call_original
@@ -302,9 +299,72 @@ RSpec.describe Ansible::Runner do
     end
   end
 
-  describe ".ansible_python_path (private)" do
+  describe ".python_path (private)" do
+    before { described_class.instance_variable_set(:@python_path, nil) }
+    after  { described_class.instance_variable_set(:@python_path, nil) }
+
+    it "with manageiq_venv_path valid and ansible_python_version valid" do
+      expect(described_class).to receive(:manageiq_venv_path).and_return(manageiq_venv_path)
+      stub_ansible_raw(ansible_exists: true)
+
+      expect(described_class.send(:python_path)).to eq([manageiq_venv_path, ansible_python_path].join(File::PATH_SEPARATOR))
+    end
+
+    it "with manageiq_venv_path valid and ansible_python_version nil" do
+      expect(described_class).to receive(:manageiq_venv_path).and_return(manageiq_venv_path)
+      stub_ansible_raw(ansible_exists: false)
+
+      expect(described_class.send(:python_path)).to eq(manageiq_venv_path)
+    end
+
+    it "with manageiq_venv_path nil and ansible_python_version valid" do
+      expect(described_class).to receive(:manageiq_venv_path).and_return(nil)
+      stub_ansible_raw(ansible_exists: true)
+
+      expect(described_class.send(:python_path)).to eq(ansible_python_path)
+    end
+
+    it "with manageiq_venv_path nil and ansible_python_version nil" do
+      expect(described_class).to receive(:manageiq_venv_path).and_return(nil)
+      stub_ansible_raw(ansible_exists: false)
+
+      expect(described_class.send(:python_path)).to eq("")
+    end
+  end
+
+  describe ".ansible_python_paths (private)" do
+    it "with ansible_python_version valid" do
+      expect(described_class).to receive(:ansible_python_version).and_return("3.8")
+      expect(described_class).to receive(:`).with(a_string_including("python3.8 -c")).and_return(ansible_python_path)
+
+      expect(described_class.send(:ansible_python_paths)).to eq(
+        [
+          "/usr/local/lib64/python3.8/site-packages",
+          "/usr/local/lib/python3.8/site-packages",
+          "/usr/lib64/python3.8/site-packages",
+          "/usr/lib/python3.8/site-packages"
+        ]
+      )
+    end
+
+    it "with ansible_python_version nil" do
+      expect(described_class).to receive(:ansible_python_version).and_return(nil)
+      expect(described_class).to_not receive(:`).with(a_string_including("python3.8 -c"))
+
+      expect(described_class.send(:ansible_python_paths)).to eq([])
+    end
+
+    it "with ansible_python_version hacked" do
+      expect(described_class).to receive(:ansible_python_version).and_return("-hacked")
+      expect(described_class).to_not receive(:`).with(a_string_including("python-hacked -c"))
+
+      expect { described_class.send(:ansible_python_paths) }.to raise_error(RuntimeError, "ansible python version is not a number: -hacked")
+    end
+  end
+
+  describe ".ansible_python_version (private)" do
     it "with ansible using python 3.8" do
-      expect(described_class).to receive(:`).with("ansible --version 2>/dev/null").and_return(<<~EOF)
+      expect(described_class).to receive(:`).with(a_string_including("ansible --version")).and_return(<<~EOF)
         ansible [core 2.12.7]
           config file = /etc/ansible/ansible.cfg
           configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
@@ -316,26 +376,29 @@ RSpec.describe Ansible::Runner do
           libyaml = True
       EOF
 
-      expect(described_class.send(:ansible_python_path)).to eq("/usr/lib/python3.8/site-packages")
+      expect(described_class.send(:ansible_python_version)).to eq("3.8")
     end
 
-    it "with ansible using python 3.6" do
-      expect(described_class).to receive(:`).with("ansible --version 2>/dev/null").and_return(<<~EOF)
-        ansible 2.9.23
-          config file = /root/.ansible.cfg
-          configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
-          ansible python module location = /usr/lib/python3.6/site-packages/ansible
-          executable location = /usr/bin/ansible
-          python version = 3.6.8 (default, Mar 19 2021, 05:13:41) [GCC 8.4.1 20200928 (Red Hat 8.4.1-1)]
+    it "with ansible using python 3.9" do
+      expect(described_class).to receive(:`).with(a_string_including("ansible --version")).and_return(<<~EOF)
+        ansible [core 2.13.4]
+          config file = None
+          configured module search path = ['/Users/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+          ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
+          ansible collection location = /Users/root/.ansible/collections:/usr/share/ansible/collections
+          executable location = /usr/local/bin/ansible
+          python version = 3.9.13 (main, Aug  7 2022, 01:33:23) [Clang 13.1.6 (clang-1316.0.21.2.5)]
+          jinja version = 3.1.2
+          libyaml = True
       EOF
 
-      expect(described_class.send(:ansible_python_path)).to eq("/usr/lib/python3.6/site-packages")
+      expect(described_class.send(:ansible_python_version)).to eq("3.9")
     end
 
     it "when ansible is not installed" do
-      expect(described_class).to receive(:`).with("ansible --version 2>/dev/null").and_return("")
+      expect(described_class).to receive(:`).with(a_string_including("ansible --version")).and_return("")
 
-      expect(described_class.send(:ansible_python_path)).to be_blank
+      expect(described_class.send(:ansible_python_version)).to be_nil
     end
   end
 
@@ -343,5 +406,24 @@ RSpec.describe Ansible::Runner do
     content_double = instance_double(Ansible::Content)
     expect(Ansible::Content).to receive(:new).with("/path/to/my").and_return(content_double)
     expect(content_double).to receive(:fetch_galaxy_roles)
+  end
+
+  def stub_ansible_raw(ansible_exists: true)
+    if ansible_exists
+      expect(described_class).to receive(:ansible_python_version_raw).and_return(<<~EOF)
+        ansible [core 2.12.7]
+          config file = /etc/ansible/ansible.cfg
+          configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
+          ansible python module location = /usr/lib/python3.8/site-packages/ansible
+          ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
+          executable location = /usr/bin/ansible
+          python version = 3.8.13 (default, Jun 24 2022, 15:27:57) [GCC 8.5.0 20210514 (Red Hat 8.5.0-13)]
+          jinja version = 2.11.3
+          libyaml = True
+      EOF
+      expect(described_class).to receive(:ansible_python_paths_raw).and_return(ansible_python_path)
+    else
+      expect(described_class).to receive(:ansible_python_version_raw).and_return("")
+    end
   end
 end


### PR DESCRIPTION
This PR changes the ansible runner python paths detection from being a
hardcoded list to detecting the list of paths from python itself. This
will help facilitate easier upgrades, and also is less error-prone.

Additionally this PR drops python 2 and awx modules support, which was only in place for developers.

@agrare Please review