### PR TITLE
Allow `supports?(feature)` to work without requiring `supports_not`

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -78,7 +78,13 @@ module SupportsFeatureMixin
 
   # query the instance if the feature is supported or not
   def supports?(feature)
-    public_send("supports_#{feature}?")
+    method_name = "supports_#{feature}?"
+    if respond_to?(method_name)
+      public_send(method_name)
+    else
+      unsupported_reason_add(feature)
+      false
+    end
   end
 
   private
@@ -108,7 +114,13 @@ module SupportsFeatureMixin
 
     # query the class if the feature is supported or not
     def supports?(feature)
-      public_send("supports_#{feature}?")
+      method_name = "supports_#{feature}?"
+      if respond_to?(method_name)
+        public_send(method_name)
+      else
+        unsupported_reason_add(feature)
+        false
+      end
     end
 
     # all subclasses that are considered for supporting features
@@ -147,7 +159,7 @@ module SupportsFeatureMixin
     # query the class for the reason why something is unsupported
     def unsupported_reason(feature)
       feature = feature.to_sym
-      public_send("supports_#{feature}?") unless unsupported.key?(feature)
+      supports?(feature) unless unsupported.key?(feature)
       unsupported[feature]
     end
 

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe SupportsFeatureMixin do
       expect(test_class.supports?(:dynamic_feature)).to be_truthy
     end
 
+    it "handles unknown supports" do
+      expect(test_class.supports?(:denial_unknown_feature)).to be_falsey
+    end
+
     context "with child class" do
       it "overrides to deny" do
         child_class = define_model(nil, test_class, :std_accept => false, :module_accept => false, :dynamic_feature => false)
@@ -97,6 +101,10 @@ RSpec.describe SupportsFeatureMixin do
     it "denies with no reason given" do
       test_class.supports_not :denial_no_reason
       expect(test_inst.supports?(:denial_no_reason)).to be_falsey
+    end
+
+    it "handles unknown supports" do
+      expect(test_inst.supports?(:denial_unknown_feature)).to be_falsey
     end
 
     it "denies dynamic attrs" do
@@ -183,6 +191,10 @@ RSpec.describe SupportsFeatureMixin do
       test_class.supports_not :denial_no_reason
       expect(test_class.unsupported_reason(:denial_no_reason)).to eq("Feature not available/supported")
     end
+
+    it "defaults denial reason for unknown feature" do
+      expect(test_class.unsupported_reason(:denial_unknown_feature)).to eq("Feature not available/supported")
+    end
   end
 
   describe '#unsupported_reason' do
@@ -195,6 +207,10 @@ RSpec.describe SupportsFeatureMixin do
     it "gives defaults denial reason" do
       test_class.supports_not :denial_no_reason
       expect(test_inst.unsupported_reason(:denial_no_reason)).to eq("Feature not available/supported")
+    end
+
+    it "defaults denial reason for unknown feature" do
+      expect(test_inst.unsupported_reason(:denial_unknown_feature)).to eq("Feature not available/supported")
     end
 
     it "gives reason when dynamic feature" do

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe SupportsFeatureMixin do
 
   describe ".supports_feature?" do
     it "defines supports on the class" do
-      expect(test_class.supports?(:std_accept)).to be_truthy
-      expect(test_class.supports?(:module_accept)).to be_truthy
-      expect(test_class.supports?(:std_denial)).to be_falsey
+      expect(test_class.supports_std_accept?).to be_truthy
+      expect(test_class.supports_module_accept?).to be_truthy
+      expect(test_class.supports_std_denial?).to be_falsey
     end
   end
 


### PR DESCRIPTION
`supports :feature` helps us determine if a model has implemented a given feature.

Previously, a call to `supports? :feature` required that a `supports` or a `supports_not`
was previously declared on the model class or parent class.

Before
======

All models had `supports_not :feature` on the base of all trees.
We automatically called `supports_not` for the 4 crud methods.

If we forget to declare `supports_not :feature` for a model, or if the feature
is misspelled, the code will throw a runtime error. (good / bad)

After
=====

A model defaults to not supported whether a `supports_not` is used or not.

No runtime errors surprise us.
No typos show up in runtime either.

Long play
====

This originated from #21179 and probably from elsewhere. I believe the question came up how to define fewer methods on the classes, so we'd remove all the supports_feature method definitions.

- Don't define `supports_not` crud methods (4 of them)
- Remove all `supports_not` on base classes (152 of them)
- Don't define any `supports_#{feature}?` methods and use a hash lookup
instead.

Issues
======

- It is nice to have `supports_not` declare the supports values for discoverability/documentation.
- It is nice to have errors thrown when a feature is misspelled.
- `try` and some other methods read better with `detect(&:supports_feature?)` rather than `try(:supports?, feature)`
