### PR TITLE
Precache rollup values

### DIFF
--- a/app/models/metric/ci_mixin/state_finders.rb
+++ b/app/models/metric/ci_mixin/state_finders.rb
@@ -32,11 +32,20 @@ module Metric::CiMixin::StateFinders
     @states_by_ts = vim_performance_states.where(conditions).index_by { |x| x.timestamp.utc.iso8601 }
   end
 
+  # Use VimPerformanceState to populate the scopes with the values from a particular point in time
+  # using @last_vps_ts to ensure we don't load at one time and then use at another
   def vim_performance_state_association(ts, assoc)
     if assoc.to_s == "miq_regions"
       return respond_to?(:miq_regions) ? miq_regions : []
     end
 
-    vim_performance_state_for_ts(ts).public_send(assoc)
+    if !defined?(@last_vps_ts) || @last_vps_ts != ts
+      @last_vps_ts = ts
+      public_send(assoc).reset
+
+      MiqPreloader.preload(self, assoc, vim_performance_state_for_ts(ts).public_send(assoc).load)
+    end
+
+    public_send(assoc)
   end
 end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -268,7 +268,7 @@ module Metric::Rollup
 
   def self.rollup_child_metrics(obj, timestamp, interval_name, assoc)
     ts = timestamp.kind_of?(Time) ? timestamp.utc.iso8601 : timestamp
-    recs = obj.vim_performance_state_association(timestamp, assoc)
+    recs = obj.vim_performance_state_association(timestamp, assoc).to_a
 
     result = {}
     counts = {}

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -111,42 +111,42 @@ class VimPerformanceState < ApplicationRecord
 
   def storages
     ids = get_assoc(:storages, :on)
-    ids.empty? ? [] : Storage.where(:id => ids).order(:id).to_a
+    ids.empty? ? Storage.none : Storage.where(:id => ids).order(:id)
   end
 
   def ext_management_systems
     ids = get_assoc(:ext_management_systems, :on)
-    ids.empty? ? [] : ExtManagementSystem.where(:id => ids).order(:id).to_a
+    ids.empty? ? ExtManagementSystem.none : ExtManagementSystem.where(:id => ids).order(:id)
   end
 
   def ems_clusters
     ids = get_assoc(:ems_clusters, :on)
-    ids.empty? ? [] : EmsCluster.where(:id => ids).order(:id).to_a
+    ids.empty? ? EmsCluster.none : EmsCluster.where(:id => ids).order(:id)
   end
 
   def hosts
     ids = get_assoc(:hosts)
-    ids.empty? ? [] : Host.where(:id => ids).order(:id).to_a
+    ids.empty? ? Host.none : Host.where(:id => ids).order(:id)
   end
 
   def vms
     ids = get_assoc(:vms)
-    ids.empty? ? [] : VmOrTemplate.where(:id => ids).order(:id).to_a
+    ids.empty? ? VmOrTemplate.none : VmOrTemplate.where(:id => ids).order(:id)
   end
 
   def container_nodes
     ids = get_assoc(:container_nodes)
-    ids.empty? ? [] : ContainerNode.where(:id => ids).order(:id).to_a
+    ids.empty? ? ContainerNode.none : ContainerNode.where(:id => ids).order(:id)
   end
 
   def container_groups
     ids = get_assoc(:container_groups)
-    ids.empty? ? [] : ContainerGroup.where(:id => ids).order(:id).to_a
+    ids.empty? ? ContainerGroup.none : ContainerGroup.where(:id => ids).order(:id)
   end
 
   def containers
     ids = get_assoc(:containers)
-    ids.empty? ? [] : Container.where(:id => ids).order(:id).to_a
+    ids.empty? ? Container.none : Container.where(:id => ids).order(:id)
   end
 
   def all_container_groups

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -56,7 +56,7 @@ class VimPerformanceTagValue
     return [] if eligible_cats.empty?
 
     ts = parent_perf.timestamp
-    children = parent_perf.resource.vim_performance_state_association(ts, assoc)
+    children = parent_perf.resource.vim_performance_state_association(ts, assoc).to_a
     return [] if children.empty?
     vim_performance_daily = parent_perf.kind_of?(VimPerformanceDaily)
     recs = get_metrics(children, ts, parent_perf.capture_interval_name, vim_performance_daily, options[:category])

--- a/lib/extensions/ar_preloader.rb
+++ b/lib/extensions/ar_preloader.rb
@@ -1,0 +1,18 @@
+module ActiveRecordPreloadScopes
+  # based upon active record 6.1
+  def records_for(ids)
+    # use our logic if passing in [ActiveRecord::Base] or passing in a loaded Relation/scope
+    unless (preload_scope.kind_of?(Array) && preload_scope.first.kind_of?(ActiveRecord::Base)) ||
+            preload_scope.try(:loaded?)
+      return super
+    end
+
+    preload_scope.each do |record|
+      owner = owners_by_key[convert_key(record[association_key_name])].first
+      association = owner.association(reflection.name)
+      association.set_inverse_instance(record)
+    end
+  end
+end
+
+ActiveRecord::Associations::Preloader::Association.prepend(ActiveRecordPreloadScopes)

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -36,6 +36,45 @@ RSpec.describe MiqPreloader do
       expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 1)
     end
 
+    it "preloads with a loaded relation (records is a relation)" do
+      ems = FactoryBot.create(:ems_infra)
+      FactoryBot.create_list(:vm, 2, :ext_management_system => ems)
+
+      emses = ExtManagementSystem.all.load
+      vms   = Vm.where(:ems_id => emses.select(:id)).load
+
+      expect { preload(emses, :vms, vms) }.not_to make_database_queries
+      expect { preload(emses, :vms, vms) }.not_to make_database_queries
+      expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
+      expect { expect(vms.first.ext_management_system).to eq(ems) }.not_to make_database_queries
+    end
+
+    it "preloads with an array (records is a relation)" do
+      ems = FactoryBot.create(:ems_infra)
+      FactoryBot.create_list(:vm, 2, :ext_management_system => ems)
+
+      emses = ExtManagementSystem.all.load
+      vms = Vm.where(:ems_id => emses.select(:id)).to_a
+
+      expect { preload(emses, :vms, vms) }.not_to make_database_queries
+      expect { preload(emses, :vms, vms) }.not_to make_database_queries
+      expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
+      expect { expect(vms.first.ext_management_system).to eq(ems) }.not_to make_database_queries
+    end
+
+    it "preloads with an array (records is an array)" do
+      ems = FactoryBot.create(:ems_infra)
+      FactoryBot.create_list(:vm, 2, :ext_management_system => ems)
+
+      emses = ExtManagementSystem.all.load.to_a
+      vms   = Vm.where(:ems_id => emses.map(&:id)).to_a
+
+      expect { preload(emses, :vms, vms) }.not_to make_database_queries
+      expect { preload(emses, :vms, vms) }.not_to make_database_queries
+      expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
+      expect { expect(vms.first.ext_management_system).to eq(ems) }.not_to make_database_queries
+    end
+
     def preload(*args)
       MiqPreloader.preload(*args)
     end

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -4,22 +4,36 @@ RSpec.describe MiqPreloader do
       ems = FactoryBot.create(:ems_infra)
       expect(ems.vms).not_to be_loaded
       expect { preload(ems, :vms) }.to make_database_queries(:count => 1)
+
       expect(ems.vms).to be_loaded
-      expect { preload(ems, :vms) }.to_not make_database_queries
+      expect { preload(ems, :vms) }.not_to make_database_queries
+      expect { ems.vms.size }.not_to make_database_queries
     end
 
-    it "preloads from an array" do
+    it "preloads an array" do
       emses = FactoryBot.create_list(:ems_infra, 2)
       expect { preload(emses, :vms) }.to make_database_queries(:count => 1)
-      expect(emses[0].vms).to be_loaded
+
+      expect(emses.first.vms).to be_loaded
+      expect { emses.first.vms.size }.not_to make_database_queries
     end
 
-    it "preloads from an association" do
+    it "preloads a relation (record is a relation)" do
+      FactoryBot.create_list(:vm, 2, :ext_management_system => FactoryBot.create(:ems_infra))
+      emses = ExtManagementSystem.all
+      expect { preload(emses, :vms) }.to make_database_queries(:count => 2)
+
+      expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
+    end
+
+    it "preloads with a relation (records is a relation)" do
       ems = FactoryBot.create(:ems_infra)
       FactoryBot.create_list(:vm, 2, :ext_management_system => ems)
 
-      emses = ExtManagementSystem.all
-      expect { preload(emses, :vms) }.to make_database_queries(:count => 2)
+      emses = ExtManagementSystem.all.load
+      vms   = Vm.where(:ems_id => emses.select(:id))
+
+      expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 1)
     end
 
     def preload(*args)
@@ -34,7 +48,7 @@ RSpec.describe MiqPreloader do
 
       vms = nil
       expect { vms = preload_and_map(ems, :vms) }.to make_database_queries(:count => 1)
-      expect { expect(vms.size).to eq(2) }.to_not make_database_queries
+      expect { expect(vms.size).to eq(2) }.not_to make_database_queries
     end
 
     it "preloads from an association" do
@@ -56,7 +70,7 @@ RSpec.describe MiqPreloader do
       FactoryBot.create_list(:vm, 2, :ext_management_system => ems)
 
       vms = nil
-      expect { vms = preload_and_scope(ems, :vms) }.to_not make_database_queries
+      expect { vms = preload_and_scope(ems, :vms) }.not_to make_database_queries
       expect { expect(vms.count).to eq(2) }.to make_database_queries(:count => 1)
     end
 
@@ -65,7 +79,7 @@ RSpec.describe MiqPreloader do
       FactoryBot.create(:template, :ext_management_system => FactoryBot.create(:ems_infra))
 
       vms = nil
-      expect { vms = preload_and_scope(ExtManagementSystem.all, :vms_and_templates) }.to_not make_database_queries
+      expect { vms = preload_and_scope(ExtManagementSystem.all, :vms_and_templates) }.not_to make_database_queries
       expect { expect(vms.count).to eq(3) }.to make_database_queries(:count => 1)
     end
 
@@ -86,8 +100,8 @@ RSpec.describe MiqPreloader do
 
       hosts = nil
       vms = nil
-      expect { vms = preload_and_scope(ExtManagementSystem.all, :vms_and_templates) }.to_not make_database_queries
-      expect { hosts = preload_and_scope(vms, :host) }.to_not make_database_queries
+      expect { vms = preload_and_scope(ExtManagementSystem.all, :vms_and_templates) }.not_to make_database_queries
+      expect { hosts = preload_and_scope(vms, :host) }.not_to make_database_queries
       expect { expect(hosts.count).to eq(2) }.to make_database_queries(:count => 1)
     end
 
@@ -103,8 +117,8 @@ RSpec.describe MiqPreloader do
 
       emses = nil
       vms = nil
-      expect { emses = preload_and_scope(Host.all, :ext_management_system) }.to_not make_database_queries
-      expect { vms = preload_and_scope(emses, :vms) }.to_not make_database_queries
+      expect { emses = preload_and_scope(Host.all, :ext_management_system) }.not_to make_database_queries
+      expect { vms = preload_and_scope(emses, :vms) }.not_to make_database_queries
       expect { expect(vms.count).to eq(3) }.to make_database_queries(:count => 1)
     end
 


### PR DESCRIPTION
reference:
- https://github.com/ManageIQ/manageiq/issues/22593

For Metrics rollup, we fetch the `container_image` from each of the `container` objects.
This change preloads the parent `container_image` value into the `containers` so we avoid the N+1.

TODO: I need to followup to find the test case to ensure I'm fixing the issue at hand

before
======

```ruby
container_image = ContainerImage.first
containers = container_image.vim_performance_state(timestamp).containers
containers.map(&:container_image) # N+1
```

after
=====

```ruby
container_image = ContainerImage.first
containers = container_image.vim_performance_state(timestamp).containers
containers.map(&:container_image) # ==> array of container_image object
```