### PR TITLE
Add CustomizationScriptPayload as option for dynamic dialogs

### DIFF
--- a/app/models/configuration_script_payload.rb
+++ b/app/models/configuration_script_payload.rb
@@ -6,4 +6,8 @@ class ConfigurationScriptPayload < ConfigurationScriptBase
   def self.base_model
     ConfigurationScriptPayload
   end
+
+  def run(*)
+    raise NotImplementedError, _("run must be implemented in a subclass")
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < Manage
     n_('Playbook (Embedded Ansible)', 'Playbooks (Embedded Ansible)', number)
   end
 
-  def run(vars = {})
+  def run(vars = {}, _userid = nil)
     workflow = ManageIQ::Providers::AnsiblePlaybookWorkflow
 
     extra_vars = build_extra_vars(vars[:extra_vars])

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -1,6 +1,7 @@
 class ResourceAction < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :configuration_template, :polymorphic => true
+  belongs_to :configuration_script
   belongs_to :dialog
 
   serialize  :ae_attributes, Hash

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -11,7 +11,7 @@ class ResourceAction < ApplicationRecord
   def ensure_configuration_script_or_automate
     return if configuration_script_payload.nil? || fqname.blank?
 
-    errors.add(:configuration_script_id, N_("Cannot have configuration_script_id and ae_namespace, ae_class, and ae_instance present"))
+    errors.add(:configuration_script_id, N_("cannot have configuration_script_id and ae_namespace, ae_class, and ae_instance present"))
   end
 
   PROVISION   = 'Provision'.freeze

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -85,7 +85,7 @@ class ResourceAction < ApplicationRecord
     _log.info("Queuing <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
 
     if configuration_script_payload
-      configuration_script_payload.execute(:run_by_userid => user.userid, :inputs => dialog_hash_values)
+      configuration_script_payload.run(dialog_hash_values, user.userid)
     else
       MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
                                 :zone     => target.try(:my_zone),

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -1,7 +1,7 @@
 class ResourceAction < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :configuration_template, :polymorphic => true
-  belongs_to :configuration_script
+  belongs_to :configuration_script_payload, :foreign_key => :configuration_script_id
   belongs_to :dialog
 
   serialize  :ae_attributes, Hash
@@ -9,7 +9,7 @@ class ResourceAction < ApplicationRecord
   validate :ensure_configuration_script_or_automate
 
   def ensure_configuration_script_or_automate
-    return if configuration_script_id.nil? || fqname.nil?
+    return if configuration_script_payload.nil? || fqname.blank?
 
     errors.add(:configuration_script_id, N_("Cannot have configuration_script_id and ae_namespace, ae_class, and ae_instance present"))
   end
@@ -60,8 +60,6 @@ class ResourceAction < ApplicationRecord
   end
 
   def fqname
-    return if ae_namespace.nil? && ae_class.nil? && ae_instance.nil?
-
     MiqAeEngine::MiqAePath.new(
       :ae_namespace => ae_namespace,
       :ae_class     => ae_class,
@@ -85,10 +83,15 @@ class ResourceAction < ApplicationRecord
 
   def deliver_queue(dialog_hash_values, target, user, task_id = nil)
     _log.info("Queuing <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
-    MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
-                              :zone     => target.try(:my_zone),
-                              :priority => MiqQueue::HIGH_PRIORITY,
-                              :task_id  => "#{self.class.name.underscore}_#{id}")
+
+    if configuration_script_payload
+      configuration_script_payload.execute(:run_by_userid => user.userid, :inputs => dialog_hash_values)
+    else
+      MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
+                                :zone     => target.try(:my_zone),
+                                :priority => MiqQueue::HIGH_PRIORITY,
+                                :task_id  => "#{self.class.name.underscore}_#{id}")
+    end
   end
 
   def deliver_task(dialog_hash_values, target, user)
@@ -101,7 +104,13 @@ class ResourceAction < ApplicationRecord
   def deliver(dialog_hash_values, target, user)
     _log.info("Running <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
 
-    workflow = MiqAeEngine.deliver(automate_queue_hash(target, dialog_hash_values[:dialog], user))
-    workflow.root.attributes
+    if configuration_script_payload
+      task = MiqTask.wait_for_taskid(deliver_queue(dialog_hash_values, target, user))
+      configuration_script = ConfigurationScript.find(task.context_data[:workflow_instance_id])
+      configuration_script.output
+    else
+      workflow = MiqAeEngine.deliver(automate_queue_hash(target, dialog_hash_values[:dialog], user))
+      workflow.root.attributes
+    end
   end
 end

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -6,6 +6,14 @@ class ResourceAction < ApplicationRecord
 
   serialize  :ae_attributes, Hash
 
+  validate :ensure_configuration_script_or_automate
+
+  def ensure_configuration_script_or_automate
+    return if configuration_script_id.nil? || fqname.nil?
+
+    errors.add(:configuration_script_id, N_("Cannot have configuration_script_id and ae_namespace, ae_class, and ae_instance present"))
+  end
+
   PROVISION   = 'Provision'.freeze
   RETIREMENT  = 'Retirement'.freeze
   RECONFIGURE = 'Reconfigure'.freeze
@@ -52,10 +60,13 @@ class ResourceAction < ApplicationRecord
   end
 
   def fqname
+    return if ae_namespace.nil? && ae_class.nil? && ae_instance.nil?
+
     MiqAeEngine::MiqAePath.new(
       :ae_namespace => ae_namespace,
       :ae_class     => ae_class,
-      :ae_instance  => ae_instance).to_s
+      :ae_instance  => ae_instance
+    ).to_s
   end
   alias_method :ae_path, :fqname
 

--- a/spec/lib/task_helpers/exports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/exports/custom_buttons_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
                     "ae_attributes"               => {},
                     "configuration_template_id"   => nil,
                     "configuration_template_type" => nil,
+                    "configuration_script_id"     => nil,
                     "resource_type"               => "CustomButton"
                   }
                 }]
@@ -270,6 +271,7 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
                 "ae_attributes"               => {},
                 "configuration_template_id"   => nil,
                 "configuration_template_type" => nil,
+                "configuration_script_id"     => nil,
                 "dialog_label"                => "label1"
               }
             }]

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe ResourceAction do
       end
     end
 
+    context 'with configuration_script_payload' do
+      let(:configuration_script_payload) { FactoryBot.create(:configuration_script_payload) }
+
+      it 'prevents both configuration_script_payload and ae_path from being set' do
+        ra.configuration_script_payload = configuration_script_payload
+        ra.fqname = "/NAMESPACE/CLASS/INSTANCE"
+
+        expect { ra.save! }.to raise_exception(ActiveRecord::RecordInvalid, "Validation failed: ResourceAction: Configuration script cannot have configuration_script_id and ae_namespace, ae_class, and ae_instance present")
+      end
+    end
+
     context '#deliver_task' do
       it 'creates a task' do
         allow(ra).to(receive(:deliver_queue))

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -97,6 +97,22 @@ RSpec.describe ResourceAction do
     end
   end
 
+  describe "#deliver" do
+    context 'with configuration_script_payload' do
+      let(:configuration_script_payload) { FactoryBot.create(:configuration_script_payload) }
+      let(:configuration_script)         { FactoryBot.create(:configuration_script, :parent => configuration_script_payload, :output => output) }
+      let(:output)                       { {"hello" => "world"} }
+
+      let(:ra)   { FactoryBot.create(:resource_action, :configuration_script_payload => configuration_script_payload) }
+      let(:task) { FactoryBot.create(:miq_task, :state => MiqTask::STATE_FINISHED, :context_data => {:workflow_instance_id => configuration_script.id}) }
+
+      it "calls deliver_queue" do
+        expect(configuration_script_payload).to receive(:run).with({}, user.userid).and_return(task.id)
+        expect(ra.deliver({}, nil, user)).to eq(output)
+      end
+    end
+  end
+
   context "uri validation" do
     let(:ra) do
       FactoryBot.build(:resource_action,


### PR DESCRIPTION
Add a customization_script_id to `ResourceAction` and allow for customization_scripts to be run for dynamic dialogs via ResourceActions

[Screencast from 2023-05-01 15-41-27.webm](https://user-images.githubusercontent.com/12851112/235518150-bbf736d6-6916-479f-96e2-f08159ad9d77.webm)

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/690

TODO:
- [ ] Specs for resource_actions with workflows

NOTES:
- [ ] This depends on `ManageIQ::Providers::Workflows::AutomationManager::Workflow#execute`, is there a generic `ConfigurationScriptPayload#execute` equivalent we could use?  This would allow for ansible-playbooks to be used as well in the future
- [ ] I don't like the `if configuration_script_payload; else; end` but it seemed impractical to subclass this, resource_actions are automatically initialized in a number of places making it difficult to always set a `:type` up front