### PR TITLE
Precache rollup values

### DIFF
--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -26,6 +26,15 @@ module MiqPreloader
     preloader.preload(records, associations, preload_scope)
   end
 
+  # for a record, cache results. Also cache the children's links back
+  # currently preload works for simple associations, but this is needed for reverse associations
+  def self.preload_from_array(record, association_name, values)
+    association = record.association(association_name.to_sym)
+    values = Array.wrap(values)
+    association.target = association.reflection.collection? ? values : values.first
+    values.each { |value| association.set_inverse_instance(value) }
+  end
+
   # it will load records and their associations, and return the children
   #
   # instead of N+1:

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MiqPreloader do
   let(:image) do
     FactoryBot.create(:container_image).tap do |image|
       FactoryBot.create(
-        :container, 
+        :container,
         :container_image => image,
         :container_group => FactoryBot.create(:container_group, :container_node => FactoryBot.create(:container_node))
       )
@@ -222,10 +222,10 @@ RSpec.describe MiqPreloader do
     it "preloads (object.all).has_many.belongs_to" do
       ems = FactoryBot.create(:ems_infra)
       FactoryBot.create_list(:vm, 2,
-                              :ext_management_system => ems,
-                              :host                  => FactoryBot.create(:host, :ext_management_system => ems))
+                             :ext_management_system => ems,
+                             :host                  => FactoryBot.create(:host, :ext_management_system => ems))
       FactoryBot.create(:vm, :ext_management_system => ems,
-                              :host                  => FactoryBot.create(:host, :ext_management_system => ems))
+                             :host                  => FactoryBot.create(:host, :ext_management_system => ems))
 
       hosts = nil
       vms = nil

--- a/spec/models/metric/ci_mixin/state_finders_spec.rb
+++ b/spec/models/metric/ci_mixin/state_finders_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe Metric::CiMixin::StateFinders do
 
   private
 
-  def create_vps(image, ts, containers = [], nodes = [])
+  def create_vps(image, timestamp, containers = [], nodes = [])
     FactoryBot.create(
       :vim_performance_state,
-      :resource => image,
-      :timestamp => ts,
+      :resource   => image,
+      :timestamp  => timestamp,
       :state_data => {
         :assoc_ids => {
           :containers      => {:on => containers.map(&:id), :off => []},


### PR DESCRIPTION
Before
=====

https://github.com/ManageIQ/manageiq/pull/22594 introduced an issue when loading multiple associations from the same `VimPerformanceState` record.

It seems like we only use one relationship per vps record, so I'm a little confused by the problem, but regardless, the code needs to change.

After
=====

Handles `virtual_has_many` and multiple associations.

Alternate
========

We could use `MiqPreloader.preload` or introduce `MiqPreloader.preload_from_array`.

- The `preload` is nice since it is standard rails. It should work with `habtm` and `belongs_to` (should not affect us). 
- The `preload_from_array` is nice since it removes an N+1 and should work better with `has_many :through`. 
