### PR TITLE
[WIP] Allow for other Embedded ConfigurationScriptSources

### DIFF
--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -223,6 +223,14 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Configur
         )
       end
 
+      it "deletes old playbooks" do
+        record = build_record
+        record.configuration_script_payloads.create!(:name => "deleted.yaml")
+        record.sync
+
+        expect(playbooks_for(record)).to eq(%w[hello_world.yaml])
+      end
+
       context "with a nested playbooks dir" do
         let(:nested_repo) { File.join(clone_dir, "hello_world_nested") }
 


### PR DESCRIPTION
Currently the bulk of the logic for syncing configuration_script_sources from git_repositories lives in `EmbeddedAnsible`.  This makes it impractical to share this with other Embedded managers.

This moves the code out of `EmbeddedAnsible` and up into `EmbeddedAutomationManager`