### PR TITLE
Fetch playbook payload from embedded_ansible repos

### DIFF
--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -213,6 +213,16 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Configur
         expect(playbooks_for(record)).to eq(%w[hello_world.yaml])
       end
 
+      it "saves the playbook payload" do
+        record = build_record
+
+        expect(record.configuration_script_payloads.first).to have_attributes(
+          :name         => "hello_world.yaml",
+          :payload      => a_string_including("msg: \"Hello World! (from hello_world.yaml)\""),
+          :payload_type => "yaml"
+        )
+      end
+
       context "with a nested playbooks dir" do
         let(:nested_repo) { File.join(clone_dir, "hello_world_nested") }
 


### PR DESCRIPTION
When pulling in playbooks from embedded_ansible repositories also fetch the playbook content

https://github.com/ManageIQ/manageiq-schema/pull/688 added the payload and payload_type columns so that ASL files can be run but we can use this for embedded ansible as well.
