### PR TITLE
Add docker and podman as known commands

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -39,7 +39,7 @@ module MiqEnvironment
   end
 
   class Command
-    EVM_KNOWN_COMMANDS = %w[apachectl nohup service systemctl].freeze
+    EVM_KNOWN_COMMANDS = %w[apachectl docker nohup podman service systemctl].freeze
 
     def self.supports_systemd?
       return @supports_systemd unless @supports_systemd.nil?


### PR DESCRIPTION
Allow `MiqEnvironment::Command.supports_command?` to check for `docker` and `podman` binaries

Required for:
* https://github.com/ManageIQ/manageiq-providers-workflows/pull/28