### PR TITLE
Force i18n 1.12.0 to avoid frozen string error with 1.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "fast_gettext",                     "~>2.0.1"
 gem "gettext_i18n_rails",               "~>1.7.2"
 gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
+gem "i18n",                             "=1.12.0"  # Temporary hack because 1.13.0 is causing can't modify frozen String: "Bytes" in ui-classic spec/helpers/storage_helper/textual_summary_spec.rb
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.0",             :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime


### PR DESCRIPTION
We're seeing an error in ui classic with 1.13.0:
can't modify frozen String: "Bytes" in spec/helpers/storage_helper/textual_summary_spec.rb

We can allow 1.13.0 once we determine the cause/fix.