### PR TITLE
Vim performance state time interval

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -177,15 +177,6 @@ module Metric::Helper
     start_time..end_time
   end
 
-  def self.get_time_interval(obj, timestamp)
-    timestamp = Time.parse(timestamp).utc if timestamp.kind_of?(String)
-
-    state = obj.vim_performance_state_for_ts(timestamp)
-    start_time = timestamp - state[:capture_interval]
-
-    start_time..timestamp
-  end
-
   def self.latest_metrics(resource_type, since_timestamp, resource_ids = nil)
     metrics = Metric.where(:resource_type => resource_type)
     metrics = metrics.where(:resource_id => resource_ids) if resource_ids

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -1,17 +1,17 @@
 module Metric::Statistic
   # @param timestamp [String|Time] hourly timestamp used for hourly_rollups (prefer Time)
   def self.calculate_stat_columns(obj, timestamp)
-    capture_interval = VimPerformanceState.get_time_interval(timestamp)
+    date_range = VimPerformanceState.get_time_interval(timestamp)
     stats = {}
 
     if obj.respond_to?(:all_container_groups)
       container_groups = obj.all_container_groups # Get disconnected entities as well
-      stats[:stat_container_group_create_rate] = container_groups.where(:ems_created_on => capture_interval).count
-      stats[:stat_container_group_delete_rate] = container_groups.where(:deleted_on => capture_interval).count
+      stats[:stat_container_group_create_rate] = container_groups.where(:ems_created_on => date_range).count
+      stats[:stat_container_group_delete_rate] = container_groups.where(:deleted_on => date_range).count
     end
 
     if obj.respond_to?(:all_container_images)
-      stats[:stat_container_image_registration_rate] = obj.all_container_images.where(:registered_on => capture_interval).count
+      stats[:stat_container_image_registration_rate] = obj.all_container_images.where(:registered_on => date_range).count
     end
 
     stats

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -1,6 +1,7 @@
 module Metric::Statistic
+  # @param timestamp [String|Time] hourly timestamp used for hourly_rollups (prefer Time)
   def self.calculate_stat_columns(obj, timestamp)
-    capture_interval = Metric::Helper.get_time_interval(obj, timestamp)
+    capture_interval = VimPerformanceState.get_time_interval(obj, timestamp)
     stats = {}
 
     if obj.respond_to?(:all_container_groups)

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -1,7 +1,7 @@
 module Metric::Statistic
   # @param timestamp [String|Time] hourly timestamp used for hourly_rollups (prefer Time)
   def self.calculate_stat_columns(obj, timestamp)
-    capture_interval = VimPerformanceState.get_time_interval(obj, timestamp)
+    capture_interval = VimPerformanceState.get_time_interval(timestamp)
     stats = {}
 
     if obj.respond_to?(:all_container_groups)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -162,10 +162,9 @@ class VimPerformanceState < ApplicationRecord
     ids.nil? ? [] : ids.uniq.sort
   end
 
-  # @param obj object holding vps records
   # @param timestamp [Time|String] hourly timestamp, prefer Time
   # @returns [Range] time range
-  def self.get_time_interval(obj, timestamp)
+  def self.get_time_interval(timestamp)
     timestamp = Time.parse(timestamp).utc if timestamp.kind_of?(String)
     (timestamp - 1.hour)..timestamp
   end

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -162,6 +162,20 @@ class VimPerformanceState < ApplicationRecord
     ids.nil? ? [] : ids.uniq.sort
   end
 
+  # @param obj object holding vps records
+  # @param timestamp [Time|String] hourly timestamp, prefer Time
+  # @returns [Range] time range
+  def self.get_time_interval(obj, timestamp)
+    timestamp = Time.parse(timestamp).utc if timestamp.kind_of?(String)
+
+    state = obj.vim_performance_state_for_ts(timestamp)
+    # NOTE: this is using timestamp passed in and not timestamp on the object (which could be now)
+    # NOTE: capture_interval is always 3600
+    start_time = timestamp - state[:capture_interval]
+
+    start_time..timestamp
+  end
+
   private
 
   def capture_disk_types

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -61,7 +61,7 @@ class VimPerformanceState < ApplicationRecord
 
   def capture
     self.state_data ||= {}
-    self.capture_interval = 3600
+    self.capture_interval = 1.hour.to_i
     capture_assoc_ids
     capture_parent_host
     capture_parent_storage
@@ -167,13 +167,7 @@ class VimPerformanceState < ApplicationRecord
   # @returns [Range] time range
   def self.get_time_interval(obj, timestamp)
     timestamp = Time.parse(timestamp).utc if timestamp.kind_of?(String)
-
-    state = obj.vim_performance_state_for_ts(timestamp)
-    # NOTE: this is using timestamp passed in and not timestamp on the object (which could be now)
-    # NOTE: capture_interval is always 3600
-    start_time = timestamp - state[:capture_interval]
-
-    start_time..timestamp
+    (timestamp - 1.hour)..timestamp
   end
 
   private


### PR DESCRIPTION
Moved Helper#get_time_interval to the concept that it represented.

second commit: it also was retrieving a hardcoded value, so avoided the lookup