### PR TITLE
Bump appliance_console for IPA/certmonger principal name fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -275,7 +275,7 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
-  gem "manageiq-appliance_console",     "~>7.2", ">=7.2.1",   :require => false
+  gem "manageiq-appliance_console",     "~>7.2", ">=7.2.2",   :require => false
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-appliance_console/pull/215

- [x] ~~(Awaiting gem release)~~
