### PR TITLE
Disallow timecop 0.9.7 due to buggy release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -292,7 +292,7 @@ group :test do
   gem "db-query-matchers",              "~>0.10.0"
   gem "factory_bot",                    "~>5.1",             :require => false
   gem "simplecov",                      ">=0.21.2",          :require => false
-  gem "timecop",                        "~>0.9",             :require => false
+  gem "timecop",                        "~>0.9", "!= 0.9.7", :require => false
   gem "vcr",                            "~>5.0",             :require => false
   gem "webmock",                        "~>3.7",             :require => false
 end


### PR DESCRIPTION
0.9.8 includes the following PRs to fix some issues: https://github.com/travisjeffery/timecop/pull/408
https://github.com/travisjeffery/timecop/pull/409

Our miq_widget_spec was failing with 0.9.7 but passing with 0.9.6 and 0.9.8.