### PR TITLE
Change Perf capture timer to medium priority

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -25,11 +25,12 @@ class MiqQueue < ApplicationRecord
 
   MAX_PRIORITY    = 0
   HIGH_PRIORITY   = 20
+  MEDIUM_PRIORITY = 50
   NORMAL_PRIORITY = 100
   LOW_PRIORITY    = 150
   MIN_PRIORITY    = 200
 
-  PRIORITY_WHICH  = [:max, :high, :normal, :low, :min]
+  PRIORITY_WHICH  = [:max, :high, :medium, :normal, :low, :min]
   PRIORITY_DIR    = [:higher, :lower]
 
   def self.messaging_type

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -200,7 +200,7 @@ class MiqScheduleWorker::Jobs
 
   def queue_work(options)
     return if options.nil?
-    options = {:zone => MiqServer.my_zone, :priority => MiqScheduleWorker::Runner::SCHEDULE_MEDIUM_PRIORITY}.merge(options)
+    options = {:zone => MiqServer.my_zone, :priority => MiqQueue::MEDIUM_PRIORITY}.merge(options)
     # always has class_name, method_name, zone, priority [often has role]
     MiqQueue.put_unless_exists(options)
   end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -83,7 +83,6 @@ class MiqScheduleWorker::Jobs
         :method_name => "perf_capture_timer",
         :args        => [ems.id],
         :role        => "ems_metrics_coordinator",
-        :priority    => MiqQueue::HIGH_PRIORITY,
         :state       => ["ready", "dequeue"]
       )
     end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -4,7 +4,6 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
   set_callback(:dst_change, :after, :load_user_schedules)
 
   ROLES_NEEDING_RESTART = ["scheduler", "ems_metrics_coordinator", "event"]
-  SCHEDULE_MEDIUM_PRIORITY = MiqQueue.priority(:normal, :higher, 10)
   CLASS_TAG = "MiqSchedule"
 
   def after_initialize

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -297,6 +297,7 @@ RSpec.describe MiqQueue do
     it "should return adjusted value" do
       expect(MiqQueue.priority(:max)).to eq(MiqQueue::MAX_PRIORITY)
       expect(MiqQueue.priority(:high)).to eq(MiqQueue::HIGH_PRIORITY)
+      expect(MiqQueue.priority(:medium)).to eq(MiqQueue::MEDIUM_PRIORITY)
       expect(MiqQueue.priority(:normal)).to eq(MiqQueue::NORMAL_PRIORITY)
       expect(MiqQueue.priority(:low)).to eq(MiqQueue::LOW_PRIORITY)
       expect(MiqQueue.priority(:min)).to eq(MiqQueue::MIN_PRIORITY)

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe MiqScheduleWorker::Jobs do
         :class_name  => "ManageIQ::Providers::Vmware::InfraManager",
         :instance_id => nil,
         :method_name => "refresh_all_ems_timer",
-        :zone        => zone.name
+        :zone        => zone.name,
+        :priority    => MiqQueue::MEDIUM_PRIORITY
       )
     end
   end
@@ -45,7 +46,8 @@ RSpec.describe MiqScheduleWorker::Jobs do
       expect(MiqQueue.first).to have_attributes(
         :class_name  => "Service",
         :method_name => "queue_chargeback_reports",
-        :args        => [{:report_source => "Rspec - Chargeback reports queue"}]
+        :args        => [{:report_source => "Rspec - Chargeback reports queue"}],
+        :priority    => MiqQueue::MEDIUM_PRIORITY
       )
     end
   end
@@ -56,7 +58,8 @@ RSpec.describe MiqScheduleWorker::Jobs do
       described_class.new.check_for_timed_out_active_tasks
       expect(MiqQueue.first).to have_attributes(
         :class_name  => "MiqTask",
-        :method_name => "update_status_for_timed_out_active_tasks"
+        :method_name => "update_status_for_timed_out_active_tasks",
+        :priority    => MiqQueue::MEDIUM_PRIORITY
       )
     end
   end
@@ -69,28 +72,28 @@ RSpec.describe MiqScheduleWorker::Jobs do
     context "queues for miq_server process" do
       it "#vmdb_database_connection_log_statistics" do
         described_class.new.vmdb_database_connection_log_statistics
-        expect(MiqQueue.where(:method_name => "log_statistics").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+        expect(MiqQueue.where(:method_name => "log_statistics").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name, :priority => MiqQueue::MEDIUM_PRIORITY)
       end
 
       it "#miq_server_audit_managed_resources" do
         described_class.new.miq_server_audit_managed_resources
-        expect(MiqQueue.where(:method_name => "audit_managed_resources").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+        expect(MiqQueue.where(:method_name => "audit_managed_resources").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name, :priority => MiqQueue::MEDIUM_PRIORITY)
       end
 
       it "#miq_server_status_update" do
         described_class.new.miq_server_status_update
-        expect(MiqQueue.where(:method_name => "status_update").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+        expect(MiqQueue.where(:method_name => "status_update").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name, :priority => MiqQueue::HIGH_PRIORITY)
       end
 
       it "#miq_server_worker_log_status" do
         described_class.new.miq_server_worker_log_status
-        expect(MiqQueue.where(:method_name => "log_status").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
-        expect(MiqQueue.where(:method_name => "log_status_all").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+        expect(MiqQueue.where(:method_name => "log_status").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name, :priority => MiqQueue::HIGH_PRIORITY)
+        expect(MiqQueue.where(:method_name => "log_status_all").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name, :priority => MiqQueue::HIGH_PRIORITY)
       end
 
       it "#vmdb_appliance_log_config" do
         described_class.new.vmdb_appliance_log_config
-        expect(MiqQueue.where(:method_name => "log_config").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name)
+        expect(MiqQueue.where(:method_name => "log_config").first).to have_attributes(:queue_name => "miq_server", :server_guid => guid, :zone => zone.name, :priority => MiqQueue::MEDIUM_PRIORITY)
       end
     end
   end

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe MiqScheduleWorker::Jobs do
     end
   end
 
+  it "#metric_capture_perf_capture_timer" do
+    zone = EvmSpecHelper.local_miq_server.zone
+    ems = FactoryBot.create(:ems_vmware, :zone => zone)
+    described_class.new.metric_capture_perf_capture_timer
+    expect(MiqQueue.first).to have_attributes(
+      :class_name  => "Metric::Capture",
+      :method_name => "perf_capture_timer",
+      :args        => [ems.id],
+      :priority    => MiqQueue::MEDIUM_PRIORITY
+    )
+  end
+
   context "with guid, server, zone" do
     let!(:server) { EvmSpecHelper.local_miq_server }
     let(:guid) { server.guid }


### PR DESCRIPTION
* Add MiqQueue::MEDIUM_PRIORITY
* Switch queue_work in scheduler to use it by default
* Change perf_capture_timer to no longer use HIGH_PRIORITY in favor of the default, MEDIUM

We were seeing perf_capture_timer timing out after 10 minutes in a priority worker. Priority worker should never run long running tasks.  Making it use MEDIUM priority will keep it in the generic worker but run before NORMAL priority work.

EDIT: It's easier to review commit by commit.