### PR TITLE
Fix some deliver_to_automate method overries not accepting any args

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -45,7 +45,7 @@ class MiqProvision < MiqProvisionTask
     set_dns_domain
   end
 
-  def deliver_to_automate
+  def deliver_to_automate(*)
     super("vm_provision", my_zone)
   end
 

--- a/app/models/physical_server_provision_task.rb
+++ b/app/models/physical_server_provision_task.rb
@@ -17,7 +17,7 @@ class PhysicalServerProvisionTask < MiqProvisionTask
     PhysicalServer
   end
 
-  def deliver_to_automate
+  def deliver_to_automate(*)
     super('physical_server_provision', my_zone)
   end
 end


### PR DESCRIPTION
There were some `#deliver_to_automate` overrides which didn't accept any arguments causing issues with creating request tasks.

```
[----] I, [2023-06-06T12:56:22.847006 #13431:a17c]  INFO -- evm: MIQ(ManageIQ::Providers::Vmware::InfraManager::Provision#deliver_queue) Queuing VM Provisioning: [Provision from [ag_template] to [ag-prov-test-2]]...
[----] E, [2023-06-06T12:56:22.847115 #13431:a17c] ERROR -- evm: [ArgumentError]: wrong number of arguments (given 2, expected 0)  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2023-06-06T12:56:22.847149 #13431:a17c] ERROR -- evm: /home/agrare/src/manageiq/manageiq/app/models/miq_provision.rb:48:in `deliver_to_automate'
/home/agrare/src/manageiq/manageiq/app/models/miq_request_task.rb:143:in `deliver_queue'
/home/agrare/src/manageiq/manageiq/app/models/miq_request.rb:470:in `block in create_request_tasks'
/home/agrare/src/manageiq/manageiq/app/models/miq_request.rb:467:in `each'
/home/agrare/src/manageiq/manageiq/app/models/miq_request.rb:467:in `create_request_tasks'
```

Ref: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/455#issuecomment-1578844038
Introduced by: https://github.com/ManageIQ/manageiq/pull/22544
Related:
* https://github.com/ManageIQ/manageiq-providers-foreman/pull/116
* https://github.com/ManageIQ/manageiq-providers-lenovo/pull/388