### PR TITLE
fix test by giving metrics endpoint to metrics capture ems

### DIFF
--- a/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ManageIQ::Providers::ContainerManager::MetricsCapture do
       end
 
       context "with inventory" do
+        let(:ems)              { FactoryBot.create(:ems_container, :with_metrics_endpoint, :zone => miq_server.zone) }
         let(:deleted_on)       { nil }
         let!(:container_node)  { FactoryBot.create(:container_node, :ext_management_system => ems, :deleted_on => deleted_on) }
         let!(:container_group) { FactoryBot.create(:container_group, :ext_management_system => ems, :deleted_on => deleted_on) }


### PR DESCRIPTION
introduced by:
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/493

This makes sure the ems is all good and tests pass
