### PR TITLE
add miqExpression::Target equality

### DIFF
--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -163,6 +163,21 @@ class MiqExpression::Target
     false
   end
 
+  def hash
+    [column, associations, model].hash
+  end
+
+  def ==(other)
+    other.kind_of?(MiqExpression::Target) &&
+      column == other.column &&
+      model == other.model &&
+      associations == other.associations
+  end
+
+  def eql?(other)
+    other.class == self.class && self == other
+  end
+
   private
 
   def tag_path

--- a/spec/lib/miq_expression/target_spec.rb
+++ b/spec/lib/miq_expression/target_spec.rb
@@ -71,4 +71,32 @@ describe MiqExpression::Target do
       expect(subject).to be_nil
     end
   end
+
+  describe "#==" do
+    it "equals" do
+      expect(described_class.parse("Vm-name")).to eq(MiqExpression::Field.new(Vm, [], "name"))
+      expect(described_class.parse("Vm-name")).to eq(MiqExpression::Tag.new(Vm, [], "name"))
+      expect(described_class.parse("Vm.host-name")).to eq(MiqExpression::Field.new(Vm, ["host"], "name"))
+    end
+
+    it "doesn't equal" do
+      expect(described_class.parse("Vm.host-name")).not_to eq(MiqExpression::Field.new(Vm, [], "name"))
+      expect(described_class.parse("Vm.host-name")).not_to eq("Vm-host-name")
+      expect(described_class.parse("Vm-name")).not_to eql(["name", [], Vm])
+    end
+  end
+
+  describe "#eql?" do
+    it "equals" do
+      expect(described_class.parse("Vm-name")).to eq(MiqExpression::Field.new(Vm, [], "name"))
+      expect(described_class.parse("Vm.host-name")).to eq(MiqExpression::Field.new(Vm, ["host"], "name"))
+    end
+
+    it "doesn't equal" do
+      expect(described_class.parse("Vm-name")).to eq(MiqExpression::Tag.new(Vm, [], "name"))
+      expect(described_class.parse("Vm.host-name")).not_to eql(described_class.parse("Vm-name"))
+      expect(described_class.parse("Vm.host-name")).not_to eql("Vm.host-name")
+      expect(described_class.parse("Vm-name")).not_to eql(["name", [], Vm])
+    end
+  end
 end


### PR DESCRIPTION
Equality is only planned for use in tests

Implement `==` so we can use `expect(x).to eq(other)` / `x == other` in rspec tests.

