### PR TITLE
Keep archived out of VimPerformanceState

### DIFF
--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -197,19 +197,9 @@ class VimPerformanceState < ApplicationRecord
   def capture_assoc_ids
     result = {}
     ASSOCIATIONS.each do |assoc|
-      method = if assoc == :vms
-                 if resource.kind_of?(EmsCluster)
-                   :all_vms_and_templates
-                 elsif resource.kind_of?(Service)
-                   :vms
-                 else
-                   :vms_and_templates
-                 end
-               else
-                 assoc
-               end
-      next unless resource.respond_to?(method)
-      assoc_recs = resource.send(method)
+      assoc_recs = fetch_assoc_records(resource, assoc)
+      next if assoc_recs == false
+
       has_state = assoc_recs[0] && assoc_recs[0].respond_to?(:state)
 
       r = result[assoc] = {:on => [], :off => []}
@@ -229,6 +219,23 @@ class VimPerformanceState < ApplicationRecord
       r_off.sort!
     end
     self.assoc_ids = result.presence
+  end
+
+  def fetch_assoc_records(resource, assoc)
+    method = if assoc == :vms
+               if resource.kind_of?(EmsCluster)
+                 :all_vms_and_templates
+               elsif resource.kind_of?(Service)
+                 :vms
+               else
+                 :vms_and_templates
+               end
+             else
+               assoc
+             end
+    return false unless resource.respond_to?(method)
+
+    resource.send(method)
   end
 
   def capture_parent_cluster

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -235,7 +235,9 @@ class VimPerformanceState < ApplicationRecord
              end
     return false unless resource.respond_to?(method)
 
-    resource.send(method)
+    records = resource.send(method)
+    records = records.not_archived_before(timestamp) if records.try(:klass).respond_to?(:not_archived_before)
+    records
   end
 
   def capture_parent_cluster

--- a/spec/models/vim_performance_state_spec.rb
+++ b/spec/models/vim_performance_state_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe VimPerformanceState do
     end
   end
 
+  describe "#capture_assoc_ids" do
+    it "captures running containers" do
+      container_image = FactoryBot.create(:container_image)
+      containers = create_past_present_future(:container, {:container_image => container_image})
+
+      state = VimPerformanceState.capture(container_image)
+      expect(state.get_assoc(:containers).map(&:to_i)).to match_array(containers.map(&:id))
+      expect(state.containers.map(&:id)).to match_array(containers.map(&:id))
+    end
+  end
+
   describe "#containers" do
     let(:capture_time) { 5.hours.ago.utc.beginning_of_hour }
 
@@ -135,10 +146,13 @@ RSpec.describe VimPerformanceState do
 
     it "fetches active container objects" do
       container_image = FactoryBot.create(:container_image, :created_on => 6.hours.ago)
-      containers = FactoryBot.create_list(:container, 1, :container_image => container_image)
+      containers = create_past_present_future(:container, {:container_image => container_image})
 
       results = fetch_records(container_image, :containers, capture_time)
       expect(results).to eq(containers)
+
+      state = VimPerformanceState.capture(container_image)
+      expect(state.get_assoc(:containers).map(&:to_i)).to match_array(containers.map(&:id))
     end
   end
 


### PR DESCRIPTION
reference:
- https://github.com/ManageIQ/manageiq/issues/22593

requires:
- [x] https://github.com/ManageIQ/manageiq/pull/22594
- [x] https://github.com/ManageIQ/manageiq/pull/22589 (first 4 commits)

extracted:
- [x] https://github.com/ManageIQ/manageiq/pull/22611 (not required but related)

Overview
========

We were putting too many archived container ids in the `VimPerformanceState` records.
This was filling up the database, causing us to process too many records, slowing down metrics capture, and slowing down metrics rollups.

Before
======

- Don't take into account whether a record was archived.

After
=====

- We are no longer putting the ids for records that were archived before our time window in the performance state records

Numbers
=======

|       ms |       bytes |   objects |query |  qry ms |     rows |` comments`
|      ---:|         ---:|       ---:|  ---:|     ---:|      ---:|  ---
|  2,131.6 | 77,558,748* | 1,070,108 |   13 | 1,760.5 |   13,680 |`rollup-create-vps-before`
|  1,632.5 |  5,139,458* |   393,268 |   13 | 1,517.7 |      174 |`rollup-create-vps-after`
|     23%  |         93% |       63% |      |   13.8% |      99% | diff

```
* Memory usage does not reflect 175,949 freed objects.
* Memory usage does not reflect 59,056 freed objects.
```

- this example was chosen because of the high number of archived records
- this example created an VimPerformanceState record. otherwise, there would have been no change
- Estimated bytes total changed to 90311091 and 5911237 respectively. This resulted in the same bytes savings
- The query ms savings is very dependent upon the cache status, and was not stable during the tests. But rows returned does give an indicator that the work on the database was reduced significantly
- the number of rows returned is the difference between bringing back the archived records for creating the VPS and not.
- The size of the VPS#state_data went from 167,234 => 1,752 characters. The record is more than 150x smaller.

Outstanding
===========

- migration/script to prune out existing VimPerformanceStates that contain archived ids