### PR TITLE
[WIP] Allow updating all plugins when building the lockfile

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -187,7 +187,7 @@ namespace :release do
     update_gems = ENV["UPDATE_GEMS"].to_s.split(" ")
     if ENV["UPDATE_PLUGINS"]
       require "vmdb/plugins"
-      update_gems += Vmdb::Plugins.paths.values.map { |p| p.match(%r{/gems/(.+)-\h+$}).captures.first }
+      update_gems += Vmdb::Plugins.repos.values
     end
 
     root = Pathname.new(__dir__).join("../..")

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -185,6 +185,10 @@ namespace :release do
     end
 
     update_gems = ENV["UPDATE_GEMS"].to_s.split(" ")
+    if ENV["UPDATE_PLUGINS"]
+      require "vmdb/plugins"
+      update_gems += Vmdb::Plugins.paths.values.map { |p| p.match(%r{/gems/(.+)-\h+$}).captures.first }
+    end
 
     root = Pathname.new(__dir__).join("../..")
 

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -35,7 +35,7 @@ module Vmdb
           :name    => engine.name,
           :version => version(engine),
           :path    => engine.root.to_s,
-          :repo    => engine.root.to_s.match(%r{/gems/(.+)-\h+$}).captures.first
+          :repo    => engine.root.to_s.match(%r{/gems/(.+)-\h+$})&.captures&.first || File.dirname(engine.root.to_s)
         }
       end
     end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -34,7 +34,8 @@ module Vmdb
         hash[engine] = {
           :name    => engine.name,
           :version => version(engine),
-          :path    => engine.root.to_s
+          :path    => engine.root.to_s,
+          :repo    => engine.root.to_s.match(%r{/gems/(.+)-\h+$}).captures.first
         }
       end
     end
@@ -45,6 +46,10 @@ module Vmdb
 
     def versions
       details.transform_values { |v| v[:version] }
+    end
+
+    def repos
+      details.transform_values { |v| v[:repo] }
     end
 
     # Ansible content (roles) that come out-of-the-box, for use by both Automate


### PR DESCRIPTION
The lockfile generator is very conservative and doesn't update the lockfile refs for git repos (i.e. plugins). As such, when gem updates happen in plugins, they aren't automatically pulled into the lockfile. This new option allows me to see which specific plugins are making changes. I can then choose to just update them all, or pick and choose.

@bdunne Please review.