### PR TITLE
Add MiqTask reference to ConfigurationScript

### DIFF
--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -7,8 +7,9 @@ class ConfigurationScriptBase < ApplicationRecord
 
   belongs_to :inventory_root_group, :class_name => "EmsFolder"
   belongs_to :manager,              :class_name => "ExtManagementSystem"
-
   belongs_to :parent,               :class_name => "ConfigurationScriptBase"
+  belongs_to :miq_task
+
   has_many   :children,
              :class_name  => "ConfigurationScriptBase",
              :foreign_key => "parent_id",


### PR DESCRIPTION
Allows us to track running configuration_scripts with an MiqTask.

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/688

Dependents:
- [ ] https://github.com/ManageIQ/manageiq-providers-workflows/pull/12

https://github.com/ManageIQ/manageiq/issues/22311