### PR TITLE
Fix migrations being run from a plugin

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -24,8 +24,10 @@ module ManageIQ
       ensure_config_files
 
       unless ENV["CI"]
-        migrate_database
-        seed_database
+        # Update the local development database
+        create_database(plugin_root)
+        migrate_database(plugin_root)
+        seed_database(plugin_root)
       end
 
       setup_test_environment(:task_prefix => 'app:', :root => plugin_root) unless ENV["SKIP_TEST_RESET"]
@@ -96,19 +98,19 @@ module ManageIQ
       puts "===== Begin Gemfile.lock =====\n\n#{lockfile_contents}\n\n===== End Gemfile.lock ====="
     end
 
-    def self.create_database
-      puts "\n== Updating database =="
-      run_rake_task("db:create")
+    def self.create_database(root = APP_ROOT)
+      puts "\n== Creating database =="
+      run_rake_task("db:create", :root => root)
     end
 
-    def self.migrate_database
+    def self.migrate_database(root = APP_ROOT)
       puts "\n== Migrating database =="
-      run_rake_task("db:migrate")
+      run_rake_task("db:migrate", :root => root)
     end
 
-    def self.seed_database
+    def self.seed_database(root = APP_ROOT)
       puts "\n== Seeding database =="
-      run_rake_task("db:seed")
+      run_rake_task("db:seed", :root => root)
     end
 
     def self.setup_test_environment(task_prefix: '', root: APP_ROOT)


### PR DESCRIPTION
Before this commit, when running bin/setup on a fresh checkout of
ui-classic, the migrate_database step would fail because it would run in
the spec/manageiq directory as opposed to the plugin root directory.

What happens is that the spec/manageiq directory doesn't have a
Gemfile.lock, because the bundle install happens in the plugin root, and
so when migrate_database runs db:migrate from the spec/manageiq
directory it fails saying it can't find certain gems.

This commit changes it to run db:migrate from the plugin root directory.
Additionally, I've added a create_database step, which is a noop when
the database exists, but also simplifies brand new checkout runs.

@agrare Please review.