### PR TITLE
Drop dependent destroy

### DIFF
--- a/app/models/container_build.rb
+++ b/app/models/container_build.rb
@@ -4,10 +4,10 @@ class ContainerBuild < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
 
-  has_many :labels, -> { where(:section => "labels") },
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,
-           :dependent  => :destroy
+           :inverse_of => :resource
 
   has_many :container_build_pods
 

--- a/app/models/container_build_pod.rb
+++ b/app/models/container_build_pod.rb
@@ -4,10 +4,10 @@ class ContainerBuildPod < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_build
 
-  has_many :labels, -> { where(:section => "labels") },
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,
-           :dependent  => :destroy
+           :inverse_of => :resource
 
   has_one :container_group
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -17,8 +17,14 @@ class ContainerGroup < ApplicationRecord
   has_many :containers, :dependent => :destroy
   has_many :container_images, -> { distinct }, :through => :containers
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many :node_selector_parts, -> { where(:section => "node_selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
+  has_many :node_selector_parts, -> { where(:section => "node_selectors") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :container_conditions, :class_name => "ContainerCondition", :as => :container_entity, :dependent => :destroy
   belongs_to :container_node
   has_and_belongs_to_many :container_services, :join_table => :container_groups_container_services

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -29,8 +29,14 @@ class ContainerImage < ApplicationRecord
   has_one :operating_system, :through => :computer_system
   has_one :openscap_result, :dependent => :destroy
   has_many :openscap_rule_results, :through => :openscap_result
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many :docker_labels, -> { where(:section => "docker_labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
+  has_many :docker_labels, -> { where(:section => "docker_labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_one :last_scan_result, :class_name => "ScanResult", :as => :resource, :dependent => :destroy, :autosave => true
 
   has_many :metric_rollups, :as => :resource, :dependent => :nullify, :inverse_of => :resource

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -23,8 +23,14 @@ class ContainerNode < ApplicationRecord
   has_many   :container_services, -> { distinct }, :through => :container_groups
   has_many   :container_routes, -> { distinct }, :through => :container_services
   has_many   :container_replicators, -> { distinct }, :through => :container_groups
-  has_many   :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many   :additional_attributes, -> { where(:section => "additional_attributes") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many   :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :class_name => "CustomAttribute",
+             :as         => :resource,
+             :inverse_of => :resource
+  has_many   :additional_attributes, -> { where(:section => "additional_attributes") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :class_name => "CustomAttribute",
+             :as         => :resource,
+             :inverse_of => :resource
   has_one    :computer_system, :as => :managed_entity, :dependent => :destroy
   belongs_to :lives_on, :polymorphic => true
   has_one    :hardware, :through => :computer_system

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -34,7 +34,10 @@ class ContainerProject < ApplicationRecord
   has_many :metric_rollups,         :as => :resource
   has_many :vim_performance_states, :as => :resource
 
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
 
   virtual_total :groups_count,      :container_groups
   virtual_total :services_count,    :container_services

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -10,8 +10,14 @@ class ContainerReplicator < ApplicationRecord
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :container_groups
   belongs_to :container_project
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
+  has_many :selector_parts, -> { where(:section => "selectors") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :container_nodes, -> { distinct }, :through => :container_groups
 
   # Needed for metrics

--- a/app/models/container_route.rb
+++ b/app/models/container_route.rb
@@ -6,7 +6,10 @@ class ContainerRoute < ApplicationRecord
   belongs_to :container_service
   has_many :container_nodes, -> { distinct }, :through => :container_service
   has_many :container_groups, -> { distinct }, :through => :container_service
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
 
   acts_as_miq_taggable
 end

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -9,8 +9,14 @@ class ContainerService < ApplicationRecord
   has_many :container_routes
   has_many :container_service_port_configs, :dependent => :destroy
   belongs_to :container_project
-  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many :selector_parts, -> { where(:section => "selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
+  has_many :selector_parts, -> { where(:section => "selectors") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :container_nodes, -> { distinct }, :through => :container_groups
   belongs_to :container_image_registry
 

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -6,10 +6,10 @@ class ContainerTemplate < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
   has_many :container_template_parameters, :dependent => :destroy
-  has_many :labels, -> { where(:section => "labels") },
+  has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,
-           :dependent  => :destroy
+           :inverse_of => :resource
 
   serialize :objects, Array
   serialize :object_labels, Hash

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -105,7 +105,10 @@ class Host < ApplicationRecord
   include EventMixin
 
   include CustomAttributeMixin
-  has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  has_many :ems_custom_attributes, -> { where(:source => 'VC') }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :filesystems_custom_attributes, :through => :filesystems, :source => 'custom_attributes'
 
   acts_as_miq_taggable

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -8,17 +8,29 @@ module ManageIQ::Providers
     include HasInfraManagerMixin
     include SupportsFeatureMixin
 
-    has_many :container_nodes, -> { active }, :foreign_key => :ems_id
-    has_many :container_groups, -> { active }, :foreign_key => :ems_id
+    has_many :container_nodes, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :foreign_key => :ems_id,
+             :inverse_of  => :ext_management_system
+    has_many :container_groups, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :foreign_key => :ems_id,
+             :inverse_of  => :ext_management_system
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :containers, -> { active }, :foreign_key => :ems_id
-    has_many :container_projects, -> { active }, :foreign_key => :ems_id
-    has_many :container_quotas, -> { active }, :foreign_key => :ems_id
+    has_many :containers, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :foreign_key => :ems_id,
+             :inverse_of  => :ext_management_system
+    has_many :container_projects, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :foreign_key => :ems_id,
+             :inverse_of  => :ext_management_system
+    has_many :container_quotas, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :foreign_key => :ems_id,
+             :inverse_of  => :ext_management_system
     has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_images, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_images, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :foreign_key => :ems_id,
+             :inverse_of  => :ext_management_system
     has_many :persistent_volumes, :as => :parent, :dependent => :destroy
     has_many :persistent_volume_claims, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_builds, :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -10,7 +10,10 @@ module CustomAttributeMixin
 
   included do
     has_many   :custom_attributes,     :as => :resource, :dependent => :destroy
-    has_many   :miq_custom_attributes, -> { where(:source => 'EVM') }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+    has_many   :miq_custom_attributes, -> { where(:source => 'EVM') }, # rubocop:disable Rails/HasManyOrHasOneDependent
+               :class_name => "CustomAttribute",
+               :as         => :resource,
+               :inverse_of => :resource
 
     # This is a set of helper getter and setter methods to support the transition
     # between "custom_*" fields in the model and using the custom_attributes table.

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -135,8 +135,14 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :service_resources, :as => :resource
   has_many                  :direct_services, :through => :service_resources, :source => :service
   has_many                  :connected_shares, -> { where(:resource_type => "VmOrTemplate") }, :foreign_key => :resource_id, :class_name => "Share"
-  has_many                  :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many                  :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  has_many                  :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+                            :class_name => "CustomAttribute",
+                            :as         => :resource,
+                            :inverse_of => :resource
+  has_many                  :ems_custom_attributes, -> { where(:source => 'VC') }, # rubocop:disable Rails/HasManyOrHasOneDependent
+                            :class_name => "CustomAttribute",
+                            :as         => :resource,
+                            :inverse_of => :resource
   has_many                  :counterparts, :as => :counterpart, :class_name => "ConfiguredSystem", :dependent => :nullify
 
   has_and_belongs_to_many   :storages, :join_table => 'storages_vms_and_templates'


### PR DESCRIPTION
We have some overlapping dependent destroy clauses

2 commits:

CustomAttributes are destroyed with the relation custom_attributes (/via CustomAttributeMixin)
There is no need to have dependent destroy for other custom attribute associations 

ContainerManager#container_images (only active images) are destroyed with the relation all_container_images.
There is no need to have dependent destroy for the qualified container_images


This is not a bug, but it is not accurate and causes some duplicate destroys when we are destroying the Ems records