### PR TITLE
Fix cloud provision quota memory and cpu counting

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -365,7 +365,9 @@ module MiqProvisionQuotaMixin
   end
 
   def number_of_cpus(prov, cloud, flavor_obj)
-    return flavor_obj.try(:cpus) if cloud
+    num_cpus = flavor_obj.try(:cpus) if cloud
+    return num_cpus if num_cpus.present?
+
     request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
     num_cpus = request.get_option(:number_of_sockets).to_i * request.get_option(:cores_per_socket).to_i
     num_cpus.zero? ? request.get_option(:number_of_cpus).to_i : num_cpus
@@ -384,7 +386,9 @@ module MiqProvisionQuotaMixin
   end
 
   def memory(prov, cloud, vendor, flavor_obj = nil)
-    return flavor_obj.try(:memory) if cloud
+    memory = flavor_obj.try(:memory) if cloud
+    return memory if memory.present?
+
     request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
     memory = request.get_option(:vm_memory).to_i
     %w(amazon openstack google).include?(vendor) ? memory : memory.megabytes


### PR DESCRIPTION
Cloud providers are not required to use flavors to set VM memory and cpu allocation during provisioning (for example `IbmCloud::PowerVirtualServers::CloudManager`). These 'number_of_cpus' and 'memory' methods are expected to return int values. In the case where a 'cloud' type provision is associated with a flavor without 'memory' or 'cpus' values the non-cloud logic is better than returning nil. Depending on how the provider implements the provision request, the return value will be something useful or just 0, avoiding raising an exception.

This partially fixes the following provider issue. I also included information on how Flavor is used in PowerVS:
* ManageIQ/manageiq-providers-ibm_cloud#454

