### PR TITLE
Quiesce before raising 'stop' event and ignore any exceptions

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -289,9 +289,9 @@ class MiqServer < ApplicationRecord
 
   def shutdown
     _log.info("initiated for #{format_full_log_msg}")
-    MiqEvent.raise_evm_event(self, "evm_server_stop")
-
     quiesce
+
+    MiqEvent.raise_evm_event(self, "evm_server_stop") rescue nil
   end
 
   def shutdown_and_exit(exit_status = 0)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -86,10 +86,18 @@ RSpec.describe MiqServer do
       expect(@miq_server.errors.messages[:zone]).to be_present
     end
 
-    it "shutdown will raise an event and quiesce" do
-      expect(MiqEvent).to receive(:raise_evm_event)
-      expect(@miq_server).to receive(:quiesce)
-      @miq_server.shutdown
+    context "#shutdown" do
+      it "will quiesce and raise an event" do
+        expect(MiqEvent).to receive(:raise_evm_event)
+        expect(@miq_server).to receive(:quiesce)
+        @miq_server.shutdown
+      end
+
+      it "exceptions during raise event will not prevent quiesce and will be ignored" do
+        allow(MiqEvent).to receive(:raise_evm_event).and_raise(StandardError)
+        expect(@miq_server).to receive(:quiesce)
+        @miq_server.shutdown
+      end
     end
 
     it "sync stop will do nothing if stopped" do


### PR DESCRIPTION
The server isn't stopped until the roles are deactivated and workers stopped.
Raising an event is not important enough to deal with exceptions during shutdown.

Raising an event expects servers and zones to exist so it can fail if the server is removed.
It's expected that the server doesn't exist in the database.
In fact, evm_server's logic assumes the servers in the db doesn't match what we've
been monitoring and issues a shutdown.

See: https://github.com/ManageIQ/manageiq/blob/ba12966c70068e2a9b96bc363ff53ef7510c6630/lib/workers/evm_server.rb#L67-L81

This should resolve an issue where the shutdown is interrupted with a fatal exception before quiesce can occur.

```
 XXX/lib/miq_automation_engine/engine/miq_ae_engine.rb:22:in `deliver_queue': undefined method `has_active_role?' for nil:NilClass (NoMethodError)
         from XXX/lib/miq_automation_engine/engine/miq_ae_event.rb:164:in `call_automate'
         from XXX/lib/miq_automation_engine/engine/miq_ae_event.rb:54:in `raise_evm_event'
         from /var/www/miq/vmdb/app/models/miq_event.rb:98:in `raise_evm_event'
         from /var/www/miq/vmdb/app/models/miq_server.rb:286:in `shutdown'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:79:in `block in refresh_servers_to_monitor'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:77:in `each'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:77:in `refresh_servers_to_monitor'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:50:in `block in monitor_servers'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:49:in `loop'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:49:in `monitor_servers'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:31:in `start'
         from /var/www/miq/vmdb/lib/workers/evm_server.rb:84:in `start'
         from /var/www/miq/vmdb/lib/workers/bin/evm_server.rb:4:in `<main>'
```