### PR TITLE
storage service edit mode: check which attached resources are compliant to selected capabilities

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6473,6 +6473,10 @@
       :description: Remove a Storage Service
       :feature_type: admin
       :identifier: storage_service_delete
+    - :name: Check Compliant Resources
+      :description: Given a set of capabilities, check which attached resources will comply
+      :feature_type: admin
+      :identifier: check_compliant_resources
 
   # Volume Mapping
 - :name: Volume Mapping


### PR DESCRIPTION
issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/8749

added button in service edit mode which enables user to check what currently attached resources will comply with the selected capabilities.

this PR adds the necessary methods for this action in the main `storage_service` model and in `miq_product_features`