### PR TITLE
Chargeback project date only

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -238,17 +238,17 @@ class Chargeback < ActsAsArModel
   end
 
   def self.set_chargeback_report_options(rpt, group_by, header_for_tag, groupby_label, tz)
-    rpt.cols = %w(start_date display_range)
-
-    static_cols       = report_static_cols
-    static_cols      -= ["image_name"] if group_by == "project"
-    static_cols      -= ["vm_name"] if group_by == "date-only"
-    static_cols       = group_by == "tag" ? [report_tag_field] : static_cols
-    static_cols       = group_by == "label" ? [report_label_field] : static_cols
-    static_cols       = group_by == "tenant" ? ['tenant_name'] : static_cols
-    rpt.cols         += static_cols
-    rpt.col_order     = static_cols + ["display_range"]
-    rpt.sortby        = static_cols + ["start_date"]
+    static_cols = case group_by
+                  when "project"   then report_static_cols - ["image_name"]
+                  when "date-only" then report_static_cols - ["vm_name"]
+                  when "tag"       then [report_tag_field]
+                  when "label"     then [report_label_field]
+                  when "tenant"    then ["tenant_name"]
+                  else                  report_static_cols
+                  end
+    rpt.cols      = %w(start_date display_range) + static_cols
+    rpt.col_order = static_cols + ["display_range"]
+    rpt.sortby    = static_cols + ["start_date"]
 
     rpt.col_order.each do |c|
       header_column = if (c == report_tag_field && header_for_tag)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -239,8 +239,8 @@ class Chargeback < ActsAsArModel
 
   def self.set_chargeback_report_options(rpt, group_by, header_for_tag, groupby_label, tz)
     static_cols = case group_by
-                  when "project"   then report_static_cols - ["image_name"]
-                  when "date-only" then report_static_cols - ["vm_name"]
+                  when "project"   then ["project_name"]
+                  when "date-only" then []
                   when "tag"       then [report_tag_field]
                   when "label"     then [report_label_field]
                   when "tenant"    then ["tenant_name"]

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -18,9 +18,9 @@ describe Chargeback do
       it "groups by project" do
         chargeback_model.set_chargeback_report_options(rpt, "project", "Tag", "Group By", "UTF")
 
-        expect(rpt.cols).to eq(%w[start_date display_range vm_name])
-        expect(rpt.col_order).to eq(%w[vm_name display_range])
-        expect(rpt.sortby).to eq(%w[vm_name start_date])
+        expect(rpt.cols).to eq(%w[start_date display_range project_name])
+        expect(rpt.col_order).to eq(%w[project_name display_range])
+        expect(rpt.sortby).to eq(%w[project_name start_date])
       end
 
       it "groups by other" do
@@ -37,9 +37,9 @@ describe Chargeback do
       it "groups by date-only" do
         chargeback_model.set_chargeback_report_options(rpt, "date-only", "Tag", "Group By", "UTF")
 
-        expect(rpt.cols).to eq(%w[start_date display_range project_name])
-        expect(rpt.col_order).to eq(%w[project_name display_range])
-        expect(rpt.sortby).to eq(%w[project_name start_date])
+        expect(rpt.cols).to eq(%w[start_date display_range])
+        expect(rpt.col_order).to eq(%w[display_range])
+        expect(rpt.sortby).to eq(%w[start_date])
       end
 
       it "groups by project" do

--- a/spec/models/chargeback_spec.rb
+++ b/spec/models/chargeback_spec.rb
@@ -1,0 +1,62 @@
+describe Chargeback do
+  let(:rpt) { MiqReport.new(:db => chargeback_model.name, :headers => [], :col_formats => []) }
+  let(:chargeback_model) { ChargebackVm }
+
+  # called from ReportController::Reports::Editor
+  # must be called on a subclass of Chargeback
+  describe ".set_chargeback_report_options" do
+    context "with ChargebackVm" do
+      let(:chargeback_model) { ChargebackVm }
+      it "groups by date-only" do
+        chargeback_model.set_chargeback_report_options(rpt, "date-only", "Tag", "Group By", "UTF")
+
+        expect(rpt.cols).to eq(%w[start_date display_range])
+        expect(rpt.col_order).to eq(%w[display_range])
+        expect(rpt.sortby).to eq(%w[start_date])
+      end
+
+      it "groups by project" do
+        chargeback_model.set_chargeback_report_options(rpt, "project", "Tag", "Group By", "UTF")
+
+        expect(rpt.cols).to eq(%w[start_date display_range vm_name])
+        expect(rpt.col_order).to eq(%w[vm_name display_range])
+        expect(rpt.sortby).to eq(%w[vm_name start_date])
+      end
+
+      it "groups by other" do
+        chargeback_model.set_chargeback_report_options(rpt, "xx", "Tag", "Group By", "UTF")
+
+        expect(rpt.cols).to eq(%w[start_date display_range vm_name])
+        expect(rpt.col_order).to eq(%w[vm_name display_range])
+        expect(rpt.sortby).to eq(%w[vm_name start_date])
+      end
+    end
+
+    context "with ChargebackContainerProject" do
+      let(:chargeback_model) { ChargebackContainerProject }
+      it "groups by date-only" do
+        chargeback_model.set_chargeback_report_options(rpt, "date-only", "Tag", "Group By", "UTF")
+
+        expect(rpt.cols).to eq(%w[start_date display_range project_name])
+        expect(rpt.col_order).to eq(%w[project_name display_range])
+        expect(rpt.sortby).to eq(%w[project_name start_date])
+      end
+
+      it "groups by project" do
+        chargeback_model.set_chargeback_report_options(rpt, "project", "Tag", "Group By", "UTF")
+
+        expect(rpt.cols).to eq(%w[start_date display_range project_name])
+        expect(rpt.col_order).to eq(%w[project_name display_range])
+        expect(rpt.sortby).to eq(%w[project_name start_date])
+      end
+
+      it "groups by other" do
+        chargeback_model.set_chargeback_report_options(rpt, "xx", "Tag", "Group By", "UTF")
+
+        expect(rpt.cols).to eq(%w[start_date display_range project_name])
+        expect(rpt.col_order).to eq(%w[project_name display_range])
+        expect(rpt.sortby).to eq(%w[project_name start_date])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before

When chargebacks are run for date only, the data is grouped by date, and across all projects. So displaying a project is not correct.

### After

Project is no longer displayed.
The Vm was correctly removed from the report for the vm date-only reports.
Made the changes for the other chargeback reports to properly remove those columns.