### PR TITLE
Drop responders as we don't use it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -262,7 +262,6 @@ end
 
 group :web_server, :manageiq_default do
   gem "puma",                           "~>4.2"
-  gem "responders",                     "~>3.0"
   gem "ruby-dbus" # For external auth
   gem "secure_headers",                 "~>3.9"
 end


### PR DESCRIPTION
dependents:
- [x] https://github.com/ManageIQ/manageiq-api/pull/1222

This gem was introduced in d05fa221 for Rails 4 upgrade, but I don't think we still use it.

@miq-bot cross-repo-test /all