### PR TITLE
Upgrade i18n version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,9 +41,6 @@ gem "fast_gettext",                     "~>2.0.1"
 gem "gettext_i18n_rails",               "~>1.10.1"
 gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
-# rails-i18n typically takes care of this dependency
-# hardcoding to avoid 1.14 issue. remove once 1.15 comes out
-gem "i18n",                             "~>1.13.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.0",             :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "default_value_for",                "~>3.3"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false
 gem "fast_gettext",                     "~>2.0.1"
-gem "gettext_i18n_rails",               "~>1.10.1"
+gem "gettext_i18n_rails",               "~>1.11"
 gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -52,7 +52,7 @@ class Dictionary
 
   def self.i18n_lookup(type, text)
     result = I18n.t("dictionary.#{type}.#{text}", :locale => "en")
-    result.start_with?("translation missing:") ? nil : result
+    result if result && !result.match?(/Translation missing:/i)
   end
   private_class_method :i18n_lookup
 end


### PR DESCRIPTION
## Overview

i18n version 1.14 broke our build.

## Temporary Solution

We had pegged i18n to version 1.13

## Permanent Solution (this PR)

This reverts commit 6e1123215424d2197080836e6538b5f755d03496, reversing changes made to b4c75931b5e75e0299715a5845abb6dcb8f598c1.

We then added the 3 following fixes to resolve issues of i18n v 1.14

- i18n 1.14 introduced an issue around empty default values, 1.14.1 fixed this issue.
- i18n 1.14 introduces an issue around frozen strings. rails-i18n 1.11 fixes that 
- i18n 1.14 changes a string returned breaking our string compare. A commit fixes that.

For that last one, we had 2 options:

- peg i18n to `>=1.14` and have a single string comparison.
- Handle both string comparisons

We chose to handle both string comparisons. (thank you Jason for making sure we got the best performing code)
