### PR TITLE
introduce Chargeback group_by date-first

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -101,6 +101,8 @@ class Chargeback < ActsAsArModel
       [{:key => "#{tenant ? tenant.id : 'none'}_#{ts_key}"}]
     elsif @options.group_by_date_only?
       [{:key => ts_key.to_s}]
+    elsif @options.group_by_date_first?
+      [{:key => "#{ts_key}_#{consumption.resource_id}"}]
     else
       [{:key => default_key(consumption, ts_key)}]
     end
@@ -247,8 +249,13 @@ class Chargeback < ActsAsArModel
                   else                  report_static_cols
                   end
     rpt.cols      = %w(start_date display_range) + static_cols
-    rpt.col_order = static_cols + ["display_range"]
-    rpt.sortby    = static_cols + ["start_date"]
+    if group_by == "date-first"
+      rpt.col_order = ["display_range"] + static_cols
+      rpt.sortby    = (["start_date"] + static_cols)
+    else
+      rpt.col_order = static_cols + ["display_range"]
+      rpt.sortby    = (static_cols + ["start_date"])
+    end
 
     rpt.col_order.each do |c|
       header_column = if (c == report_tag_field && header_for_tag)

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -18,8 +18,6 @@ class Chargeback
     :ext_options,
     :include_metrics,      # enable charging allocated resources with C & U
     :method_for_allocated_metrics,
-    :group_by_tenant?,
-    :group_by_date_only?,
     :cumulative_rate_calculation,
   ) do
     def self.new_from_h(hash)
@@ -146,6 +144,10 @@ class Chargeback
 
     def group_by_tenant?
       self[:groupby] == 'tenant'
+    end
+
+    def group_by_date_first?
+      self[:groupby] == 'date-first'
     end
 
     def group_by_date_only?

--- a/spec/models/chargeback/report_options_spec.rb
+++ b/spec/models/chargeback/report_options_spec.rb
@@ -1,0 +1,36 @@
+describe Chargeback::ReportOptions do
+  describe "#group_by_tenant?" do
+    it "detects groupby - true" do
+      report_options = described_class.new_from_h(:groupby => "tenant")
+      expect(report_options.group_by_tenant?).to eq(true)
+    end
+    it "detects groupby - false" do
+      report_options = described_class.new_from_h(:groupby => "date")
+      expect(report_options.group_by_tenant?).to eq(false)
+    end
+  end
+
+  describe "#group_by_date_only?" do
+    it "detects groupby - true" do
+      report_options = described_class.new_from_h(:groupby => "date-only")
+      expect(report_options.group_by_date_only?).to eq(true)
+    end
+
+    it "detects groupby - false" do
+      report_options = described_class.new_from_h(:groupby => "date")
+      expect(report_options.group_by_date_only?).to eq(false)
+    end
+  end
+
+  describe "#group_by_date_first?" do
+    it "detects groupby - true" do
+      report_options = described_class.new_from_h(:groupby => "date-first")
+      expect(report_options.group_by_date_first?).to eq(true)
+    end
+
+    it "detects groupby - false" do
+      report_options = described_class.new_from_h(:groupby => "date")
+      expect(report_options.group_by_date_only?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
The original drop down group by "Date" (now called "Project and Date") is option `date` and displays:

## Before

```
# UI dropdown: "Date and Project"
# option parameter: date
project1
  date1
  date2
project2
  date1
  date2
```

## After

```
# UI dropdown: "Project and Date"
# option parameter: date
project1
  date1
  date2
project2
  date1
  date2
```

```
# UI Dropdown: "Date and Project"
# option parameter: date-first
date1
  project1
  project2
date2
  project1
  project2
```

## Unchanged

```
# UI dropdown: "Date Only"
# option parameter: date-only
date1
date2
```


This can be merged before the UI, but does require a change in the ui to give users the option to choose pick: https://github.com/ManageIQ/manageiq-ui-classic/pull/8763
