### PR TITLE
Add validation for configuration script payload credentials

### DIFF
--- a/app/models/configuration_script_payload.rb
+++ b/app/models/configuration_script_payload.rb
@@ -3,11 +3,28 @@ class ConfigurationScriptPayload < ConfigurationScriptBase
 
   belongs_to :configuration_script_source
 
+  validate :validate_credentials_payload, :if => :credentials_changed?
+
   def self.base_model
     ConfigurationScriptPayload
   end
 
   def run(*)
     raise NotImplementedError, _("run must be implemented in a subclass")
+  end
+
+  def validate_credentials_payload
+    return if credentials.blank?
+
+    error   = "credentials must be a hash" unless credentials.kind_of?(Hash)
+    error ||= credentials.each_value.collect do |val|
+      if val.kind_of?(Hash)
+        "credential value must have credential_ref and credential_field" unless val.key?("credential_ref") && val.key?("credential_field")
+      elsif !val.kind_of?(String)
+        "credential value must be string or a hash"
+      end
+    end.compact.first
+
+    errors.add(:credentials, N_("Invalid payload: %{error}") % {:error => error}) if error
   end
 end

--- a/spec/models/configuration_script_payload_spec.rb
+++ b/spec/models/configuration_script_payload_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe ConfigurationScriptPayload do
+  let(:subject) { FactoryBot.create(:configuration_script_payload) }
+
+  describe "#credentials=" do
+    context "with a valid payload" do
+      let(:credentials) { {"my_username" => {"credential_ref" => "my", "credential_field" => "userid"}, "my_password" => "password"} }
+
+      it "saves without error" do
+        subject.credentials = credentials
+        subject.save!
+        expect(subject.reload.credentials).to eq(credentials)
+      end
+    end
+
+    context "with an invalid payload" do
+      context "with an array" do
+        let(:credentials) { ["foo", "bar"] }
+
+        it "raises a validation exception" do
+          subject.credentials = credentials
+          expect { subject.save! }.to raise_error("Validation failed: ConfigurationScriptPayload: Credentials Invalid payload: credentials must be a hash")
+        end
+      end
+
+      context "with invalid values" do
+        let(:credentials) { {"my_username" => 0.1} }
+
+        it "raises a validation exception" do
+          subject.credentials = credentials
+          expect { subject.save! }.to raise_error("Validation failed: ConfigurationScriptPayload: Credentials Invalid payload: credential value must be string or a hash")
+        end
+      end
+
+      context "with missing credential keys" do
+        let(:credentials) { {"my_username" => {"credential_ref" => "my"}} }
+
+        it "raises a validation exception" do
+          subject.credentials = credentials
+          expect { subject.save! }.to raise_error("Validation failed: ConfigurationScriptPayload: Credentials Invalid payload: credential value must have credential_ref and credential_field")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add validation checks on the configuration script payload format to ensure it is a hash with proper keys.