### PR TITLE
Add purging of ems's relationships in async batches

### DIFF
--- a/tools/purge_ems.rb
+++ b/tools/purge_ems.rb
@@ -37,7 +37,7 @@ ems = ExtManagementSystem.find(id)
 if ems.enabled?
   log("Pausing management system with id: #{id} #{ems.name}...")
   ems.pause!
-  log("Pausing ems with id: #{ems.id} #{ems.name}...done")
+  log("Pausing management system with id: #{ems.id} #{ems.name}...Complete")
 end
 
 if ems.reload.enabled?
@@ -51,14 +51,14 @@ end
 create_messages = true
 backlog = current_backlog
 if backlog > 0
-  log("There is already a backlog of #{backlog} destroy messages, skipping creating more.")
+  log("A backlog of #{backlog} work items is already in progress, skipping creating more.")
   create_messages = false
 end
 
 if create_messages
   batch = opts[:batch]
   timeout = opts[:timeout].to_i.minutes
-  log("Adding destroy messages in batches of #{batch}...")
+  log("Adding work items with batches of #{batch}...")
   ems.class.reflections.select { |_, v| v.options[:dependent] }.map { |n, _v| ems.send(n) }.each do |rel|
     next unless rel
 
@@ -75,7 +75,7 @@ if create_messages
     end
   end
 
-  log("Adding destroy messages in batches of #{batch}...done")
+  log("Adding work items with batches of #{batch}...Complete")
 
   MiqQueue.put(
     :class_name  => ems.class,
@@ -89,7 +89,7 @@ end
 
 if opts[:follow] == "true"
   start_backlog = current_backlog
-  log("Following #{start_backlog} destroy messages...")
+  log("Destruction in progress...#{start_backlog} initial items")
   require 'ruby-progressbar'
 
   # Example format output:
@@ -106,5 +106,5 @@ if opts[:follow] == "true"
     sleep 10
   end
   pbar.finish
-  log("Following #{start_backlog} destroy messages...Complete")
+  log("Destruction in progress...Complete")
 end

--- a/tools/purge_ems.rb
+++ b/tools/purge_ems.rb
@@ -38,11 +38,6 @@ if ems.enabled?
   log("Pausing management system with id: #{ems.id} #{ems.name}...Complete")
 end
 
-if ems.reload.enabled?
-  log("Management system with id: #{ems.id} #{ems.name} is still enabled!")
-  exit 1
-end
-
 # Watching the destroy queue messages be processed can take a long time so terminal disconnects
 # are likely.  Therefore, if running it again, detect when it's in progress, skip queueing more
 # and skip right to watching the updated progress if desired.

--- a/tools/purge_ems.rb
+++ b/tools/purge_ems.rb
@@ -96,14 +96,11 @@ if opts[:follow]
   # Example format output:
   # Progress: 5/10 |=====     |
   pbar = ProgressBar.create(:title => "Progress", :total => start_backlog, :autofinish => false, :format => "%t: %c/%C |%B|")
-  done = 0
   loop do
     remaining = current_backlog
-    newly_finished = start_backlog - remaining - done
-    done += newly_finished
-    pbar.progress += newly_finished
-
     break if remaining == 0
+
+    pbar.progress = start_backlog - remaining
     sleep 10
   end
   pbar.finish

--- a/tools/purge_ems.rb
+++ b/tools/purge_ems.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+require 'optimist'
+
+ARGV.shift if ARGV[0] == '--' # if invoked with rails runner
+opts = Optimist.options do
+  banner "Purge managements system records in the background via the queue.\n\nUsage: ruby #{$0} [options]\n\nOptions:\n\t"
+  opt :id,      "Mangement System id",                                         :short => :i, :type => :integer,                    :required => true
+  opt :follow,  "Follow the progress or exit after creating messages",         :short => :f, :type => :string,  :default => "true"
+  opt :batch,   "How many rows in each relationship to be deleted in a batch", :short => :b, :type => :integer, :default => 1_000
+  opt :timeout, "How many minutes should each message be allowed to run",      :short => :t, :type => :integer, :default => 30
+end
+
+Optimist.die :id,      "must be a positive number"                             if opts[:id] < 1
+Optimist.die :batch,   "must be a positive number"                             if opts[:batch] < 1
+Optimist.die :timeout, "must be a positive number greater than or equal to 10" if opts[:timeout] < 10
+
+opts[:follow] = opts[:follow].to_s.downcase
+Optimist.die :follow, "must be true or false" unless %w[true false].include?(opts[:follow])
+
+RELATIONSHIP_DESTROY_METHOD = "destroy".freeze
+EMS_DESTROY_METHOD          = "destroy_queue".freeze
+ZONE                        = "default".freeze
+
+def log(msg)
+  $log.info("MIQ(#{__FILE__}) #{msg}")
+  puts msg
+end
+
+def current_backlog
+  MiqQueue.where(:method_name => [EMS_DESTROY_METHOD, RELATIONSHIP_DESTROY_METHOD], :zone => ZONE).count
+end
+
+id = opts[:id]
+ems = ExtManagementSystem.find(id)
+if ems.enabled?
+  log("Pausing management system with id: #{id} #{ems.name}...")
+  ems.pause!
+  log("Pausing ems with id: #{ems.id} #{ems.name}...done")
+end
+
+if ems.reload.enabled?
+  log("Management system with id: #{ems.id} #{ems.name} is still enabled!")
+  exit 1
+end
+
+# Watching the destroy queue messages be processed can take a long time so terminal disconnects
+# are likely.  Therefore, if running it again, detect when it's in progress, skip queueing more
+# and skip right to watching the updated progress if desired.
+create_messages = true
+backlog = current_backlog
+if backlog > 0
+  log("There is already a backlog of #{backlog} destroy messages, skipping creating more.")
+  create_messages = false
+end
+
+if create_messages
+  batch = opts[:batch]
+  timeout = opts[:timeout].to_i.minutes
+  log("Adding destroy messages in batches of #{batch}...")
+  ems.class.reflections.select { |_, v| v.options[:dependent] }.map { |n, _v| ems.send(n) }.each do |rel|
+    next unless rel
+
+    log("  Adding #{rel.klass}")
+    rel.order(:id).pluck(:id).each_slice(batch) { |x| MiqQueue.put(:class_name => rel.klass.to_s, :method_name => RELATIONSHIP_DESTROY_METHOD, :args => [x], :zone => ZONE, :msg_timeout => timeout ) }
+  end
+
+  log("Adding destroy messages in batches of #{batch}...done")
+
+  MiqQueue.put(
+    :class_name  => ems.class,
+    :instance_id => ems.id,
+    :method_name => EMS_DESTROY_METHOD,
+    :zone        => ZONE
+  )
+end
+
+if opts[:follow] == "true"
+  start_backlog = current_backlog
+  log("Following #{start_backlog} destroy messages...")
+  require 'ruby-progressbar'
+
+  # Example format output:
+  # Progress: 5/10 |=====     |
+  pbar = ProgressBar.create(:title => "Progress", :total => start_backlog, :autofinish => false, :format => "%t: %c/%C |%B|")
+  done = 0
+  loop do
+    remaining = current_backlog
+    newly_finished = start_backlog - remaining - done
+    done += newly_finished
+    pbar.progress += newly_finished
+
+    break if remaining == 0
+    sleep 10
+  end
+  pbar.finish
+  log("Following #{start_backlog} destroy messages...Complete")
+end


### PR DESCRIPTION
Add purging of ems's relationships in async batches

Example usage:
`bundle exec ruby tools/purge_ems.rb --id 2`

```
  -i, --id=<i>                 Management System id
  -f, --follow, --no-follow    Follow the progress or exit after creating work items. (Default: true)
  -b, --batch=<i>              For each relationship, the number of rows to be removed in a batch. A lower number may decrease memory usage but also take longer. (Default: 1000)
  -t, --timeout=<i>            The number of minutes
```

Example output:

![image](https://github.com/ManageIQ/manageiq/assets/19339/e9fa73a6-4985-43c4-ab6b-4603e69d903a)
If you get kicked out of your terminal and run it again, it picks up following the remaining queue items:


![image](https://github.com/ManageIQ/manageiq/assets/19339/1a8906a5-7f7d-41c1-8302-981f9976f939)