### PR TITLE
Drop validate_credentials_task

### DIFF
--- a/app/models/mixins/verify_credentials_mixin.rb
+++ b/app/models/mixins/verify_credentials_mixin.rb
@@ -2,33 +2,6 @@ module VerifyCredentialsMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def validate_credentials_task(args, user_id, zone)
-      task_opts = {
-        :action => "Validate EMS Provider Credentials",
-        :userid => user_id
-      }
-
-      queue_opts = {
-        :args        => [*args],
-        :class_name  => name,
-        :method_name => "raw_connect?",
-        :queue_name  => "generic",
-        :role        => "ems_operations",
-        :zone        => zone
-      }
-
-      task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
-      task = MiqTask.wait_for_taskid(task_id, :timeout => 30)
-
-      if task.nil?
-        error_message = "Task Error"
-      elsif MiqTask.status_error?(task.status) || MiqTask.status_timeout?(task.status)
-        error_message = task.message
-      end
-
-      [error_message.blank?, error_message]
-    end
-
     def verify_credentials_task(userid, zone, options)
       task_opts = {
         :action => "Verify EMS Provider Credentials",

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -267,43 +267,6 @@ RSpec.describe AuthenticationMixin do
       end
     end
 
-    context ".validate_credentials_task" do
-      let(:args) { %w(userid password foo) }
-      let(:queue_opts) do
-        {
-          :args        => [*args],
-          :class_name  => "ExtManagementSystem",
-          :method_name => "raw_connect?",
-          :queue_name  => "generic",
-          :role        => "ems_operations",
-          :zone        => 'zone'
-        }
-      end
-      let(:task_opts) do
-        {
-          :action => "Validate EMS Provider Credentials",
-          :userid => 'userid'
-        }
-      end
-
-      it "returns success with no error message" do
-        ok_task = FactoryBot.create(:miq_task, :status => 'Ok')
-        allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
-        allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(ok_task)
-
-        expect(ExtManagementSystem.validate_credentials_task(args, 'userid', 'zone')).to eq([true, nil])
-      end
-
-      it "returns failure with an error message" do
-        message = 'Login failed due to a bad username or password.'
-        error_task = FactoryBot.create(:miq_task, :status => 'Error', :message => message)
-        allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
-        allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(error_task)
-
-        expect(ExtManagementSystem.validate_credentials_task(args, 'userid', 'zone')).to eq([false, message])
-      end
-    end
-
     context "with a host and ems" do
       before do
         @host         = FactoryBot.create(:host_vmware_esx_with_authentication)


### PR DESCRIPTION
For the validate button, we are using `verify_credentials{_task}`
This code is not used

also related to https://github.com/ManageIQ/manageiq-providers-openstack/pull/846
But they do not necessarily depend upon each other. (since neither are called)

WIP: I have not tested that Openstack still works with this code removed.