### PR TITLE
added password encryption before adding task to queue in validate and create

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -85,6 +85,8 @@ class PhysicalStorage < ApplicationRecord
   end
 
   def self.validate_storage_queue(userid, ext_management_system, options = {})
+    options["password"] = ManageIQ::Password.encrypt(options["password"])
+
     task_opts = {
       :action => "validating PhysicalStorage for user #{userid}",
       :userid => userid
@@ -101,6 +103,8 @@ class PhysicalStorage < ApplicationRecord
   end
 
   def self.create_physical_storage_queue(userid, ext_management_system, options = {})
+    options["password"] = ManageIQ::Password.encrypt(options["password"])
+
     task_opts = {
       :action => "creating PhysicalStorage for user #{userid}",
       :userid => userid


### PR DESCRIPTION
As suggested by Adam, I added physical storage password encryption before queueing validate and create tasks so the password will not be shown in the logs.
This PR is related to Autosde's Providers PR: 

Password in logs after the changes: https://github.com/ManageIQ/manageiq-providers-autosde/pull/225
![Screenshot 2023-04-04 at 9 22 51](https://user-images.githubusercontent.com/62609377/229705463-1c7828a1-ef3d-4246-a9e8-361d6ba2244c.png)
![Screenshot 2023-04-04 at 9 23 11](https://user-images.githubusercontent.com/62609377/229705489-2d612067-ddee-4cd9-86f5-5de06a0831fd.png)


Discussion with Adam:
<img width="1227" alt="Adam discuss encrypt" src="https://user-images.githubusercontent.com/62609377/229705867-7040f81b-1f15-4670-993c-21b0513f803d.png">


