### PR TITLE
Add arm64-darwin to generate_lockfile

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -221,10 +221,10 @@ namespace :release do
       end
 
       platforms = %w[
+        arm64-darwin
         ruby
         x86_64-linux
         x86_64-darwin
-        x86_64-darwin-21
         powerpc64le-linux
       ].sort_by { |p| [RUBY_PLATFORM.start_with?(p) ? 0 : 1, p] }
 


### PR DESCRIPTION
This is a partial forward port of 2e2690ec6629e38bf97d652120d86df96cd26fa4 that was added to gets things working in petrosian

@bdunne Please review.