### PR TITLE
Fix api_system_auth_token missing MiqServer

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -235,8 +235,11 @@ class MiqRegion < ApplicationRecord
   end
 
   def api_system_auth_token(userid)
+    miq_server = remote_ws_miq_server
+    return if miq_server.nil?
+
     token_hash = {
-      :server_guid   => remote_ws_miq_server.guid,
+      :server_guid   => miq_server.guid,
       :userid        => userid,
       :timestamp     => Time.now.utc,
       :user_metadata => User.metadata_for_system_token(userid)


### PR DESCRIPTION
If remote_ws_miq_server returns nil then api_system_auth_token was raising an exception:
`app/models/miq_region.rb:239:in 'api_system_auth_token': undefined method 'guid' for nil:NilClass (NoMethodError)`

This will happen in development if you are running `rails s`