### PR TITLE
Add deep delete functionality

### DIFF
--- a/lib/manageiq/deep_delete.rb
+++ b/lib/manageiq/deep_delete.rb
@@ -1,0 +1,177 @@
+# USAGE:
+#
+#   toggle_console_sql_logging
+#   ManageIQ::DeepDelete.delete(ExtManagementSystem.find(2))
+#
+# currently only tested on ContainerManager / ems
+module ManageIQ
+  class DeepDelete
+    include Vmdb::Logging
+    # list of callbacks that we have reviewed and can safely ignore
+    IGNORE_CALLBACKS = {
+      # Storages#all_relationships(ems_metadata) - we're deleting all children anyway
+      "Storages"            => 1,
+      # EmsFolders#all_relationships(ems_metadata)
+      "EmsFolders"          => 1,
+      # EmsClusters#all_relationships(ems_metadata)
+      "EmsClusters"         => 1,
+      # ResourcePools#all_relationships(ems_metadata) - TODO: do we want ancestry here?
+      "ResourcePools"       => 1,
+      # MonitorManager => ExtManagementSystem
+      "ExtManagementSystem" => 1,
+      # ContainerManager#monitoring_manager (apply_orphan_strategy?)
+      # MonitorManager#endpoints: endpoint_destroyed (using this/destroy_queue instead of dependent => destroy)
+      # ContainerManager#persistent_volumes (?)
+      # InfraManager#orchestration_templates (check_not_in_use (before destroy)
+      # InfraManager#orchestration_stacks apply_orphan_strategy
+      # BlacklistedEvent#reload_all_server_settings, BlacklistedEvent#audit_deletion
+      "BlacklistedEvent"    => 2,
+      # EventStream.after_commit :emit_notifications, :on => :create
+      "EventStream"         => 1
+      # VmOrTemplate#apply_orphan_strategy (/via ancesty - needed to destroy tree)
+      # Relationship#apply_orphan_strategy (/via ancestry - needed to destroy tree)
+      # Endpoint#endpoint_destroyed (using this/destroy_queue instead of dependent => destroy)
+    }.freeze
+
+    IGNORE_CONSTRAINTS = {
+      # Hardware.disks is an order clause
+      "Hardware.disks"                          => true,
+      # MiqAlertStatus.miq_alert_status_actions is an order clause
+      "MiqAlertStatus.miq_alert_status_actions" => true,
+      # BinaryBlob.binary_blob_parts is an order clause
+      "BinaryBlob.binary_blob_parts"            => true
+    }.freeze
+
+    # true to recurse into associations that have no values and would be skipped
+    # Useful for developers to ensure all relationships could be reached
+    attr_accessor :visit_skips
+
+    def initialize(visit_skips: false)
+      @visit_skips = visit_skips
+    end
+
+    # @param scope the record(s) to be destroyed - only a single child class/type can be passed in
+    def self.delete(scope, **options)
+      if scope.kind_of?(ActiveRecord::Base)
+        # convert an individual record into a scope
+        scope = scope.class.where(:id => scope.id)
+      else
+        # update scope.klass to a more specific class.
+        # Ems child classes have additional relationships defined
+        record = scope.first
+        if record.nil?
+          _log.error("DeepDelete found no records")
+          return
+        end
+        scope = record.class.merge(scope)
+      end
+
+      name = scope.klass.name.split(":").last
+      _, timing = Benchmark.realtime_block(:deep_delete) do
+        new(**options).recursive_delete(scope, :name => name)
+      end
+      _log.info("Finished DeepDelete in #{timing[:deep_delete]} seconds")
+
+      self
+    end
+
+    # @param scope [Relation] scope used to reach this relation
+    # @param klass [Class] class for this relation (default to scope's klass)
+    # @param name [String] name of this relation relative to the root node
+    # @param mode [:delete_all, :destroy] what we are to do with this node
+    #             If we are deleting this node, then we do not traverse into children to destroy them
+    # @return [Numeric] number of outstanding callbacks (so others know not to delete this object)
+    def recursive_delete(scope, klass = scope.klass, name: klass.name)
+      _log.debug { "=> deep_delete #{name} begin" }
+      # TODO: fetch distinct.pluck(:type).map(&:constantize).map { |k| refs_callbacks(k)} - to handle STI?
+      #       current code does not require this but may be more future proof
+      refs, callbacks = refs_callbacks(scope.klass)
+
+      has_record = scope.exists?
+      if has_record || visit_skips
+        refs.each do |n, relation|
+          rscope = rel_scope(klass, relation, scope)
+          # rscope = select * from hardwares where host_id in (select id from hosts where ems_id in (select id from ems where id = 2))
+          rname = "#{name}.#{n}"
+          case relation.options[:dependent]
+          when :destroy
+            # If we recurse to self without ensuring a record exists, then this will be an infinite loop
+            if has_record || relation.klass != scope.klass
+              recursive_delete(rscope, :name => rname)
+            end
+          when :delete_all
+            run(rname, "delete") { rscope.delete_all }
+          when :nullify
+            run(rname, "null") { rscope.update_all(relation.foreign_key => nil) } # rubocop:disable Rails/SkipsModelValidations
+          else
+            raise "unknown relation dependent option #{rname} :dependent => #{relation.options[:dependent]}"
+          end
+        end
+      end
+
+      if !has_record
+        skip_run(name, callbacks ? "destroy" : "delete")
+      elsif callbacks
+        # issue - this works for after destroy, but may have problems with a before destroy hook
+        #   they can reference children
+        run(name, "destroy") { scope.destroy_all.count }
+      else
+        run(name, "delete") { scope.delete_all }
+      end
+      _log.debug { "/> deep_delete #{name}" }
+    end
+
+    private
+
+    # @param scope starting table
+    # @param relation foreign table (i.e.: relation = scope.klass.send(relation.name))
+    def rel_scope(klass, relation, scope)
+      # Hardware#disks MiqAlertStatus#miq_alert_status_action have order constraint - so are false positives
+      # TODO: TEST harnes if there is a constraint, don't have dependent destroy
+      if !relation.constraints.empty? && !IGNORE_CONSTRAINTS["#{scope.klass.name}.#{relation.name}"]
+        _log.warn("CONSTRAINT: #{scope.klass.name}.#{relation.name} not handled")
+      end
+
+      # For a :through, point to the link record not the target record
+      # ASIDE: chances are the :through relation also has a destroy, so this will be a no-op
+      if relation.options[:through]
+        _log.warn("RELATION: #{scope.klass.name}.#{relation.name} has a :through. move destroy to linking record")
+        relation = klass.reflections[relation.options[:through].to_s]
+      end
+
+      relation.chain.reverse.inject(scope) do |sc, ar|
+        ret = ar.klass.where(ar.join_primary_key => sc.select(ar.join_foreign_key))
+        ar.type ? ret.where(ar.type => sc.klass.polymorphic_name) : ret
+      end
+    end
+
+    # @param  klass [Class] class of model that has reflections
+    # @return [Array<Reflection>, Boolean]
+    def refs_callbacks(klass)
+      dependent_refs = klass.reflections.select { |_, v| v.options[:dependent] }
+      callback_count = klass._destroy_callbacks.count + klass._commit_callbacks.count
+      ruby_callback_count = callback_count - dependent_refs.count
+
+      ruby_callbacks_we_can_ignore = IGNORE_CALLBACKS[klass.name]&.to_i || IGNORE_CALLBACKS[klass.base_class.name].to_i
+      need_to_call_ruby_callbacks = ruby_callback_count > ruby_callbacks_we_can_ignore
+      [dependent_refs, need_to_call_ruby_callbacks]
+    end
+
+    def run(name, action, &block)
+      count, timings = Benchmark.realtime_block(action, &block)
+      _log.info("%-7{action} %{name} %{count} records in %.6<timings>d seconds" % {
+        :action  => action,
+        :count   => count,
+        :name    => name,
+        :timings => timings[action]
+      })
+    end
+
+    def skip_run(name, action)
+      _log.debug("%-7{action} %{name} skipped" % {
+        :action => action,
+        :name   => name
+      })
+    end
+  end
+end

--- a/spec/lib/manageiq/deep_delete_spec.rb
+++ b/spec/lib/manageiq/deep_delete_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe ManageIQ::DeepDelete do
+  let(:ems) { FactoryBot.create(:ems_container) }
+  let(:ems_other) { FactoryBot.create(:ems_container) }
+
+  it "calls destroy for objects with ruby callbacks" do
+    expect_any_instance_of(ems.class).to receive(:destroy)
+
+    described_class.delete(ems)
+  end
+
+  it "deletes Ems#has_many" do
+    child1 = FactoryBot.create(:storage, :ext_management_system => ems)
+    child2 = FactoryBot.create(:storage, :ext_management_system => ems_other)
+    described_class.delete(ems)
+
+    expect(child1).to be_deleted
+    expect(child2).not_to be_deleted
+  end
+
+  it "nulls out Ems#has_many" do
+    child1 = FactoryBot.create(:vm, :ext_management_system => ems)
+    child2 = FactoryBot.create(:vm, :ext_management_system => ems_other)
+    described_class.delete(ems)
+
+    expect(child1.reload.ext_management_system).to eq(nil)
+    expect(child2.reload.ext_management_system).to eq(ems_other)
+  end
+
+  it "deletes (child STI class) ContainerManager#has_many" do
+    child1 = FactoryBot.create(:container_service, :ext_management_system => ems)
+    child2 = FactoryBot.create(:container_service, :ext_management_system => ems_other)
+
+    described_class.delete(ExtManagementSystem.where(:id => ems.id))
+    expect(child1).to be_deleted
+    expect(child2).not_to be_deleted
+  end
+
+  it "deletes has_many :through deletes the join record not the target record" do
+    ems = FactoryBot.create(:ems_cloud)
+    net_ems     = ems.network_manager
+    subnet      = FactoryBot.create(:cloud_subnet, :ext_management_system => net_ems)
+    # has_many :cloud_subnet_network_port, :dependent => destroy
+    # has_many :network_ports, :through => :cloud_subnet_network_ports
+    # we've since moved the :dependent => :destroy from network_ports, to cloud_subnet_network_port
+    # but it would have the same outcome
+    net_port    = FactoryBot.create(:network_port, :ext_management_system => net_ems)
+    subnet_port = FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => net_port)
+
+    described_class.delete(subnet)
+
+    expect(subnet).to be_deleted
+    expect(net_port).not_to be_deleted
+    expect(subnet_port).to be_deleted
+  end
+end


### PR DESCRIPTION
# links

- [x] https://github.com/ManageIQ/manageiq/pull/22670 (2 commits)
- [x] https://github.com/ManageIQ/manageiq/pull/22669 (2 commits)
- [x] https://github.com/ManageIQ/manageiq/pull/22694
- [x] https://github.com/ManageIQ/manageiq/pull/22695

### Problem

We need to destroy an ems. Unfortunately, the ems has a lot of child objects. Too many objects are loaded into memory and the sheer number of queries means this takes up too much memory and time.

It was traversing each layer; loading all the objects in a layer and then loading all child objects into memory before destroying the layer. This is a typical N+1 `parent_id` algorithm and can result in loading billions of objects into memory.


### Solution approaches

The solution either needs to a) cut up the problem into smaller chunks that avoids loading the entire ems tree into memory, b) avoiding loading relations into memory, c) some combination of those two approaches.

Converting `:dependent => :destroy` to `:dependent => :delete` does this, and can be done if there are not ruby callbacks.

By extension, if an object has no ruby callbacks and only has `:dependent => :delete`, then these can records can be deleted (not destroyed), just so long that the same code deletes the children first.

As you can guess, you end up with a ton of `DELETE` queries with a root of `WHERE ems_id = $ems_id`.
This reduces the N+1 queries, and no longer loads the leaf records or tree records into memory.

For records that have a callback defined, they are brought into memory and destroyed the old fashion way. But most `:dependent => :destroy` are converted to `:dependent => :delete`. And these deletes are done as a single query from the top level.

### Before

Each object is traversed and all children are then destroyed.
Each of those children's children are then destroyed before the child can be destroyed.

This is a typical N+1 `parent_id` scenario and for a large EMS. It takes 45 minutes on macbook metal.

Issues: 

- Object in each tier needs to be loaded into memory before the children can be brought back and destroyed.
- The records are brought back in N+1 fashion, and deleted individually. There are tens of thousands of containers. Ignoring the child relations for those containers, this overwhelms our system.

### After

#### Algorithm

This algorithm is similar to the original N+1 algorithm but with a few caveats:

- use ruby `has_many` to define children rather than loading the objects into memory (via `refs_callbacks`)
- Instead of locating each child for each object, all children for each layer are referenced  together (via `rel_scope`).
- deepest leaf children are deleted first.
  - If a relation is a `nullify` then the records are all updated with a single query.
  - If a relation is a `delete` or a `destroy` but there are no ruby callbacks, then all children are deleted with a single query
  - If a relation is a `destroy` and it has ruby callback, then `destroy` it. These are loaded into memory

#### Implications

(going through the above list bullet by bullet:

- `has_many`
  - Objects no longer need to be loaded into memory.
  - For STI classes, care needs to be made to ensure all relations are properly discovered since STI child classes can also define relations or alter relations.
- `rel_scope`
  - referencing all children at each level across parents increases our efficient from `O(n)` where n is the number of records to `O(associations)` or around 100.
  - Referencing all children at each level means we need to reimplement their scope. This is error prone.
  - see limitations below
- deepest leaf first
  - traversing a tree means this is still a recursive algorithm.
  - `:nullify`
    - This is a simple `UPDATE` like stock rails. The difference being that it is a single query for all updates.
  - `:delete`
    - These are also not loaded into memory. The code favors `:destroy` over `:delete`, but if there are no callbacks, then there is no need for `:destroy`.
 - `:destroy`
   - If we do destroy, it will attempt to destroy all relations. Since we walk the tree from child to parent, we will hit a number of queries, but they will all bring back no records. I had tried to fix this but this simplicity with a dozen or so no-op queries seemed minor.

### Limitations

2 main limitations:

#### Constraints

When building the child scopes, constraints on the relations are ignored. (this is my limitation) I reviewed all of the constraints and none of them altered the records we wanted to delete. Most of the constraints overlapped with other relations that were the same, just more genthat deleted them. This is the reaosn for the 2 PRs that correct the duplicate `:dependent => :destroy` definitions.

This still works correctly without those PR modifications, since only use constraints to divide relations that are still dependent.

#### Child STI classes

We build the relations from the relation class, so if relations are defined in a STI child class, those relations will not get picked up. This is the reason why the entry `delete` method rebuilds the query to ensure the `class` is not a generic `ExtManagementSystem` but rather something like a `ContainerManager`. This is only an issue if the relation defined specifies a parent class when the actual child class adds relations.

It seems that only the Ems adds relations to classes, so the top level ems is at risk. The ContainerManager does link to other ExtManagementSystem providers, but it properly specifies the specific class, so this works properly. Again, it is only an issue if a relation is defined that points to a generic class that has a child class that defines a `dependent => destroy, nullify, delete` relationships.

### Numbers

For a large ems (acania) this was taking 45 minutes on a mac. It takes much longer in an openshift cluster and is killed due to taking too many gigs of memory.

|       ms |   bytes | objects |query |  qry ms |     rows |` comments`
|          ---:|         ---:|         ---:|  ---:|         ---:|      ---:|  ---
|  3,141,337.7 | 3,429,864,842* | 1,397,325,234 |1,755,195 | 2,178,918.6 |  578,412 | destroy
|  9,361.0 | 61,629,818* | 7,759,264 |  292 | 8,265.7 |       14 |`deep_delete`

\* Memory usage does not reflect 679,643,104 freed objects.
\* Memory usage does not reflect 3,592,320 freed objects.

queries as follows:

count|query
-----|-----
129|COUNT
49 |DELETE
87 |SELECT
11 |COMMIT
11 |BEGIN
5  |UPDATE

It appears the 87 `SELECT` queries are to bring back objects for destroying. 51 of those are from the top level ems destroy. Most if not all of those are already removed from deletes. This is probably why there were only 14 records brought back for `SELECT` clauses. Most of the child records are already deleted before we call destroy on objects. Either that or the instantiations were not showing up for some other reason in instrumentation code.
