### PR TITLE
Fix workflows operations queued on embedded_ansible

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -9,6 +9,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     true
   end
 
+  private_class_method def self.queue_role
+    "embedded_ansible"
+  end
+
   def sync
     update!(:status => "running")
     transaction do

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < ManageIQ::Providers::EmbeddedAutomationManager::Authentication
   FRIENDLY_NAME = "Embedded Ansible Credential".freeze
+
+  private_class_method def self.queue_role
+    "embedded_ansible"
+  end
 end

--- a/app/models/manageiq/providers/embedded_automation_manager/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/crud_common.rb
@@ -13,7 +13,7 @@ module ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
         :priority    => MiqQueue::HIGH_PRIORITY,
         :class_name  => name,
         :method_name => method_name,
-        :role        => "embedded_ansible",
+        :role        => queue_role,
         :zone        => nil
       }
       queue_opts[:instance_id] = instance_id if instance_id
@@ -57,6 +57,10 @@ module ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
     end
 
     private
+
+    def queue_role
+      nil
+    end
 
     def send_notification(op_type, manager_id, params, success)
       op_arg = params.except(*notification_excludes).collect { |k, v| "#{k}=#{v}" }.join(', ')


### PR DESCRIPTION
The CrudCommon module was always using the embedded_ansible role which is not required for workflows functionality.  If this role wasn't enabled then these operations would hang.