### PR TITLE
Add IBM PowerVM to OS types

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -31,7 +31,8 @@ class OperatingSystem < ApplicationRecord
     ["linux_oracle",    %w[oracle]],
     ["linux_generic",   %w[linux]],
     ["unix_aix",        %w[aix vios]],
-    ["ibm_i",           %w[ibmi]]
+    ["ibm_i",           %w[ibmi]],
+    ["ibm_power_vm",    %w[phyp]]
   ].freeze
 
   def self.add_elements(vm, xmlNode)


### PR DESCRIPTION
The PowerVM hypervison (phyp) doesn't have it's own decorator, so it is included as a generic IBM PowerVM type.

Related to:
- https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/138
- https://github.com/ManageIQ/manageiq-decorators/pull/89