### PR TITLE
Refactor `ResourceAction#deliver*` methods

### DIFF
--- a/app/models/dynamic_dialog_field_value_processor.rb
+++ b/app/models/dynamic_dialog_field_value_processor.rb
@@ -5,7 +5,7 @@ class DynamicDialogFieldValueProcessor
 
   def values_from_automate(dialog_field)
     dialog_values = {:dialog => dialog_field.dialog.try(:automate_values_hash)}
-    workspace = dialog_field.resource_action.deliver_to_automate_from_dialog_field(
+    workspace = dialog_field.resource_action.deliver(
       dialog_values,
       dialog_field.dialog.try(:target_resource),
       User.current_user

--- a/app/models/dynamic_dialog_field_value_processor.rb
+++ b/app/models/dynamic_dialog_field_value_processor.rb
@@ -5,13 +5,13 @@ class DynamicDialogFieldValueProcessor
 
   def values_from_automate(dialog_field)
     dialog_values = {:dialog => dialog_field.dialog.try(:automate_values_hash)}
-    workspace = dialog_field.resource_action.deliver(
+    attributes = dialog_field.resource_action.deliver(
       dialog_values,
       dialog_field.dialog.try(:target_resource),
       User.current_user
     )
 
-    dialog_field.normalize_automate_values(workspace.root.attributes)
+    dialog_field.normalize_automate_values(attributes)
   rescue => e
     $log.log_backtrace(e)
 

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -89,6 +89,7 @@ class ResourceAction < ApplicationRecord
   def deliver(dialog_hash_values, target, user)
     _log.info("Running <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
 
-    MiqAeEngine.deliver(automate_queue_hash(target, dialog_hash_values[:dialog], user))
+    workflow = MiqAeEngine.deliver(automate_queue_hash(target, dialog_hash_values[:dialog], user))
+    workflow.root.attributes
   end
 end

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -71,7 +71,7 @@ class ResourceAction < ApplicationRecord
     uri
   end
 
-  def deliver_to_automate_from_dialog(dialog_hash_values, target, user, task_id = nil)
+  def deliver_queue(dialog_hash_values, target, user, task_id = nil)
     _log.info("Queuing <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
     MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
                               :zone     => target.try(:my_zone),
@@ -79,14 +79,14 @@ class ResourceAction < ApplicationRecord
                               :task_id  => "#{self.class.name.underscore}_#{id}")
   end
 
-  def deliver_to_automate_from_dialog_with_miq_task(dialog_hash_values, target, user)
+  def deliver_task(dialog_hash_values, target, user)
     task = MiqTask.create(:name => "Automate method task for open_url", :userid => user.userid)
-    deliver_to_automate_from_dialog(dialog_hash_values, target, user, task.id)
+    deliver_queue(dialog_hash_values, target, user, task.id)
     task.update_status(MiqTask::STATE_QUEUED, MiqTask::STATUS_OK, 'MiqTask has been queued.')
     task.id
   end
 
-  def deliver_to_automate_from_dialog_field(dialog_hash_values, target, user)
+  def deliver(dialog_hash_values, target, user)
     _log.info("Running <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
 
     MiqAeEngine.deliver(automate_queue_hash(target, dialog_hash_values[:dialog], user))

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -44,9 +44,9 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     else
       ra = load_resource_action(values)
       if ra.resource.try(:open_url?)
-        result[:task_id] = ra.deliver_to_automate_from_dialog_with_miq_task(values, @target, @requester)
+        result[:task_id] = ra.deliver_task(values, @target, @requester)
       else
-        ra.deliver_to_automate_from_dialog(values, @target, @requester)
+        ra.deliver_queue(values, @target, @requester)
       end
     end
 

--- a/spec/models/dynamic_dialog_field_value_processor_spec.rb
+++ b/spec/models/dynamic_dialog_field_value_processor_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DynamicDialogFieldValueProcessor do
 
       before do
         User.current_user = user
-        allow(resource_action).to receive(:deliver_to_automate_from_dialog_field).with(
+        allow(resource_action).to receive(:deliver).with(
           {:dialog => "automate_values_hash"},
           "target_resource",
           user
@@ -60,7 +60,7 @@ RSpec.describe DynamicDialogFieldValueProcessor do
 
     context "when there is an error delivering to automate from dialog field" do
       before do
-        allow(resource_action).to receive(:deliver_to_automate_from_dialog_field).and_raise("O noes")
+        allow(resource_action).to receive(:deliver).and_raise("O noes")
       end
 
       it "returns the dialog field's script error values" do

--- a/spec/models/dynamic_dialog_field_value_processor_spec.rb
+++ b/spec/models/dynamic_dialog_field_value_processor_spec.rb
@@ -28,16 +28,14 @@ RSpec.describe DynamicDialogFieldValueProcessor do
     context "when there is no error delivering to automate from dialog field" do
       let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime") }
       let(:workspace_attributes) do
-        double(
-          :attributes => {
-            "sort_by"       => "none",
-            "sort_order"    => "descending",
-            "data_type"     => "datatype",
-            "default_value" => "default",
-            "required"      => true,
-            "values"        => "workspace values"
-          }
-        )
+        {
+          "sort_by"       => "none",
+          "sort_order"    => "descending",
+          "data_type"     => "datatype",
+          "default_value" => "default",
+          "required"      => true,
+          "values"        => "workspace values"
+        }
       end
 
       before do
@@ -46,9 +44,8 @@ RSpec.describe DynamicDialogFieldValueProcessor do
           {:dialog => "automate_values_hash"},
           "target_resource",
           user
-        ).and_return(workspace)
-        allow(workspace).to receive(:root).and_return(workspace_attributes)
-        allow(dialog_field).to receive(:normalize_automate_values).with(workspace_attributes.attributes).and_return(
+        ).and_return(workspace_attributes)
+        allow(dialog_field).to receive(:normalize_automate_values).with(workspace_attributes).and_return(
           "normalized values"
         )
       end

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ResourceAction do
-  context "#deliver_to_automate_from_dialog" do
+  context "#deliver_queue" do
     let(:user) { FactoryBot.create(:user_with_group) }
     let(:zone_name) { "default" }
     let(:ra) { FactoryBot.create(:resource_action) }
@@ -43,7 +43,7 @@ RSpec.describe ResourceAction do
       it "validates queue entry" do
         target             = nil
         expect(MiqQueue).to receive(:put).with(q_options).once
-        ra.deliver_to_automate_from_dialog({}, target, user)
+        ra.deliver_queue({}, target, user)
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe ResourceAction do
         q_args[:object_type] = target.class.base_class.name
         q_args[:object_id]   = target.id
         expect(MiqQueue).to receive(:put).with(q_options).once
-        ra.deliver_to_automate_from_dialog({}, target, user)
+        ra.deliver_queue({}, target, user)
       end
     end
 
@@ -65,14 +65,14 @@ RSpec.describe ResourceAction do
         klass = targets.first.id.class
         ae_attributes['Array::target_object_ids'] = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
         expect(MiqQueue).to receive(:put).with(q_options).once
-        ra.deliver_to_automate_from_dialog({}, targets, user)
+        ra.deliver_queue({}, targets, user)
       end
     end
 
-    context '#deliver_to_automate_from_dialog_with_miq_task' do
-      it '' do
-        allow(ra).to(receive(:deliver_to_automate_from_dialog))
-        miq_task = MiqTask.find(ra.deliver_to_automate_from_dialog_with_miq_task({}, nil, user))
+    context '#deliver_task' do
+      it 'creates a task' do
+        allow(ra).to(receive(:deliver_queue))
+        miq_task = MiqTask.find(ra.deliver_task({}, nil, user))
         expect(miq_task.state).to(eq(MiqTask::STATE_QUEUED))
         expect(miq_task.status).to(eq(MiqTask::STATUS_OK))
         expect(miq_task.message).to(eq('MiqTask has been queued.'))

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ResourceActionWorkflow do
           it "calls automate" do
             EvmSpecHelper.local_miq_server
             expect(subject).not_to receive(:make_request)
-            expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog).and_call_original
+            expect_any_instance_of(ResourceAction).to receive(:deliver_queue).and_call_original
             expect(MiqAeEngine).to receive(:deliver_queue) # calls into automate
             expect(AuditEvent).not_to receive(:success)
             expect(dialog_fields(@dialog)).to eq("field_2" => nil, "field_1" => nil)
@@ -114,7 +114,7 @@ RSpec.describe ResourceActionWorkflow do
 
           it "calls automate" do
             expect(subject).not_to receive(:make_request)
-            expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog)
+            expect_any_instance_of(ResourceAction).to receive(:deliver_queue)
 
             subject.submit_request(data)
             expect(dialog_fields(@dialog)).to eq("field_1" => nil, "field_2" => nil)
@@ -122,7 +122,7 @@ RSpec.describe ResourceActionWorkflow do
 
           it "calls automate with miq_task" do
             options[:open_url] = true
-            allow(resource_action).to(receive(:deliver_to_automate_from_dialog))
+            allow(resource_action).to(receive(:deliver_queue))
             allow(subject).to(receive(:load_resource_action)).and_return(resource_action)
 
             result   = subject.submit_request
@@ -164,7 +164,7 @@ RSpec.describe ResourceActionWorkflow do
           it "calls automate" do
             EvmSpecHelper.local_miq_server
             expect(subject).not_to receive(:make_request)
-            expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog).and_call_original
+            expect_any_instance_of(ResourceAction).to receive(:deliver_queue).and_call_original
             expect(MiqAeEngine).to receive(:deliver_queue) # calls into automate
             expect(AuditEvent).not_to receive(:success)
             response = subject.submit_request(data)
@@ -184,7 +184,7 @@ RSpec.describe ResourceActionWorkflow do
 
           it "calls automate" do
             expect(subject).not_to receive(:make_request)
-            expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog)
+            expect_any_instance_of(ResourceAction).to receive(:deliver_queue)
 
             subject.submit_request(data)
             expect(dialog_fields(@dialog)).to eq("field_2" => nil, "field_1" => "new_value")
@@ -192,7 +192,7 @@ RSpec.describe ResourceActionWorkflow do
 
           it "calls automate with miq_task" do
             options[:open_url] = true
-            allow(resource_action).to(receive(:deliver_to_automate_from_dialog))
+            allow(resource_action).to(receive(:deliver_queue))
             allow(subject).to(receive(:load_resource_action)).and_return(resource_action)
 
             result   = subject.submit_request


### PR DESCRIPTION
These methods embed `_automate_` in the method name precluding other backend runtimes.

Broken into two commits:
1. Rename the methods from `deliver_to_automate_*` to a simpler `deliver` for "synchronous" and `deliver_queue` for "asynchronous"
2. Return the `workspace.root.attributes` to the caller rather than the whole `workspace` allowing for non-automate `ResourceActions`