### PR TITLE
remove extra vim_performance_state finders

### DIFF
--- a/app/models/metric/ci_mixin/state_finders.rb
+++ b/app/models/metric/ci_mixin/state_finders.rb
@@ -32,43 +32,11 @@ module Metric::CiMixin::StateFinders
     @states_by_ts = vim_performance_states.where(conditions).index_by { |x| x.timestamp.utc.iso8601 }
   end
 
-  def hosts_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).hosts
-  end
+  def vim_performance_state_association(ts, assoc)
+    if assoc.to_s == "miq_regions"
+      return respond_to?(:miq_regions) ? miq_regions : []
+    end
 
-  def container_nodes_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).container_nodes
-  end
-
-  def vms_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).vms
-  end
-
-  def container_groups_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).container_groups
-  end
-
-  def all_container_groups_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).all_container_groups
-  end
-
-  def ext_management_systems_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).ext_management_systems
-  end
-
-  def ems_clusters_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).ems_clusters
-  end
-
-  def storages_from_vim_performance_state_for_ts(ts)
-    vim_performance_state_for_ts(ts).storages
-  end
-
-  def miq_regions_from_vim_performance_state_for_ts(_ts)
-    self.respond_to?(:miq_regions) ? miq_regions : []
-  end
-
-  def containers_from_vim_performance_state_for_ts(timestamp)
-    vim_performance_state_for_ts(timestamp).containers
+    vim_performance_state_for_ts(ts).public_send(assoc)
   end
 end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -268,7 +268,7 @@ module Metric::Rollup
 
   def self.rollup_child_metrics(obj, timestamp, interval_name, assoc)
     ts = timestamp.kind_of?(Time) ? timestamp.utc.iso8601 : timestamp
-    recs = obj.send("#{assoc}_from_vim_performance_state_for_ts", timestamp)
+    recs = obj.vim_performance_state_association(timestamp, assoc)
 
     result = {}
     counts = {}

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -56,7 +56,7 @@ class VimPerformanceTagValue
     return [] if eligible_cats.empty?
 
     ts = parent_perf.timestamp
-    children = parent_perf.resource.send("#{assoc}_from_vim_performance_state_for_ts", ts)
+    children = parent_perf.resource.vim_performance_state_association(ts, assoc)
     return [] if children.empty?
     vim_performance_daily = parent_perf.kind_of?(VimPerformanceDaily)
     recs = get_metrics(children, ts, parent_perf.capture_interval_name, vim_performance_daily, options[:category])


### PR DESCRIPTION
This doesn't buy us anything other than the deletes.