### PR TITLE
Set init.defaultBranch for specs

### DIFF
--- a/bin/before_install
+++ b/bin/before_install
@@ -19,6 +19,7 @@ if [ -n "$CI" ]; then
   echo "== Setup git config =="
   git config --global user.name "ManageIQ"
   git config --global user.email "contact@manageiq.org"
+  git config --global init.defaultBranch "master"
   echo
 
   # Gemfile.lock.release only applies to non-master branches and PRs to non-master branches


### PR DESCRIPTION
This is relatively minor, but it causes noise in the specs that looks like the following for each one of our git repository specs.

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
```

