### PR TITLE
Check if an EMS is enabled before `perf_capture_*`

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -42,6 +42,11 @@ module Metric::Capture
     _log.info("Queueing performance capture...")
 
     ems = ExtManagementSystem.find(ems_id)
+    if !ems.enabled?
+      _log.info("Queueing performance capture...Skipping because name: [#{ems.name}] id: [#{ems.id}] is paused")
+      return
+    end
+
     ems.perf_capture_object.perf_capture_all_queue
 
     _log.info("Queueing performance capture...Complete")

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -29,9 +29,16 @@ module Metric::CiMixin::Capture
     raise ArgumentError, _("end_time cannot be specified if start_time is nil") if start_time.nil? && !end_time.nil?
 
     # if target (== self) is archived, skip it
-    if respond_to?(:ems_id) && ems_id.nil?
-      _log.warn("C&U collection's target is archived (no EMS associated), skipping. Target: #{log_target}")
-      return
+    if respond_to?(:ext_management_system)
+      if ext_management_system.nil?
+        _log.warn("C&U collection's target is archived (no EMS associated), skipping. Target: #{log_target}")
+        return
+      end
+
+      if !ext_management_system.enabled?
+        _log.warn("C&U collection's target's EMS is paused, skipping. Target: #{log_target}")
+        return
+      end
     end
 
     metrics_capture = perf_capture_object(target_ids ? self.class.where(:id => target_ids).to_a : self)

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -2,7 +2,28 @@ RSpec.describe Metric::Capture do
   include Spec::Support::MetricHelper
 
   before do
+    Zone.seed
     @zone = EvmSpecHelper.local_miq_server.zone
+  end
+
+  describe ".perf_capture_timer" do
+    let(:ems) { FactoryBot.create(:ext_management_system) }
+
+    before { allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems) }
+
+    it "calls perf_capture_all_queue" do
+      expect(ems).to receive_message_chain(:perf_capture_object, :perf_capture_all_queue)
+      described_class.perf_capture_timer(ems.id)
+    end
+
+    context "with a paused EMS" do
+      let(:ems) { FactoryBot.create(:ext_management_system, :zone => Zone.maintenance_zone, :enabled => false) }
+
+      it "doesn't call perf_capture_all_queue" do
+        expect(ems).not_to receive(:perf_capture_object)
+        described_class.perf_capture_timer(ems.id)
+      end
+    end
   end
 
   describe ".alert_capture_threshold" do

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Metric::CiMixin::Capture do
   let(:vm) { FactoryBot.create(:vm_perf_openstack, :ext_management_system => ems_openstack) }
 
   before do
+    Zone.seed
     allow(ems_openstack).to receive(:connect).with(:service => "Metering").and_return(metering)
   end
 
@@ -184,6 +185,15 @@ RSpec.describe Metric::CiMixin::Capture do
             expected_timestamps.each do |timestamp|
               expect(@metrics_by_ts[timestamp.iso8601].try(:cpu_usage_rate_average)).not_to eq nil
             end
+          end
+        end
+
+        context "with a paused EMS" do
+          let(:ems_openstack) { FactoryBot.create(:ems_openstack, :zone => Zone.maintenance_zone, :enabled => false) }
+
+          it "doesn't run just_perf_capture" do
+            expect(vm).not_to receive(:just_perf_capture)
+            vm.perf_capture_realtime
           end
         end
       end


### PR DESCRIPTION
If an EMS is paused we shouldn't run `perf_capture_timer` or `perf_capture`