### PR TITLE
drop Vmdb::GlobalMethod#column_type

### DIFF
--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -27,10 +27,6 @@ module Vmdb
       arrayin.deep_clone
     end
 
-    def column_type(model, column)
-      MiqExpression.create_field(model, [], column).column_type
-    end
-
     # Had to add timezone methods here, they are being called from models
     # returns formatted time in specified timezone and format
     def format_timezone(time, timezone = Time.zone.name, ftype = "view")


### PR DESCRIPTION
depends upon:

- [x] https://github.com/ManageIQ/manageiq-api/pull/1226
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8796

after merging those, lets cross repo all and go from there