### PR TITLE
Separate role access restrictions for catalog items

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -101,12 +101,12 @@ class MiqUserRole < ApplicationRecord
   virtual_total :group_count, :miq_groups
 
   def vm_restriction
-    vmr = settings && settings.fetch_path(:restrictions, :vms)
+    vmr = settings&.dig(:restrictions, :vms)
     vmr ? RESTRICTIONS[vmr] : "None"
   end
 
   def service_template_restriction
-    str = settings && settings.fetch_path(:restrictions, :service_templates)
+    str = settings&.dig(:restrictions, :service_templates)
     str ? RESTRICTIONS[str] : "None"
   end
 

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -7,7 +7,8 @@ class MiqUserRole < ApplicationRecord
   has_many                :miq_groups, :through => :entitlements
   has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features
 
-  virtual_column :vm_restriction,                   :type => :string
+  virtual_column :vm_restriction,               :type => :string
+  virtual_column :service_template_restriction, :type => :string
 
   validates :name, :presence => true, :uniqueness_when_changed => {:case_sensitive => false}
 
@@ -56,12 +57,12 @@ class MiqUserRole < ApplicationRecord
     end
   end
 
-  def self_service?
-    [:user_or_group, :user].include?((settings || {}).fetch_path(:restrictions, :vms))
+  def self_service?(klass = nil)
+    [:user_or_group, :user].include?((settings || {}).fetch_path(:restrictions, restriction_type(klass)))
   end
 
-  def limited_self_service?
-    (settings || {}).fetch_path(:restrictions, :vms) == :user
+  def limited_self_service?(klass = nil)
+    (settings || {}).fetch_path(:restrictions, restriction_type(klass)) == :user
   end
 
   def self.with_roles_excluding(identifier)
@@ -104,6 +105,11 @@ class MiqUserRole < ApplicationRecord
     vmr ? RESTRICTIONS[vmr] : "None"
   end
 
+  def service_template_restriction
+    str = settings && settings.fetch_path(:restrictions, :service_templates)
+    str ? RESTRICTIONS[str] : "None"
+  end
+
   def super_admin_user?
     allows?(:identifier => MiqProductFeature::SUPER_ADMIN_FEATURE)
   end
@@ -130,5 +136,16 @@ class MiqUserRole < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Role', 'Roles', number)
+  end
+
+  private
+
+  def restriction_type(klass)
+    case klass.to_s
+    when "ServiceTemplate"
+      :service_templates
+    else
+      :vms
+    end
   end
 end

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -948,6 +948,7 @@
   :settings:
     :restrictions:
       :vms: :user
+      :service_templates: :user
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
@@ -1134,6 +1135,7 @@
   :settings:
     :restrictions:
       :vms: :user_or_group
+      :service_templates: :user_or_group
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -496,7 +496,7 @@ module Rbac
 
     def self_service_ownership_scope?(miq_group, klass)
       is_ownership_class = OWNERSHIP_CLASSES.any? { |allowed_ownership_klass| klass <= allowed_ownership_klass.safe_constantize }
-      miq_group.present? && miq_group.self_service? && is_ownership_class && klass.respond_to?(:user_or_group_owned)
+      miq_group.present? && miq_group.self_service?(klass) && is_ownership_class && klass.respond_to?(:user_or_group_owned)
     end
 
     def self_service_ownership_scope(user, miq_group, klass)
@@ -504,7 +504,7 @@ module Rbac
 
       # for limited_self_service, use user's resources, not user.current_group's resources
       # for reports (user = nil), still use miq_group
-      miq_group = nil if user && miq_group.limited_self_service?
+      miq_group = nil if user && miq_group.limited_self_service?(klass)
 
       # Get the list of objects that are owned by the user or their LDAP group
       klass.user_or_group_owned(user, miq_group).except(:order)


### PR DESCRIPTION
Closes #22421

Previously user role access restriction for Catalog Items, Orchestration
Stacks, Key Pairs, Services, VMs, and Templates were set with a single
control (vm_restriction).

Break out the ability to set access restriction for catalog items
separately from other types.

This feature is useful when an administrator wants to give a group
access to a catalog item (service_template) but wants any services
ordered to be restricted to the individual users.

Corresponding UI PR:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/8833