### PR TITLE
Dont queue refresh unsupported ems

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -34,7 +34,10 @@ module EmsRefresh
             t.manager
           end
 
-      h[e] << t unless e.nil?
+      next if e.nil?
+      next unless e.supports?(:refresh_ems) # Remove targets from any EMS that doesn't support refresh_ems
+
+      h[e] << t
     end
 
     # Queue the refreshes

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -18,6 +18,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :Job
   require_nested :Playbook
 
+  supports_not :refresh_ems
+
   def self.ems_type
     @ems_type ||= "embedded_ansible_automation".freeze
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -625,7 +625,8 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
   # @returns Hash<class, Integer> Hash of ems_class => refresh_interval
   def schedule_settings_for_ems_refresh
     ExtManagementSystem.permitted_subclasses.each.with_object({}) do |klass, hash|
-      next unless klass.ems_type
+      next if klass.ems_type.nil? || !klass.supports?(:refresh_ems)
+
       every = ::Settings.ems_refresh[klass.ems_type].try(:refresh_interval) || ::Settings.ems_refresh.refresh_interval
       every = every.respond_to?(:to_i_with_method) ? every.to_i_with_method : every.to_i
       hash[klass] = every unless every == 0

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -1,6 +1,8 @@
 require "inventory_refresh"
 
 RSpec.describe EmsRefresh do
+  include Spec::Support::SupportsHelper
+
   context ".queue_refresh" do
     before do
       zone = EvmSpecHelper.local_miq_server.zone
@@ -10,6 +12,12 @@ RSpec.describe EmsRefresh do
     it "with Ems" do
       target = @ems
       queue_refresh_and_assert_queue_item(target, [target])
+    end
+
+    it "with Ems that doesn't support refresh_ems" do
+      stub_supports_not(@ems, :refresh_ems)
+      described_class.queue_refresh(@ems)
+      expect(MiqQueue.count).to be_zero
     end
 
     it "with InventoryRefresh::Target" do

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -499,6 +499,7 @@ RSpec.describe MiqScheduleWorker::Runner do
 
     it "#schedule_settings_for_ems_refresh (private)" do
       _ = ManageIQ::Providers::Amazon::CloudManager # FIXME: Loader
+      _ = ManageIQ::Providers::EmbeddedAnsible::AutomationManager # FIXME: Loader
 
       stub_settings(
         :ems_refresh => {
@@ -509,8 +510,14 @@ RSpec.describe MiqScheduleWorker::Runner do
 
       settings = @schedule_worker.send(:schedule_settings_for_ems_refresh)
 
-      expect(settings[ManageIQ::Providers::Vmware::InfraManager]).to eq(86_400) # Uses default
-      expect(settings[ManageIQ::Providers::Amazon::CloudManager]).to eq(900)    # Uses override
+      # Uses default
+      expect(settings[ManageIQ::Providers::Vmware::InfraManager]).to eq(86_400)
+
+      # Uses override
+      expect(settings[ManageIQ::Providers::Amazon::CloudManager]).to eq(900)
+
+      # Skips providers not supporting refresh_ems
+      expect(settings.keys).not_to include(ManageIQ::Providers::EmbeddedAnsible::AutomationManager)
     end
 
     def while_calling_job(job)


### PR DESCRIPTION
Some providers don't have a Refresher class and do not implement refresh (specifically the embedded automation managers: `EmbeddedAnsible::AutomationManager` and `Workflows::AutomationManager`)

These end up being included in the `MiqScheduleWorker::Jobs#ems_refresh_timer` and fail later on due to missing credentials which clutters the logs with errors for not a "real" issue.