### PR TITLE
[WIP] Delete evm_server_db_backup_low_space event

### DIFF
--- a/db/fixtures/miq_event_definition_events.yml
+++ b/db/fixtures/miq_event_definition_events.yml
@@ -76,10 +76,6 @@
   description: Server High DB Disk Usage
   event_type: Default
   set_type: evm_operations
-- name: evm_server_db_backup_low_space
-  description: Server Database Backup Insufficient Space
-  event_type: Default
-  set_type: evm_operations
 - name: evm_worker_start
   description: Worker Started
   event_type: Default


### PR DESCRIPTION
> Followup to deleting database backups, this removes an event that should only be triggered via db backups.  Will most likely require a migration to fully remove.

this is a revival of #21430 

