### PR TITLE
Fix normal priority reports not being run in reporting workers

### DIFF
--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -997,6 +997,32 @@ RSpec.describe MiqQueue do
     end
   end
 
+  context ".queue_name_for_priority_service" do
+    it "returns generic queue for high priority work" do
+      expect(described_class.queue_name_for_priority_service('service', described_class::HIGH_PRIORITY)).to eq('generic')
+    end
+
+    it "returns generic queue for max priority work" do
+      expect(described_class.queue_name_for_priority_service('service', described_class::MAX_PRIORITY)).to eq('generic')
+    end
+
+    it "returns service queue for normal priority work" do
+      expect(described_class.queue_name_for_priority_service('service', described_class::NORMAL_PRIORITY)).to eq('service')
+    end
+
+    it "returns service queue for slightly higher than normal priority work" do
+      expect(described_class.queue_name_for_priority_service('service', described_class::NORMAL_PRIORITY - 10)).to eq('service')
+    end
+
+    it "returns service queue for slightly lower than high priority work" do
+      expect(described_class.queue_name_for_priority_service('service', described_class::HIGH_PRIORITY + 10)).to eq('service')
+    end
+
+    it "returns service queue for work with no priority specified" do
+      expect(described_class.queue_name_for_priority_service('service', nil)).to eq('service')
+    end
+  end
+
   describe ".messaging_client_options" do
     context "with ENV" do
       let(:env_vars) { ENV.to_h.merge("MESSAGING_HOSTNAME" => "server.example.com", "MESSAGING_PORT" => "9092", "MESSAGING_USERNAME" => "admin") }


### PR DESCRIPTION
Fixes #22562

With this change, for services with a dedicated queue_name and worker, such as reporting, high priority work is run in the 'generic' queue with HIGH_PRIORITY so priority workers or even generic workers can pick it up immediately. Anything but high priority work or higher is run in the service's queue, such as 'reporting', and the dedicated worker will process this message following priority processing.

Why? Reports are often started by a user who is actively waiting for the result so we need a way to expedite their request in workers who deal with high priority work.  At the same time, if a user isn't actively waiting for a report, it should be handled by reporting workers and not sit behind other items in the generic queue as it's far easier to scale these workers up and down as needed.

Priority work still enqueues in generic queue as high priority, 20:

```
irb(main):001:1*         MiqQueue.submit_job(
irb(main):002:1*           :service      => "reporting",
irb(main):003:1*           :class_name   => MiqReport,
irb(main):004:1*           :method_name  => "_async_generate_table",
irb(main):005:1*           :args         => [1],
irb(main):006:1*           :priority     => MiqQueue::HIGH_PRIORITY,
irb(main):007:1*           :miq_callback => nil,
irb(main):008:1*           :msg_timeout  => 10.minutes
irb(main):009:0>         )
=>
#<MiqQueue:0x00000001132c5790
 id: 17,
 target_id: nil,
 priority: 20,          # <=== high priority
 method_name: "_async_generate_table",
 state: "ready",
 created_on: Tue, 13 Jun 2023 16:11:31.750274000 UTC +00:00,
 updated_on: Tue, 13 Jun 2023 16:11:31.750274000 UTC +00:00,
 lock_version: 0,
 task_id: nil,
 deliver_on: nil,
 queue_name: "generic", # <=== Generic
 class_name: "MiqReport",
 instance_id: nil,
 args: [1],
 miq_callback: {},
 msg_data: nil,
 zone: nil,
 role: "reporting",
 server_guid: nil,
 msg_timeout: 600,
 handler_id: nil,
 handler_type: nil,
 expires_on: nil,
 tracking_label: nil,
 user_id: nil,
 group_id: nil,
 tenant_id: nil,
 miq_task_id: nil>
```

Normal priority reporting work now submits job to reporting queue with normal priority:

```
irb(main):010:1*         MiqQueue.submit_job(
irb(main):011:1*           :service      => "reporting",
irb(main):012:1*           :class_name   => MiqReport,
irb(main):013:1*           :method_name  => "_async_generate_table",
irb(main):014:1*           :args         => [1],
irb(main):015:1*           :priority     => MiqQueue::NORMAL_PRIORITY,
irb(main):016:1*           :miq_callback => nil,
irb(main):017:1*           :msg_timeout  => 10.minutes
irb(main):018:0>         )
=>
#<MiqQueue:0x0000000107a24858
 id: 18,
 target_id: nil,
 priority: 100,          # <=== normal priority
 method_name: "_async_generate_table",
 state: "ready",
 created_on: Tue, 13 Jun 2023 16:11:44.513286000 UTC +00:00,
 updated_on: Tue, 13 Jun 2023 16:11:44.513286000 UTC +00:00,
 lock_version: 0,
 task_id: nil,
 deliver_on: nil,
 queue_name: "reporting", # <=== reporting queue
 class_name: "MiqReport",
 instance_id: nil,
 args: [1],
 miq_callback: {},
 msg_data: nil,
 zone: nil,
 role: "reporting",
 server_guid: nil,
 msg_timeout: 600,
 handler_id: nil,
 handler_type: nil,
 expires_on: nil,
 tracking_label: nil,
 user_id: nil,
 group_id: nil,
 tenant_id: nil,
 miq_task_id: nil>
```