### PR TITLE
Add PhysicalInfraManager::Vm subclass

### DIFF
--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class PhysicalInfraManager < BaseManager
+    require_nested :Vm
+
     include SupportsFeatureMixin
 
     has_many :physical_chassis,  :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system

--- a/app/models/manageiq/providers/physical_infra_manager/vm.rb
+++ b/app/models/manageiq/providers/physical_infra_manager/vm.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::PhysicalInfraManager::Vm < ::Vm
+  default_value_for :cloud, false
+
+  def self.display_name(number = 1)
+    n_('Virtual Machine', 'Virtual Machines', number)
+  end
+end


### PR DESCRIPTION
Cisco Intersight has a `PhysicalInfraManager::Vm` subclass which should have a core equivalent.

ref: https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/91/files#diff-0405b5850261249103e58366a2e1d5c6a8f205da155af3fd00881ce86dd8feccL2