### PR TITLE
730715 custom task queuing massage

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -70,9 +70,9 @@ class CloudVolume < ApplicationRecord
   # instance and a userid are mandatory. Any +options+ are forwarded as
   # arguments to the +create_volume+ method.
   #
-  def self.create_volume_queue(userid, ext_management_system, options = {})
-    task_opts = {
-      :action => "creating Cloud Volume for user #{userid}",
+  def self.create_volume_queue(userid, ext_management_system, options = {}, task_opts = nil)
+    task_opts ||= {
+      :action => "Creating Cloud Volume for user #{userid}",
       :userid => userid
     }
 

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -70,11 +70,11 @@ class CloudVolume < ApplicationRecord
   # instance and a userid are mandatory. Any +options+ are forwarded as
   # arguments to the +create_volume+ method.
   #
-  def self.create_volume_queue(userid, ext_management_system, options = {}, task_opts = nil)
-    task_opts ||= {
+  def self.create_volume_queue(userid, ext_management_system, options = {}, task_opts = {})
+    task_opts.reverse_merge!(
       :action => "Creating Cloud Volume for user #{userid}",
       :userid => userid
-    }
+    )
 
     queue_opts = {
       :class_name  => 'CloudVolume',

--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -27,8 +27,8 @@ class HostInitiator < ApplicationRecord
     ext_management_system&.class_by_ems(:HostInitiator)
   end
 
-  def self.create_host_initiator_queue(userid, ext_management_system, options = {})
-    task_opts = {
+  def self.create_host_initiator_queue(userid, ext_management_system, options = {}, task_opts = nil)
+    task_opts ||= {
       :action => "creating HostInitiator for user #{userid}",
       :userid => userid
     }

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -102,10 +102,10 @@ class PhysicalStorage < ApplicationRecord
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
-  def self.create_physical_storage_queue(userid, ext_management_system, options = {})
+  def self.create_physical_storage_queue(userid, ext_management_system, options = {}, task_opts = nil)
     options["password"] = ManageIQ::Password.encrypt(options["password"])
 
-    task_opts = {
+    task_opts ||= {
       :action => "creating PhysicalStorage for user #{userid}",
       :userid => userid
     }

--- a/app/models/storage_service.rb
+++ b/app/models/storage_service.rb
@@ -20,8 +20,8 @@ class StorageService < ApplicationRecord
     ext_management_system&.class_by_ems(:StorageService)
   end
 
-  def self.create_storage_service_queue(userid, ext_management_system, options = {})
-    task_opts = {
+  def self.create_storage_service_queue(userid, ext_management_system, options = {}, task_opts = nil)
+    task_opts ||= {
       :action => "creating Storage Service for user #{userid}",
       :userid => userid
     }


### PR DESCRIPTION
currently miq task queue shows a success message for sending a request to the backend as if the backend actually succeeded in performing the request, even if the request subsequently fails:
<img width="1193" alt="60eca5a2-9295-43dc-a38e-35e757503886" src="https://user-images.githubusercontent.com/74841666/232318943-56385d20-747b-468b-8b31-646a56550a12.png">

we changed this inside task_opts so that the action label will show queuing massage correctly:
<img width="2277" alt="Screenshot 2023-04-17 at 13 44 59" src="https://user-images.githubusercontent.com/74841666/232462339-99680625-b496-483d-b7b8-78f6b291e444.png">