### PR TITLE
Drop Ems destroy callback

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -233,8 +233,6 @@ class ExtManagementSystem < ApplicationRecord
   include ComplianceMixin
   include CustomAttributeMixin
 
-  after_destroy { |record| $log.info("MIQ(ExtManagementSystem.after_destroy) Removed EMS [#{record.name}] id [#{record.id}]") }
-
   acts_as_miq_taggable
 
   include FilterableMixin


### PR DESCRIPTION
This is a logging only callback and not needed

It is ok if we still want this, I can just program DeepDelete to make an exception here.