### PR TITLE
Kafka SSL options from env if available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "manageiq-api-client",              "~>0.3.6",           :require => false
 gem "manageiq-loggers",                 "~>1.0",             :require => false
-gem "manageiq-messaging",               "~>1.0", ">=1.2.0",  :require => false
+gem "manageiq-messaging",               "~>1.0", ">=1.3.0",  :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.2",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -677,7 +677,7 @@ class MiqQueue < ApplicationRecord
   private_class_method def self.messaging_options_from_env
     return unless ENV["MESSAGING_HOSTNAME"] && ENV["MESSAGING_PORT"] && ENV["MESSAGING_USERNAME"] && ENV["MESSAGING_PASSWORD"]
 
-    {
+    options = {
       :host     => ENV["MESSAGING_HOSTNAME"],
       :port     => ENV["MESSAGING_PORT"].to_i,
       :username => ENV["MESSAGING_USERNAME"],
@@ -685,6 +685,15 @@ class MiqQueue < ApplicationRecord
       :protocol => ENV.fetch("MESSAGING_PROTOCOL", "Kafka"),
       :encoding => ENV.fetch("MESSAGING_ENCODING", "json")
     }
+
+    if ENV["MESSAGING_KEYSTORE_PASSWORD"].present?
+      options[:ssl] = true
+      options[:ca_file] = ENV.fetch("MESSAGING_SSL_CA", nil)
+      options[:keystore_location] = ENV.fetch("MESSAGING_KEYSTORE", nil)
+      options[:keystore_password] = ENV["MESSAGING_KEYSTORE_PASSWORD"]
+    end
+
+    options
   end
 
   MESSAGING_CONFIG_FILE = Rails.root.join("config", "messaging.yml")

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -100,6 +100,11 @@ class ContainerOrchestrator
             ],
           }
         }
+
+        if ENV["MESSAGING_KEYSTORE_PASSWORD"].present?
+          volume = deployment[:spec][:template][:spec][:volumes].find { |vol| vol[:name] == "internal-root-certificate" }
+          volume[:secret][:items].append({:key => "kafka_keystore", :path => "kafka.keystore.jks"})
+        end
       end
 
       deployment
@@ -168,6 +173,9 @@ class ContainerOrchestrator
       [
         {:name => "MESSAGING_PORT", :value => ENV["MESSAGING_PORT"]},
         {:name => "MESSAGING_TYPE", :value => ENV["MESSAGING_TYPE"]},
+        {:name => "MESSAGING_SSL_CA", :value => ENV["MESSAGING_SSL_CA"]},
+        {:name => "MESSAGING_KEYSTORE", :value => ENV["MESSAGING_KEYSTORE"]},
+        {:name => "MESSAGING_KEYSTORE_PASSWORD", :value => ENV["MESSAGING_KEYSTORE_PASSWORD"]},
         {:name      => "MESSAGING_HOSTNAME",
          :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "hostname"}}},
         {:name      => "MESSAGING_PASSWORD",

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1032,6 +1032,29 @@ RSpec.describe MiqQueue do
             :username => "admin"
           )
         end
+
+        it "with SSL enabled" do
+          stub_const("ENV", env_vars.to_h.merge("MESSAGING_PASSWORD" => "password",
+                                                "MESSAGING_SSL_CA" => "/path/root.crt",
+                                                "MESSAGING_KEYSTORE" => "/path/keystore.jks",
+                                                "MESSAGING_KEYSTORE_PASSWORD" => "keystore_password"
+                                                ))
+
+          expect(YAML).not_to receive(:load_file).with(MiqQueue::MESSAGING_CONFIG_FILE)
+
+          expect(MiqQueue.send(:messaging_client_options)).to eq(
+            :encoding          => "json",
+            :host              => "server.example.com",
+            :password          => "password",
+            :port              => 9092,
+            :protocol          => "Kafka",
+            :username          => "admin",
+            :ssl               => true,
+            :ca_file           => "/path/root.crt",
+            :keystore_location => "/path/keystore.jks",
+            :keystore_password => "keystore_password"
+          )
+        end
       end
 
       it "prefers settings from file if any ENV vars are missing" do


### PR DESCRIPTION
- if Kafka SSL is enabled on podified as indicated by `ENV["MESSAGING_KEYSTORE_PASSWORD"]`, set the necessary SSL options to be used by messaging client
- updated object definition with `ENV["MESSAGING_KEYSTORE_PASSWORD"] and keystore mount

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-pods/pull/951
- [x] https://github.com/ManageIQ/manageiq-messaging/pull/77

Ref:
- https://github.com/ManageIQ/manageiq-pods/issues/789

@miq-bot assign @agrare 
@miq-bot add_reviewer @bdunne  
@miq-bot add_labels core, enhancement