### PR TITLE
Fix Workflows Service Entrypoint arguments

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -140,7 +140,7 @@ class MiqRequestTask < ApplicationRecord
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 
     if resource_action&.configuration_script_payload
-      resource_action.configuration_script_payload.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone)
+      resource_action.configuration_script_payload.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone, :object => self)
     elsif self.class::AUTOMATE_DRIVES
       deliver_to_automate(req_type, zone)
     else

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -140,7 +140,7 @@ class MiqRequestTask < ApplicationRecord
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 
     if resource_action&.configuration_script_payload
-      resource_action.configuration_script_payload.run(dialog_values, get_user.userid)
+      resource_action.configuration_script_payload.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone)
     elsif self.class::AUTOMATE_DRIVES
       deliver_to_automate(req_type, zone)
     else


### PR DESCRIPTION
`Workflow#run` takes a hash argument, forgot about this caller when making changes in https://github.com/ManageIQ/manageiq-providers-workflows/pull/22