### PR TITLE
fix GuestDevice#child_device references

### DIFF
--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -9,12 +9,13 @@ class GuestDevice < ApplicationRecord
 
   belongs_to :switch    # pNICs link to one switch
   belongs_to :lan       # vNICs link to one lan
+  belongs_to :parent_device, :class_name => "GuestDevice"
 
   has_one :network, :foreign_key => "device_id", :dependent => :destroy, :inverse_of => :guest_device
   has_many :miq_scsi_targets, :dependent => :destroy
 
   has_many :firmwares, :dependent => :destroy
-  has_many :child_devices, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
+  has_many :child_devices, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy, :inverse_of => :parent_device
 
   has_many :physical_network_ports, :dependent => :destroy
   has_many :connected_physical_switches, :through => :physical_network_ports

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -14,7 +14,7 @@ class GuestDevice < ApplicationRecord
   has_many :miq_scsi_targets, :dependent => :destroy
 
   has_many :firmwares, :dependent => :destroy
-  has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
+  has_many :child_devices, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
 
   has_many :physical_network_ports, :dependent => :destroy
   has_many :connected_physical_switches, :through => :physical_network_ports

--- a/spec/models/guest_device_spec.rb
+++ b/spec/models/guest_device_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe GuestDevice do
   describe "#child_device" do
     it "brings back children" do
       parent = FactoryBot.create(:guest_device)
-      child1 = FactoryBot.create(:guest_device, :parent_device_id => parent.id)
-      child2 = FactoryBot.create(:guest_device, :parent_device_id => parent.id)
+      child1 = FactoryBot.create(:guest_device, :parent_device => parent)
+      child2 = FactoryBot.create(:guest_device, :parent_device => parent)
       FactoryBot.create(:guest_device) # sad path (though the let! probably created lots of those)
 
       expect(parent.reload.child_devices).to match_array([child1, child2])

--- a/spec/models/guest_device_spec.rb
+++ b/spec/models/guest_device_spec.rb
@@ -31,4 +31,15 @@ RSpec.describe GuestDevice do
     expect(template_gd.host).to be_nil
     expect(host_gd.host).to eq(host)
   end
+
+  describe "#child_device" do
+    it "brings back children" do
+      parent = FactoryBot.create(:guest_device)
+      child1 = FactoryBot.create(:guest_device, :parent_device_id => parent.id)
+      child2 = FactoryBot.create(:guest_device, :parent_device_id => parent.id)
+      FactoryBot.create(:guest_device) # sad path (though the let! probably created lots of those)
+
+      expect(parent.reload.child_devices).to match_array([child1, child2])
+    end
+  end
 end


### PR DESCRIPTION
The child_devices added unneeded scope (and therefore an extra `GuestDevices.pluck(:id)`)

Before
======

```ruby
has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id"
# rewritten to make the issue more obvious: 
has_many :child_devices, -> { where(:parent_device_id => GuestDevice.ids) }, :foreign_key => "parent_device_id"

SELECT "guest_devices".*
FROM "guest_devices"
WHERE "guest_devices"."parent_device_id" = 26000000000035
  AND "guest_devices"."parent_device_id" IN (26000000000032, 26000000000033, 26000000000034, 26000000000035, 26000000000036, 26000000000037, 26000000000038)
```

After
=====

```ruby
has_many :child_devices, :foreign_key => "parent_device_id"

SELECT "guest_devices".*
FROM "guest_devices"
WHERE "guest_devices"."parent_device_id" = 26000000000035
```

This was introduce in https://github.com/ManageIQ/manageiq/pull/15371
The way the PR was batted around, it looked like this was not an intentional side effect.