### PR TITLE
Remove User#unlock_queue use of put_or_update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -466,13 +466,12 @@ class User < ApplicationRecord
   private
 
   def unlock_queue
-    MiqQueue.put_or_update(
+    MiqQueue.create_with(:deliver_on => Time.now.utc + ::Settings.authentication.locked_account_timeout.to_i)
+            .put_unless_exists(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'unlock!',
       :priority    => MiqQueue::MAX_PRIORITY
-    ) do |_msg, queue_options|
-      queue_options.merge(:deliver_on => Time.now.utc + ::Settings.authentication.locked_account_timeout.to_i)
-    end
+    )
   end
 end


### PR DESCRIPTION
Overview
========

`MiqQueue#put_or_update` is a powerful method but manipulates a queue in a way foreign to (all?) other implementations of queues.
We have been getting away from this method and are down to 3 uses.

This Specific Use case
========

When a user attempts too many logins, their account is locked. `User#unlock_queue` sets a task in the future to unlock the account after a timeout.

This functionality can be implemented using `MiqQueue#put_unless_exists` instead, getting us closer to the goal of dropping all usage of `put_unless_exists`.


This method does introduce one change, and while I prefer the current behavior, the change is worth it.

Before
======

A failed login attempt resets the unlock timer.

Once a user attempts too many logins, their account is locked for a set amount of time.
Further attempts fail during the lock period and the timer is reset - lengthening the lock.

After
=====

A failed login attempt does not reset the unlock timeout.

Once a user attempts too many logins, their account is locked for a set amount of time.
Further attempts fail, but that does not change the amount of time the account is locked.
