### PR TITLE
Allow `ResourceAction#fqname=nil` to clear `ae_*`

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -56,7 +56,7 @@ class ResourceAction < ApplicationRecord
   end
 
   def fqname=(value)
-    self.ae_namespace, self.ae_class, self.ae_instance, _attr_name = MiqAeEngine::MiqAePath.split(value)
+    self.ae_namespace, self.ae_class, self.ae_instance, _attr_name = value.blank? ? nil : MiqAeEngine::MiqAePath.split(value)
   end
 
   def fqname

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -2,6 +2,33 @@ RSpec.describe ResourceAction do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:ra)   { FactoryBot.create(:resource_action) }
 
+  describe "#fqname=" do
+    context "with an automate fully-qualified name" do
+      it "sets the ae_* attributes" do
+        ra.fqname = "/NAMESPACE/CLASS/INSTANCE"
+        expect(ra).to have_attributes(
+          :ae_namespace => "NAMESPACE",
+          :ae_class     => "CLASS",
+          :ae_instance  => "INSTANCE"
+        )
+      end
+    end
+
+    context "with a nil" do
+      context "with existing ae_attributes" do
+        let(:ra) { FactoryBot.create(:resource_action, :ae_namespace => "NAMESPACE", :ae_class => "CLASS", :ae_instance => "INSTANCE") }
+        it "clears the ae_* attributes" do
+          ra.fqname = nil
+          expect(ra).to have_attributes(
+            :ae_namespace => nil,
+            :ae_class     => nil,
+            :ae_instance  => nil
+          )
+        end
+      end
+    end
+  end
+
   context "#deliver_queue" do
     let(:zone_name) { "default" }
     let(:miq_server) { FactoryBot.create(:miq_server) }


### PR DESCRIPTION
Now that resource actions can have either embedded_automate `ae_*` values _or_ a `configuration_script_id` it is helpful to clear the `ae_*` values for an existing resource action.

Ref: https://github.com/ManageIQ/manageiq-ui-classic/pull/8815