### PR TITLE
Mark Strings in Request Details for Translation

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -1,7 +1,7 @@
 class AutomationRequest < MiqRequest
   alias_attribute :automation_tasks, :miq_request_tasks
 
-  TASK_DESCRIPTION  = 'Automation Request'
+  TASK_DESCRIPTION  = N_('Automation Request')
   DEFAULT_NAMESPACE = "SYSTEM"
   DEFAULT_CLASS     = "PROCESS"
   DEFAULT_INSTANCE  = "AUTOMATION_REQUEST"

--- a/app/models/miq_provision_configured_system_request.rb
+++ b/app/models/miq_provision_configured_system_request.rb
@@ -1,5 +1,5 @@
 class MiqProvisionConfiguredSystemRequest < MiqRequest
-  TASK_DESCRIPTION  = 'Configured System Provisioning'
+  TASK_DESCRIPTION  = N_('Configured System Provisioning')
   SOURCE_CLASS_NAME = 'ConfiguredSystem'
 
   validates_inclusion_of :request_state, :in => %w(pending finished) + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -6,7 +6,7 @@ class MiqProvisionRequest < MiqRequest
 
   delegate :my_zone, :to => :source
 
-  TASK_DESCRIPTION  = 'VM Provisioning'
+  TASK_DESCRIPTION  = N_('VM Provisioning')
   SOURCE_CLASS_NAME = 'Vm'
   ACTIVE_STATES     = %w(migrated) + base_class::ACTIVE_STATES
 

--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -11,7 +11,7 @@ class MiqRetireTask < MiqRequestTask
              req_obj.source.name
            end
 
-    "#{request_class::TASK_DESCRIPTION} for: #{name}"
+    _("%{request_description} for: %{request_source}") % {:request_description => _(request_class::TASK_DESCRIPTION), :request_source => name}
   end
 
   def deliver_to_automate(req_type = request_type, zone = nil)

--- a/app/models/orchestration_stack_retire_request.rb
+++ b/app/models/orchestration_stack_retire_request.rb
@@ -1,4 +1,4 @@
 class OrchestrationStackRetireRequest < MiqRetireRequest
-  TASK_DESCRIPTION  = 'OrchestrationStack Retire'.freeze
+  TASK_DESCRIPTION  = N_('OrchestrationStack Retire').freeze
   SOURCE_CLASS_NAME = 'OrchestrationStack'.freeze
 end

--- a/app/models/physical_server_firmware_update_request.rb
+++ b/app/models/physical_server_firmware_update_request.rb
@@ -1,5 +1,5 @@
 class PhysicalServerFirmwareUpdateRequest < MiqRequest
-  TASK_DESCRIPTION  = 'Physical Server Firmware Update'.freeze
+  TASK_DESCRIPTION  = N_('Physical Server Firmware Update').freeze
   SOURCE_CLASS_NAME = 'PhysicalServer'.freeze
 
   def description

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -1,5 +1,5 @@
 class PhysicalServerProvisionRequest < MiqRequest
-  TASK_DESCRIPTION  = 'Physical Server Provisioning'.freeze
+  TASK_DESCRIPTION  = N_('Physical Server Provisioning').freeze
   SOURCE_CLASS_NAME = 'PhysicalServer'.freeze
 
   def description

--- a/app/models/service_reconfigure_request.rb
+++ b/app/models/service_reconfigure_request.rb
@@ -1,5 +1,5 @@
 class ServiceReconfigureRequest < MiqRequest
-  TASK_DESCRIPTION  = 'Service Reconfigure'
+  TASK_DESCRIPTION  = N_('Service Reconfigure')
   SOURCE_CLASS_NAME = 'Service'
 
   validates_inclusion_of :request_state, :in      => %w(pending finished) + ACTIVE_STATES,

--- a/app/models/service_retire_request.rb
+++ b/app/models/service_retire_request.rb
@@ -1,5 +1,5 @@
 class ServiceRetireRequest < MiqRetireRequest
-  TASK_DESCRIPTION  = 'Service Retire'.freeze
+  TASK_DESCRIPTION  = N_('Service Retire').freeze
   SOURCE_CLASS_NAME = 'Service'.freeze
   ACTIVE_STATES     = %w(retired) + base_class::ACTIVE_STATES
 

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -1,5 +1,5 @@
 class ServiceTemplateProvisionRequest < MiqRequest
-  TASK_DESCRIPTION  = 'Service_Template_Provisioning'
+  TASK_DESCRIPTION  = N_('Service_Template_Provisioning')
   SOURCE_CLASS_NAME = 'ServiceTemplate'
   ACTIVE_STATES     = %w( migrated ) + base_class::ACTIVE_STATES
   SERVICE_ORDER_CLASS = '::ServiceOrderCart'.freeze

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -40,7 +40,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     end
 
     if req_obj.kind_of?(ServiceTemplateProvisionRequest)
-      result = "Provisioning Service [#{svc_target_name}] from [#{prov_source.name}]"
+      result = _("Provisioning Service [%{svc_target_name}] from [%{prov_source_name}]") % {:svc_target_name => svc_target_name, :prov_source_name => prov_source.name}
     else
       service_resource = prov_source
       rsc_name = service_resource.name if service_resource.respond_to?(:name)
@@ -56,11 +56,11 @@ class ServiceTemplateProvisionTask < MiqRequestTask
 
       result = case req_template
                when ServiceTemplate
-                 "Provisioning Service [#{rsc_name}] for Service [#{svc_target_name}]"
+                 _("Provisioning Service [%{rsc_name}] for Service [%{svc_target_name}]") % {:rsc_name => rsc_name, :svc_target_name => svc_target_name}
                when MiqProvisionRequestTemplate
-                 "Provisioning VM [#{rsc_name}] for Service [#{svc_target_name}]"
+                 _("Provisioning VM [%{rsc_name}] for Service [%{svc_target_name}]") % {:rsc_name => rsc_name, :svc_target_name => svc_target_name}
                else
-                 "Provisioning [#{rsc_name}] for Service [#{svc_target_name}]"
+                 _("Provisioning [%{rsc_name}] for Service [%{svc_target_name}]") % {:rsc_name => rsc_name, :svc_target_name => svc_target_name}
                end
     end
 

--- a/app/models/vm_cloud_reconfigure_request.rb
+++ b/app/models/vm_cloud_reconfigure_request.rb
@@ -1,5 +1,5 @@
 class VmCloudReconfigureRequest < MiqRequest
-  TASK_DESCRIPTION  = 'VM Cloud Reconfigure'.freeze
+  TASK_DESCRIPTION  = N_('VM Cloud Reconfigure').freeze
   SOURCE_CLASS_NAME = 'Vm'.freeze
   ACTIVE_STATES     = %w(reconfigured) + base_class::ACTIVE_STATES
 

--- a/app/models/vm_migrate_request.rb
+++ b/app/models/vm_migrate_request.rb
@@ -1,5 +1,5 @@
 class VmMigrateRequest < MiqRequest
-  TASK_DESCRIPTION  = 'VM Migrate'
+  TASK_DESCRIPTION  = N_('VM Migrate')
   SOURCE_CLASS_NAME = 'Vm'
   ACTIVE_STATES     = %w( migrated ) + base_class::ACTIVE_STATES
 

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -1,5 +1,5 @@
 class VmReconfigureRequest < MiqRequest
-  TASK_DESCRIPTION  = 'VM Reconfigure'
+  TASK_DESCRIPTION  = N_('VM Reconfigure')
   SOURCE_CLASS_NAME = 'Vm'
   ACTIVE_STATES     = %w( reconfigured ) + base_class::ACTIVE_STATES
 

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -13,26 +13,27 @@ class VmReconfigureTask < MiqRequestTask
     options = req.options
 
     msg = []
-    msg << build_message(options, :vm_memory, "Memory: %d MB")
-    msg << build_message(options, :number_of_sockets, "Processor Sockets: %d")
-    msg << build_message(options, :cores_per_socket, "Processor Cores Per Socket: %d")
-    msg << build_message(options, :number_of_cpus, "Total Processors: %d")
+    msg << build_message(options, :vm_memory, N_("Memory: %{value} MB"))
+    msg << build_message(options, :number_of_sockets, N_("Processor Sockets: %{value}"))
+    msg << build_message(options, :cores_per_socket, N_("Processor Cores Per Socket: %{value}"))
+    msg << build_message(options, :number_of_cpus, N_("Total Processors: %{value}"))
     msg << build_disk_message(options)
-    msg << build_message(options, :disk_remove, "Remove Disks: %d", :length)
-    msg << build_message(options, :disk_resize, "Resize Disks: %d", :length)
-    msg << build_message(options, :network_adapter_add, "Add Network Adapters: %d", :length)
-    msg << build_message(options, :network_adapter_remove, "Remove Network Adapters: %d", :length)
-    msg << build_message(options, :network_adapter_edit, "Edit Network Adapters: %d", :length)
-    msg << build_message(options, :cdrom_connect, "Attach CD/DVDs: %d", :length)
-    msg << build_message(options, :cdrom_disconnect, "Detach CD/DVDs: %d", :length)
-    "#{request_class::TASK_DESCRIPTION} for: #{resource_name(req)} - #{msg.compact.join(", ")}"
+    msg << build_message(options, :disk_remove, N_("Remove Disks: %{value}"), :length)
+    msg << build_message(options, :disk_resize, N_("Resize Disks: %{value}"), :length)
+    msg << build_message(options, :network_adapter_add, N_("Add Network Adapters: %{value}"), :length)
+    msg << build_message(options, :network_adapter_remove, N_("Remove Network Adapters: %{value}"), :length)
+    msg << build_message(options, :network_adapter_edit, N_("Edit Network Adapters: %{value}"), :length)
+    msg << build_message(options, :cdrom_connect, N_("Attach CD/DVDs: %{value}"), :length)
+    msg << build_message(options, :cdrom_disconnect, N_("Detach CD/DVDs: %{value}"), :length)
+
+    _("%{request_description} for: %{resource_name} - %{message}") % {:request_description => _(request_class::TASK_DESCRIPTION), :resource_name => resource_name(req), :message => msg.compact.join(", ")}
   end
 
   def self.build_message(options, key, message, modifier = nil)
     if options[key].present?
       value = options[key]
       value = value.send(modifier) if modifier
-      message % value
+      _(message) % {:value => value}
     end
   end
   private_class_method :build_message

--- a/app/models/vm_retire_request.rb
+++ b/app/models/vm_retire_request.rb
@@ -1,5 +1,5 @@
 class VmRetireRequest < MiqRetireRequest
-  TASK_DESCRIPTION  = 'VM Retire'.freeze
+  TASK_DESCRIPTION  = N_('VM Retire').freeze
   SOURCE_CLASS_NAME = 'Vm'.freeze
   ACTIVE_STATES     = %w(retired) + base_class::ACTIVE_STATES
 


### PR DESCRIPTION
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/8788

Marks strings for translation in the Request Details page. Most of these strings used to be marked prior to the recent form conversion.