### PR TITLE
Add new Workflow Credential Mapping Feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5197,6 +5197,10 @@
         :description: Edit a Playbook
         :feature_type: admin
         :identifier: embedded_configuration_script_payload_edit
+      - :name: Map Credentials
+        :description: Map Credentials to Workflow
+        :feature_type: admin
+        :identifier: embedded_configuration_script_payload_map_credentials
       - :name: Refresh Playbooks
         :description: Ansible Playbooks Refresh
         :feature_type: control

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1481,6 +1481,8 @@ en:
       ManageIQ::Providers::Workflows::AutomationManager::Workflow:                        Workflow
       ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSource:       Repository (Embedded Workflows)
       ManageIQ::Providers::Workflows::AutomationManager::Credential:                      Credential (Embedded Workflows)
+      ManageIQ::Providers::Workflows::AutomationManager::ScmCredential:                   Credential (SCM)
+      ManageIQ::Providers::Workflows::AutomationManager::WorkflowCredential:              Credential (Workflow)
       ManageIQ::Providers::ExternalAutomationManager:                                     Automation Manager
       ManageIQ::Providers::AutomationManager::Authentication:                             Credential
       ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential:             Credential (Amazon)


### PR DESCRIPTION
Needs to be Merged Before: https://github.com/ManageIQ/manageiq-ui-classic/pull/8905

Adds the new Map Credentials feature to `miq_product_features.yml`. Also updates `en.yml` to include new strings for the two new Workflow Credential types.

Before:
![image](https://github.com/ManageIQ/manageiq/assets/64800041/6aac3e11-161f-452a-bf9b-e684c9966bf9)

After:
![image](https://github.com/ManageIQ/manageiq/assets/64800041/3c328991-3a39-4a1d-a68e-cf21cbc017c8)