### PR TITLE
merge MiqReport#db_klass and db_class

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -166,7 +166,7 @@ class MiqReport < ApplicationRecord
   end
 
   def db_class
-    db.kind_of?(Class) ? db : Object.const_get(db)
+    @db_class ||= db.kind_of?(Class) ? db : Object.const_get(db)
   end
 
   def contains_records?
@@ -226,9 +226,9 @@ class MiqReport < ApplicationRecord
   end
 
   def load_custom_attributes
-    return unless db_klass < CustomAttributeMixin || Chargeback.db_is_chargeback?(db)
+    return unless db_class < CustomAttributeMixin || Chargeback.db_is_chargeback?(db)
 
-    db_klass.load_custom_attributes_for(cols.uniq)
+    db_class.load_custom_attributes_for(cols.uniq)
   end
 
   # this method adds :custom_attributes => {} to MiqReport#include
@@ -330,9 +330,5 @@ class MiqReport < ApplicationRecord
     @va_sql_cols ||= cols.select do |col|
       db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
     end
-  end
-
-  def db_klass
-    @db_klass ||= db.kind_of?(Class) ? db : Object.const_get(db)
   end
 end

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -42,13 +42,13 @@ module MiqReport::Generator::Trend
                                   :filter       => db_options[:trend_filter],
                                   :userid       => options[:userid],
                                   :miq_group_id => options[:miq_group_id])
-    self.title = db_klass.report_title(db_options)
-    self.cols, self.headers = db_klass.report_cols(db_options)
+    self.title = db_class.report_title(db_options)
+    self.cols, self.headers = db_class.report_cols(db_options)
     options[:only] ||= cols_for_report
 
     # Build and filter trend data from performance data
     build_apply_time_profile(results)
-    results = db_klass.build(results, db_options)
+    results = db_class.build(results, db_options)
 
     if conditions
       tz = User.lookup_by_userid(options[:userid]).get_timezone if options[:userid]


### PR DESCRIPTION
They are both defined as `db.kind_of?(Class) ? db : Object.const_get(db)` The only difference being that db_klass has caching.

We introduced db_klass in 87629bd007a
It consolidated a bunch of `constantize` lookups.
But `db_class` was already around. Must have missed that one


This is change. So closing this because we don't want to change any code is totally viable.
I just saw it and putting in the PR was less work than trying to remember to do it later