### PR TITLE
[QUINTEROS] Quinteros lock timecop 0.9.8 after #22659

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -1226,7 +1226,7 @@ GEM
     text (1.3.1)
     thor (1.2.2)
     tilt (2.2.0)
-    timecop (0.9.7)
+    timecop (0.9.8)
     timeliness (0.3.10)
     timeout (0.4.0)
     trailblazer-option (0.1.2)
@@ -1439,7 +1439,7 @@ DEPENDENCIES
   sys-filesystem (~> 1.4.3)
   systemd-journal (~> 1.4.2)
   terminal
-  timecop (~> 0.9)
+  timecop (~> 0.9, != 0.9.7)
   vcr (~> 5.0)
   webmock (~> 3.7)
   websocket-driver (~> 0.6.3)


### PR DESCRIPTION
0.9.7 is disallowed after #22659 was backported so we need to either use 0.9.8 or 0.9.6.
I chose the former.

This fixes the following error on quinteros for the security suite because it uses the Gemfile.lock.release on CI:

```
Resolving dependencies...
Fetching bundler-inject 2.0.0
Installing bundler-inject 2.0.0
Installed plugin bundler-inject
The dependencies in your gemfile changed, but the lockfile can't be updated
because frozen mode is set

You have added to the Gemfile:
* timecop (~> 0.9, != 0.9.7)

You have deleted from the Gemfile:
* timecop (~> 0.9)

Run `bundle install` elsewhere and add the updated Gemfile.lock to version
control.
If this is a development machine, remove the Gemfile freeze by running `bundle
config set frozen false`.
```