### PR TITLE
Messaging SASL mechanism updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "manageiq-api-client",              "~>0.3.6",           :require => false
 gem "manageiq-loggers",                 "~>1.0",             :require => false
-gem "manageiq-messaging",               "~>1.0", ">=1.3.0",  :require => false
+gem "manageiq-messaging",               "~>1.0", ">=1.4.0",  :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.2",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -696,12 +696,13 @@ class MiqQueue < ApplicationRecord
     return unless ENV["MESSAGING_HOSTNAME"] && ENV["MESSAGING_PORT"] && ENV["MESSAGING_USERNAME"] && ENV["MESSAGING_PASSWORD"]
 
     options = {
-      :host     => ENV["MESSAGING_HOSTNAME"],
-      :port     => ENV["MESSAGING_PORT"].to_i,
-      :username => ENV["MESSAGING_USERNAME"],
-      :password => ENV["MESSAGING_PASSWORD"],
-      :protocol => ENV.fetch("MESSAGING_PROTOCOL", "Kafka"),
-      :encoding => ENV.fetch("MESSAGING_ENCODING", "json")
+      :host           => ENV["MESSAGING_HOSTNAME"],
+      :port           => ENV["MESSAGING_PORT"].to_i,
+      :username       => ENV["MESSAGING_USERNAME"],
+      :password       => ENV["MESSAGING_PASSWORD"],
+      :protocol       => ENV.fetch("MESSAGING_PROTOCOL", "Kafka"),
+      :encoding       => ENV.fetch("MESSAGING_ENCODING", "json"),
+      :sasl_mechanism => ENV.fetch("MESSAGING_SASL_MECHANISM", "PLAIN")
     }
 
     if ENV["MESSAGING_SSL_CA"].present?

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -704,11 +704,9 @@ class MiqQueue < ApplicationRecord
       :encoding => ENV.fetch("MESSAGING_ENCODING", "json")
     }
 
-    if ENV["MESSAGING_KEYSTORE_PASSWORD"].present?
+    if ENV["MESSAGING_SSL_CA"].present?
       options[:ssl] = true
-      options[:ca_file] = ENV.fetch("MESSAGING_SSL_CA", nil)
-      options[:keystore_location] = ENV.fetch("MESSAGING_KEYSTORE", nil)
-      options[:keystore_password] = ENV["MESSAGING_KEYSTORE_PASSWORD"]
+      options[:ca_file] = ENV["MESSAGING_SSL_CA"]
     end
 
     options

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -170,12 +170,9 @@ class ContainerOrchestrator
         {:name => "MESSAGING_TYPE", :value => ENV["MESSAGING_TYPE"]},
         {:name => "MESSAGING_SSL_CA", :value => ENV["MESSAGING_SSL_CA"]},
         {:name => "MESSAGING_SASL_MECHANISM", :value => ENV["MESSAGING_SASL_MECHANISM"]},
-        {:name      => "MESSAGING_HOSTNAME",
-         :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "hostname"}}},
-        {:name      => "MESSAGING_PASSWORD",
-         :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "password"}}},
-        {:name      => "MESSAGING_USERNAME",
-         :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "username"}}}
+        {:name => "MESSAGING_HOSTNAME", :value => ENV["MESSAGING_HOSTNAME"]},
+        {:name => "MESSAGING_PASSWORD", :value => ENV["MESSAGING_PASSWORD"]},
+        {:name => "MESSAGING_USERNAME", :value => ENV["MESSAGING_USERNAME"]}
       ]
     end
 

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -100,11 +100,6 @@ class ContainerOrchestrator
             ],
           }
         }
-
-        if ENV["MESSAGING_KEYSTORE_PASSWORD"].present?
-          volume = deployment[:spec][:template][:spec][:volumes].find { |vol| vol[:name] == "internal-root-certificate" }
-          volume[:secret][:items].append({:key => "kafka_keystore", :path => "kafka.keystore.jks"})
-        end
       end
 
       deployment
@@ -174,8 +169,6 @@ class ContainerOrchestrator
         {:name => "MESSAGING_PORT", :value => ENV["MESSAGING_PORT"]},
         {:name => "MESSAGING_TYPE", :value => ENV["MESSAGING_TYPE"]},
         {:name => "MESSAGING_SSL_CA", :value => ENV["MESSAGING_SSL_CA"]},
-        {:name => "MESSAGING_KEYSTORE", :value => ENV["MESSAGING_KEYSTORE"]},
-        {:name => "MESSAGING_KEYSTORE_PASSWORD", :value => ENV["MESSAGING_KEYSTORE_PASSWORD"]},
         {:name      => "MESSAGING_HOSTNAME",
          :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "hostname"}}},
         {:name      => "MESSAGING_PASSWORD",

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -169,6 +169,7 @@ class ContainerOrchestrator
         {:name => "MESSAGING_PORT", :value => ENV["MESSAGING_PORT"]},
         {:name => "MESSAGING_TYPE", :value => ENV["MESSAGING_TYPE"]},
         {:name => "MESSAGING_SSL_CA", :value => ENV["MESSAGING_SSL_CA"]},
+        {:name => "MESSAGING_SASL_MECHANISM", :value => ENV["MESSAGING_SASL_MECHANISM"]},
         {:name      => "MESSAGING_HOSTNAME",
          :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "hostname"}}},
         {:name      => "MESSAGING_PASSWORD",

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -67,18 +67,27 @@ RSpec.describe ContainerOrchestrator do
     end
 
     context "when MESSAGING_TYPE is set" do
-      before { stub_const("ENV", ENV.to_h.merge("MESSAGING_TYPE" => "kafka", "MESSAGING_PORT" => "9092")) }
+      before do
+        stub_const("ENV", ENV.to_h.merge(
+                            "MESSAGING_TYPE"           => "kafka",
+                            "MESSAGING_PORT"           => "9092",
+                            "MESSAGING_SSL_CA"         => "/etc/pki/ca-trust/source/anchors/root.crt",
+                            "MESSAGING_SASL_MECHANISM" => "PLAIN",
+                            "MESSAGING_HOSTNAME"       => "hostname",
+                            "MESSAGING_PASSWORD"       => "password",
+                            "MESSAGING_USERNAME"       => "username"
+                          ))
+      end
 
       it "sets the messaging env vars" do
         expect(subject.send(:default_environment)).to include(
           {:name => "MESSAGING_PORT", :value => "9092"},
           {:name => "MESSAGING_TYPE", :value => "kafka"},
-          {:name      => "MESSAGING_HOSTNAME",
-           :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "hostname"}}},
-          {:name      => "MESSAGING_PASSWORD",
-           :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "password"}}},
-          {:name      => "MESSAGING_USERNAME",
-           :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "username"}}}
+          {:name => "MESSAGING_SSL_CA", :value => "/etc/pki/ca-trust/source/anchors/root.crt"},
+          {:name => "MESSAGING_SASL_MECHANISM", :value => "PLAIN"},
+          {:name => "MESSAGING_HOSTNAME", :value => "hostname"},
+          {:name => "MESSAGING_PASSWORD", :value => "password"},
+          {:name => "MESSAGING_USERNAME", :value => "username"}
         )
       end
     end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1035,12 +1035,13 @@ RSpec.describe MiqQueue do
           expect(YAML).not_to receive(:load_file).with(MiqQueue::MESSAGING_CONFIG_FILE)
 
           expect(MiqQueue.send(:messaging_client_options)).to eq(
-            :encoding => "json",
-            :host     => "server.example.com",
-            :password => "password",
-            :port     => 9092,
-            :protocol => "Kafka",
-            :username => "admin"
+            :encoding       => "json",
+            :host           => "server.example.com",
+            :password       => "password",
+            :port           => 9092,
+            :protocol       => "Kafka",
+            :sasl_mechanism => "PLAIN",
+            :username       => "admin"
           )
         end
 
@@ -1051,35 +1052,33 @@ RSpec.describe MiqQueue do
 
           expect(ENV["MESSAGING_PASSWORD"]).to be_encrypted
           expect(MiqQueue.send(:messaging_client_options)).to eq(
-            :encoding => "json",
-            :host     => "server.example.com",
-            :password => "password",
-            :port     => 9092,
-            :protocol => "Kafka",
-            :username => "admin"
+            :encoding       => "json",
+            :host           => "server.example.com",
+            :password       => "password",
+            :port           => 9092,
+            :protocol       => "Kafka",
+            :sasl_mechanism => "PLAIN",
+            :username       => "admin"
           )
         end
 
         it "with SSL enabled" do
           stub_const("ENV", env_vars.to_h.merge("MESSAGING_PASSWORD" => "password",
-                                                "MESSAGING_SSL_CA" => "/path/root.crt",
-                                                "MESSAGING_KEYSTORE" => "/path/keystore.jks",
-                                                "MESSAGING_KEYSTORE_PASSWORD" => "keystore_password"
+                                                "MESSAGING_SSL_CA"   => "/path/root.crt"
                                                 ))
 
           expect(YAML).not_to receive(:load_file).with(MiqQueue::MESSAGING_CONFIG_FILE)
 
           expect(MiqQueue.send(:messaging_client_options)).to eq(
-            :encoding          => "json",
-            :host              => "server.example.com",
-            :password          => "password",
-            :port              => 9092,
-            :protocol          => "Kafka",
-            :username          => "admin",
-            :ssl               => true,
-            :ca_file           => "/path/root.crt",
-            :keystore_location => "/path/keystore.jks",
-            :keystore_password => "keystore_password"
+            :encoding       => "json",
+            :host           => "server.example.com",
+            :password       => "password",
+            :port           => 9092,
+            :protocol       => "Kafka",
+            :username       => "admin",
+            :sasl_mechanism => "PLAIN",
+            :ssl            => true,
+            :ca_file        => "/path/root.crt"
           )
         end
       end


### PR DESCRIPTION
- Added env var to specify sasl mechanism allowing for another mechanism to be used in podified i.e. `SCRAM-SHA-512` and will default to PLAIN if not provided. This allows us to support other SASL mechanisms on podified without having to implement changes on the appliance side to support the same mechanism 
- Turns out keystores aren't needed because they are only used for mTLS authentication. Since we are using SASL for authentication, a client side keystore isn't needed because you can only have one authentication method: SASL or mTLS. For a better explanation see https://docs.confluent.io/platform/current/kafka/configure-mds/mutual-tls-auth-rbac.html#authentication

TODO:
- [x] update specs

Depends on:
- [x] https://github.com/ManageIQ/manageiq-messaging/pull/80

@miq-bot assign @agrare 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_labels enhancement, bug