### PR TITLE
Skip processing of duplicate events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -138,6 +138,8 @@ class EmsEvent < EventStream
 
     # Write the event
     new_event = create_event(event_hash)
+    return if new_event.nil? # If the event is a duplicate skip further processing
+
     # Create a 'completed task' event if this is the last in a series of events
     create_completed_event(event_hash) if task_final_events.key?(event_type.to_sym)
 

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -226,6 +226,19 @@ RSpec.describe EmsEvent do
           expect(ems_event).to be_nil
         end
 
+        context "with event syndication" do
+          before do
+            stub_settings_merge(:event_streams => {:syndicate_events => true})
+          end
+
+          it "doesn't syndicate duplicate events" do
+            expect(EmsEvent).not_to receive(:syndicate_event)
+
+            ems_event = EmsEvent.add(@ems.id, @event_hash)
+            expect(ems_event).to be_nil
+          end
+        end
+
         it "should add a new event if it has a different ems_ref" do
           ems_event = EmsEvent.add(
             @ems.id,


### PR DESCRIPTION
Don't create task_final events or syndicate events if the event just processed was evaluated to be a duplicate.