### PR TITLE
Updated Titles in Embedded Workflow Pages

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1477,6 +1477,10 @@ en:
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential:          Credential (VMware)
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook:                  Playbook (Embedded Ansible)
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource: Repository (Embedded Ansible)
+      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential:                Credential (Embedded Ansible)
+      ManageIQ::Providers::Workflows::AutomationManager::Workflow:                        Workflow
+      ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSource:       Repository (Embedded Workflows)
+      ManageIQ::Providers::Workflows::AutomationManager::Credential:                      Credential (Embedded Workflows)
       ManageIQ::Providers::ExternalAutomationManager:                                     Automation Manager
       ManageIQ::Providers::AutomationManager::Authentication:                             Credential
       ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential:             Credential (Amazon)


### PR DESCRIPTION
The Workflow pages currently display the model as the title in the `show_list` pages. This adds proper titles to those pages matching the naming convention of the Embedded Ansible pages. Also https://github.com/ManageIQ/manageiq-ui-classic/pull/8834, when merged will update the Ansible Credential controller's model, so I'm addressing that in advance as well.

Before:
![image](https://github.com/ManageIQ/manageiq/assets/64800041/e62e8cbc-bff8-4961-9293-470bb0135fa7)

After:
![image](https://github.com/ManageIQ/manageiq/assets/64800041/06232809-01ce-452d-a3d5-b14050d507af)