### PR TITLE
Fix collect_current_logs collecting everything

### DIFF
--- a/tools/collect_logs/collect_archive_logs.sh
+++ b/tools/collect_logs/collect_archive_logs.sh
@@ -18,11 +18,11 @@ tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
     echo "This ManageIQ appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files BUILD GUID VERSION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
 else
     echo "This ManageIQ appliance is not a Database server"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/* /var/log/* log/apache/*
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files BUILD GUID VERSION log/* config/* /var/log/* log/apache/*
 fi
 
 # and restore previous current directory
@@ -30,4 +30,3 @@ popd
 
 # let the user know where the archive is
 echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"
-

--- a/tools/collect_logs/collect_current_logs.sh
+++ b/tools/collect_logs/collect_current_logs.sh
@@ -3,7 +3,7 @@
 # save directory from which command is initiated
 collect_logs_directory=$(pwd)
 
-# make the vmdb/log directory the current directory 
+# make the vmdb/log directory the current directory
 vmdb_logs_directory="/var/www/miq/vmdb"
 pushd ${vmdb_logs_directory}
 
@@ -18,11 +18,11 @@ tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
     echo "This ManageIQ appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files --exclude="/var/log/messages-*" --exclude="/var/log/journal/*/system@*.journal" BUILD GUID VERSION log/*.log log/*.txt config/* /var/log/* log/apache/*.log $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
 else
     echo "This ManageIQ appliance is not a Database server"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files --exclude="/var/log/messages-*" --exclude="/var/log/journal/*/system@*.journal"  BUILD GUID VERSION log/*.log log/*.txt config/* /var/log/* log/apache/*.log
 fi
 
 # and restore previous current directory
@@ -30,4 +30,3 @@ popd
 
 # let the user know where the archive is
 echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"
-


### PR DESCRIPTION
The `collect_current_logs.sh` utility would only filter out "archive" logs in the `/var/www/miq/vmdb/log/` directory, it would get everything in e.g. `/var/log/` which includes all of the archived `/var/log/messages-*` and all of the archived `/var/log/journal/*/system@*.journal` files.

Fixes https://github.com/ManageIQ/manageiq/issues/22432