### PR TITLE
Move MiqRequestTask entrypoint to `#deliver_queue`

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -467,7 +467,7 @@ class MiqRequest < ApplicationRecord
       requested_tasks.each do |idx|
         req_task = create_request_task(idx)
         miq_request_tasks << req_task
-        req_task.deliver_to_automate
+        req_task.deliver_queue
         request_task_created += 1
       end
       update_request_status

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -164,9 +164,9 @@ class MiqRequestTask < ApplicationRecord
       :args           => [args],
       :role           => 'automate',
       :zone           => options.fetch(:miq_zone, zone),
-      :tracking_label => tracking_label_id,
+      :tracking_label => tracking_label_id
     )
-    update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
+    update_and_notify_parent(:state => "pending", :status => "Ok", :message => "Automation Starting")
   end
 
   def execute_queue(queue_options = {})

--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -15,35 +15,28 @@ class MiqRetireTask < MiqRequestTask
   end
 
   def deliver_to_automate(req_type = request_type, zone = nil)
-    task_check_on_delivery
+    args = {
+      :object_type   => self.class.name,
+      :object_id     => id,
+      :attrs         => {"request" => req_type},
+      :instance_name => "AUTOMATION",
+      :user_id       => miq_request.requester.id,
+      :miq_group_id  => miq_request.requester.current_group_id,
+      :tenant_id     => miq_request.requester.current_group.tenant_id,
+    }
 
-    _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
-    if self.class::AUTOMATE_DRIVES
-      args = {
-        :object_type   => self.class.name,
-        :object_id     => id,
-        :attrs         => {"request" => req_type},
-        :instance_name => "AUTOMATION",
-        :user_id       => miq_request.requester.id,
-        :miq_group_id  => miq_request.requester.current_group_id,
-        :tenant_id     => miq_request.requester.current_group.tenant_id,
-      }
+    MiqAeEngine::set_automation_attributes_from_objects(source, args[:attrs])
 
-      MiqAeEngine::set_automation_attributes_from_objects(source, args[:attrs])
-
-      zone ||= source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
-      MiqQueue.put(
-        :class_name     => 'MiqAeEngine',
-        :method_name    => 'deliver',
-        :args           => [args],
-        :role           => 'automate',
-        :zone           => options.fetch(:miq_zone, zone),
-        :tracking_label => tracking_label_id,
-      )
-      update_and_notify_parent(:state => "pending", :status => "Ok", :message => "Automation Starting")
-    else
-      execute_queue
-    end
+    zone ||= source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
+    MiqQueue.put(
+      :class_name     => 'MiqAeEngine',
+      :method_name    => 'deliver',
+      :args           => [args],
+      :role           => 'automate',
+      :zone           => options.fetch(:miq_zone, zone),
+      :tracking_label => tracking_label_id,
+    )
+    update_and_notify_parent(:state => "pending", :status => "Ok", :message => "Automation Starting")
   end
 
   def after_request_task_create

--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -25,7 +25,7 @@ class MiqRetireTask < MiqRequestTask
       :tenant_id     => miq_request.requester.current_group.tenant_id,
     }
 
-    MiqAeEngine::set_automation_attributes_from_objects(source, args[:attrs])
+    MiqAeEngine.set_automation_attributes_from_objects(source, args[:attrs])
 
     zone ||= source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
     MiqQueue.put(
@@ -34,7 +34,7 @@ class MiqRetireTask < MiqRequestTask
       :args           => [args],
       :role           => 'automate',
       :zone           => options.fetch(:miq_zone, zone),
-      :tracking_label => tracking_label_id,
+      :tracking_label => tracking_label_id
     )
     update_and_notify_parent(:state => "pending", :status => "Ok", :message => "Automation Starting")
   end

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -16,9 +16,6 @@ class ServiceReconfigureTask < MiqRequestTask
   end
 
   def deliver_to_automate(req_type = request_type, zone = nil)
-    task_check_on_execute
-
-    _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
     dialog_values = options[:dialog] || {}
 
     ra = source.service_template.resource_actions.find_by(:action => 'Reconfigure')

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -50,7 +50,7 @@ class ServiceRetireTask < MiqRetireTask
       new_task = create_task(svc_rsc, parent_service, nh, parent_task)
       new_task.after_request_task_create
       miq_request.miq_request_tasks << new_task
-      new_task.tap(&:deliver_to_automate)
+      new_task.tap(&:deliver_queue)
     end.compact!
   end
 

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -88,7 +88,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
       _log.info(message)
       update_and_notify_parent(:state => 'provisioned', :message => message)
     else
-      miq_request_tasks.each(&:deliver_to_automate)
+      miq_request_tasks.each(&:deliver_queue)
       message = "Service Provision started"
       _log.info(message)
       update_and_notify_parent(:message => message)
@@ -117,10 +117,6 @@ class ServiceTemplateProvisionTask < MiqRequestTask
   end
 
   def deliver_to_automate(req_type = request_type, _zone = nil)
-    task_check_on_delivery
-
-    _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
-
     if self.class::AUTOMATE_DRIVES
       dialog_values = options[:dialog] || {}
       dialog_values["request"] = req_type

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ServiceTemplateProvisionTask do
       end
     end
 
-    describe "#deliver_to_automate" do
+    describe "#deliver_queue" do
       context "when the state is not active" do
         before do
           @st_zone            = FactoryBot.create(:zone, :name => "service_template_zone")
@@ -111,31 +111,31 @@ RSpec.describe ServiceTemplateProvisionTask do
             :zone           => 'special',
             :tracking_label => tracking_label
           )
-          @task_0.deliver_to_automate
+          @task_0.deliver_queue
         end
 
         it "sets queue item to zone specified in dialog" do
           zone = FactoryBot.create(:zone, :name => 'dialog_zone')
           @task_0.update(:options => {:dialog => {"dialog_zone" => zone.name}})
           expect(MiqQueue).to receive(:put).with(hash_including(:zone => zone.name))
-          @task_0.deliver_to_automate
+          @task_0.deliver_queue
         end
 
         it "sets queue item to zone specified in service template without dialog" do
           expect(MiqQueue).to receive(:put).with(hash_including(:zone => @st_zone.name))
-          @task_0.deliver_to_automate
+          @task_0.deliver_queue
         end
 
         it "sets queue item to server's zone if not specified in dialog and service template" do
           @task_0.source.update(:zone => nil)
           expect(MiqQueue).to receive(:put).with(hash_including(:zone => 'a_server_zone'))
-          @task_0.deliver_to_automate
+          @task_0.deliver_queue
         end
       end
 
       it "raises an error when the state is already active" do
         @task_0.state = 'active'
-        expect { @task_0.deliver_to_automate }.to raise_error('Service_Template_Provisioning request is already being processed')
+        expect { @task_0.deliver_queue }.to raise_error('Service_Template_Provisioning request is already being processed')
       end
     end
 


### PR DESCRIPTION
The entrypoint to MiqRequestTask is currently `#deliver_to_automate` which then decided if we should deliver to automate.

This adds a new top-level `#deliver_queue` method which handles the "to automate or not to automate" question.

Extracted from https://github.com/ManageIQ/manageiq/pull/22511