### PR TITLE
Update fix_auth to convert openssl_verify_mode value

### DIFF
--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -81,11 +81,17 @@ module FixAuth
     serialize :value
 
     def self.contenders
-      query = Vmdb::SettingsWalker::PASSWORD_FIELDS.collect do |field|
+      query = password_fields.collect do |field|
         "(key LIKE '%/#{field}')"
       end.join(" OR ")
 
       super.where(query)
+    end
+
+    # keys that contain protected fields in the settings
+    def self.password_fields
+      Vmdb::SettingsWalker::PASSWORD_FIELDS +
+        %w(openssl_verify_mode)
     end
   end
 


### PR DESCRIPTION
fix_auth did not know that openssl_verify_mode could be encrypted. It doesn't seem like it should be encrypted, but it is.

This change updates the tool so it will properly convert the encrypted value when we are updating a value encrypted with a legacy key

Scenario:

- I have a database from support.
- I do not have the `v2_key`. (which should be the case with all databases from support)
- I used fix_auth to rewrite the encrypted values to a known value

Result:

- Refresh and other actions that would use the passwords do not work
- The application starts and works for everything but the operations that would have needed those passwords.