### PR TITLE
VimPerformanceState do not bring back archived records

### DIFF
--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -4,6 +4,9 @@ module ArchivedMixin
   included do
     scope :archived, -> { where.not(:deleted_on => nil) }
     scope :active, -> { where(:deleted_on => nil) }
+    scope :not_archived_before, ->(timestamp) {
+      unscope(:where => :deleted_on).where(arel_table[:deleted_on].eq(nil).or(arel_table[:deleted_on].gteq(timestamp)))
+    }
   end
 
   def archived?

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -151,7 +151,7 @@ class VimPerformanceState < ApplicationRecord
 
   def all_container_groups
     ids = get_assoc(:all_container_groups)
-    ids.empty? ? [] : ContainerGroup.where(:id => ids).order(:id).to_a
+    ids.empty? ? ContainerGroup.none : ContainerGroup.where(:id => ids).order(:id)
   end
 
   def get_assoc(relat, mode = nil)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -141,7 +141,7 @@ class VimPerformanceState < ApplicationRecord
 
   def container_groups
     ids = get_assoc(:container_groups)
-    ids.empty? ? ContainerGroup.none : ContainerGroup.where(:id => ids).order(:id)
+    ids.empty? ? ContainerGroup.none : ContainerGroup.where(:id => ids).order(:id).not_archived_before(timestamp)
   end
 
   def containers

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -146,7 +146,7 @@ class VimPerformanceState < ApplicationRecord
 
   def containers
     ids = get_assoc(:containers)
-    ids.empty? ? Container.none : Container.where(:id => ids).order(:id)
+    ids.empty? ? Container.none : Container.where(:id => ids).order(:id).not_archived_before(timestamp)
   end
 
   def all_container_groups

--- a/spec/models/mixins/archived_mixin_spec.rb
+++ b/spec/models/mixins/archived_mixin_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe ArchivedMixin do
+  let(:model_name) { :container }
+  let(:klass) { Container }
+
+  let(:timestamp) { Time.now.utc }
+  let(:active_model) { FactoryBot.create(model_name) }
+  let(:archived_model) { FactoryBot.create(model_name, :deleted_on => timestamp) }
+
+  describe ".archived" do
+    it "fetches archived records" do
+      active_model
+      archived_model
+
+      expect(klass.archived).to eq([archived_model])
+    end
+  end
+
+  describe ".active" do
+    it "fetches active records" do
+      active_model
+      archived_model
+
+      expect(klass.active).to eq([active_model])
+    end
+  end
+
+  describe ".not_archived_before" do
+    it "detects active are in the range" do
+      active_model
+      expect(klass.not_archived_before(2.years.ago)).to eq([active_model])
+    end
+
+    it "detects not yet deleted records are in the range" do
+      archived_model
+      expect(klass.not_archived_before(2.years.ago)).to eq([archived_model])
+    end
+
+    it "detects already deleted records are not in the range" do
+      archived_model
+      expect(klass.not_archived_before(1.year.from_now)).to be_empty
+    end
+
+    # some associations have active as a default scope e.g.: ContainerProject#container_groups
+    # this makes sure not_archived_before will override the scope
+    it "overrides active scope" do
+      archived_model
+      expect(klass.active.not_archived_before(2.years.ago)).to eq([archived_model])
+    end
+  end
+
+  describe "#archived?", "#archived" do
+    it "detects not archived" do
+      expect(active_model.archived?).to be false
+    end
+
+    it "detects archived" do
+      expect(archived_model.archived?).to be true
+    end
+  end
+
+  describe "#active", "#active?" do
+    it "detects not active" do
+      expect(archived_model.active?).to be false
+    end
+
+    it "detects active" do
+      expect(active_model.active?).to be true
+    end
+  end
+
+  describe "#archive!" do
+    let(:model) { active_model }
+    it "makes archived" do
+      expect(model.archived?).to be false
+      model.archive!
+      expect(model.archived?).to be true
+      expect(model.deleted_on).not_to be_nil
+    end
+  end
+
+  describe "#unarchive!" do
+    let(:model) { archived_model }
+    it "makes unarchived" do
+      expect(model.archived?).to be true
+      model.unarchive!
+      expect(model.archived?).to be false
+      expect(model.deleted_on).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
reference:
- https://github.com/ManageIQ/manageiq/issues/22593
- extracted from #22585 

Some archived node references got into `VimPerformanceState#state_data`
When pulling back these records, this caused a lot of data to go over the wire

## Before

`VimPerformanceState#container_groups` and `containers` brings back all nodes in `state_data`.

## After

`VimPerformanceState#container_groups` and `containers` only brings back nodes in `state_data` that are active (`deleted_at` is not set) at the time of capture.

## Numbers

#22579 made the query larger - lost some time there b/c there are so many records.
still concerned around this

- last commit is `after-fetch-time`
- before that commit is `after-fetch`

|       ms |       bytes |   objects |query |  qry ms |     rows |` comments`
|      ---:|         ---:|       ---:|  ---:|     ---:|      ---:|  ---
|  1,945.5 | 41,916,080* | 1,024,324 |    9 | 1,516.0 |    6,859 |` master-before-#22579`
|  5,509.5 | 47,162,198* | 1,115,818 |    9 | 5,146.4 |    6,859 |`master`
|  1,699.1 | 19,618,021* |   283,526 |    9 | 1,519.6 |       79 |`after-fetch`
|  1,664.1 | 15,672,327* |   225,826 |    5 | 1,550.8 |       75 |`after-fetch-time`
|    14.4% |        >63% |       78% |   44%|     -2% |       99%| diff

Comments and explanation:

- This example was chosen to highlight what happens when there are a lot of archived records in the list. Infra examples and providers with smaller churn will have smaller gains.
- Do note the decrease in the number of rows brought back from the same number of queries. These are basically metrics and archived containers that were not brought back.
- #22579 introduces a query that contains the ids in question, so it is physically larger, and therefore increases the query time. Since after-fetch reduced the number of ids in question, the code no longer produced such a big query, and the timing went back down. But it is still bigger than if that PR had not been merged. (but potentially the number of rows brought back have been reduced in many cases)
- The reduction in query count (after-fetch-time) is due to using the iso8601 format in our cache. We find the VimPerformanceState record on the parent object and do not need to fetch it multiple times.
- The memory usage chart below says that on the master branch, it GC'd 280k objects, so the `bytes` displayed does not reflect those objects. The object count is correct. The memory used is probably 60M (you can get that number by percentage of objects or from the 283k objects number in after-fetch) and the memory savings was closer to 74%. Which again checks out from the object savings.

```
* Memory usage does not reflect 283,543 freed objects. => ["naq6czdxziv7ka4f1ifn"]
* Memory usage does not reflect 286,616 freed objects. => ["3vpqnqo79olcvjsk64x9"]
* Memory usage does not reflect 2 freed objects. => ["x5l6rlsllem3hltnrsok"]
* Memory usage does not reflect 2 freed objects. => ["b7w5q1426nhah0tkhwny"]
```