### PR TITLE
Add an AutomationWorker to orchestrate workflows/playbooks

### DIFF
--- a/app/models/automation_worker.rb
+++ b/app/models/automation_worker.rb
@@ -1,0 +1,13 @@
+class AutomationWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
+  require_nested :Runner
+
+  self.required_roles               = ["automate"]
+  self.default_queue_name           = "automate"
+  self.maximum_workers_count        = 1
+
+  def self.kill_priority
+    MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
+  end
+end

--- a/app/models/automation_worker.rb
+++ b/app/models/automation_worker.rb
@@ -10,4 +10,10 @@ class AutomationWorker < MiqQueueWorkerBase
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
   end
+
+  def configure_worker_deployment(definition, replicas = 0)
+    super
+
+    definition[:spec][:template][:spec][:serviceAccountName] = "manageiq-automation"
+  end
 end

--- a/app/models/automation_worker/runner.rb
+++ b/app/models/automation_worker/runner.rb
@@ -1,0 +1,2 @@
+class AutomationWorker::Runner < MiqQueueWorkerBase::Runner
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1089,6 +1089,7 @@
         :dequeue_method: drb
         :poll_method: normal
         :queue_timeout: 10.minutes
+      :automation_worker: {}
       :ems_metrics_collector_worker:
         :defaults:
           :count: 2

--- a/spec/models/automation_worker_spec.rb
+++ b/spec/models/automation_worker_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe AutomationWorker do
+  describe "kubernetes worker deployment" do
+    let(:test_deployment) do
+      {
+        :metadata => {
+          :name      => "test",
+          :labels    => {:app => "manageiq"},
+          :namespace => "manageiq",
+        },
+        :spec     => {
+          :selector => {:matchLabels => {:name => "test"}},
+          :template => {
+            :metadata => {:name => "test", :labels => {:name => "test", :app => "manageiq"}},
+            :spec     => {
+              :containers => [{
+                :name => "test",
+                :env  => []
+              }]
+            }
+          }
+        }
+      }
+    end
+
+    it "#configure_worker_deplyoment adds a node selector based on the zone name" do
+      EvmSpecHelper.local_miq_server
+
+      worker = described_class.new
+      worker.configure_worker_deployment(test_deployment)
+
+      expect(test_deployment.dig(:spec, :template, :spec, :nodeSelector)).to eq("manageiq/zone-#{MiqServer.my_zone}".tr(" ", "-") => "true")
+      expect(test_deployment.dig(:spec, :template, :spec, :serviceAccountName)).to eq("manageiq-automation")
+    end
+  end
+end

--- a/systemd/manageiq-automation.target
+++ b/systemd/manageiq-automation.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=manageiq.target

--- a/systemd/manageiq-automation@.service
+++ b/systemd/manageiq-automation@.service
@@ -1,0 +1,13 @@
+[Unit]
+PartOf=manageiq-automation.target
+[Install]
+WantedBy=manageiq-automation.target
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb AutomationWorker --heartbeat --guid=%i
+User=manageiq
+Restart=no
+Type=notify
+Slice=manageiq-automation.slice


### PR DESCRIPTION
Add an automation worker to orchestrate running "external" automate code like Workflows and Ansible Playbooks.

Dependents:
* https://github.com/ManageIQ/manageiq-pods/pull/995
* https://github.com/ManageIQ/manageiq-providers-workflows/pull/50

- part of: https://github.com/ManageIQ/manageiq/issues/22311
- solves https://github.com/ManageIQ/manageiq/issues/22568