### PR TITLE
Normalize screaming case html yaml for zeitwerk

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,7 +1,7 @@
 class Authentication < ApplicationRecord
   acts_as_miq_taggable
   include_concern 'ImportExport'
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
   include SupportsFeatureMixin
   include NewWithTypeStiMixin
   def self.new(*args, &block)

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -2,7 +2,7 @@ class FileDepot < ApplicationRecord
   include NewWithTypeStiMixin
   include AuthenticationMixin
   include_concern 'ImportExport'
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
 
   has_many              :miq_schedules, :dependent => :nullify
   has_many              :miq_servers,   :dependent => :nullify, :foreign_key => :log_file_depot_id

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -1,5 +1,5 @@
 class GenericObjectDefinition < ApplicationRecord
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
   include_concern 'ImportExport'
 
   TYPE_MAP = {

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -32,7 +32,7 @@ class MiqPolicy < ApplicationRecord
   include_concern 'ImportExport'
 
   include UuidMixin
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
   before_validation :default_name_to_guid, :on => :create
 
   default_value_for :towhat, 'Vm'

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -9,7 +9,7 @@ class MiqReport < ApplicationRecord
   include_concern 'Notification'
   include_concern 'Schedule'
   include_concern 'Search'
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
 
   serialize :cols
   serialize :conditions

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -3,7 +3,7 @@ class MiqSchedule < ApplicationRecord
   include_concern 'ImportExport'
   include_concern 'Filters'
 
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
   deprecate_attribute :towhat, :resource_type
 
   validates :name, :uniqueness_when_changed => {:scope => [:userid, :resource_type]}

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -2,7 +2,7 @@ class MiqSearch < ApplicationRecord
   serialize :options
   serialize :filter
   include_concern 'ImportExport'
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
 
   validates :name, :uniqueness_when_changed => {:scope => "db"}
 

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -31,7 +31,7 @@ class MiqWidget < ApplicationRecord
 
   include_concern 'ImportExport'
   include UuidMixin
-  include YAMLImportExportMixin
+  include YamlImportExportMixin
   acts_as_miq_set_member
 
   WIDGET_REPORT_SOURCE = "Generated for widget".freeze

--- a/app/models/mixins/yaml_import_export_mixin.rb
+++ b/app/models/mixins/yaml_import_export_mixin.rb
@@ -1,4 +1,4 @@
-module YAMLImportExportMixin
+module YamlImportExportMixin
   extend ActiveSupport::Concern
 
   module ClassMethods

--- a/lib/manageiq/reporting/formatter.rb
+++ b/lib/manageiq/reporting/formatter.rb
@@ -31,7 +31,7 @@ module ReportFormatter
   deprecate_constant 'C3Charting',        'ManageIQ::Reporting::Formatter::C3Charting'
   deprecate_constant 'ChartCommon',       'ManageIQ::Reporting::Formatter::ChartCommon'
   deprecate_constant 'Converter',         'ManageIQ::Reporting::Formatter::Converter'
-  deprecate_constant 'ReportHTML',        'ManageIQ::Reporting::Formatter::HTML'
+  deprecate_constant 'ReportHTML',        'ManageIQ::Reporting::Formatter::Html'
   deprecate_constant 'ReportRenderer',    'ManageIQ::Reporting::Formatter::ReportRenderer'
   deprecate_constant 'ReportText',        'ManageIQ::Reporting::Formatter::Text'
   deprecate_constant 'ReportTimeline',    'ManageIQ::Reporting::Formatter::Timeline'

--- a/lib/manageiq/reporting/formatter/html.rb
+++ b/lib/manageiq/reporting/formatter/html.rb
@@ -1,7 +1,7 @@
 module ManageIQ
   module Reporting
     module Formatter
-      class HTML < Ruport::Formatter
+      class Html < Ruport::Formatter
         renders :html, :for => ManageIQ::Reporting::Formatter::ReportRenderer
 
         def build_html_title

--- a/spec/models/mixins/yaml_import_export_mixin_spec.rb
+++ b/spec/models/mixins/yaml_import_export_mixin_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe YAMLImportExportMixin do
-  let(:test_class) { Class.new { include YAMLImportExportMixin } }
+RSpec.describe YamlImportExportMixin do
+  let(:test_class) { Class.new { include YamlImportExportMixin } }
 
   before do
     @report1 = FactoryBot.create(:miq_report, :name => "test_report_1")


### PR DESCRIPTION
Extracted from the [zeitwerk PR](https://github.com/ManageIQ/manageiq/pull/22488)

## Normalize on Camelcase Html for consistency with loading

We need to match MiqReport::Formatters:Html and MiqReport::Generator::Html or
change them to also be HTML.  I decided on Html because HTML would also require
us to teach zeitwerk another acronym.

## Use Yaml as YAML looks awful in YAMLImportExportMixin

Acronym make sense when the change to use Camelcase is hard or it reads better.
We already use Yaml in constant names so it makes sense to convert this and get
rid of YAML.  Then, we also don't need to define an acronym.