### PR TITLE
Set associations during targeted refresh for VMs and MiqTemplate

### DIFF
--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -94,4 +94,8 @@ class MiqTemplate < VmOrTemplate
       _("N/A")
     end
   end
+
+  private_class_method def self.refresh_association
+    :miq_templates
+  end
 end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -166,4 +166,8 @@ class Vm < VmOrTemplate
       :message => unsupported_reason(:launch_native_console)
     }
   end
+
+  private_class_method def self.refresh_association
+    :vms
+  end
 end


### PR DESCRIPTION
Since `Vm` and `MiqTemplate` come from the same base class `VmOrTemplate`, when triggering a targeted refresh directly from an instance i.e. `vm.refresh` the `:vm_or_templates` association was being used instead of `:vm` or `:miq_templates`. 

As a result, VMs were not being retrieved during inventory collection due to using the wrong association. However, this is not the case when performing a targeted refresh from the UI.

@miq-bot assign @agrare 
@miq-bot add_labels enhancement, petrosian/yes?

