### PR TITLE
Set configuration_script_id in MiqRequestTask#options

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -140,7 +140,9 @@ class MiqRequestTask < ApplicationRecord
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 
     if resource_action&.configuration_script_payload
-      resource_action.configuration_script_payload.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone, :object => self)
+      configuration_script = resource_action.configuration_script_payload.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone, :object => self)
+      options[:configuration_script_payload_id] = resource_action.configuration_script_payload.id
+      options[:configuration_script_id]         = configuration_script.id
     elsif self.class::AUTOMATE_DRIVES
       deliver_to_automate(req_type, zone)
     else


### PR DESCRIPTION
If a MiqRequestTask is run using a configuration_script set the ID of that configuration_script in `#options`

The Service record:
```
>> Service.first
  Service Load (0.2ms)  SELECT "services".* FROM "services" ORDER BY "services"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Service Inst Including Associations (0.1ms - 1rows)
=> 
#<Service:0x000056494afbf3f8
 id: 1,
 name: "Provision a VM",
 description: nil,
 guid: "22848955-59f5-4e87-b1c5-484448a5f2a5",
 type: nil,
 service_template_id: 1,
 options: {:dialog=>{"dialog_vm_name"=>"ag-prov-test", "dialog_provider"=>"3", "dialog_source_template"=>"vm-2299"}},
 visible: true,
 created_at: Fri, 22 Sep 2023 16:49:27.958443000 UTC +00:00,
 updated_at: Fri, 22 Sep 2023 16:49:27.958443000 UTC +00:00,
 evm_owner_id: 1,
 miq_group_id: 2,
 retired: false,
 retires_on: nil,
 retirement_warn: nil,
 retirement_last_warn: nil,
 retirement_state: nil,
 retirement_requester: nil,
 tenant_id: 1,
 ancestry: nil,
 initiator: "user",
 lifecycle_state: "unprovisioned",
 currency_id: nil,
 price: nil>
```

The MiqRequestTask:
```
>> Service.first.miq_request_task
  Service Load (0.2ms)  SELECT "services".* FROM "services" ORDER BY "services"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Service Inst Including Associations (0.1ms - 1rows)
  MiqRequestTask Load (0.2ms)  SELECT "miq_request_tasks".* FROM "miq_request_tasks" WHERE "miq_request_tasks"."destination_id" = $1 AND "miq_request_tasks"."destination_type" = $2 LIMIT $3  [["destination_id", 1], ["destination_type", "Service"], ["LIMIT", 1]]
  MiqRequestTask Inst Including Associations (0.2ms - 1rows)
=> 
#<ServiceTemplateProvisionTask:0x000056494a0788b8
 id: 1,
 description: "Provisioning [Provision a VM] for Service [Provision a VM]",
 state: "active",
 request_type: "clone_to_service",
 userid: "admin",
 options:
  {:dialog=>{"dialog_vm_name"=>"ag-prov-test", "dialog_provider"=>"3", "dialog_source_template"=>"vm-2299"},
   :workflow_settings=>{:resource_action_id=>4, :dialog_id=>1},
   :initiator=>nil,
   :src_id=>1,
   :request_options=>{:submit_workflow=>true, :init_defaults=>false},
   :cart_state=>"ordered",
   :requester_group=>"EvmGroup-super_administrator",
   :executed_on_servers=>[1],
   :delivered_on=>2023-09-22 16:49:27.523978054 UTC,
   :configuration_script_id=>12,
   :pass=>0},
 created_on: Fri, 22 Sep 2023 16:49:27.571103000 UTC +00:00,
 updated_on: Fri, 22 Sep 2023 16:49:28.320092000 UTC +00:00,
 message: "In Process",
 status: "Ok",
 type: "ServiceTemplateProvisionTask",
 miq_request_id: 1,
 source_id: 1,
 source_type: "ServiceTemplate",
 destination_id: 1,
 destination_type: "Service",
 miq_request_task_id: nil,
 phase: nil,
 phase_context: {},
 tenant_id: 1,
 cancelation_status: nil,
 conversion_host_id: nil>
```

Required for: https://github.com/ManageIQ/manageiq-ui-classic/pull/8782