### PR TITLE
Fix Chargeback not working when company name settings changes

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -195,7 +195,7 @@ class ChargebackVm < Chargeback
             _log.info("#{error_message}. Calculating chargeback costs skipped for #{@options[:tenant_id]} in region #{region}.")
             Vm.none
           else
-            Vm.where(:id => tenant.subtree.map { |t| t.vms.ids }.flatten)
+            Vm.where(:tenant_id => tenant.subtree.select(:id))
           end
         elsif @options[:service_id]
           service = Service.find(@options[:service_id])

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -185,11 +185,15 @@ class ChargebackVm < Chargeback
           end
 
           tenant_name = tenant.name
-          tenant = Tenant.in_region(region).find_by(:name => tenant.name)
-          if tenant.nil?
-            error_message = "Unable to find tenant '#{tenant_name}' (based on tenant id '#{@options[:tenant_id]}' from default region) in region #{region}"
-            _log.info("#{error_message}. Calculating chargeback costs skipped for #{@options[:tenant_id]} in region #{region}.")
-            return Vm.none
+          # NOTE: tenant.name has settings applied.
+          # i.e.: Tenant.where(:id => tenant.id, :name => tenant.name).exists? could be false
+          if tenant.region_number != region
+            tenant = Tenant.in_region(region).find_by(:name => tenant.name)
+            if tenant.nil?
+              error_message = "Unable to find tenant '#{tenant_name}' (based on tenant id '#{@options[:tenant_id]}' from default region) in region #{region}"
+              _log.info("#{error_message}. Calculating chargeback costs skipped for #{@options[:tenant_id]} in region #{region}.")
+              return Vm.none
+            end
           end
           Vm.where(:id => tenant.subtree.map { |t| t.vms.ids }.flatten)
         elsif @options[:service_id]

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -189,13 +189,14 @@ class ChargebackVm < Chargeback
           # i.e.: Tenant.where(:id => tenant.id, :name => tenant.name).exists? could be false
           if tenant.region_number != region
             tenant = Tenant.in_region(region).find_by(:name => tenant.name)
-            if tenant.nil?
-              error_message = "Unable to find tenant '#{tenant_name}' (based on tenant id '#{@options[:tenant_id]}' from default region) in region #{region}"
-              _log.info("#{error_message}. Calculating chargeback costs skipped for #{@options[:tenant_id]} in region #{region}.")
-              return Vm.none
-            end
           end
-          Vm.where(:id => tenant.subtree.map { |t| t.vms.ids }.flatten)
+          if tenant.nil?
+            error_message = "Unable to find tenant '#{tenant_name}' (based on tenant id '#{@options[:tenant_id]}' from default region) in region #{region}"
+            _log.info("#{error_message}. Calculating chargeback costs skipped for #{@options[:tenant_id]} in region #{region}.")
+            Vm.none
+          else
+            Vm.where(:id => tenant.subtree.map { |t| t.vms.ids }.flatten)
+          end
         elsif @options[:service_id]
           service = Service.find(@options[:service_id])
           if service.nil?

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -443,24 +443,22 @@ RSpec.describe ChargebackVm do
     end
 
     context "Report a chargeback of a tenant" do
-      let(:options_tenant) { base_options.merge(:tenant_id => @tenant.id).tap { |t| t.delete(:tag) } }
+      let(:tenant) { FactoryBot.create(:tenant) }
+      let(:tenant_child) { FactoryBot.create(:tenant, :parent => tenant) }
+      let(:options_tenant) { base_options.merge(:tenant_id => tenant).tap { |t| t.delete(:tag) } }
 
       let(:start_time)  { report_run_time - 17.hours }
       let(:finish_time) { report_run_time - 14.hours }
-
-      before do
-        @tenant = FactoryBot.create(:tenant)
-        @tenant_child = FactoryBot.create(:tenant, :parent => @tenant)
-        @vm_tenant = FactoryBot.create(:vm_vmware, :tenant_id => @tenant_child.id,
-                                        :name => "test_vm_tenant", :created_on => month_beginning)
-
-        add_metric_rollups_for(@vm_tenant, start_time...finish_time, 1.hour, metric_rollup_params)
+      let!(:vm) do
+        FactoryBot.create(:vm_vmware, :tenant => tenant_child, :created_on => month_beginning).tap do |vm|
+          add_metric_rollups_for(vm, start_time...finish_time, 1.hour, metric_rollup_params)
+        end
       end
 
       subject { ChargebackVm.build_results_for_report_ChargebackVm(options_tenant).first.first }
 
       it "report a chargeback of a subtenant" do
-        expect(subject.vm_name).to eq(@vm_tenant.name)
+        expect(subject.vm_name).to eq(vm.name)
       end
     end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -460,6 +460,16 @@ RSpec.describe ChargebackVm do
       it "report a chargeback of a subtenant" do
         expect(subject.vm_name).to eq(vm.name)
       end
+
+      context "with settings derived tenant name" do
+        let(:tenant) { FactoryBot.create(:tenant, :use_config_for_attributes => true) }
+
+        before { stub_settings_merge(:server => {:company => "Special Name"}) }
+
+        it "report a chargeback of a subtenant" do
+          expect(subject&.vm_name).to eq(vm.name)
+        end
+      end
     end
 
     context "Monthly" do


### PR DESCRIPTION
In ChargebacVm, we are looking up a tenant by `tenant.name`.
This is a typical technique we use when introducing cross regional support.

Unfortunately, the tenant can have the name overridden by the settings. In this case,
searching by the name would not find the record.

To fix this, we are skipping looking up the tenant when the tenant is in the desired
region.

This will still not work for multi region searching and tenant names are derived from the
settings names.