### PR TITLE
pg_log changed to log in postgres 10 as default log directory

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -78,7 +78,7 @@ module MiqServer::LogManagement
     return [] unless pg_data
 
     pg_data = Pathname.new(pg_data)
-    [pg_data.join("*.conf"), pg_data.join("pg_log/*"), Pathname.new("/etc/manageiq/postgresql.conf.d/*")]
+    [pg_data.join("*.conf"), pg_data.join("log/*"), Pathname.new("/etc/manageiq/postgresql.conf.d/*")]
   end
 
   def log_start_and_end_for_pattern(pattern)

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe MiqServer do
 
       it "pg_data_dir set" do
         allow(@miq_server).to receive_messages(:pg_data_dir => '/var/lib/pgsql/data')
-        expected = %w(/var/lib/pgsql/data/*.conf /var/lib/pgsql/data/pg_log/* /etc/manageiq/postgresql.conf.d/*)
+        expected = %w(/var/lib/pgsql/data/*.conf /var/lib/pgsql/data/log/* /etc/manageiq/postgresql.conf.d/*)
         expect(@miq_server.pg_log_patterns.collect(&:to_s)).to match_array expected
       end
     end

--- a/tools/collect_logs/collect_archive_logs.sh
+++ b/tools/collect_logs/collect_archive_logs.sh
@@ -15,10 +15,10 @@ source /etc/default/evm
 
 tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
+if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/log" ]]; then
     echo "This ManageIQ appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files BUILD GUID VERSION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files BUILD GUID VERSION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/log/* $APPLIANCE_PG_DATA/postgresql.conf
 else
     echo "This ManageIQ appliance is not a Database server"
     echo " Log collection starting:"

--- a/tools/collect_logs/collect_current_logs.sh
+++ b/tools/collect_logs/collect_current_logs.sh
@@ -15,10 +15,10 @@ source /etc/default/evm
 
 tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
+if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/log" ]]; then
     echo "This ManageIQ appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files --exclude="/var/log/messages-*" --exclude="/var/log/journal/*/system@*.journal" BUILD GUID VERSION log/*.log log/*.txt config/* /var/log/* log/apache/*.log $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files --exclude="/var/log/messages-*" --exclude="/var/log/journal/*/system@*.journal" BUILD GUID VERSION log/*.log log/*.txt config/* /var/log/* log/apache/*.log $APPLIANCE_PG_DATA/log/* $APPLIANCE_PG_DATA/postgresql.conf
 else
     echo "This ManageIQ appliance is not a Database server"
     echo " Log collection starting:"


### PR DESCRIPTION
https://www.postgresql.org/docs/9.6/runtime-config-logging.html

log_directory (string)
When logging_collector is enabled, this parameter determines the directory in which log files will be created. It can be specified as an absolute path, or relative to the cluster data directory. This parameter can only be set in the postgresql.conf file or on the server command line. The default is pg_log.

vs.

https://www.postgresql.org/docs/10/runtime-config-logging.html#RUNTIME-CONFIG-LOGGING-WHERE log_directory (string)
When logging_collector is enabled, this parameter determines the directory in which log files will be created. It can be specified as an absolute path, or relative to the cluster data directory. This parameter can only be set in the postgresql.conf file or on the server command line. The default is log.

It remains the same in postgresql 13.

See also https://github.com/ManageIQ/manageiq-appliance/pull/377