### PR TITLE
Seed an initial service catalog

### DIFF
--- a/app/models/service_template_catalog.rb
+++ b/app/models/service_template_catalog.rb
@@ -7,6 +7,10 @@ class ServiceTemplateCatalog < ApplicationRecord
 
   acts_as_miq_taggable
 
+  def self.seed
+    create!(:name => "My Catalog", :tenant => Tenant.root_tenant) unless any?
+  end
+
   def self.display_name(number = 1)
     n_('Catalog', 'Catalogs', number)
   end

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -30,6 +30,7 @@ class EvmDatabase
     ChargeableField
     Currency
     ChargebackRate
+    ServiceTemplateCatalog
 
     BlacklistedEvent
     Classification

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -3,6 +3,26 @@ RSpec.describe ServiceTemplateCatalog do
     Tenant.seed
   end
 
+  describe ".seed" do
+    it "seeds when the table is empty" do
+      expect(described_class.count).to eq(0)
+
+      described_class.seed
+
+      expect(described_class.count).to eq(1)
+      expect(described_class.first.name).to eq("My Catalog")
+    end
+
+    it "does not seed when the table is not empty" do
+      described_class.create!(:name => "Custom Catalog", :tenant => root_tenant)
+
+      described_class.seed
+
+      expect(described_class.count).to eq(1)
+      expect(described_class.first.name).to eq("Custom Catalog")
+    end
+  end
+
   it "doesn’t access database when unchanged model is saved" do
     f1 = described_class.create!(:name => 'f1')
     expect { f1.valid? }.to make_database_queries(:count => 2)


### PR DESCRIPTION
Only seed the catalog if no catalogs exist (i.e. initial installation). This way we don't introduce a catalog that can't be removed or renamed.

Part of #22505

@agrare Please review.