### PR TITLE
MiqUserRole restriction_type method fixup (Separate role access restrictions for catalog items)

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -141,8 +141,7 @@ class MiqUserRole < ApplicationRecord
   private
 
   def restriction_type(klass)
-    case klass.to_s
-    when "ServiceTemplate"
+    if klass <= ServiceTemplate
       :service_templates
     else
       :vms

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -141,6 +141,7 @@ class MiqUserRole < ApplicationRecord
   private
 
   def restriction_type(klass)
+    klass ||= Class
     if klass <= ServiceTemplate
       :service_templates
     else


### PR DESCRIPTION
Follow-up of #22573

Change requested by @Fryguy here:
https://github.com/ManageIQ/manageiq/pull/22573#discussion_r1258349457