### PR TITLE
Fixed physical storage table missing translation

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1834,6 +1834,8 @@ en:
       operating_system:            OS
       physical_server:             Physical Server
       physical_servers:            Physical Servers
+      physical_storage:            Physical Storage
+      physical_storages:           Physical Storages
       registry_items:              Registry
       repository:                  Repository
       resource_pool:               Resource Pool


### PR DESCRIPTION
Fixed a missing translation for the physical storages table.

Before:
<img width="1371" alt="Screenshot 2023-10-11 at 12 29 50 PM" src="https://github.com/ManageIQ/manageiq/assets/32444791/7025c37b-8f4f-4b49-a668-cc3d5a7120b4">

After:
<img width="1351" alt="AfterStorage" src="https://github.com/ManageIQ/manageiq/assets/32444791/8ae85be8-f897-43d6-9f26-a9931e5b6984">

@miq-bot add_reviewer @Fryguy
@miq-bot assign @Fryguy 
@miq-bot add-label bug
@miq-bot add-label internationalization