### PR TITLE
[WIP] Zeitwerk

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -96,6 +96,11 @@ module Vmdb
 
     config.autoload_paths += config.eager_load_paths
 
+    config.autoloader = :zeitwerk
+
+    # config.load_defaults 6.1
+    # Disable defaults as ActiveRecord::Base.belongs_to_required_by_default = true causes MiqRegion.seed to fail validation on belongs_to maintenance zone
+
     # NOTE:  If you are going to make changes to autoload_paths, please make
     # sure they are all strings.  Rails will push these paths into the
     # $LOAD_PATH.

--- a/config/application.rb
+++ b/config/application.rb
@@ -164,6 +164,15 @@ module Vmdb
       Vmdb::Loggers.apply_config(::Settings.log)
     end
 
+    initializer :eager_load_all_the_things, :after => :load_config_initializers do
+      if ENV['DEBUG_MANAGEIQ_ZEITWERK'].present?
+        config.eager_load_paths += config.autoload_paths
+        Vmdb::Plugins.each do |plugin|
+          plugin.config.eager_load_paths += plugin.config.autoload_paths
+        end
+      end
+    end
+
     config.after_initialize do
       Vmdb::Initializer.init
       ActiveRecord::Base.connection_pool.release_connection

--- a/config/initializers/yaml_autoloader.rb
+++ b/config/initializers/yaml_autoloader.rb
@@ -7,6 +7,9 @@
 #
 # Note, this is used to autoload constants serialized as yaml from one process and loaded in another such as through
 # args in the MiqQueue. An alternative would be to eager load all of our autoload_paths in all processes.
+#
+# This is still needed in some areas for zeitwerk, such as YAML files for tests in the manageiq-providers-vmware
+# that reference a constant: RbVmomi::VIM::TaskEvent
 Psych::Visitors::ToRuby.prepend Module.new {
   def resolve_class(klass_name)
     (class_loader.class != Psych::ClassLoader::Restricted && klass_name && klass_name.safe_constantize) || super

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,4 +1,9 @@
 if Rails.application.config.autoloader == :zeitwerk && Rails.autoloaders.main
+  if ENV['DEBUG_MANAGEIQ_ZEITWERK'].present?
+    Zeitwerk::Loader.default_logger = method(:puts)
+    Rails.autoloaders.main.logger = Logger.new($stdout)
+  end
+
   # These specific directories are for code organization, not namespacing:
   # TODO: these should be either renamed with good names, the intermediate directory removed
   # and/or both.

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -2,4 +2,10 @@ if Rails.application.config.autoloader == :zeitwerk && Rails.autoloaders.main
   # These specific directories are for code organization, not namespacing:
   Rails.autoloaders.main.collapse(Rails.root.join("lib/manageiq/reporting/charting"))
   Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
+
+  # requires qpid, which is an optional dependency because LOL mac
+  if RUBY_PLATFORM.include?("darwin")
+    message_handler_path = Pathname.new(Vmdb::Plugins.paths[ManageIQ::Providers::Nuage::Engine]).join("app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb")
+    Rails.autoloaders.main.ignore(message_handler_path)
+  end
 end

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,5 @@
+if Rails.application.config.autoloader == :zeitwerk && Rails.autoloaders.main
+  # These specific directories are for code organization, not namespacing:
+  Rails.autoloaders.main.collapse(Rails.root.join("lib/manageiq/reporting/charting"))
+  Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
+end

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,7 +1,10 @@
 if Rails.application.config.autoloader == :zeitwerk && Rails.autoloaders.main
   # These specific directories are for code organization, not namespacing:
+  # TODO: these should be either renamed with good names, the intermediate directory removed
+  # and/or both.
   Rails.autoloaders.main.collapse(Rails.root.join("lib/manageiq/reporting/charting"))
   Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
+  Rails.autoloaders.main.collapse(Rails.root.join("lib/pdf_generator"))
 
   # requires qpid, which is an optional dependency because LOL mac
   if RUBY_PLATFORM.include?("darwin")

--- a/spec/initializers/yaml_autoloader_spec.rb
+++ b/spec/initializers/yaml_autoloader_spec.rb
@@ -6,6 +6,7 @@ describe Psych::Visitors::ToRuby do
   let(:missing_model)   { model_directory.join("zzz_model.rb") }
 
   before do
+    skip "This is currently not testable with zeitwerk!" if Rails.application.config.autoloader == :zeitwerk
     File.write(missing_model, "class ZzzModel\nend\n")
     ActiveSupport::Dependencies.autoload_paths << model_directory
   end


### PR DESCRIPTION
Depends on:

- [x] Core using classic loader - green cross repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/800
- [x] Core using zeitwerk - green cross repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/799
- [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/551

This PR enabled zeitwerk.  It adds some acronyms/inflections that are backward compatible but required for zeitwerk.  Most of the extractable content has been extracted in other PRs.

Regarding the debug flag `DEBUG_MANAGEIQ_ZEITWERK`:

We have a debug flag to enable logging and testing of the plugin autoload paths by eager loading them:

With no debug flag, we get not debug output and engines autoload paths are not eager loaded:

```
 % bin/rails zeitwerk:check
:zeitwerk is the configured autoloader. This patched file should be removed: /Users/joerafaniello/Code/manageiq/lib/extensions/as_dependencies_interlock.rb once support for the classic loader is dropped. Additionally remove all uses of AS::Depedencies.interlock.
** ManageIQ master, codename: Quinteros
Hold on, I am eager loading the application.

WARNING: The following directories will only be checked if you configure
them to be eager loaded:

  /Users/joerafaniello/Code/manageiq/app/channels
  /Users/joerafaniello/Code/manageiq/app/mailers
  /Users/joerafaniello/Code/manageiq/app/models
  /Users/joerafaniello/Code/manageiq/app/models/aliases
  /Users/joerafaniello/Code/manageiq/app/models/mixins
  /Users/joerafaniello/Code/manageiq/lib
  /Users/joerafaniello/Code/manageiq/lib/services
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-ui-classic-cc269e54618e/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-decorators-d32a9713e7e7/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-consumption-377567af9e99/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-content-e48d454fbe1d/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-api-c49eac7c3a2e/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-api-c49eac7c3a2e/lib/services
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-automation_engine-04cf2b9720ad/app/models/mixins
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-automation_engine-04cf2b9720ad/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-automation_engine-04cf2b9720ad/lib/miq_automation_engine
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-automation_engine-04cf2b9720ad/lib/miq_automation_engine/engine
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-workflows-d2bca8106496/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-vmware-e045cb18a750/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ovirt-94295f48af08/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-openstack-0cec9e559744/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-openshift-f2a2efdbf167/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-red_hat_virtualization-faf084bd29ee/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-redfish-5857bf0e3e45/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-oracle_cloud-80b43001a055/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-nuage-24aeaae5eac1/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-nsxt-025179cf5ec2/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-nsxt-025179cf5ec2/app/helpers/helper
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-lenovo-d442875edc73/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-kubevirt-c18da31236be/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-kubernetes-6acc47038ceb/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ibm_terraform-c1e38d12b021/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ibm_power_vc-af22b799ed70/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ibm_power_hmc-ba995d7c12a7/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ibm_cloud-0bd58c1075ca/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ibm_cic-9bdb24cbfa38/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-google-c6ccbb837a66/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-foreman-73663c08eb5e/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-cisco_intersight-3c74cf9a0ade/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-azure_stack-9b712689921f/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-azure-cd77aa129982/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-awx-25902304ac63/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-autosde-0671b7003471/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-ansible_tower-293a57d01191/lib
  /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-amazon-7d71bb678dc3/lib

You may verify them manually, or add them to config.eager_load_paths
in config/application.rb and run zeitwerk:check again.

Otherwise, all is good!
```
---

With debugging, we get debug logging and we eager load all autoload paths to ensure those plugins define things correctly:

```
% DEBUG_MANAGEIQ_ZEITWERK=true bin/rails zeitwerk:check
...
D, [2023-06-05T14:05:41.045721 #44126] DEBUG -- : Zeitwerk@rails.main: eager load directory /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-providers-amazon-7d71bb678dc3/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker end
D, [2023-06-05T14:05:41.045732 #44126] DEBUG -- : Zeitwerk@rails.main: eager load directory /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-schema-31a4f46a4493/app/models start
D, [2023-06-05T14:05:41.046027 #44126] DEBUG -- : Zeitwerk@rails.main: constant SchemaMigration loaded from file /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-schema-31a4f46a4493/app/models/schema_migration.rb
D, [2023-06-05T14:05:41.046038 #44126] DEBUG -- : Zeitwerk@rails.main: eager load directory /Users/joerafaniello/.gem/ruby/3.0.6/bundler/gems/manageiq-schema-31a4f46a4493/app/models end
D, [2023-06-05T14:05:41.046074 #44126] DEBUG -- : Zeitwerk@rails.main: eager load end
All is good!
```