### PR TITLE
Remove N+1 from ContainerNode

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -17,6 +17,7 @@ class ContainerNode < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many   :container_groups, -> { active }
   has_many   :container_conditions, :class_name => "ContainerCondition", :as => :container_entity, :dependent => :destroy
+  has_one    :ready_condition, -> { where(:name => "Ready") }, :class_name => "ContainerCondition", :as => :container_entity, :inverse_of => :container_entity # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many   :containers, :through => :container_groups
   has_many   :container_images, -> { distinct }, :through => :container_groups
   has_many   :container_services, -> { distinct }, :through => :container_groups
@@ -26,7 +27,8 @@ class ContainerNode < ApplicationRecord
   has_many   :additional_attributes, -> { where(:section => "additional_attributes") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
   has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
   belongs_to :lives_on, :polymorphic => true
-  has_one   :hardware, :through => :computer_system
+  has_one    :hardware, :through => :computer_system
+  has_one    :operating_system, :through => :computer_system
 
   # Metrics destroy is handled by purger
   has_many :metrics, :as => :resource
@@ -39,10 +41,6 @@ class ContainerNode < ApplicationRecord
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
   virtual_column :system_distribution, :type => :string
   virtual_column :kernel_version, :type => :string
-
-  def ready_condition
-    container_conditions.find_by(:name => "Ready")
-  end
 
   def ready_condition_status
     ready_condition.try(:status) || 'None'

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -39,19 +39,11 @@ class ContainerNode < ApplicationRecord
 
 
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
-  virtual_column :system_distribution, :type => :string
-  virtual_column :kernel_version, :type => :string
+  virtual_delegate :system_distribution, :to => "operating_system.distribution", :allow_nil => true, :type => :string
+  virtual_delegate :kernel_version, :to => :operating_system, :allow_nil => true, :type => :string
 
   def ready_condition_status
     ready_condition.try(:status) || 'None'
-  end
-
-  def system_distribution
-    computer_system.try(:operating_system).try(:distribution)
-  end
-
-  def kernel_version
-    computer_system.try(:operating_system).try(:kernel_version)
   end
 
   include EventMixin

--- a/spec/models/container_node_spec.rb
+++ b/spec/models/container_node_spec.rb
@@ -2,4 +2,89 @@ RSpec.describe ContainerNode do
   subject { FactoryBot.create(:container_node) }
 
   include_examples "MiqPolicyMixin"
+
+  describe "#operating_system" do
+    it "handles null computer system" do
+      expect(subject.operating_system).to be_nil
+    end
+
+    it "handles null operating system" do
+      FactoryBot.create(:computer_system, :managed_entity => subject)
+      expect(subject.operating_system).to be_nil
+    end
+
+    it "delegates value" do
+      os = FactoryBot.create(:operating_system, :distribution => "coreos")
+      FactoryBot.create(:computer_system, :managed_entity => subject, :operating_system => os)
+      expect(subject.operating_system).to eq(os)
+    end
+  end
+
+  describe "#ready_condition" do
+    it "handles no container_conditions" do
+      expect(subject.ready_condition).to be_nil
+    end
+
+    it "handles other container conditions" do
+      FactoryBot.create(:container_conditions, :name => "Other", :container_entity => subject)
+      expect(subject.ready_condition).to be_nil
+    end
+
+    it "finds container conditions" do
+      ready = FactoryBot.create(:container_conditions, :name => "Ready", :container_entity => subject, :status => "Great")
+      FactoryBot.create(:container_conditions, :name => "Other", :container_entity => subject)
+      expect(subject.ready_condition).to eq(ready)
+    end
+  end
+
+  describe "#ready_condition_status" do
+    it "handles no container_conditions" do
+      expect(subject.ready_condition_status).to eq("None")
+    end
+
+    it "handles other container conditions" do
+      FactoryBot.create(:container_conditions, :name => "Other", :container_entity => subject)
+      expect(subject.ready_condition_status).to eq("None")
+    end
+
+    it "finds container conditions" do
+      FactoryBot.create(:container_conditions, :name => "Ready", :container_entity => subject, :status => "Great")
+      FactoryBot.create(:container_conditions, :name => "Other", :container_entity => subject, :status => "Not Good")
+      expect(subject.ready_condition_status).to eq("Great")
+    end
+  end
+
+  describe "#system_distribution" do # on os
+    it "handles null computer system" do
+      expect(subject.system_distribution).to be_nil
+    end
+
+    it "handles null operating system" do
+      FactoryBot.create(:computer_system, :managed_entity => subject)
+      expect(subject.system_distribution).to be_nil
+    end
+
+    it "delegates value" do
+      os = FactoryBot.create(:operating_system, :distribution => "coreos")
+      FactoryBot.create(:computer_system, :managed_entity => subject, :operating_system => os)
+      expect(subject.system_distribution).to eq("coreos")
+    end
+  end
+
+  describe "#kernel_version" do # on os
+    it "handles null computer system" do
+      expect(subject.kernel_version).to be_nil
+    end
+
+    it "handles null operating system" do
+      FactoryBot.create(:computer_system, :managed_entity => subject)
+      expect(subject.kernel_version).to be_nil
+    end
+
+    it "delegates value" do
+      os = FactoryBot.create(:operating_system, :kernel_version => "1.0.0")
+      FactoryBot.create(:computer_system, :managed_entity => subject, :operating_system => os)
+      expect(subject.kernel_version).to eq("1.0.0")
+    end
+  end
 end


### PR DESCRIPTION

On the container nodes page, we have an N+1 for fetching `system_distribution` and `kernel_version`.

For a page of 20 records, we end up with 20*2 extra queries.

|       ms |query |  qry ms |     rows |` comments`
|      ---:|  ---:|     ---:|      ---:|  ---
|  1,231.9 |   72 |   868.3 |      168 |` /container_node/report_data#before`
|    692.6 |   32 |   370.2 |      128 |` after`
|    43.8% |  56% |   57.4% |      24% | diff


details
=======

### before

|       ms |query |  qry ms |     rows |` comments`
|      ---:|  ---:|     ---:|      ---:|  ---
|     16.0 |    1 |    16.0 |          |`... SELECT DISTINCT LOWER(container_nodes.name) AS alias_0, container_nodes.id `
|    308.3 |    1 |    16.7 |      100 |`... SELECT container_nodes.id AS t0_r0, container_nodes.ems_ref AS t0_r1, container_nodes.name AS t0_r2, `
|    386.0 |   20 |   383.2 |       20 |`... SELECT container_conditions.* `
|     16.3 |   20 |     7.0 |       20 |`... SELECT computer_systems.* `
|     19.8 |   20 |     7.6 |       20 |`... SELECT operating_systems.* `

### after

|       ms |query |  qry ms |     rows |` comments`
|      ---:|  ---:|     ---:|      ---:|  ---
|     15.8 |    1 |    15.8 |          |`... SELECT DISTINCT LOWER(container_nodes.name) AS alias_0, container_nodes.id `
|     19.9 |    1 |    16.6 |      100 |`... SELECT container_nodes.*, (SELECT operating_systems.distribution `
|    287.0 |   20 |   285.3 |       20 |`... SELECT container_conditions.* `

There is one remaining N+1 that will come at another time