### PR TITLE
[WIP] Embedded workflows resource actions

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -2,6 +2,7 @@ class ResourceAction < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :configuration_template, :polymorphic => true
   belongs_to :dialog
+  belongs_to :workflow
 
   serialize  :ae_attributes, Hash
 

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -83,7 +83,10 @@ class ResourceAction < ApplicationRecord
   def deliver_queue(dialog_hash_values, target, user, task_id = nil)
     _log.info("Queuing <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
     if workflow
-      workflow.execute(:userid => user.userid, :inputs => dialog_hash_values)
+      args = {:object_type => target.class.name, :object_id => target.id}
+      queue_opts = {:zone => target.try(:my_zone)}
+
+      workflow.execute(:userid => user.userid, :inputs => dialog_hash_values, :queue_opts => queue_opts, :args => args)
     else
       MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
                                 :zone     => target.try(:my_zone),

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -10,6 +10,14 @@ class ResourceAction < ApplicationRecord
   RETIREMENT  = 'Retirement'.freeze
   RECONFIGURE = 'Reconfigure'.freeze
 
+  validate :ensure_workflow_or_automate
+
+  def ensure_workflow_or_automate
+    return if workflow_id.nil? || (ae_namespace.nil? && ae_class.nil? && ae_instance.nil?)
+
+    errors.add(:workflow_id, N_("Cannot have workflow_id and ae_namespace, ae_class, and ae_instance present"))
+  end
+
   def readonly?
     return true if super
     resource.readonly? if resource.kind_of?(ServiceTemplate)

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -22,7 +22,9 @@ class ServiceReconfigureTask < MiqRequestTask
     dialog_values = options[:dialog] || {}
 
     ra = source.service_template.resource_actions.find_by(:action => 'Reconfigure')
-    if ra
+    if ra&.workflow
+      ra.deliver_queue(dialog_values, self, get_user)
+    elsif ra
       dialog_values["request"] = req_type
       args = {
         :object_type      => self.class.name,

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -125,41 +125,46 @@ class ServiceTemplateProvisionTask < MiqRequestTask
       dialog_values = options[:dialog] || {}
       dialog_values["request"] = req_type
 
-      args = {
-        :object_type      => self.class.name,
-        :object_id        => id,
-        :namespace        => "Service/Provisioning/StateMachines",
-        :class_name       => "ServiceProvision_Template",
-        :instance_name    => req_type,
-        :automate_message => "create",
-        :attrs            => dialog_values
-      }
-
       # Automate entry point overrides from the resource_action
       ra = resource_action
 
-      unless ra.nil?
-        args[:namespace]        = ra.ae_namespace unless ra.ae_namespace.blank?
-        args[:class_name]       = ra.ae_class     unless ra.ae_class.blank?
-        args[:instance_name]    = ra.ae_instance  unless ra.ae_instance.blank?
-        args[:automate_message] = ra.ae_message   unless ra.ae_message.blank?
-        args[:attrs].merge!(ra.ae_attributes)
+      if ra&.workflow
+        ra.deliver_queue(dialog_values, self, get_user)
+      else
+        args = {
+          :object_type      => self.class.name,
+          :object_id        => id,
+          :namespace        => "Service/Provisioning/StateMachines",
+          :class_name       => "ServiceProvision_Template",
+          :instance_name    => req_type,
+          :automate_message => "create",
+          :attrs            => dialog_values
+        }
+
+        unless ra.nil?
+          args[:namespace]        = ra.ae_namespace unless ra.ae_namespace.blank?
+          args[:class_name]       = ra.ae_class     unless ra.ae_class.blank?
+          args[:instance_name]    = ra.ae_instance  unless ra.ae_instance.blank?
+          args[:automate_message] = ra.ae_message   unless ra.ae_message.blank?
+          args[:attrs].merge!(ra.ae_attributes)
+        end
+
+        args[:attrs].merge!(MiqAeEngine.create_automation_attributes(destination.class.base_model.name => destination)) if destination.present?
+        args[:user_id]      = get_user.id
+        args[:miq_group_id] = get_user.current_group.id
+        args[:tenant_id]    = get_user.current_tenant.id
+
+        MiqQueue.put(
+          :class_name     => 'MiqAeEngine',
+          :method_name    => 'deliver',
+          :args           => [args],
+          :role           => 'automate',
+          :zone           => options.fetch(:miq_zone, my_zone),
+          :tracking_label => tracking_label_id
+        )
       end
 
-      args[:attrs].merge!(MiqAeEngine.create_automation_attributes(destination.class.base_model.name => destination)) if destination.present?
-      args[:user_id]      = get_user.id
-      args[:miq_group_id] = get_user.current_group.id
-      args[:tenant_id]    = get_user.current_tenant.id
-
-      MiqQueue.put(
-        :class_name     => 'MiqAeEngine',
-        :method_name    => 'deliver',
-        :args           => [args],
-        :role           => 'automate',
-        :zone           => options.fetch(:miq_zone, my_zone),
-        :tracking_label => tracking_label_id
-      )
-      update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
+      update_and_notify_parent(:state => "pending", :status => "Ok", :message => "Automation Starting")
     else
       execute_queue
     end

--- a/spec/lib/task_helpers/exports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/exports/custom_buttons_spec.rb
@@ -236,6 +236,8 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
                     "ae_attributes"               => {},
                     "configuration_template_id"   => nil,
                     "configuration_template_type" => nil,
+                    "workflow_id"                 => nil,
+                    "type"                        => nil,
                     "resource_type"               => "CustomButton"
                   }
                 }]
@@ -270,6 +272,8 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
                 "ae_attributes"               => {},
                 "configuration_template_id"   => nil,
                 "configuration_template_type" => nil,
+                "workflow_id"                 => nil,
+                "type"                        => nil,
                 "dialog_label"                => "label1"
               }
             }]


### PR DESCRIPTION
Currently only automate domains are supported for executing services / dialogs / custom_buttons.  We want to add support for running Workflows as well

TODO:
- [ ] Call before_ae_starts / after_ae_delivery

Depends:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/686
- [x] https://github.com/ManageIQ/manageiq/pull/22446
- [ ] https://github.com/ManageIQ/manageiq-providers-workflows/pull/13

Dependents:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/8743

https://github.com/ManageIQ/manageiq/issues/22435