### PR TITLE
[WIP] Virtual attributes for Containers and friends (performance changes)

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -45,7 +45,7 @@ class ContainerImage < ApplicationRecord
   serialize :exposed_ports, :type => Hash
   serialize :environment_variables, :type => Hash
 
-  virtual_column :display_registry, :type => :string
+  virtual_delegate :display_registry, :to => "container_image_registry.full_name", :allow_nil => true, :type => :string
   virtual_total :total_containers, :containers
 
   after_create :raise_creation_event
@@ -83,10 +83,6 @@ class ContainerImage < ApplicationRecord
 
   # The guid is required by the smart analysis infrastructure
   alias_method :guid, :docker_id
-
-  def display_registry
-    container_image_registry.present? ? container_image_registry.full_name : _("Unknown image source")
-  end
 
   def scan(userid = "system")
     ext_management_system.scan_job_create(self, userid)

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -48,12 +48,9 @@ class ContainerNode < ApplicationRecord
   delegate :my_zone, :to => :ext_management_system, :allow_nil => true
 
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
+  virtual_delegate :status, :prefix => true, :to => :ready_condition, :allow_nil => true, :default => "None", :type => :string
   virtual_delegate :system_distribution, :to => "operating_system.distribution", :allow_nil => true, :type => :string
   virtual_delegate :kernel_version, :to => :operating_system, :allow_nil => true, :type => :string
-
-  def ready_condition_status
-    ready_condition.try(:status) || 'None'
-  end
 
   include EventMixin
   include Metric::CiMixin

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -46,23 +46,25 @@ RSpec.describe ContainerGroup do
   end
 
   context "#ready_condition_status" do
-    let(:condition_ready) { FactoryBot.create(:container_condition, :container_entity => container_group, :name => "Ready") }
+    let(:condition_ready) { FactoryBot.create(:container_condition, :container_entity => container_group, :name => "Ready", :status => "Good") }
     let(:condition_other) { FactoryBot.create(:container_condition, :container_entity => container_group, :name => "Other") }
     let(:container_group) { FactoryBot.create(:container_group) }
 
-    it "preloads the conditions" do
+    it "handles no container_conditions (select and direct)" do
       condition_other
-      cr = condition_ready
-      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status).find_by(:id => container_group.id)
 
-      expect { expect(cg.ready_condition).to eq(cr) }.to_not make_database_queries
+      subj = described_class.where(:id => container_group.id)
+      expect(subj.first.ready_condition_status).to eq("None")
+      expect(subj.select(:ready_condition_status).first.ready_condition_status).to eq("None")
     end
 
-    it "handles non-preloaded conditions" do
+    it "selects ready_condition_status" do
+      condition_ready
       condition_other
-      cr = condition_ready
-      cg = ContainerGroup.find_by(:id => container_group.id)
-      expect { expect(cg.ready_condition).to eq(cr) }.to make_database_queries(:count => 1)
+
+      subj = described_class.where(:id => container_group.id)
+      expect(subj.first.ready_condition_status).to eq(condition_ready.status)
+      expect(subj.select(:ready_condition_status).first.ready_condition_status).to eq(condition_ready.status)
     end
   end
 

--- a/spec/models/container_image_registry_spec.rb
+++ b/spec/models/container_image_registry_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe ContainerImageRegistry do
-  it "#full_name" do
-    reg = ContainerImageRegistry.new(:name => "docker.io", :host => "docker.io")
-    expect(reg.full_name).to eq("docker.io")
+  describe "#full_name" do
+    it "works with no port" do
+      reg = FactoryBot.create(:container_image_registry, :name => "docker.io", :host => "docker.io")
+      expect(reg.full_name).to eq("docker.io")
 
-    reg.port = "1234"
-    expect(reg.full_name).to eq("docker.io:1234")
+      reg = ContainerImageRegistry.where(:id => reg.id).select(:full_name).first
+      expect(reg.full_name).to eq("docker.io")
+    end
+
+    it "works with port" do
+      reg = FactoryBot.create(:container_image_registry, :name => "docker.io", :host => "docker.io", :port => "1234")
+      expect(reg.full_name).to eq("docker.io:1234")
+
+      reg = ContainerImageRegistry.where(:id => reg.id).select(:full_name).first
+      expect(reg.full_name).to eq("docker.io:1234")
+    end
   end
 end

--- a/spec/models/container_image_spec.rb
+++ b/spec/models/container_image_spec.rb
@@ -21,23 +21,25 @@ RSpec.describe ContainerImage do
 
   context "#display_registry" do
     it "finds unknown with unknown name" do
-      image = ContainerImage.new(:name => "fedora")
-      expect(image.display_registry).to eq("Unknown image source")
-    end
+      image = FactoryBot.create(:container_image, :name => "fedora")
+      expect(image.display_registry).to be_nil
 
-    it "localizes for unknown" do
-      I18n.with_locale(:es) do
-        image = ContainerImage.new(:name => "fedora")
-        reg = image.display_registry
-        expect(reg).to eq("Fuente de imagen desconocida")
-      end
+      image = ContainerImage.where(:id => image.id).select(:display_registry).first
+      expect do
+        expect(image.display_registry).to be_nil
+      end.not_to make_database_queries
     end
 
     it "finds name with valid name" do
-      image = ContainerImage.new(:name => "fedora")
-      reg = ContainerImageRegistry.new(:name => "docker.io", :host => "docker.io", :port => "1234")
-      image.container_image_registry = reg
+      reg = FactoryBot.create(:container_image_registry, :name => "docker.io", :host => "docker.io", :port => "1234")
+      image = FactoryBot.create(:container_image, :name => "fedora", :container_image_registry => reg)
+
       expect(image.display_registry).to eq("docker.io:1234")
+
+      image = ContainerImage.where(:id => image.id).select(:display_registry).first
+      expect do
+        expect(image.display_registry).to eq("docker.io:1234")
+      end.not_to make_database_queries
     end
   end
 

--- a/spec/models/container_node_spec.rb
+++ b/spec/models/container_node_spec.rb
@@ -47,10 +47,13 @@ RSpec.describe ContainerNode do
       expect(subject.ready_condition_status).to eq("None")
     end
 
-    it "finds container conditions" do
+    it "finds ready container conditions" do
       FactoryBot.create(:container_conditions, :name => "Ready", :container_entity => subject, :status => "Great")
       FactoryBot.create(:container_conditions, :name => "Other", :container_entity => subject, :status => "Not Good")
       expect(subject.ready_condition_status).to eq("Great")
+
+      subj = described_class.where(:id => subject.id)
+      expect(subj.select(:ready_condition_status).first.ready_condition_status).to eq("Great")
     end
   end
 


### PR DESCRIPTION
depends upon:

- [x] https://github.com/ManageIQ/activerecord-virtual_attributes/pull/120
- ~~https://github.com/ManageIQ/activerecord-virtual_attributes/pull/127~~

@agrare Can we outright claim that `PersistentVolume#parent` is always an `Ems`?
I get that a `ContainerVolume#parent` is polymorphic, but curious about the child class (i.e.: `PersistentVolume`). If not, may need to drop that change.

## Numbers

|     ms |query | qry ms |     rows |` comments`
|    ---:|  ---:|   ---:|      ---:|  ---
|  347.2 |   32 |  53.2 |      128 |` /container_node/report_data#node-index`
|  308.8 |   11 |  10.3 |       28 |` /container_node/report_data#node-after`
|  11.1% |  66% | 80.6% |      78% | diff

|     ms |query | qry ms |     rows |` comments`
|    ---:|  ---:|   ---:|      ---:|  ---
|  428.0 |   32 | 123.2 |       88 |` /container_group/report_data#group-index`
|  336.5 |   11 |  65.5 |       28 |` /container_group/report_data#group-after`
|  21.4% |  66% | 46.8% |      68% | diff

|     ms |query | qry ms |     rows |` comments`
|    ---:|  ---:|   ---:|      ---:|  ---
|  424.3 |   51 |  98.7 |       48 |` /container_image/report_data`
|  345.1 |   11 |  34.4 |       28 |` /container_image/report_data`
|   18.7%|   78%|  65.1%|       42%| diff

---

no longer:

|     ms |query | qry ms |     rows |` comments`
|    ---:|  ---:|   ---:|      ---:|  ---
|  278.6 |   31 |  12.7 |       48 |` /persistent_volume/report_data#before`
|  258.7 |   11 |   9.9 |       28 |` /persistent_volume/report_data#after`
|   7.1% |   65%|  22.0%|      42% | diff

