### PR TITLE
Remove extra newlines from persister/builder/infra

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -273,9 +273,6 @@ module ManageIQ::Providers
           add_dependency_attributes(:vms =>persister.collections.values_at(:vms, :miq_templates, :vms_and_templates).compact)
         end
 
-
-
-
         def iso_images
           add_properties(
             :parent_inventory_collections => %i[storages],


### PR DESCRIPTION
I saw this while looking through this file, went to the `git blame` and it was me!  Turns out another PR removed a bunch of methods that were in the middle but left all of the surrounding newlines making it look like it was all mine :laughing: 