### PR TITLE
Fixed massage emsrefresh completed successfully

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -16,8 +16,8 @@ module EmsRefresh
 
   cache_with_timeout(:queue_timeout) { MiqEmsRefreshWorker.worker_settings[:queue_timeout] || 60.minutes }
 
-  def self.queue_refresh_task(target, id = nil)
-    queue_refresh(target, id, :create_task => true)
+  def self.queue_refresh_task(targets, id = nil)
+    queue_refresh(targets, id, :create_task => true)
   end
 
   def self.queue_refresh(target, id = nil, opts = {})


### PR DESCRIPTION
currently there's no dedicated success message for propagating success from autosde backend to miq_task.
we only get an EmsRefresh success msg like:

<img width="1192" alt="a93b3af1-f7cb-4a64-ad4d-3b5b87161e8c" src="https://user-images.githubusercontent.com/74841666/232780831-481d98cb-d573-419e-b2da-06c3059b4eca.png">

After the changes we made it looks like this : 
<img width="1506" alt="Screenshot 2023-04-18 at 15 43 35" src="https://user-images.githubusercontent.com/74841666/232781106-a8b37d14-1afd-4428-b6db-b55085aabe38.png">

- [ ] Provider: https://github.com/ManageIQ/manageiq-providers-autosde/pull/228
