### PR TITLE
fix refresh for storage manager models

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6449,7 +6449,7 @@
     :identifier: storage_service_control
     :children:
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Physical Storages
+      :description: Refresh the storage manager of this storage service
       :feature_type: control
       :identifier: storage_service_refresh
     - :name: Edit Tags
@@ -6499,7 +6499,7 @@
     :identifier: volume_mapping_control
     :children:
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Volume Mapping
+      :description: Refresh the storage manager of this volume mapping
       :feature_type: control
       :identifier: volume_mapping_refresh
     - :name: Edit Tags
@@ -6545,7 +6545,7 @@
     :identifier: host_initiator_control
     :children:
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Host Initiators
+      :description: Refresh the storage manager of this host initiator
       :feature_type: control
       :identifier: host_initiator_refresh
     - :name: Edit Tags
@@ -6595,7 +6595,7 @@
     :identifier: host_initiator_group_control
     :children:
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Host Initiator Groups
+      :description: Refresh the storage manager of this host initiator group
       :feature_type: control
       :identifier: host_initiator_group_refresh
     - :name: Edit Tags
@@ -6854,7 +6854,7 @@
     :identifier: physical_storage_control
     :children:
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Physical Storages
+      :description: Refresh the storage manager of this physical storages
       :feature_type: control
       :identifier: physical_storage_refresh
     - :name: Edit Tags


### PR DESCRIPTION
fix refresh for physical_storage, cloud_volume, host_initiator, host_initiator_group, volume_mapping, storage_service.

refresh button now works on show_list view when selecting 1+ record(s), both from the general show_list of each model and from the provider show_list (ems_storage/<ems_id>?display=model_name).
it also works from the show (textual summary) view of a specific record.

- [ ] related ui repo PR (see demo video there): https://github.com/ManageIQ/manageiq-ui-classic/pull/8756

**_should the model refresh action be added to `db/fixtures/miq_user_roles.yml`? it seems to work without adding it there.._**