### PR TITLE
Prevent more than 1 event_handler from running

### DIFF
--- a/app/models/miq_event_handler.rb
+++ b/app/models/miq_event_handler.rb
@@ -6,6 +6,7 @@ class MiqEventHandler < MiqQueueWorkerBase
   self.required_roles               = ["event"]
   self.default_queue_name           = "ems"
   self.miq_messaging_subscribe_mode = "topic"
+  self.maximum_workers_count        = 1
 
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_EVENT_HANDLERS

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -197,6 +197,12 @@ module Vmdb
             valid = false
             errors += new_errors
           end
+
+          result, new_errors = validate_worker_count(worker_class, data)
+          if result == false
+            valid = false
+            errors += new_errors
+          end
         end
 
         return valid, errors
@@ -235,6 +241,22 @@ module Vmdb
         if memory_request > memory_limit
           valid = false
           errors << [:memory_request, "#{worker_class.settings_name}: memory_request: #{memory_request} cannot exceed memory_threshold: #{memory_limit}"]
+        end
+        return valid, errors
+      end
+
+      def validate_worker_count(worker_class, data)
+        valid  = true
+        errors = []
+
+        worker_settings = worker_class.fetch_worker_settings_from_options_hash(data[:config])
+
+        count                 = worker_settings[:count]
+        maximum_workers_count = worker_class.maximum_workers_count
+
+        if maximum_workers_count.kind_of?(Integer) && count > maximum_workers_count
+          valid = false
+          errors << [:count, "#{worker_class.settings_name}: count: #{count} exceeds maximum worker count: #{maximum_workers_count}"]
         end
         return valid, errors
       end

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -156,5 +156,19 @@ RSpec.describe Vmdb::Settings::Validator do
       expect(result).to eql(true)
       expect(errors.empty?).to eql(true)
     end
+
+    it "changing count is valid for a scalable worker" do
+      stub_settings_merge(:workers => {:worker_base => {:queue_worker_base => {:generic_worker => {:count => 4}}}})
+      result, errors = subject.validate
+      expect(result).to be_truthy
+      expect(errors.empty?).to eql(true)
+    end
+
+    it "changing count is invalid for a non-scalable worker" do
+      stub_settings_merge(:workers => {:worker_base => {:queue_worker_base => {:event_handler => {:count => 2}}}})
+      result, errors = subject.validate
+      expect(result).to be_falsey
+      expect(errors).to include("workers-count" => "event_handler: count: 2 exceeds maximum worker count: 1")
+    end
   end
 end


### PR DESCRIPTION
Only one EventHandler should be running at a time