### PR TITLE
Don't instantiate queue records on deleting a zone  - Fix UI deletion of zone with many rows growing memory beyond limits

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -12,7 +12,7 @@ class Zone < ApplicationRecord
   has_many :container_managers, :class_name => "ManageIQ::Providers::ContainerManager"
   has_many :miq_schedules, :dependent => :destroy
   has_many :providers
-  has_many :miq_queues, :dependent => :destroy, :foreign_key => :zone, :primary_key => :name
+  has_many :miq_queues, :dependent => :delete_all, :foreign_key => :zone, :primary_key => :name
 
   has_many :hosts,                 :through => :ext_management_systems
   has_many :clustered_hosts,       :through => :ext_management_systems


### PR DESCRIPTION
MiqQueue has no associations it needs to instantiate to walk so it's safe to issue a delete call instead of instantiating possibly many thousands of rows associated with a zone when deleting that zone.

This throwaway test completely fails with "destroy" at 10_000 rows but passes with 200_000 rows using "delete_all".

In other words, it takes more than 25 MB of memory growth or 2 seconds to delete a zone with "dependent => :destroy" on 10_000 queue rows while "dependent => :delete_all" with 200_000 queue rows doesn't grow 25 MB or take more than 2 seconds.

```ruby
  it "removes queued items on destroy" do
    Zone.seed
    zone = FactoryBot.create(:zone)
    count = 200_000
    args = [["MiqServer", 2], "evm_worker_start", {:event_details=>"Worker started: ID [12345], PID [54321], GUID [407054c3-e9da-4040-b919-9487580f9d48]" , :type=>"MiqPriorityWorker"}]
    count.times { FactoryBot.create(:miq_queue, :zone => zone.name, :args => args) }
    expect(MiqQueue.where(:zone => zone.name).count).to eq(count)
    require "sys/proctable"
    memory_before = Sys::ProcTable.ps(:pid => Process.pid).resident_size
    time_before = Time.now.utc
    zone.destroy!
    time_after = Time.now.utc
    memory_after = Sys::ProcTable.ps(:pid => Process.pid).resident_size
    expect(memory_after).to be_within(25.megabytes).of(memory_before)
    expect(time_after).to be_within(2.seconds).of(time_before)
    expect(MiqQueue.where(:zone => zone.name).count).to eq(0)
  end
```