### PR TITLE
Pre-zeitwerk - Add inflections and acronyms

### DIFF
--- a/lib/vmdb/inflections.rb
+++ b/lib/vmdb/inflections.rb
@@ -46,7 +46,24 @@ module Vmdb
         inflect.plural(/quota$/, "quotas")
         inflect.irregular("container_quota", "container_quotas")
 
+        inflect.acronym('DBus')
+        inflect.acronym('DDF')
+        inflect.acronym('GHT')
+        inflect.acronym('IPMI')
         inflect.acronym('ManageIQ')
+        inflect.acronym('MKS')
+        inflect.acronym('OAuth')
+        inflect.acronym('REXML')
+        inflect.acronym('SAP')
+        inflect.acronym('SSL')
+        inflect.acronym('UI')
+      end
+
+      # ActiveSupport::Inflector.inflections doesn't allow us to blanket tell how to autoload a constant from a file
+      # This works around the UI acronym above.
+      Rails.autoloaders.each do |autoloader|
+        autoloader.inflector.inflect('miq_ui_worker' => "MiqUiWorker")
+        autoloader.inflector.inflect('vpc' => "VPC")
       end
     end
 


### PR DESCRIPTION
These should be backward compatible changes and gets us closer to minimizing the changes for zeitwerk.  Extracted from #22488

* OAuth acronym
  * For loading OAuthSessionsController from ui-classic.
* GHT acronym
  * For loading ApplicationHelper::Button::ViewGHT and ApplicationHelper::Button::ViewGHTAlways.
* REXML acronym
  * Add acronym since the stdlib constant is all caps. This is needed to load TreeNode::REXML::Attribute. The other libraries that Use Rexml, such as MiqRexml, are gems and can do this on their own.
* UI acronym
  * For loading ManageIQ::Providers::Ovirt::InfraManager::AdminUI
* SAP acronym
  * For loading of ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile
* VPC inflection
  * Allows loading of ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC. Note, an acronym for VPC would onflict with FixVpcFlavorsSti migration, so we're doing just this inflection.
* Tell the autoloader how to load the ui worker. This works around the UI acronym.
* MKS acronym
  * For the remote_console/client_adapter/web_mks* tests
* DBus acronym.
  * DBus is really D-Bus but we're not going to try to get that to work. Fixes:

    An error occurred while loading ./spec/lib/httpd_dbus_api_spec.rb. Failure/Error: require 'httpd_dbus_api'

      Zeitwerk::NameError:
        expected file /Users/joerafaniello/Code/manageiq/lib/httpd_dbus_api.rb to define constant HttpdDbusApi, but didn't
* DDF acronym Fixes:

  NameError: uninitialized constant DDF Did you mean?  Ddf

* IPMI acronym
  * Allows loading of MiqIPMI in manageiq-gems-pending.
