### PR TITLE
[WIP] Allow more specific restriction types for roles

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -947,8 +947,11 @@
   :read_only: true
   :settings:
     :restrictions:
-      :vms: :user
+      :auth_key_pairs: :user
+      :orchestration_stacks: :user
       :service_templates: :user
+      :services: :user
+      :vms: :user
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
@@ -1134,8 +1137,11 @@
   :read_only: true
   :settings:
     :restrictions:
-      :vms: :user_or_group
+      :auth_key_pairs: :user_or_group
+      :orchestration_stacks: :user_or_group
       :service_templates: :user_or_group
+      :services: :user_or_group
+      :vms: :user_or_group
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules


### PR DESCRIPTION
Follow up to #22573, which introduced separate restrictions for Catalog Items.

This changes further splits the role restriction settings to include the following types:
- Catalog Items
- Key Pairs
- Orchestration Stacks
- Services
- VMs and Templates

Depends on:
- ManageIQ/manageiq-ui-classic#8891
- ManageIQ/manageiq-schema#700