### PR TITLE
allow dialogs to be destroyed with read only dialog fields

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -1,6 +1,5 @@
 class DialogField < ApplicationRecord
   include NewWithTypeStiMixin
-  include_concern "ReadOnlyMixin"
 
   attr_accessor :value
   attr_accessor :dialog

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -130,6 +130,18 @@ RSpec.describe Dialog do
       expect(dialog.destroy).to be_truthy
       expect(Dialog.count).to eq(0)
     end
+
+    # had an issue around dialog_field thinking read_only meant seeded.
+    it "does destroy dialog with only a field" do
+      dialog_group = FactoryBot.create(:dialog_group)
+      dialog_field = FactoryBot.create(:dialog_field, :read_only => true)
+      dialog_tab   = FactoryBot.create(:dialog_tab)
+      dialog_group.dialog_fields << dialog_field
+      dialog_tab.dialog_groups << dialog_group
+      dialog.dialog_tabs << dialog_tab
+      dialog.destroy
+      expect(dialog).to be_deleted
+    end
   end
 
   describe "dialog structures" do


### PR DESCRIPTION
dialog fields has a read_only field
It was incorrectly assumed to mean seeded in https://github.com/ManageIQ/manageiq/pull/22232 But dialog fields have a number of html attributes, so this was wrong.

Updating the field to allow it to be deleted
Which means that dialogs can be deleted.
