### PR TITLE
fix rake issue

### DIFF
--- a/container-assets/entrypoint
+++ b/container-assets/entrypoint
@@ -31,7 +31,9 @@ if [ $? -eq 0 ]; then
   su postgres -c "pg_ctl -D ${APPLIANCE_PG_DATA} start"
   test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
 
-  bundle exec rake db:migrate
+  pushd ${APP_ROOT}
+    bundle exec rake db:migrate
+  popd
 else
   echo "** DB has not been initialized"
 


### PR DESCRIPTION
on second start appears error:
...
  server started
  rake aborted!
  No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
  .../gems/rake-13.0.6/exe/rake:27:in `<top (required)>'

and DB migration is not executed
