### PR TITLE
Move repository sync to embedded_automation_manager

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,19 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
   FRIENDLY_NAME = "Embedded Ansible Project".freeze
 
-  virtual_attribute :verify_ssl, :integer
-
-  validates :name,       :presence => true # TODO: unique within region?
-  validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }
-  validates :scm_branch, :presence => true
-
   supports :create
-
-  default_value_for :scm_type,   "git"
-  default_value_for :scm_branch, "master"
-
-  belongs_to :git_repository, :autosave => true, :dependent => :destroy
-  before_validation :sync_git_repository
 
   include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
 
@@ -25,84 +13,12 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     true
   end
 
-  def self.raw_create_in_provider(manager, params)
-    params.delete(:scm_type)   if params[:scm_type].blank?
-    params.delete(:scm_branch) if params[:scm_branch].blank?
-
-    transaction { create!(params.merge(:manager => manager, :status => "new")) }
-  end
-
   def self.create_in_provider(manager_id, params)
     super.tap(&:sync_and_notify)
   end
 
-  def raw_update_in_provider(params)
-    transaction do
-      update!(params.except(:task_id, :miq_task_id))
-    end
-  end
-
   def update_in_provider(params)
     super.tap(&:sync_and_notify)
-  end
-
-  def raw_delete_in_provider
-    destroy!
-  end
-
-  def git_repository
-    (super || (ensure_git_repository && super)).tap { |r| sync_git_repository(r) }
-  end
-
-  def verify_ssl=(val)
-    @verify_ssl = case val
-                  when 0, false then OpenSSL::SSL::VERIFY_NONE
-                  when 1, true  then OpenSSL::SSL::VERIFY_PEER
-                  else
-                    OpenSSL::SSL::VERIFY_NONE
-                  end
-
-    if git_repository_id && git_repository.verify_ssl != @verify_ssl
-      @verify_ssl_changed = true
-    end
-  end
-
-  def verify_ssl
-    if @verify_ssl
-      @verify_ssl
-    elsif git_repository_id
-      git_repository.verify_ssl
-    else
-      @verify_ssl ||= OpenSSL::SSL::VERIFY_NONE
-    end
-  end
-
-  private def ensure_git_repository
-    transaction do
-      repo = GitRepository.create!(attrs_for_sync_git_repository)
-      if new_record?
-        self.git_repository_id = repo.id
-      elsif !update_columns(:git_repository_id => repo.id) # rubocop:disable Rails/SkipsModelValidations
-        raise ActiveRecord::RecordInvalid, "git_repository_id could not be set"
-      end
-    end
-    true
-  end
-
-  private def sync_git_repository(git_repository = nil)
-    return unless name_changed? || scm_url_changed? || authentication_id_changed? || @verify_ssl_changed
-
-    git_repository ||= self.git_repository
-    git_repository.attributes = attrs_for_sync_git_repository
-  end
-
-  private def attrs_for_sync_git_repository
-    {
-      :name              => name,
-      :url               => scm_url,
-      :authentication_id => authentication_id,
-      :verify_ssl        => verify_ssl
-    }
   end
 
   def sync
@@ -145,11 +61,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
         playbook_dir?(filename) && playbook?(filename, worktree)
       end
     end
-  end
-
-  def checkout_git_repository(target_directory)
-    git_repository.update_repo
-    git_repository.checkout(scm_branch, target_directory)
   end
 
   ERROR_MAX_SIZE = 50.kilobytes

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,24 +1,12 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
   FRIENDLY_NAME = "Embedded Ansible Project".freeze
 
-  supports :create
-
-  include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
-
   def self.display_name(number = 1)
     n_('Repository (Embedded Ansible)', 'Repositories (Embedded Ansible)', number)
   end
 
   def self.notify_on_provider_interaction?
     true
-  end
-
-  def self.create_in_provider(manager_id, params)
-    super.tap(&:sync_and_notify)
-  end
-
-  def update_in_provider(params)
-    super.tap(&:sync_and_notify)
   end
 
   def sync
@@ -43,14 +31,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
             :last_updated_on   => Time.zone.now,
             :last_update_error => format_sync_error(error))
     raise error
-  end
-
-  def sync_and_notify
-    notify("syncing") { sync }
-  end
-
-  def sync_queue(auth_user = nil)
-    queue("sync", [], "Synchronizing", auth_user)
   end
 
   def playbooks_in_git_repository

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   belongs_to :git_repository, :autosave => true, :dependent => :destroy
   before_validation :sync_git_repository
 
-  include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
+  include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
 
   def self.display_name(number = 1)
     n_('Repository (Embedded Ansible)', 'Repositories (Embedded Ansible)', number)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
 
   FRIENDLY_NAME = "Embedded Ansible Credential".freeze
 
-  include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
+  include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
 
   def self.params_to_attributes(_params)
     raise NotImplementedError, "must be implemented in a subclass"

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
   virtual_attribute :verify_ssl, :integer
 
   validates :name,       :presence => true # TODO: unique within region?
-  validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }
+  validates :scm_type,   :presence => true, :inclusion => {:in => %w[git]}
   validates :scm_branch, :presence => true
 
   default_value_for :scm_type,   "git"

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -1,7 +1,100 @@
-class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource <
-  ManageIQ::Providers::AutomationManager::ConfigurationScriptSource
+class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource < ManageIQ::Providers::AutomationManager::ConfigurationScriptSource
+  virtual_attribute :verify_ssl, :integer
+
+  validates :name,       :presence => true # TODO: unique within region?
+  validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }
+  validates :scm_branch, :presence => true
+
+  default_value_for :scm_type,   "git"
+  default_value_for :scm_branch, "master"
+
+  belongs_to :git_repository, :autosave => true, :dependent => :destroy
+  before_validation :sync_git_repository
 
   def self.display_name(number = 1)
     n_('Repository', 'Repositories', number)
+  end
+
+  def self.raw_create_in_provider(manager, params)
+    params.delete(:scm_type)   if params[:scm_type].blank?
+    params.delete(:scm_branch) if params[:scm_branch].blank?
+
+    transaction { create!(params.merge(:manager => manager, :status => "new")) }
+  end
+
+  def raw_update_in_provider(params)
+    transaction do
+      update!(params.except(:task_id, :miq_task_id))
+    end
+  end
+
+  def raw_delete_in_provider
+    destroy!
+  end
+
+  def git_repository
+    (super || (ensure_git_repository && super)).tap { |r| sync_git_repository(r) }
+  end
+
+  def verify_ssl=(val)
+    @verify_ssl = case val
+                  when 0, false then OpenSSL::SSL::VERIFY_NONE
+                  when 1, true  then OpenSSL::SSL::VERIFY_PEER
+                  else
+                    OpenSSL::SSL::VERIFY_NONE
+                  end
+
+    if git_repository_id && git_repository.verify_ssl != @verify_ssl
+      @verify_ssl_changed = true
+    end
+  end
+
+  def verify_ssl
+    if @verify_ssl
+      @verify_ssl
+    elsif git_repository_id
+      git_repository.verify_ssl
+    else
+      @verify_ssl ||= OpenSSL::SSL::VERIFY_NONE
+    end
+  end
+
+  def sync
+    raise NotImplementedError, N_("sync must be implemented in a subclass")
+  end
+
+  def checkout_git_repository(target_directory)
+    git_repository.update_repo
+    git_repository.checkout(scm_branch, target_directory)
+  end
+
+  private
+
+  def ensure_git_repository
+    transaction do
+      repo = GitRepository.create!(attrs_for_sync_git_repository)
+      if new_record?
+        self.git_repository_id = repo.id
+      elsif !update_columns(:git_repository_id => repo.id) # rubocop:disable Rails/SkipsModelValidations
+        raise ActiveRecord::RecordInvalid, "git_repository_id could not be set"
+      end
+    end
+    true
+  end
+
+  def sync_git_repository(git_repository = nil)
+    return unless name_changed? || scm_url_changed? || authentication_id_changed? || @verify_ssl_changed
+
+    git_repository ||= self.git_repository
+    git_repository.attributes = attrs_for_sync_git_repository
+  end
+
+  def attrs_for_sync_git_repository
+    {
+      :name              => name,
+      :url               => scm_url,
+      :authentication_id => authentication_id,
+      :verify_ssl        => verify_ssl
+    }
   end
 end

--- a/app/models/manageiq/providers/embedded_automation_manager/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/crud_common.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
+module ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
   extend ActiveSupport::Concern
 
   module ClassMethods


### PR DESCRIPTION
The general git repository sync code is not embedded_ansible specific and can move up to the embedded_automation_manager.

This is the first PR in a set to allow for Repositories for Embedded Workflows