### PR TITLE
Add manageiq user to allowed_uids for sssd

### DIFF
--- a/spec/tools/miq_config_sssd_ldap/sssd_conf_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/sssd_conf_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe MiqConfigSssdLdap::SssdConf do
         pam_initgroups_scheme = always
 
         [ifp]
-        allowed_uids = apache, root
+        allowed_uids = apache, root, manageiq
         user_attributes = +mail, +givenname, +sn, +displayname, +domainname
       SSSD_CONF_UPDATED
     end

--- a/tools/miq_config_sssd_ldap/sssd_conf/ifp.rb
+++ b/tools/miq_config_sssd_ldap/sssd_conf/ifp.rb
@@ -7,7 +7,7 @@ module MiqConfigSssdLdap
     end
 
     def allowed_uids
-      "apache, root"
+      "apache, root, manageiq"
     end
 
     def user_attributes


### PR DESCRIPTION
When we moved to using a manageiq user, we need to add this user so it has permission in sssd.conf.

See also:
https://github.com/ManageIQ/manageiq-documentation/pull/1743
https://github.com/ManageIQ/manageiq-appliance_console/pull/220