### PR TITLE
Add APPLICATION_DOMAIN to pod environment

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -406,7 +406,7 @@ class MiqServer < ApplicationRecord
 
   def ui_hostname
     if MiqEnvironment::Command.is_podified?
-      ENV.fetch("APPLICATION_DOMAIN")
+      ENV.fetch("APPLICATION_DOMAIN", nil)
     else
       hostname || ipaddress
     end
@@ -422,7 +422,7 @@ class MiqServer < ApplicationRecord
 
   def ui_address(contact_with = :hostname)
     if MiqEnvironment::Command.is_podified?
-      ENV.fetch("APPLICATION_DOMAIN")
+      ENV.fetch("APPLICATION_DOMAIN", nil)
     else
       contact_with == :hostname ? ui_hostname : ui_ipaddress
     end
@@ -440,7 +440,7 @@ class MiqServer < ApplicationRecord
 
   def ws_hostname
     if MiqEnvironment::Command.is_podified?
-      ENV.fetch("APPLICATION_DOMAIN")
+      ENV.fetch("APPLICATION_DOMAIN", nil)
     else
       hostname || ipaddress
     end
@@ -456,7 +456,7 @@ class MiqServer < ApplicationRecord
 
   def ws_address
     if MiqEnvironment::Command.is_podified?
-      ENV.fetch("APPLICATION_DOMAIN")
+      ENV.fetch("APPLICATION_DOMAIN", nil)
     else
       ::Settings.webservices.contactwith == 'hostname' ? ws_hostname : ws_ipaddress
     end

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -140,6 +140,7 @@ class ContainerOrchestrator
       [
         {:name => "GUID",                    :value => MiqServer.my_guid},
         {:name => "HOME",                    :value => Rails.root.join("tmp").to_s},
+        {:name => "APPLICATION_DOMAIN",      :value => ENV["APPLICATION_DOMAIN"]},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -102,6 +102,11 @@ RSpec.describe ContainerOrchestrator do
       expect(subject.send(:default_environment)).not_to include({:name => "DATABASE_NAME", :valueFrom => {:secretKeyRef => {:key => "dbname", :name => "postgresql-secrets"}}})
     end
 
+    it "sets APPLICATION_DOMAIN" do
+      stub_const("ENV", ENV.to_h.merge("APPLICATION_DOMAIN" => "manageiq"))
+      expect(subject.send(:default_environment)).to include({:name => "APPLICATION_DOMAIN", :value => "manageiq"})
+    end
+
     it "doesn't include memcached env vars by default" do
       env = subject.send(:default_environment)
 

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe MiqRegion do
       context "podified" do
         before do
           expect(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
-          expect(ENV).to receive(:fetch).with("APPLICATION_DOMAIN").and_return("manageiq.apps.mycluster.com")
+          expect(ENV).to receive(:fetch).with("APPLICATION_DOMAIN", nil).and_return("manageiq.apps.mycluster.com")
         end
 
         it "returns the applicationDomain from the CR" do
@@ -178,7 +178,7 @@ RSpec.describe MiqRegion do
       context "podified" do
         before do
           expect(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
-          expect(ENV).to receive(:fetch).with("APPLICATION_DOMAIN").and_return("manageiq.apps.mycluster.com")
+          expect(ENV).to receive(:fetch).with("APPLICATION_DOMAIN", nil).and_return("manageiq.apps.mycluster.com")
         end
 
         it "returns the applicationDomain from the CR" do


### PR DESCRIPTION
This env var is used to build URLs to the UI and API.  When
`remote_ui_url` or `remote_ws_url` were called from a pod without this
env var the call was throwing an exception due to the lack of
environment variable.

Introduced by: https://github.com/ManageIQ/manageiq/pull/22668