### PR TITLE
[WIP] Move provisioning quota calculation methods into MiqTemplate class (pluggable)

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -155,6 +155,18 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     n_('Image', 'Images', number)
   end
 
+  def memory_for_request(request, flavor_id = nil)
+    flavor_id ||= request.get_option(:instance_type)
+    flavor_obj = Flavor.find(flavor_id)
+    flavor_obj.try(:memory)
+  end
+
+  def number_of_cpus_for_request(request, flavor_id = nil)
+    flavor_id ||= request.get_option(:instance_type)
+    flavor_obj = Flavor.find(flavor_id)
+    flavor_obj.try(:cpus)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/infra_manager/template.rb
+++ b/app/models/manageiq/providers/infra_manager/template.rb
@@ -5,6 +5,16 @@ class ManageIQ::Providers::InfraManager::Template < MiqTemplate
     n_('Template', 'Templates', number)
   end
 
+  def memory_for_request(request, _flavor_id = nil)
+    memory = request.get_option(:vm_memory).to_i
+    %w[amazon openstack google].include?(vendor) ? memory : memory.megabytes
+  end
+
+  def number_of_cpus_for_request(request, _flavor_id = nil)
+    num_cpus = request.get_option(:number_of_sockets).to_i * request.get_option(:cores_per_socket).to_i
+    num_cpus.zero? ? request.get_option(:number_of_cpus).to_i : num_cpus
+  end
+
   private
 
   def raise_created_event

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -95,6 +95,24 @@ class MiqTemplate < VmOrTemplate
     end
   end
 
+  def memory_for_request(prov, cloud, vendor, flavor_obj = nil)
+    memory = flavor_obj.try(:memory) if cloud
+    return memory if memory.present?
+
+    request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
+    memory = request.get_option(:vm_memory).to_i
+    %w(amazon openstack google).include?(vendor) ? memory : memory.megabytes
+  end
+
+  def number_of_cpus_for_request(prov, cloud, flavor_obj)
+    num_cpus = flavor_obj.try(:cpus) if cloud
+    return num_cpus if num_cpus.present?
+
+    request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
+    num_cpus = request.get_option(:number_of_sockets).to_i * request.get_option(:cores_per_socket).to_i
+    num_cpus.zero? ? request.get_option(:number_of_cpus).to_i : num_cpus
+  end
+
   private_class_method def self.refresh_association
     :miq_templates
   end

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -95,8 +95,11 @@ class MiqTemplate < VmOrTemplate
     end
   end
 
-  def memory_for_request(prov, cloud, vendor, flavor_obj = nil)
-    memory = flavor_obj.try(:memory) if cloud
+  def memory_for_request(request, flavor_id = nil)
+    flavor_id ||= request.get_option(:instance_type)
+    flavor_obj = Flavor.find(flavor_id)
+
+    memory = flavor_obj.try(:memory) if request.source.try(:cloud)
     return memory if memory.present?
 
     request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
@@ -104,8 +107,11 @@ class MiqTemplate < VmOrTemplate
     %w(amazon openstack google).include?(vendor) ? memory : memory.megabytes
   end
 
-  def number_of_cpus_for_request(prov, cloud, flavor_obj)
-    num_cpus = flavor_obj.try(:cpus) if cloud
+  def number_of_cpus_for_request(request, flavor_id = nil)
+    flavor_id ||= request.get_option(:instance_type)
+    flavor_obj = Flavor.find(flavor_id)
+
+    num_cpus = flavor_obj.try(:cpus) if request.source.try(:cloud)
     return num_cpus if num_cpus.present?
 
     request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -96,27 +96,11 @@ class MiqTemplate < VmOrTemplate
   end
 
   def memory_for_request(request, flavor_id = nil)
-    flavor_id ||= request.get_option(:instance_type)
-    flavor_obj = Flavor.find(flavor_id)
-
-    memory = flavor_obj.try(:memory) if request.source.try(:cloud)
-    return memory if memory.present?
-
-    request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
-    memory = request.get_option(:vm_memory).to_i
-    %w(amazon openstack google).include?(vendor) ? memory : memory.megabytes
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def number_of_cpus_for_request(request, flavor_id = nil)
-    flavor_id ||= request.get_option(:instance_type)
-    flavor_obj = Flavor.find(flavor_id)
-
-    num_cpus = flavor_obj.try(:cpus) if request.source.try(:cloud)
-    return num_cpus if num_cpus.present?
-
-    request = prov.kind_of?(MiqRequest) ? prov : prov.miq_request
-    num_cpus = request.get_option(:number_of_sockets).to_i * request.get_option(:cores_per_socket).to_i
-    num_cpus.zero? ? request.get_option(:number_of_cpus).to_i : num_cpus
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   private_class_method def self.refresh_association

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -293,8 +293,8 @@ module MiqProvisionQuotaMixin
     return if num_vms_for_request.zero?
     flavor_obj = flavor(pr)
     result[:count] += num_vms_for_request
-    result[:memory] += pr.vm_template.memory_for_request(pr, cloud?(pr), vendor(pr), flavor_obj) * num_vms_for_request
-    result[:cpu] += pr.vm_template.number_of_cpus_for_request(pr, cloud?(pr), flavor_obj) * num_vms_for_request
+    result[:memory] += pr.vm_template.memory_for_request(pr) * num_vms_for_request
+    result[:cpu] += pr.vm_template.number_of_cpus_for_request(pr) * num_vms_for_request
     result[:storage] += storage(pr, cloud?(pr), vendor(pr), flavor_obj) * num_vms_for_request
     result[:ids] << pr.id
 
@@ -302,8 +302,8 @@ module MiqProvisionQuotaMixin
       next unless p.state == 'Active'
       host_id, storage_id = p.get_option(:dest_host).to_i, p.get_option(:dest_storage).to_i
       active = result[:active]
-      active[:memory_by_host_id][host_id] += p.vm_template.memory_for_request(p, cloud?(pr), vendor(pr), flavor_obj)
-      active[:cpu_by_host_id][host_id] += p.vm_template.number_of_cpus_for_request(p, cloud?(pr), flavor_obj)
+      active[:memory_by_host_id][host_id] += p.vm_template.memory_for_request(p)
+      active[:cpu_by_host_id][host_id] += p.vm_template.number_of_cpus_for_request(p)
       active[:storage_by_id][storage_id] += storage(p, cloud?(pr), vendor(pr), flavor_obj)
       active[:vms_by_storage_id][storage_id] << p.id
       active[:ids] << p.id


### PR DESCRIPTION
PR set:
- https://github.com/ManageIQ/manageiq-content/pull/737
- https://github.com/ManageIQ/manageiq-automation_engine/pull/532
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/469
- https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/146

Fixes #22641

Move methods making quota calculations for a given request into `MiqTemplate` base class. They can then be overridden in the `ManageIQ::Providers::CloudManager::Template` subclass (for "cloud" providers), or even in provider plug-in subclasses.

Allows an override in `ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template` to fix a bug where it reports 0 cpus for quota.

TODO:
- [ ] Fix faililng cross-repo tests
- [ ] Make storage calculations pluggable