### PR TITLE
Support Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-raise "Ruby versions < 3.0.0 are unsupported!" if RUBY_VERSION < "3.0.0"
-raise "Ruby versions >= 3.1.0 are unsupported!" if RUBY_VERSION >= "3.1.0"
+raise "Ruby versions < 3.0.0 are unsupported!"  if RUBY_VERSION < "3.0.0"
+raise "Ruby versions >= 3.2.0 are unsupported!" if RUBY_VERSION >= "3.2.0"
 
 source 'https://rubygems.org'
 

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
-gem "psych",                            "<4",                :require => false
 gem "pg",                               ">=1.4.1",           :require => false
 gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false

--- a/config/application.rb
+++ b/config/application.rb
@@ -177,6 +177,8 @@ module Vmdb
       Vmdb::Initializer.init
       ActiveRecord::Base.connection_pool.release_connection
       puts "** #{Vmdb::Appliance.BANNER}" unless Rails.env.production?
+
+      YamlPermittedClasses.initialize_app_yaml_permitted_classes
     end
 
     console do

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -3,10 +3,10 @@ module YamlLoadAliases
   # Psych 4 aliases load as safe_load.  Some loads happen early, like reading the database.yml so we don't want to load our
   # constants at that time, such as MiqExpression, Ruport, so we have two sets of permitted classes.
   def safe_load(*args, **kwargs)
-    super(*args, **kwargs.reverse_merge(:aliases => true, :permitted_classes => DEFAULT_PERMITTED_CLASSES))
+    super(*args, **kwargs.merge(:aliases => true).reverse_merge(:permitted_classes => DEFAULT_PERMITTED_CLASSES))
   rescue NameError => err
     warn "WARNING: Trying Permitted Classes due to NameError: #{err}"
-    super(*args, **kwargs.reverse_merge(:aliases => true, :permitted_classes => DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record]))
+    super(*args, **kwargs.merge(:aliases => true).reverse_merge(:permitted_classes => DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record]))
   rescue Psych::DisallowedClass => err
     # Temporary hack to fallback to psych 3 behavior to go back to unsafe load if it's a disallowed class.
     # See: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -3,7 +3,7 @@ module YamlLoadAliases
   # constants at that time, such as MiqExpression, Ruport, so we have two sets of permitted classes.
   def safe_load(yaml, permitted_classes: [], aliases: false, **kwargs)
     # permitted_classes kwarg is provided because rails 6.1.7.x expects it as a defined kwarg.  See: https://github.com/rails/rails/blob/9ab33753b6bab1809fc73d35b98a5c1d0c96ba1b/activerecord/lib/active_record/coders/yaml_column.rb#L52
-    permitted_classes += YamlPermittedClasses.initialized? ? YamlPermittedClasses.app_yaml_permitted_classes : YamlPermittedClasses.default_permitted_classes
+    permitted_classes += YamlPermittedClasses.permitted_classes
     super(yaml, permitted_classes: permitted_classes, aliases: true, **kwargs)
   rescue Psych::DisallowedClass => err
     # Temporary hack to fallback to psych 3 behavior to go back to unsafe load if it's a disallowed class.

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -1,22 +1,20 @@
 module YamlLoadAliases
-  DEFAULT_PERMITTED_CLASSES = [Regexp, Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
   # Psych 4 aliases load as safe_load.  Some loads happen early, like reading the database.yml so we don't want to load our
   # constants at that time, such as MiqExpression, Ruport, so we have two sets of permitted classes.
-  def safe_load(*args, **kwargs)
-    super(*args, **kwargs.merge(:aliases => true).reverse_merge(:permitted_classes => DEFAULT_PERMITTED_CLASSES))
-  rescue NameError => err
-    warn "WARNING: Trying Permitted Classes due to NameError: #{err}"
-    super(*args, **kwargs.merge(:aliases => true).reverse_merge(:permitted_classes => DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record]))
+  def safe_load(yaml, permitted_classes: [], aliases: false, **kwargs)
+    # permitted_classes kwarg is provided because rails 6.1.7.x expects it as a defined kwarg.  See: https://github.com/rails/rails/blob/9ab33753b6bab1809fc73d35b98a5c1d0c96ba1b/activerecord/lib/active_record/coders/yaml_column.rb#L52
+    permitted_classes += YamlPermittedClasses.initialized? ? YamlPermittedClasses.app_yaml_permitted_classes : YamlPermittedClasses.default_permitted_classes
+    super(yaml, permitted_classes: permitted_classes, aliases: true, **kwargs)
   rescue Psych::DisallowedClass => err
     # Temporary hack to fallback to psych 3 behavior to go back to unsafe load if it's a disallowed class.
     # See: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
     # The alternative is to enumerate all the classes we will allow to be loaded from YAML, such as many of the various models.
-    warn "WARNING: Using fallback due to DisallowedClass: #{err}"
-    unsafe_load(*args, **(kwargs.slice(:filename, :fallback, :symbolize_names, :freeze)))
+    warn "WARNING: Using fallback to unsafe_load due to DisallowedClass: #{err}"
+    unsafe_load(yaml, **kwargs.except(:aliases, :permitted_classes, :permitted_symbols))
   end
 end
 
-if Psych::VERSION >= "4.0"
+if Psych::VERSION >= "3.1"
   require 'yaml'
   YAML.singleton_class.prepend(YamlLoadAliases)
 end

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -1,0 +1,22 @@
+module YamlLoadAliases
+  DEFAULT_PERMITTED_CLASSES = [Regexp, Symbol, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
+  # Psych 4 aliases load as safe_load.  Some loads happen early, like reading the database.yml so we don't want to load our
+  # constants at that time, such as MiqExpression, Ruport, so we have two sets of permitted classes.
+  def safe_load(*args, **kwargs)
+    super(*args, **kwargs.reverse_merge(:aliases => true, :permitted_classes => DEFAULT_PERMITTED_CLASSES))
+  rescue NameError => err
+    warn "WARNING: Trying Permitted Classes due to NameError: #{err}"
+    super(*args, **kwargs.reverse_merge(:aliases => true, :permitted_classes => DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record]))
+  rescue Psych::DisallowedClass => err
+    # Temporary hack to fallback to psych 3 behavior to go back to unsafe load if it's a disallowed class.
+    # See: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
+    # The alternative is to enumerate all the classes we will allow to be loaded from YAML, such as many of the various models.
+    warn "WARNING: Using fallback due to DisallowedClass: #{err}"
+    unsafe_load(*args, **(kwargs.slice(:filename, :fallback, :symbolize_names, :freeze)))
+  end
+end
+
+if Psych::VERSION >= "4.0"
+  require 'yaml'
+  YAML.singleton_class.prepend(YamlLoadAliases)
+end

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -9,6 +9,8 @@ module YamlLoadAliases
     # Temporary hack to fallback to psych 3 behavior to go back to unsafe load if it's a disallowed class.
     # See: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
     # The alternative is to enumerate all the classes we will allow to be loaded from YAML, such as many of the various models.
+    raise unless Rails.env.production?
+
     warn "WARNING: Using fallback to unsafe_load due to DisallowedClass: #{err}"
     unsafe_load(yaml, **kwargs.except(:aliases, :permitted_classes, :permitted_symbols))
   end

--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -1,0 +1,21 @@
+class YamlPermittedClasses
+  DEFAULT_PERMITTED_CLASSES = [Object, Regexp, Symbol, Date, Time, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
+  def self.app_yaml_permitted_classes
+    @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record, User]
+  end
+
+  def self.default_permitted_classes
+    @default_permitted_classes ||= DEFAULT_PERMITTED_CLASSES
+  end
+
+  def self.initialize_app_yaml_permitted_classes
+    @initialize_app_yaml_permitted_classes ||= begin
+      ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes
+      true
+    end
+  end
+
+  def self.initialized?
+    !!@initialize_app_yaml_permitted_classes
+  end
+end

--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -1,7 +1,7 @@
 class YamlPermittedClasses
   DEFAULT_PERMITTED_CLASSES = [Object, Range, Regexp, Symbol, Date, Time, DateTime, ActiveSupport::Duration, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
   def self.app_yaml_permitted_classes
-    @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record, User, ConfigurationScript, ContainerImage, ContainerTemplate, OpenStruct, OrchestrationTemplate, ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::InfraManager::Vm, VimHash, VimString, VimArray, ActiveModel::Type::String, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute.const_get(:FromUser)]
+    @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression]
   end
 
   def self.default_permitted_classes

--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -4,6 +4,10 @@ class YamlPermittedClasses
     @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression]
   end
 
+  def self.app_yaml_permitted_classes=(classes)
+    @app_yaml_permitted_classes = Array(classes)
+  end
+
   def self.default_permitted_classes
     @default_permitted_classes ||= DEFAULT_PERMITTED_CLASSES
   end

--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -1,7 +1,7 @@
 class YamlPermittedClasses
-  DEFAULT_PERMITTED_CLASSES = [Object, Regexp, Symbol, Date, Time, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
+  DEFAULT_PERMITTED_CLASSES = [Object, Range, Regexp, Symbol, Date, Time, DateTime, ActiveSupport::Duration, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
   def self.app_yaml_permitted_classes
-    @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record, User]
+    @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression, MiqReport, Ruport::Data::Table, Ruport::Data::Record, User, ConfigurationScript, ContainerImage, ContainerTemplate, OpenStruct, OrchestrationTemplate, ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::InfraManager::Vm, VimHash, VimString, VimArray, ActiveModel::Type::String, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute.const_get(:FromUser)]
   end
 
   def self.default_permitted_classes

--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -1,5 +1,17 @@
 class YamlPermittedClasses
-  DEFAULT_PERMITTED_CLASSES = [Object, Range, Regexp, Symbol, Date, Time, DateTime, ActiveSupport::Duration, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]
+  DEFAULT_PERMITTED_CLASSES = [
+    ActiveSupport::Duration,
+    ActiveSupport::HashWithIndifferentAccess,
+    ActiveSupport::TimeWithZone,
+    ActiveSupport::TimeZone,
+    Date,
+    DateTime,
+    Object,
+    Range,
+    Regexp,
+    Symbol,
+    Time
+  ].freeze
   def self.app_yaml_permitted_classes
     @app_yaml_permitted_classes ||= DEFAULT_PERMITTED_CLASSES + [MiqExpression]
   end

--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -8,6 +8,10 @@ class YamlPermittedClasses
     @default_permitted_classes ||= DEFAULT_PERMITTED_CLASSES
   end
 
+  def self.permitted_classes
+    initialized? ? app_yaml_permitted_classes : default_permitted_classes
+  end
+
   def self.initialize_app_yaml_permitted_classes
     @initialize_app_yaml_permitted_classes ||= begin
       ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes

--- a/spec/lib/extensions/ar_yaml_spec.rb
+++ b/spec/lib/extensions/ar_yaml_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActiveRecord::AttributeAccessorThatYamls do
     inst = Vm.new
     inst.access1 = 1
     inst.access2 = 2
-    result = YAML.load(YAML.dump(inst))
+    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Type::String])
     expect(result.access1).to eq(1)
     expect(result.access2).to eq(2)
   end
@@ -18,14 +18,14 @@ RSpec.describe ActiveRecord::AttributeAccessorThatYamls do
   it "attr_reader_that_yamls" do
     inst = Vm.new
     inst.instance_variable_set("@read1", 1)
-    result = YAML.load(YAML.dump(inst))
+    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Type::String])
     expect(result.read1).to eq(1)
   end
 
   it "attr_writer_that_yamls" do
     inst = Vm.new
     inst.write1 = 1
-    result = YAML.load(YAML.dump(inst))
+    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Type::String])
     expect(result.instance_variable_get("@write1")).to eq(1)
   end
 end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe MiqReport do
     fake_ruport_data_table = {:data => result, :column_names => column_names}
     before = MiqReport.new
     before.table = fake_ruport_data_table
-    after = YAML.load(YAML.dump(before))
+    after = YAML.safe_load(YAML.dump(before), :permitted_classes => [MiqReport, ActiveModel::Attribute.const_get(:FromDatabase)])
     expect(after.table).to eq(fake_ruport_data_table)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,15 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.before do
+    # TODO: The following locations YAML load the Ruport objects, see if we can avoid serializing them here.
+    # rspec ./spec/models/miq_report_result_spec.rb:8 # MiqReportResult #_async_generate_result
+    # rspec ./spec/models/miq_report_result_spec.rb:111 # MiqReportResult persisting generated report results should save the original report metadata and the generated table as a binary blob
+    # rspec ./spec/models/miq_report/generator_spec.rb:275 # MiqReport::Generator sorting handles sort columns with nil values properly, when column is string
+    # rspec ./spec/models/service_spec.rb:510 # Service Chargeback report generation #chargeback_report returns chargeback report
+    YamlPermittedClasses.app_yaml_permitted_classes |= [Ruport::Data::Record, Ruport::Data::Table]
+  end
+
   config.file_fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures  = false


### PR DESCRIPTION
TODO:
- [x] resolve the YAML safe_load default so we don't need to use unsafe_load by default.
  - [x] Try to safe_load, retry with loading aliases (via true) and minimal permitted classes, retry again with aliases and a larger list of permitted classes.
  - [x] Add warning logging for disallowed classes so we can build a list of classes we need to allow in the next step
  - [x] Enumerate a list of commonly permitted classes, perhaps the list of models + some others, store this and use it with the rails activerecord yaml_column_permitted_classes similar to https://stackoverflow.com/a/75001610
- [x] update YAML.load/safe_load using positional `permitted_classes` to kwargs since positional is gone in psych 4
- [x] upgrade qpid_proton to one with ruby 3.1 support
- [x] Cross repo test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/824

Part of https://github.com/ManageIQ/manageiq/issues/22696

Note, qpid_proton and bumping ruby 3.1 in test has moved to a followup in https://github.com/ManageIQ/manageiq/pull/22808