### PR TITLE
fix no superclass method conditions= for MiqReport

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -99,7 +99,7 @@ class MiqReport < ApplicationRecord
 
   def conditions=(exp)
     exp = MiqExpression.new(exp) if exp && !exp.kind_of?(MiqExpression)
-    super
+    write_attribute("conditions", exp)
   end
 
   # NOTE: this can by dynamically manipulated


### PR DESCRIPTION
We're getting the following exception:

```
no superclass method `conditions=' for #<MiqReport
```

I can only reproduce when I reload code
and `ApplicationController#get_view` has `refresh_view = false` So it gets the view from `session[:view]`

Since the code is reloaded, the attribute methods are not written anymore. Typically the `super` call would call `method_missing` => `attribute_missing` and see that the method is not defined and define it.

But it sees our definition of `conditions=` and decides not to define the `super` implementation.

Issues:

- rails should define the method using their `attribute_missing`
- this code should not be reloaded

Anyway, the method rails defines is a single line method calling `write_attribute`. So I'm swapping super out and copy/pasting the implementation of super

This may be fixed in more recent versions of rails, but since this is the implementation that we have used for previous versions of rails, this work around doesn't seem so bad

reproducer
==========

- run server, go to vm page
- change the model (the server is currently running)

  def conditions=(exp)
    exp = MiqExpression.new(exp) if exp && !exp.kind_of?(MiqExpression)
    super
  rescue
    byebug
    write_attribute("conditions", exp)
  end

- refresh the page

I had addressed this in #22089 but since we didn't understand the solution, we held back