### PR TITLE
Remove ContainerGroup#old_container_project_id

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -9,7 +9,6 @@ class Container < ApplicationRecord
   has_one    :container_node, :through => :container_group
   has_one    :container_replicator, :through => :container_group
   has_one    :container_project, :through => :container_group
-  has_one    :old_container_project, :through => :container_group
   belongs_to :container_image
   has_many   :container_port_configs, :dependent => :destroy
   has_many   :container_env_vars, :dependent => :destroy

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -24,7 +24,6 @@ class ContainerGroup < ApplicationRecord
   has_and_belongs_to_many :container_services, :join_table => :container_groups_container_services
   belongs_to :container_replicator
   belongs_to :container_project
-  belongs_to :old_container_project, :foreign_key => "old_container_project_id", :class_name => 'ContainerProject'
   belongs_to :container_build_pod
   has_many :container_volumes, :as => :parent, :dependent => :destroy
   has_many :persistent_volume_claim, :through => :container_volumes
@@ -105,9 +104,6 @@ class ContainerGroup < ApplicationRecord
     self.container_services = []
     self.container_replicator_id = nil
     self.container_build_pod_id = nil
-    # Keeping old_container_project_id for backwards compatibility, we will need a migration that is putting it back to
-    # container_project_id
-    self.old_container_project_id = self.container_project_id
     self.deleted_on = Time.now.utc
     save
   end

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -23,7 +23,8 @@ class ContainerProject < ApplicationRecord
   has_many :container_limit_items, :through => :container_limits
   has_many :container_builds
   has_many :container_templates
-  has_many :archived_container_groups, :foreign_key => "old_container_project_id", :class_name => "ContainerGroup"
+  has_many :all_container_groups, :class_name => "ContainerGroup", :inverse_of => :container_project
+  has_many :archived_container_groups, -> { archived }, :class_name => "ContainerGroup"
   has_many :persistent_volume_claims
   has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
   has_many :computer_systems, :through => :container_nodes
@@ -50,10 +51,6 @@ class ContainerProject < ApplicationRecord
   PERF_ROLLUP_CHILDREN = [:all_container_groups].freeze
 
   delegate :my_zone, :to => :ext_management_system, :allow_nil => true
-
-  def all_container_groups
-    ContainerGroup.where(:container_project_id => id).or(ContainerGroup.where(:old_container_project_id => id))
-  end
 
   def event_where_clause(assoc = :ems_events)
     case assoc.to_sym

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -8,15 +8,15 @@ class ContainerProject < ApplicationRecord
   include TenantIdentityMixin
   include CustomActionsMixin
   include_concern 'Purging'
-  belongs_to :ext_management_system, :foreign_key => "ems_id"
-  has_many :container_groups, -> { active }
+  belongs_to :ext_management_system, :class_name => "ManageIQ::Providers::ContainerManager", :foreign_key => "ems_id", :inverse_of => :container_projects
+  has_many :container_groups, -> { active }, :inverse_of => :container_project
   has_many :container_routes
   has_many :container_replicators
   has_many :container_services
   has_many :containers, :through => :container_groups
   has_many :container_images, -> { distinct }, :through => :container_groups
   has_many :container_nodes, -> { distinct }, :through => :container_groups
-  has_many :container_quotas, -> { active }
+  has_many :container_quotas, -> { active }, :inverse_of => :container_project
   has_many :container_quota_scopes, :through => :container_quotas
   has_many :container_quota_items, :through => :container_quotas
   has_many :container_limits

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -47,7 +47,7 @@ class ContainerProject < ApplicationRecord
   include EventMixin
   include Metric::CiMixin
 
-  PERF_ROLLUP_CHILDREN = [:all_container_groups]
+  PERF_ROLLUP_CHILDREN = [:all_container_groups].freeze
 
   delegate :my_zone, :to => :ext_management_system, :allow_nil => true
 
@@ -95,6 +95,7 @@ class ContainerProject < ApplicationRecord
 
   def disconnect_inv
     return if archived?
+
     _log.info("Disconnecting Container Project [#{name}] id [#{id}] from EMS [#{ext_management_system.name}] id [#{ext_management_system.id}]")
     self.deleted_on = Time.now.utc
     save

--- a/spec/models/container_project/purging_spec.rb
+++ b/spec/models/container_project/purging_spec.rb
@@ -22,25 +22,26 @@ RSpec.describe ContainerProject do
 
     context ".purge" do
       let(:deleted_date) { 6.months.ago }
+      let(:new_container_project) { FactoryBot.create(:container_project, :deleted_on => deleted_date + 1.day) }
 
       before do
-        @old_container_project        = FactoryBot.create(:container_project, :deleted_on => deleted_date - 1.day)
-        @purge_date_container_project = FactoryBot.create(:container_project, :deleted_on => deleted_date)
-        @new_container_project        = FactoryBot.create(:container_project, :deleted_on => deleted_date + 1.day)
+        FactoryBot.create(:container_project, :deleted_on => deleted_date - 1.day)
+        FactoryBot.create(:container_project, :deleted_on => deleted_date)
+        new_container_project
       end
 
       def assert_unpurged_ids(unpurged_ids)
-        expect(described_class.order(:id).pluck(:id)).to eq(Array(unpurged_ids).sort)
+        expect(described_class.order(:id).pluck(:id)).to match_array(unpurged_ids.sort)
       end
 
       it "purge_date and older" do
         described_class.purge(deleted_date)
-        assert_unpurged_ids(@new_container_project.id)
+        assert_unpurged_ids([new_container_project.id])
       end
 
       it "with a window" do
         described_class.purge(deleted_date, 1)
-        assert_unpurged_ids(@new_container_project.id)
+        assert_unpurged_ids([new_container_project.id])
       end
     end
   end

--- a/spec/models/container_project_spec.rb
+++ b/spec/models/container_project_spec.rb
@@ -2,4 +2,35 @@ RSpec.describe ContainerProject do
   subject { FactoryBot.create(:container_project) }
 
   include_examples "MiqPolicyMixin"
+
+  describe "#all_container_projects" do
+    it "returns active and archived records" do
+      project = FactoryBot.create(:container_project)
+      group_archived = FactoryBot.create(:container_group, :container_project => project, :deleted_on => 1.day.ago.utc)
+      group_active = FactoryBot.create(:container_group, :container_project => project)
+
+      expect(project.all_container_groups).to match_array([group_archived, group_active])
+    end
+  end
+
+  describe "#archived_container_projects" do
+    it "returns archived records" do
+      project = FactoryBot.create(:container_project)
+      group_archived = FactoryBot.create(:container_group, :container_project => project, :deleted_on => 1.day.ago.utc)
+      FactoryBot.create(:container_group, :container_project => project)
+
+      expect(project.archived_container_groups).to match_array([group_archived])
+    end
+  end
+
+  describe "#container_projects" do
+    it "returns active records" do
+      project = FactoryBot.create(:container_project)
+      FactoryBot.create(:container_group, :container_project => project, :deleted_on => 1.day.ago.utc)
+      group_active = FactoryBot.create(:container_group, :container_project => project)
+
+      groups = project.container_groups.to_a
+      expect(groups).to match_array([group_active])
+    end
+  end
 end

--- a/spec/models/container_project_spec.rb
+++ b/spec/models/container_project_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe ContainerProject do
 
       groups = project.container_groups.to_a
       expect(groups).to match_array([group_active])
+      expect do
+        expect(groups.first.container_project).to eq(project)
+      end.not_to make_database_queries
     end
   end
 end

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe MeteringContainerProject do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:count_of_metric_rollup) { MetricRollup.where(:timestamp => month_beginning...month_end).count }
+  let(:ems_container) { FactoryBot.create(:ems_container) }
   let(:ems) { FactoryBot.create(:ems_vmware) }
-  let(:project) { FactoryBot.create(:container_project, :name => "my project", :ext_management_system => ems, :created_on => month_beginning) }
+  let(:project) { FactoryBot.create(:container_project, :ext_management_system => ems_container, :created_on => month_beginning) }
   let(:hardware) { FactoryBot.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576) }
   let(:host) { FactoryBot.create(:host, :storages => [storage], :hardware => hardware, :vms => [vm]) }
   let(:storage) { FactoryBot.create(:storage_vmware) }

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe EventMixin do
       end
 
       it "ContainerNode uses container_node_name and ems_id in ems events" do
-        ems   = FactoryBot.create(:ext_management_system)
+        ems   = FactoryBot.create(:ems_container)
         obj   = FactoryBot.create(:container_node, :name => "test", :ext_management_system => ems)
         event = FactoryBot.create(:event_stream, :container_node_name => obj.name, :ems_id => ems.id)
         FactoryBot.create(:event_stream, :ems_id => ems.id)
@@ -122,7 +122,7 @@ RSpec.describe EventMixin do
       end
 
       it "ContainerProject uses container_namespace(name) and ems_id in ems events" do
-        ems   = FactoryBot.create(:ext_management_system)
+        ems   = FactoryBot.create(:ems_container)
         obj   = FactoryBot.create(:container_project, :ext_management_system => ems)
         event = FactoryBot.create(:event_stream, :container_namespace => obj.name, :ems_id => ems.id)
         FactoryBot.create(:event_stream, :ems_id => ems.id)
@@ -133,7 +133,7 @@ RSpec.describe EventMixin do
       end
 
       it "ContainerReplicator uses container_namespace, container_replicator_name, and ems_id in ems events" do
-        ems      = FactoryBot.create(:ext_management_system)
+        ems      = FactoryBot.create(:ems_container)
         project  = FactoryBot.create(:container_project)
         obj      = FactoryBot.create(:container_replicator, :name => "test", :ext_management_system => ems, :container_project => project)
         event    = FactoryBot.create(:event_stream, :container_namespace => project.name, :ems_id => ems.id, :container_replicator_name => obj.name)


### PR DESCRIPTION
We use deleted_on to represent a record that is deleted. We moved over to using archived (deleted_on) from old_container_project_id

see also:
- f6fe2513486
- https://github.com/ManageIQ/manageiq/pull/16302
- https://github.com/ManageIQ/manageiq-schema/pull/696
