### PR TITLE
Filter storages in the database rather than in ruby.

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1075,11 +1075,8 @@ class MiqRequestWorkflow
 
     rails_logger('allowed_storages', 0)
     st = Time.now
-    MiqPreloader.preload(hosts, :storages => {}, :host_storages => :storage)
 
-    storages = hosts.each_with_object({}) do |host, hash|
-      host.writable_accessible_storages.each { |s| hash[s.id] = s }
-    end.values
+    storages = Storage.where(:id => HostStorage.writable_accessible.where(:host => hosts).pluck(:storage_id))
     selected_storage_profile_id = get_value(@values[:placement_storage_profile])
     if selected_storage_profile_id
       storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1076,7 +1076,7 @@ class MiqRequestWorkflow
     rails_logger('allowed_storages', 0)
     st = Time.now
 
-    storages = Storage.where(:id => HostStorage.writable_accessible.where(:host => hosts).pluck(:storage_id))
+    storages = Storage.where(:id => HostStorage.writable_accessible.where(:host => hosts).select(:storage_id))
     selected_storage_profile_id = get_value(@values[:placement_storage_profile])
     if selected_storage_profile_id
       storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }


### PR DESCRIPTION
With many storages (600+) & hosts(100+), this method can take a long time and lead to timeouts. Example: "Error requesting data from server"
![image](https://github.com/ManageIQ/manageiq/assets/651659/815620a5-ac07-42d5-838f-839926f994d5)


Before:
```json
{"@timestamp":"2023-07-20T20:37:38.903087","hostname":"1r1-ui-6b6c4748d-w2jk9","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages START"} 
{"@timestamp":"2023-07-20T20:37:46.178431","hostname":"1r1-ui-6b6c4748d-w2jk9","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 1 preloaded [7.275160327] seconds"} 
{"@timestamp":"2023-07-20T20:37:51.958811","hostname":"1r1-ui-6b6c4748d-w2jk9","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 2 storages [627] objects in [13.055675223] seconds"} 
{"@timestamp":"2023-07-20T20:37:51.958959","hostname":"1r1-ui-6b6c4748d-w2jk9","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 3 profile_id [13.055874256] seconds"} 
{"@timestamp":"2023-07-20T20:37:51.959000","hostname":"1r1-ui-6b6c4748d-w2jk9","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 4 if profile_id [13.055919117] seconds"} 
{"@timestamp":"2023-07-20T20:37:53.672755","hostname":"1r1-ui-6b6c4748d-w2jk9","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 5 returned [627] objects in [14.769639636] seconds"}
```
Preload + SQL:
```json
{"@timestamp":"2023-07-20T20:14:47.612825","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages START"} 
{"@timestamp":"2023-07-20T20:14:47.625577","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 0 before preloaded [0.012758098] seconds"} 
{"@timestamp":"2023-07-20T20:14:52.908952","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 1 preloaded [5.296050496] seconds"} 
{"@timestamp":"2023-07-20T20:14:53.811950","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 2 storages [627] objects in [6.199096575] seconds"} 
{"@timestamp":"2023-07-20T20:14:53.812249","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 3 profile_id [6.199426073] seconds"} 
{"@timestamp":"2023-07-20T20:14:53.812390","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 4 if profile_id [6.199478444] seconds"} 
{"@timestamp":"2023-07-20T20:14:55.164730","hostname":"1r1-ui-54b698dbf6-h5fkw","pid":7,"tid":"5bb6c","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 5 returned [627] objects in [7.55188282] seconds"}
```

SQL only (no preload):
```json
{"@timestamp":"2023-07-20T20:28:03.187406","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages START"} 
{"@timestamp":"2023-07-20T20:28:03.201769","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 0 before preloaded [0.014374688] seconds"} 
{"@timestamp":"2023-07-20T20:28:03.201799","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 1 preloaded [0.014411199] seconds"} 
{"@timestamp":"2023-07-20T20:28:04.713899","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 2 storages [627] objects in [1.526448355] seconds"} 
{"@timestamp":"2023-07-20T20:28:04.714047","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 3 profile_id [1.526652741] seconds"} 
{"@timestamp":"2023-07-20T20:28:04.714089","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 4 if profile_id [1.526695432] seconds"} 
{"@timestamp":"2023-07-20T20:28:06.350667","hostname":"1r1-ui-7fdfc8f74-lmr29","pid":7,"tid":"5bbbc","service":"evm","level":"info","message":"MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_storages) XXXXX allowed_storages 5 returned [627] objects in [3.163239932] seconds"}
```
