### PR TITLE
[QUINTEROS] Bump manageiq-messaging to 1.4.0

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -884,7 +884,7 @@ GEM
     manageiq-loggers (1.1.0)
       activesupport (>= 5.0)
       manageiq-password (< 2)
-    manageiq-messaging (1.3.0)
+    manageiq-messaging (1.4.0)
       activesupport (>= 5.2.4.3, < 7.0)
       rdkafka (~> 0.8)
       stomp (~> 1.4.4)
@@ -1363,7 +1363,7 @@ DEPENDENCIES
   manageiq-decorators!
   manageiq-gems-pending (> 0)!
   manageiq-loggers (~> 1.0)
-  manageiq-messaging (~> 1.0, >= 1.3.0)
+  manageiq-messaging (~> 1.0, >= 1.4.0)
   manageiq-password (~> 1.0)
   manageiq-postgres_ha_admin (~> 3.2)
   manageiq-providers-amazon!


### PR DESCRIPTION
After backport of https://github.com/ManageIQ/manageiq/pull/22692

@bdunne Please review. Note that this might be red because the tip of quinteros is red for some other seemingly sproadic test failure that is being looked at separately.