### PR TITLE
Fix undefined method reject! in allowed_storages

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1076,11 +1076,9 @@ class MiqRequestWorkflow
     rails_logger('allowed_storages', 0)
     st = Time.now
 
-    storages = Storage.where(:id => HostStorage.writable_accessible.where(:host => hosts).select(:storage_id))
     selected_storage_profile_id = get_value(@values[:placement_storage_profile])
-    if selected_storage_profile_id
-      storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }
-    end
+    storages = selected_storage_profile_id ? StorageProfile.find(selected_storage_profile_id).storages : Storage.all
+    storages = storages.where(:id => HostStorage.writable_accessible.where(:host => hosts).select(:storage_id))
     allowed_storages_cache = process_filter(:ds_filter, Storage, storages).collect do |s|
       ci_to_hash_struct(s)
     end


### PR DESCRIPTION
In the case where a StorageProfile is selected we were failing to filter out the allowed storages due to the `storages` variable now  being an ActiveRecord Association where `#reject!` isn't defined.

This also resolves an N+1 issue where each storage queries for all storage_profiles.

Failing spec: https://github.com/ManageIQ/manageiq-content/actions/runs/5651086179/job/15308573621

Related: https://github.com/ManageIQ/manageiq/pull/22625