### PR TITLE
Converge batch_size and concurrent_requests

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -26,12 +26,6 @@ module Metric::Capture
     historical_days.days.ago.utc.beginning_of_day
   end
 
-  def self.concurrent_requests(interval_name)
-    requests = ::Settings.performance.concurrent_requests[interval_name]
-    requests = 20 if requests < 20 && interval_name == 'realtime'
-    requests
-  end
-
   def self.standard_capture_threshold(target)
     target_key = target.class.base_model.to_s.underscore.to_sym
     minutes_ago(::Settings.performance.capture_threshold[target_key] ||

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -886,10 +886,6 @@
     :default: 1.minutes
     :host: 20.minutes
     :vm: 20.minutes
-  :concurrent_requests:
-    :historical: 1
-    :hourly: 1
-    :realtime: 20
   :history:
     :initial_capture_days: 0
     :keep_daily_performances: 6.months

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Metric::CiMixin::Rollup do
+  include Spec::Support::MetricHelper
+
   before do
     @zone = miq_server.zone
   end
@@ -27,7 +29,7 @@ RSpec.describe Metric::CiMixin::Rollup do
       before do
         stub_settings_merge(
           :performance => {:history => {:initial_capture_days => 7}},
-          :ems         => {:ems_vmware => {:capture_batch_size => 0}}
+          :ems         => ems_concurrent_requests("vmware")
         )
         vm
         vm2
@@ -124,7 +126,7 @@ RSpec.describe Metric::CiMixin::Rollup do
       before do
         stub_settings_merge(
           :performance => {:history => {:initial_capture_days => 7}},
-          :ems         => {:ems_vmware => {:capture_batch_size => 3}}
+          :ems         => ems_concurrent_requests("vmware", 3)
         )
       end
 

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -46,6 +46,19 @@ module Spec
       def stub_performance_settings(hash)
         stub_settings(:performance => hash)
       end
+
+      # @param batch_size [Numeric] defaults to nil / no batching
+      def ems_concurrent_requests(ems, batch_size = nil)
+        {
+          "ems_#{ems}".to_sym => {
+            :concurrent_requests => {
+              :historical => batch_size,
+              :hourly     => batch_size,
+              :realtime   => batch_size
+            }
+          }
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
related:

- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/870
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/691

Before

- concurrent_requests, thought it existed in core, was vmware only. It was split up into historical, hourly, and realtime.
- batch_size was per provider (but only implemented by vmware) It just has a single option.

After

- concurrent_requests defined in the provider (but only implemented by vmare) It is split up into historical, hourly, and realtime.

Reason for change

While  batch_size may be 250, concurrent_requests was then applied and we were sending only 20 requests for realtime and 1 for historical.

So in the end, we only are sending 1 request to the provider. The optimization has basically been disabled.

This gives better values for concurrent requests, and matches the requests sent to the collector over the queue and from the collector to the provider

This requires changes in both vmware and core.

A number of specs had the settings for vmware when they were testing openstack. This has been corrected.

