### PR TITLE
Add a default params_to_attributes for EmbeddedAutomationManager Authentications

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -48,7 +48,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential 
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
     attrs[:auth_key] = attrs.delete(:security_token) if attrs.key?(:security_token)
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -48,7 +48,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential 
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
     attrs[:auth_key] = attrs.delete(:security_token) if attrs.key?(:security_token)
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -69,7 +69,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential <
   end
 
   def self.params_to_attributes(params)
-    attrs            = super
+    attrs            = super.dup
     attrs[:auth_key] = attrs.delete(:secret) if attrs.key?(:secret)
 
     if %i[client tenant subscription].any? {|opt| attrs.has_key? opt }

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -69,7 +69,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential <
   end
 
   def self.params_to_attributes(params)
-    attrs            = params.dup
+    attrs            = super
     attrs[:auth_key] = attrs.delete(:secret) if attrs.key?(:secret)
 
     if %i[client tenant subscription].any? {|opt| attrs.has_key? opt }

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -49,7 +49,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential 
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
 
     attrs[:auth_key] = attrs.delete(:ssh_key_data)            if attrs.key?(:ssh_key_data)
     attrs[:options]  = { :project => attrs.delete(:project) } if attrs[:project]

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -49,7 +49,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential 
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
 
     attrs[:auth_key] = attrs.delete(:ssh_key_data)            if attrs.key?(:ssh_key_data)
     attrs[:options]  = { :project => attrs.delete(:project) } if attrs[:project]

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -98,7 +98,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
 
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)   if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock) if attrs.key?(:ssh_key_unlock)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -98,7 +98,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
 
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)   if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock) if attrs.key?(:ssh_key_unlock)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -77,7 +77,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
 
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)       if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)     if attrs.key?(:ssh_key_unlock)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -77,7 +77,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
 
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)       if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)     if attrs.key?(:ssh_key_unlock)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -65,7 +65,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredenti
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
 
     if %i[host domain project].any? {|opt| attrs.has_key? opt }
       attrs[:options]         ||= {}

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -65,7 +65,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredenti
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
 
     if %i[host domain project].any? {|opt| attrs.has_key? opt }
       attrs[:options]         ||= {}

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
@@ -43,7 +43,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential < M
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
     attrs[:options] = { :host => attrs.delete(:host) } if attrs[:host]
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
@@ -43,7 +43,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential < M
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
     attrs[:options] = { :host => attrs.delete(:host) } if attrs[:host]
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential <
   alias vault_password password
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
     attrs[:password] = attrs.delete(:vault_password) if attrs.key?(:vault_password)
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential <
   alias vault_password password
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
     attrs[:password] = attrs.delete(:vault_password) if attrs.key?(:vault_password)
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
@@ -47,7 +47,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential 
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
     attrs[:options] = { :host => attrs.delete(:host) } if attrs[:host]
     attrs
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
@@ -47,7 +47,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential 
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
     attrs[:options] = { :host => attrs.delete(:host) } if attrs[:host]
     attrs
   end

--- a/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager::Authentication < ManageIQ:
   include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
 
   def self.params_to_attributes(params)
-    allowed_params     = API_ATTRIBUTES.pluck(:id)
+    allowed_params     = self::API_ATTRIBUTES.pluck(:id) + %w[name type options]
     unpermitted_params = params.keys.map(&:to_s) - allowed_params
     raise ArgumentError, _("Invalid parameters: %{params}" % {:params => unpermitted_params.join(", ")}) if unpermitted_params.any?
 

--- a/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
@@ -20,8 +20,12 @@ class ManageIQ::Providers::EmbeddedAutomationManager::Authentication < ManageIQ:
 
   include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
 
-  def self.params_to_attributes(_params)
-    raise NotImplementedError, "must be implemented in a subclass"
+  def self.params_to_attributes(params)
+    allowed_params     = API_ATTRIBUTES.pluck(:id)
+    unpermitted_params = params.keys - allowed_params
+    raise ArgumentError, _("Invalid parameters: %{params}" % {:params => unpermitted_params.join(", ")}) if unpermitted_params.any?
+
+    params
   end
 
   def self.raw_create_in_provider(manager, params)

--- a/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager::Authentication < ManageIQ:
 
   def self.params_to_attributes(params)
     allowed_params     = API_ATTRIBUTES.pluck(:id)
-    unpermitted_params = params.keys - allowed_params
+    unpermitted_params = params.keys.map(&:to_s) - allowed_params
     raise ArgumentError, _("Invalid parameters: %{params}" % {:params => unpermitted_params.join(", ")}) if unpermitted_params.any?
 
     params

--- a/app/models/manageiq/providers/embedded_automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/scm_credential.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ScmCredential < ManageIQ::
   end
 
   def self.params_to_attributes(params)
-    attrs = params.dup
+    attrs = super
 
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)    if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)  if attrs.key?(:ssh_key_unlock)

--- a/app/models/manageiq/providers/embedded_automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/scm_credential.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ScmCredential < ManageIQ::
   end
 
   def self.params_to_attributes(params)
-    attrs = super
+    attrs = super.dup
 
     attrs[:auth_key]          = attrs.delete(:ssh_key_data)    if attrs.key?(:ssh_key_data)
     attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)  if attrs.key?(:ssh_key_unlock)


### PR DESCRIPTION
Use API_ATTRIBUTES to filter allowed parameters for embedded automation manager authentications