### PR TITLE
Separate vm store and datastore smartstate scan supports checks

### DIFF
--- a/app/models/vm_scan/dispatcher.rb
+++ b/app/models/vm_scan/dispatcher.rb
@@ -246,18 +246,10 @@ class VmScan
         return []
       end
 
-      if @vm.requires_storage_for_scan?
-        if @vm.storage.nil?
-          msg = "Vm [#{@vm.path}] is not located on a storage, aborting job [#{job.guid}]."
-          queue_signal(job, {:args => [:abort, msg, "error"]})
-          return []
-        else
-          unless @vm.storage.supports?(:smartstate_analysis)
-            msg = @vm.storage.unsupported_reason(:smartstate_analysis)
-            queue_signal(job, {:args => [:abort, msg, "error"]})
-            return []
-          end
-        end
+      unless @vm.supports?(:smartstate_analysis)
+        msg = @vm.unsupported_reason(:smartstate_analysis)
+        queue_signal(job, {:args => [:abort, msg, "error"]})
+        return []
       end
 
       vm_proxies, = Benchmark.realtime_block(:get_eligible_proxies_for_job__proxies4job) { @vm.proxies4job(job) }

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -663,7 +663,9 @@ RSpec.describe VmOrTemplate do
 
   context "#supports?(:smartstate_analysis)" do
     it "returns true for VMware VM" do
-      vm =  FactoryBot.create(:vm_vmware)
+      vm = FactoryBot.create(:vm_vmware,
+                             :storage => storage)
+
       allow(vm).to receive_messages(:archived? => false)
       allow(vm).to receive_messages(:orphaned? => false)
       expect(vm.supports?(:smartstate_analysis)).to eq(true)


### PR DESCRIPTION
The supports `:smartstate_analysis` block is attempting to do too many things at once with its conditional checks and this is causing issues when differentiating storage scans vs. vm scans with storages. Therefore attempting to simplify the logic by just using `supports_not` and then adding a `supports :smartstate_analysis` to vmware since its the only provider that supports storage scans. RHV/oVirt providers that support vm scans with storages will check the storage type when checking if the vm supports smartstate analysis.

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/653
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/887

@miq-bot add_label bug, refactoring
@miq-bot assign @agrare 