### PR TITLE
Use namespaced gem require instead of hyphenated name

### DIFF
--- a/tools/log_processing/broker_registry_counts.rb
+++ b/tools/log_processing/broker_registry_counts.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 require 'miq_logger_processor'
 
 logfile = ARGV[0] || File.join(RAILS_ROOT, "log/vim.log")

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
 
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 require 'miq_logger_processor'
 require 'active_support/core_ext/enumerable' # Pull in Enumerable sum method
 require 'more_core_extensions/core_ext/array'

--- a/tools/log_processing/method_call_processor.rb
+++ b/tools/log_processing/method_call_processor.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 require 'miq_logger_processor'
 
 logfile = ARGV.shift if ARGV[0] && File.file?(ARGV[0])

--- a/tools/log_processing/perf_timings.rb
+++ b/tools/log_processing/perf_timings.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 require 'miq_logger_processor'
 
 logfile = ARGV.shift if ARGV[0] && File.file?(ARGV[0])

--- a/tools/log_processing/split_log_by_pid_tid.rb
+++ b/tools/log_processing/split_log_by_pid_tid.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 require 'miq_logger_processor'
 
 logfile = ARGV.shift if ARGV[0] && File.file?(ARGV[0])

--- a/tools/log_processing/ui_request_parser.rb
+++ b/tools/log_processing/ui_request_parser.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 require 'miq_logger_processor'
 
 logfile = ARGV.shift if ARGV[0] && File.file?(ARGV[0])


### PR DESCRIPTION
Both work but the namespaced name is more friendly to zeitwerk in the future.

Related: https://github.com/ManageIQ/manageiq/issues/22000

Note, this was extracted from https://github.com/ManageIQ/manageiq/pull/22488 as it's completely backward compatible.

Related to https://github.com/ManageIQ/amazon_ssa_support/pull/96