### PR TITLE
Allow ConfigurationScripts to be used for ServiceTemplateProvisionTasks

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -139,7 +139,9 @@ class MiqRequestTask < ApplicationRecord
 
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 
-    if self.class::AUTOMATE_DRIVES
+    if resource_action&.configuration_script_payload
+      resource_action.configuration_script_payload.run(dialog_values, get_user.userid)
+    elsif self.class::AUTOMATE_DRIVES
       deliver_to_automate(req_type, zone)
     else
       execute_queue
@@ -218,6 +220,11 @@ class MiqRequestTask < ApplicationRecord
     end
   end
 
+  def resource_action
+    # Override in child class if the source has resource_actions
+    nil
+  end
+
   def self.display_name(number = 1)
     n_('Request Task', 'Request Tasks', number)
   end
@@ -250,5 +257,9 @@ class MiqRequestTask < ApplicationRecord
 
   def valid_states
     %w(pending finished) + request_class::ACTIVE_STATES
+  end
+
+  def dialog_values
+    options[:dialog] || {}
   end
 end

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -16,9 +16,7 @@ class ServiceReconfigureTask < MiqRequestTask
   end
 
   def deliver_to_automate(req_type = request_type, zone = nil)
-    dialog_values = options[:dialog] || {}
-
-    ra = source.service_template.resource_actions.find_by(:action => 'Reconfigure')
+    ra = resource_action
     if ra
       dialog_values["request"] = req_type
       args = {
@@ -48,6 +46,10 @@ class ServiceReconfigureTask < MiqRequestTask
                                :status  => "Ok",
                                :message => "#{request_class::TASK_DESCRIPTION} completed")
     end
+  end
+
+  def resource_action
+    @resource_action ||= source.service_template.resource_actions.find_by(:action => 'Reconfigure')
   end
 
   def after_ae_delivery(ae_result)

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -116,18 +116,6 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     queue_post_provision unless state == "finished"
   end
 
-  def deliver_queue(req_type = request_type, zone = nil)
-    task_check_on_delivery
-
-    _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
-
-    if resource_action&.configuration_script_payload
-      resource_action.configuration_script_payload.run(dialog_values, get_user.userid)
-    else
-      deliver_to_automate(req_type, zone)
-    end
-  end
-
   def deliver_to_automate(req_type = request_type, _zone = nil)
     args = {
       :object_type      => self.class.name,
@@ -228,9 +216,5 @@ class ServiceTemplateProvisionTask < MiqRequestTask
 
   def valid_states
     super + ["provisioned"]
-  end
-
-  def dialog_values
-    options[:dialog] || {}
   end
 end


### PR DESCRIPTION
Currently only automate is able to be run for `ServiceTemplateProvisionTask`, `ServiceReconfigureTask`, and `ServiceRetireTask`.  This adds support for calling workflows via a `ResourceAction` from these task types.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22540
- [x] https://github.com/ManageIQ/manageiq/pull/22544

https://github.com/ManageIQ/manageiq/issues/22435