### PR TITLE
Simulate queue order

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -41,7 +41,15 @@ module Vmdb
     # Development helper method for Rails console for simulating queue workers.
     def simulate_queue_worker(break_on_complete: false, quiet_polling: true)
       raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
+
       deliver_on = MiqQueue.arel_table[:deliver_on]
+
+      stale_entries = MiqQueue.where(:state => MiqQueue::STATE_DEQUEUE).count
+      puts "NOTE: there are #{stale_entries} entries on the queue that are in progress" if stale_entries > 0
+
+      future_entries = MiqQueue.where(deliver_on.gt(1.minute.from_now)).count
+      puts "NOTE: there are #{future_entries} entries in the future" if future_entries > 0
+
       loop do
         q = with_console_sql_logging_level(quiet_polling ? 1 : ActiveRecord::Base.logger.level) do
           MiqQueue.where.not(:state => MiqQueue::STATE_DEQUEUE)

--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -47,7 +47,7 @@ module Vmdb
           MiqQueue.where.not(:state => MiqQueue::STATE_DEQUEUE)
                   .where(deliver_on.eq(nil).or(deliver_on.lteq(Time.now.utc)))
                   .where.not(:queue_name => "miq_server")
-                  .order(:id)
+                  .order(:priority, :id)
                   .first
         end
         if q


### PR DESCRIPTION
When running the queue, I want to run things in the priority order.

I also noticed quite a few outstanding entries in my queue that I had control-c'd out of. Decided to add a warning for these.
And I was confused why it wasn't picking up so many metrics messages. Printed out the future values for this one.


I want the priority order
Unsure about the others. They shouldn't print out anything so I can drop if you want.