### PR TITLE
[PETROSIAN] Update manageiq-ui-classic lock reference

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -337,7 +337,7 @@ GIT
 
 GIT
   remote: https://github.com/ManageIQ/manageiq-ui-classic
-  revision: c2f371efa8cb720359250c1f2809a7bb75bf00ef
+  revision: 35586cd384a42119b8ba017650cd2335695f67a0
   branch: petrosian
   specs:
     manageiq-ui-classic (0.1.0)


### PR DESCRIPTION
@bdunne Please review.

This should get petrosian on core back to 🟢 .

Something changed somewhere that the git-based gems are no longer being updated regardless of what's in the lockfile.  The _build_ still works correctly, but for some reason the specs in GitHub Actions don't pull in the latest.