### PR TITLE
Fix Data/X-Axis Display Issue in Performance Charts

### DIFF
--- a/lib/manageiq/reporting/formatter/chart_common.rb
+++ b/lib/manageiq/reporting/formatter/chart_common.rb
@@ -3,7 +3,12 @@ module ManageIQ
     module Formatter
       module ChartCommon
         def slice_legend(string, limit = LEGEND_LENGTH)
-          string.to_s.gsub(/\n/, ' ').truncate(limit)
+          case string
+          when Date, Time, DateTime, ActiveSupport::TimeWithZone
+            string.iso8601(3)
+          else
+            string.to_s.gsub(/\n/, ' ').truncate(limit)
+          end
         end
 
         def nonblank_or_default(value)
@@ -51,14 +56,7 @@ module ManageIQ
             series = series_class.new
             mri.table.data.each_with_index do |r, d_idx|
               rec_time = r["timestamp"].in_time_zone(tz)
-
-              if mri.db.include?("Daily") || (mri.where_clause && mri.where_clause.include?("daily"))
-                categories.push(rec_time.month.to_s + "/" + rec_time.day.to_s)
-              elsif mri.extras[:realtime] == true
-                categories.push(rec_time.strftime("%H:%M:%S"))
-              else
-                categories.push(rec_time.hour.to_s + ":00")
-              end
+              categories.push(rec_time)
               val = r[col]
 
               if d_idx == mri.table.data.length - 1 && !tip.nil?

--- a/spec/lib/manageiq/reporting/formatter/c3_spec.rb
+++ b/spec/lib/manageiq/reporting/formatter/c3_spec.rb
@@ -105,7 +105,7 @@ describe ManageIQ::Reporting::Formatter::C3 do
 
     it "has right data" do
       expect(report.chart[:data][:columns][0].count).to eq(report.table.data.count + 1)
-      expect(report.chart[:data][:columns][0]).to eq(["x", "8/19", "8/20"])
+      expect(report.chart[:data][:columns][0]).to eq(["x", "2017-08-19T00:00:00.000Z", "2017-08-20T00:00:00.000Z"])
       expect(report.chart[:data][:columns][1]).to eq(["1", 19_986.0, 205_632.0])
       expect(report.chart[:data][:columns][2]).to eq(["2", 41_584.0, 41_584.0])
     end
@@ -120,7 +120,7 @@ describe ManageIQ::Reporting::Formatter::C3 do
     end
     it 'has right tabels' do
       expect(report.chart[:miq][:name_table]).to eq("1" => "Avg Used", "2" => "Max Available")
-      expect(report.chart[:miq][:category_table]).to eq(["8/19", "8/20"])
+      expect(report.chart[:miq][:category_table]).to eq(["2017-08-19T00:00:00.000Z", "2017-08-20T00:00:00.000Z"])
     end
   end
 
@@ -132,7 +132,7 @@ describe ManageIQ::Reporting::Formatter::C3 do
 
     it "has right data" do
       expect(report.chart[:data][:columns][0].count).to eq(report.table.data.count + 1)
-      expect(report.chart[:data][:columns][0]).to eq(["x", "8/19", "8/20"])
+      expect(report.chart[:data][:columns][0]).to eq(["x", "2017-08-19T00:00:00.000Z", "2017-08-20T00:00:00.000Z"])
       expect(report.chart[:data][:columns][1]).to eq(["1", 19_986.0, 205_632.0])
       expect(report.chart[:data][:columns][2]).to eq(["2", 41_584.0, 41_584.0])
     end
@@ -147,7 +147,7 @@ describe ManageIQ::Reporting::Formatter::C3 do
     end
     it 'has right tabels' do
       expect(report.chart[:miq][:name_table]).to eq("1" => "Avg Used", "2" => "Max Available")
-      expect(report.chart[:miq][:category_table]).to eq(["8/19", "8/20"])
+      expect(report.chart[:miq][:category_table]).to eq(["2017-08-19T00:00:00.000Z", "2017-08-20T00:00:00.000Z"])
     end
   end
 


### PR DESCRIPTION
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/8802

The Carbon charts used in the Monitoring -> Utilization page are capable of displaying charts axes as dates. Currently, in `chart_common.rb`, the date values for the chart axes are formatted depending on the chart being displayed which is no longer necessary and was causing issues on the front end.