### PR TITLE
Drop dependent => destroy on through associations

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -15,7 +15,7 @@ class CloudSubnet < ApplicationRecord
   belongs_to :parent_cloud_subnet, :class_name => "::CloudSubnet"
 
   has_many :cloud_subnet_network_ports, :dependent => :destroy
-  has_many :network_ports, :through => :cloud_subnet_network_ports, :dependent => :destroy
+  has_many :network_ports, :through => :cloud_subnet_network_ports
   has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
   has_many :cloud_subnets, :foreign_key => :parent_cloud_subnet_id
   has_many :security_groups, :dependent => :nullify

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -39,7 +39,7 @@ class ServiceTemplate < ApplicationRecord
   has_many   :services
 
   has_many :service_template_tenants, :dependent => :destroy
-  has_many :additional_tenants, :through => :service_template_tenants, :source => :tenant, :dependent => :destroy
+  has_many :additional_tenants, :through => :service_template_tenants, :source => :tenant
 
   has_one :picture, :dependent => :destroy, :as => :resource, :autosave => true
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -40,7 +40,7 @@ class Tenant < ApplicationRecord
   has_many :authentications, :dependent => :nullify
   has_many :miq_product_features, :dependent => :destroy
   has_many :service_template_tenants, :dependent => :destroy
-  has_many :service_templates, :through => :service_template_tenants, :dependent => :destroy
+  has_many :service_templates, :through => :service_template_tenants
 
   belongs_to :default_miq_group, :class_name => "MiqGroup", :dependent => :destroy
   belongs_to :source, :polymorphic => true


### PR DESCRIPTION
```ruby
class C
  has_many :x,                 :dependent => :destroy # A
  has_many :y, :through => :x, :dependent => :destroy # B
end
```

From A, `C.destroy` triggers `X.destroy`
From B, `C.destroy` triggers `X.destroy`

Note: case B did not trigger `Y.destroy`

They are redundant.

There is technically a little more logic that happens for case B since it will respect constraints and not delete all the associated `X` records but only those that have a `Y` record linked. But that is an unnecessary nuance for most uses.
