### PR TITLE
Lock down psych to pre-4.0.0 versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
+gem "psych",                            "<4",                :require => false
 gem "pg",                               ">=1.4.1",           :require => false
 gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false


### PR DESCRIPTION
4.0.0 has breaking changes, see:

https://bugs.ruby-lang.org/issues/17866
https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990

Note, the oci gem, released 2.19.0, added psych >= 3.1.0, < 5.0.0  as a dependency.
Previously, psych wasn't a direct dependency.  This might be why we're suddenly seeing build failures from the psych 4 breaking changes.
