### PR TITLE
Fix MiqRegion#remote_*_url returning invalid URL on podified

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -189,22 +189,15 @@ class MiqRegion < ApplicationRecord
   end
 
   def remote_ui_ipaddress
-    server = remote_ui_miq_server
-    server.try(:ipaddress)
+    remote_ui_miq_server&.ui_ipaddress
   end
 
   def remote_ui_hostname
-    server = remote_ui_miq_server
-    server && (server.hostname || server.ipaddress)
+    remote_ui_miq_server&.ui_hostname
   end
 
   def remote_ui_url(contact_with = :hostname)
-    svr = remote_ui_miq_server
-    remote_ui_url_override = svr.settings_for_resource.ui.url if svr
-    return remote_ui_url_override if remote_ui_url_override
-
-    hostname = send("remote_ui_#{contact_with}")
-    hostname && "https://#{hostname}"
+    remote_ui_miq_server&.ui_url(contact_with)
   end
 
   def remote_ws_miq_server
@@ -212,26 +205,19 @@ class MiqRegion < ApplicationRecord
   end
 
   def remote_ws_address
-    ::Settings.webservices.contactwith == 'hostname' ? remote_ws_hostname : remote_ws_ipaddress
+    remote_ws_miq_server&.ws_address
   end
 
   def remote_ws_ipaddress
-    miq_server = remote_ws_miq_server
-    miq_server.try(:ipaddress)
+    remote_ws_miq_server&.ws_ipaddress
   end
 
   def remote_ws_hostname
-    miq_server = remote_ws_miq_server
-    miq_server && (miq_server.hostname || miq_server.ipaddress)
+    remote_ws_miq_server&.ws_hostname
   end
 
   def remote_ws_url
-    svr = remote_ws_miq_server
-    remote_url_override = svr.settings_for_resource.webservices.url if svr
-    return remote_url_override if remote_url_override
-
-    hostname = remote_ws_address
-    hostname && URI::HTTPS.build(:host => hostname).to_s
+    remote_ws_miq_server&.ws_url
   end
 
   def api_system_auth_token(userid)

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -404,6 +404,50 @@ class MiqServer < ApplicationRecord
     result.merge(:message => message)
   end
 
+  def ui_hostname
+    hostname || ipaddress
+  end
+
+  def ui_ipaddress
+    ipaddress
+  end
+
+  def ui_address(contact_with = :hostname)
+    contact_with == :hostname ? ui_hostname : ui_ipaddress
+  end
+
+  def ui_url(contact_with = :hostname)
+    url_override = settings_for_resource.ui.url
+    return url_override if url_override
+
+    host = ui_address(contact_with)
+    return if host.nil?
+
+    URI::HTTPS.build(:host => host).to_s
+  end
+
+  def ws_hostname
+    hostname
+  end
+
+  def ws_ipaddress
+    ipaddress
+  end
+
+  def ws_address
+    ::Settings.webservices.contactwith == 'hostname' ? ws_hostname : ws_ipaddress
+  end
+
+  def ws_url
+    url_override = settings_for_resource.webservices.url
+    return url_override if url_override
+
+    host = ws_address
+    return if host.nil?
+
+    URI::HTTPS.build(:host => host).to_s
+  end
+
   #
   # Zone and Role methods
   #

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -405,15 +405,27 @@ class MiqServer < ApplicationRecord
   end
 
   def ui_hostname
-    hostname || ipaddress
+    if MiqEnvironment::Command.is_podified?
+      ENV.fetch("APPLICATION_DOMAIN")
+    else
+      hostname || ipaddress
+    end
   end
 
   def ui_ipaddress
-    ipaddress
+    if MiqEnvironment::Command.is_podified?
+      nil
+    else
+      ipaddress
+    end
   end
 
   def ui_address(contact_with = :hostname)
-    contact_with == :hostname ? ui_hostname : ui_ipaddress
+    if MiqEnvironment::Command.is_podified?
+      ENV.fetch("APPLICATION_DOMAIN")
+    else
+      contact_with == :hostname ? ui_hostname : ui_ipaddress
+    end
   end
 
   def ui_url(contact_with = :hostname)
@@ -427,15 +439,27 @@ class MiqServer < ApplicationRecord
   end
 
   def ws_hostname
-    hostname
+    if MiqEnvironment::Command.is_podified?
+      ENV.fetch("APPLICATION_DOMAIN")
+    else
+      hostname || ipaddress
+    end
   end
 
   def ws_ipaddress
-    ipaddress
+    if MiqEnvironment::Command.is_podified?
+      nil
+    else
+      ipaddress
+    end
   end
 
   def ws_address
-    ::Settings.webservices.contactwith == 'hostname' ? ws_hostname : ws_ipaddress
+    if MiqEnvironment::Command.is_podified?
+      ENV.fetch("APPLICATION_DOMAIN")
+    else
+      ::Settings.webservices.contactwith == 'hostname' ? ws_hostname : ws_ipaddress
+    end
   end
 
   def ws_url

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe MiqRegion do
       let(:url) { "https://www.manageiq.org" }
       let!(:web_server) do
         FactoryBot.create(:miq_server, :has_active_webservices => true,
-                                        :hostname               => hostname,
-                                        :ipaddress              => ip)
+                                       :hostname               => hostname,
+                                       :ipaddress              => ip)
       end
 
       it "fetches the url from server" do
@@ -133,6 +133,17 @@ RSpec.describe MiqRegion do
       it "fetches the url from the setting" do
         Vmdb::Settings.save!(web_server, :webservices => {:url => url})
         expect(region.remote_ws_url).to eq(url)
+      end
+
+      context "podified" do
+        before do
+          expect(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+          expect(ENV).to receive(:fetch).with("APPLICATION_DOMAIN").and_return("manageiq.apps.mycluster.com")
+        end
+
+        it "returns the applicationDomain from the CR" do
+          expect(region.remote_ws_url).to eq("https://manageiq.apps.mycluster.com")
+        end
       end
     end
 
@@ -151,8 +162,8 @@ RSpec.describe MiqRegion do
       let(:url) { "http://localhost:3000" }
       let!(:ui_server) do
         FactoryBot.create(:miq_server, :has_active_userinterface => true,
-                                        :hostname                 => hostname,
-                                        :ipaddress                => ip)
+                                       :hostname                 => hostname,
+                                       :ipaddress                => ip)
       end
 
       it "fetches the url from server" do
@@ -162,6 +173,17 @@ RSpec.describe MiqRegion do
       it "fetches the url from the setting" do
         Vmdb::Settings.save!(ui_server, :ui => {:url => url})
         expect(region.remote_ui_url).to eq(url)
+      end
+
+      context "podified" do
+        before do
+          expect(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+          expect(ENV).to receive(:fetch).with("APPLICATION_DOMAIN").and_return("manageiq.apps.mycluster.com")
+        end
+
+        it "returns the applicationDomain from the CR" do
+          expect(region.remote_ui_url).to eq("https://manageiq.apps.mycluster.com")
+        end
       end
     end
 


### PR DESCRIPTION
On appliances the remote_ui_url/remote_ws_url methods find an active MiqServer and use that server's hostname/ipaddress to build a URL for access.

On podified the hostname is the name of the orchestrator pod which isn't usable to be able to access the UI.

We have the proper hostname to access the httpd route in the APPLICATION_DOMAIN env var, use that if we are on podified.