### PR TITLE
Fix Authentication.build_credential_types

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -83,7 +83,8 @@ class Authentication < ApplicationRecord
 
   CREDENTIAL_TYPES = {
     :external_credential_types         => 'ManageIQ::Providers::ExternalAutomationManager::Authentication',
-    :embedded_ansible_credential_types => 'ManageIQ::Providers::EmbeddedAutomationManager::Authentication'
+    :embedded_ansible_credential_types => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential',
+    :workflows_credential_types        => 'ManageIQ::Providers::Workflows::AutomationManager::Credential'
   }.freeze
 
   # FIXME: To address problem with url resolution when displayed as a quadicon,


### PR DESCRIPTION
The Authentication.build_credential_types method was returning Workflows credentials under `embedded_ansible_credential_types`

Ref: https://github.com/ManageIQ/manageiq-ui-classic/pull/8836