### PR TITLE
Ruby 3.1 - net/ftp was moved out of standard library to a gem in ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "manageiq-ssh-util",                "~>0.1.1",           :require => false
 gem "memoist",                          "~>0.16.0",          :require => false
 gem "money",                            "~>6.13.5",          :require => false
 gem "more_core_extensions"                                                     # min version should be set in manageiq-gems-pending, not here
+gem "net-ftp",                          "~>0.1.2",           :require => false
 gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -1,4 +1,3 @@
-require 'net/ftp'
 require 'uri'
 require 'mount/miq_generic_mount_session'
 


### PR DESCRIPTION
Extracted from #22698
Part of #22696

See: https://github.com/rails/rails/issues/45816
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

FileDepotFtp depends on this gem so it should be a dependency in core.