### PR TITLE
Remove unnecessary supports_not

### DIFF
--- a/app/models/cloud_database.rb
+++ b/app/models/cloud_database.rb
@@ -12,10 +12,6 @@ class CloudDatabase < ApplicationRecord
 
   serialize :extra_attributes
 
-  supports_not :create
-  supports_not :delete
-  supports_not :update
-
   def self.create_cloud_database_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "creating Cloud Database for user #{userid}",

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -16,9 +16,6 @@ class CloudObjectStoreContainer < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete
-  supports_not :cloud_object_store_container_clear
-
   # Create a cloud object store container as a queued task and return the task
   # id. The queue name and the queue zone are derived from the provided EMS
   # instance. The EMS instance and a userid are mandatory. Any +options+ are

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -16,7 +16,7 @@ class CloudObjectStoreContainer < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete, :reason => N_("Delete operation is not supported.")
+  supports_not :delete
   supports_not :cloud_object_store_container_clear
 
   # Create a cloud object store container as a queued task and return the task

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -15,8 +15,6 @@ class CloudObjectStoreObject < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete
-
   def disconnect_inv
     # This is for bypassing a weird Rails behaviour. If we do a ems.cloud_object_store_objects.delete(objects) and a
     # relation in the ems is missing a :dependent => :destroy on :cloud_object_store_objects relation, it does not

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -15,7 +15,7 @@ class CloudObjectStoreObject < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete, :reason => N_("Delete operation is not supported.")
+  supports_not :delete
 
   def disconnect_inv
     # This is for bypassing a weird Rails behaviour. If we do a ems.cloud_object_store_objects.delete(objects) and a

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -24,18 +24,7 @@ class CloudVolume < ApplicationRecord
   has_many   :volume_mappings, :dependent => :destroy
   has_many   :host_initiators, :through => :volume_mappings
 
-  supports_not :backup_create
-  supports_not :backup_restore
-  supports_not :create
-  supports_not :snapshot_create
-  supports_not :update
-  supports_not :attach
-  supports_not :detach
-  supports_not :clone
-
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
-
-  supports_not :safe_delete
   virtual_column :supports_safe_delete, :type => :boolean
 
   def supports_safe_delete

--- a/app/models/cloud_volume_backup.rb
+++ b/app/models/cloud_volume_backup.rb
@@ -11,8 +11,6 @@ class CloudVolumeBackup < ApplicationRecord
   belongs_to :cloud_volume
   has_one :cloud_tenant, :through => :cloud_volume
 
-  supports_not :backup_restore
-
   # Restore a cloud volume backup as a queued task and return the task id. The queue
   # name and the queue zone are derived from the EMS. The userid is mandatory, and
   # the volumeid and name are optional.

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -13,10 +13,6 @@ class CloudVolumeSnapshot < ApplicationRecord
   belongs_to :cloud_volume
   has_many   :based_volumes, :class_name => 'CloudVolume'
 
-  supports_not :create
-  supports_not :delete
-  supports_not :update
-
   virtual_total :total_based_volumes, :based_volumes
 
   def self.class_by_ems(ext_management_system)

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -26,8 +26,6 @@ class ConfigurationProfile < ApplicationRecord
 
   delegate :my_zone, :provider, :zone, :to => :manager
 
-  supports_not :native_console
-
   virtual_has_one :configuration_architecture,  :class_name => 'ConfigurationArchitecture', :uses => :configuration_tags
   virtual_has_one :configuration_compute_profile, :class_name => 'ConfigurationProfile',    :uses => :configuration_tags
   virtual_has_one :configuration_domain,          :class_name => 'ConfigurationDomain',     :uses => :configuration_tags

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -42,8 +42,6 @@ class ConfiguredSystem < ApplicationRecord
   virtual_delegate :cpu_total_cores, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
   virtual_delegate :ram_size, :to => "hardware.memory_mb", :allow_nil => true, :default => 0, :type => :integer
 
-  supports_not :native_console
-
   virtual_column  :my_zone,                            :type => :string
   virtual_column  :configuration_architecture_name,    :type => :string
   virtual_column  :configuration_compute_profile_name, :type => :string

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -95,8 +95,6 @@ class ContainerNode < ApplicationRecord
     true
   end
 
-  supports_not :external_logging
-
   def external_logging_query
     nil # {}.to_query # TODO
   end

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -14,8 +14,6 @@ class ContainerTemplate < ApplicationRecord
   serialize :objects, Array
   serialize :object_labels, Hash
 
-  supports_not :instantiate
-
   acts_as_miq_taggable
 
   def instantiate(_params, _project_name)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -142,37 +142,7 @@ class ExtManagementSystem < ApplicationRecord
 
   serialize :options
 
-  supports_not :add_host_initiator
-  supports_not :add_storage
-  supports_not :add_volume_mapping
-  supports_not :admin_ui
-  supports_not :assume_role
-  supports_not :block_storage
-  supports_not :catalog
-  supports_not :change_password
-  supports_not :cloud_object_store_container_create
-  supports_not :cloud_subnet_create
-  supports_not :cloud_tenant_mapping
-  supports_not :cloud_volume_create
-  supports_not :storage_service_create
-  supports_not :console
-  supports_not :create_iso_datastore
-  supports_not :discovery
-  supports_not :events
-  supports_not :label_mapping
-  supports_not :metrics
-  supports_not :object_storage
-  supports_not :provisioning
-  supports_not :publish
-  supports_not :reconfigure_disks
   supports     :refresh_ems
-  supports_not :regions
-  supports_not :smartstate_analysis
-  supports_not :storage_manager
-  supports_not :streaming_refresh
-  supports_not :swift_service
-  supports_not :vm_import
-  supports_not :volume_availability_zones
 
   def edit_with_params(params, endpoints, authentications)
     tap do |ems|

--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -15,8 +15,6 @@ class FloatingIp < ApplicationRecord
   belongs_to :network_router
   alias_attribute :name, :address
 
-  supports_not :delete_floating_ip
-
   def self.available
     where(:vm_id => nil, :network_port_id => nil)
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -184,23 +184,7 @@ class Host < ApplicationRecord
 
   supports     :check_compliance_queue
   supports     :destroy
-  supports_not :quick_stats
-  supports_not :refresh_advanced_settings
-  supports_not :refresh_firewall_rules
-  supports_not :refresh_logs
-  supports_not :refresh_network_interfaces
   supports     :scan_and_check_compliance_queue
-  supports_not :set_node_maintenance
-  supports_not :smartstate_analysis
-  supports_not :unset_node_maintenance
-  supports_not :reboot
-  supports_not :shutdown
-  supports_not :standby
-  supports_not :enter_maint_mode
-  supports_not :exit_maint_mode
-  supports_not :enable_vmotion
-  supports_not :disable_vmotion
-  supports_not :vmotion_enabled
   supports     :ipmi do
     if ipmi_address.blank?
       _("The Host is not configured for IPMI")

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -17,12 +17,6 @@ class HostAggregate < ApplicationRecord
   has_many   :metric_rollups,         :as => :resource
   has_many   :vim_performance_states, :as => :resource
 
-  supports_not :add_host
-  supports_not :create
-  supports_not :delete
-  supports_not :remove_host
-  supports_not :update
-
   virtual_total :total_vms, :vms
 
   def self.create_aggregate_queue(userid, ext_management_system, options = {})

--- a/app/models/host_initiator.rb
+++ b/app/models/host_initiator.rb
@@ -15,7 +15,6 @@ class HostInitiator < ApplicationRecord
 
   virtual_total :v_total_addresses, :san_addresses
 
-  supports_not :create
   acts_as_miq_taggable
 
   def my_zone

--- a/app/models/host_initiator_group.rb
+++ b/app/models/host_initiator_group.rb
@@ -15,8 +15,6 @@ class HostInitiatorGroup < ApplicationRecord
 
   virtual_total :v_total_addresses, :san_addresses
 
-  supports_not :create
-  supports_not :delete
   acts_as_miq_taggable
 
   def my_zone

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -33,8 +33,6 @@ module ManageIQ::Providers
       self.class.http_proxy
     end
 
-    supports_not :native_console
-
     def console_url
       raise NotImplementedError, _("console_url must be implemented in a subclass")
     end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -43,13 +43,7 @@ module ManageIQ::Providers
 
     virtual_has_many :volume_availability_zones, :class_name => "AvailabilityZone", :uses => :availability_zones
 
-    supports_not :auth_key_pair_create
     supports     :authentication_status
-    supports_not :cinder_service
-    supports_not :cloud_tenants
-    supports_not :cloud_volume
-    supports_not :cloud_tenant_mapping
-    supports_not :create_flavor
 
     validates_presence_of :zone
 

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
-  supports_not :create_image
-  supports_not :delete_image
-  supports_not :import_image
-  supports_not :update_image
-
   default_value_for :cloud, true
 
   virtual_column :image?, :type => :boolean

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -42,10 +42,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
                  :type => :string_set,
                  :uses => {:load_balancer_pool_members => :load_balancer_health_check_states_with_reason}
 
-  supports_not :add_security_group
-  supports_not :associate_floating_ip
-  supports_not :disassociate_floating_ip
-
   def load_balancer_health_check_state
     return @health_check_state if @health_check_state
     return (@health_check_state = nil) if load_balancer_pool_members.blank?

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -69,7 +69,6 @@ module ManageIQ::Providers
     virtual_column :port_show, :type => :string
 
     supports     :authentication_status
-    supports_not :external_logging
     supports     :metrics
     supports     :performance
 

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -9,10 +9,6 @@ module ManageIQ::Providers
       define_method(:singular_route_key) { "ems_network" }
     end
 
-    supports_not :cloud_tenant_mapping
-    supports_not :create_floating_ip
-    supports_not :create_network_router
-
     # cloud_subnets are defined on base class, because of virtual_total performance
     has_many :floating_ips,                       :foreign_key => :ems_id, :dependent => :destroy
     has_many :security_groups,                    :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -1,18 +1,6 @@
 module ManageIQ::Providers
   class StorageManager < ManageIQ::Providers::BaseManager
     include SupportsFeatureMixin
-    supports_not :block_storage
-    supports_not :cinder_volume_types
-    supports_not :cloud_object_store_container_clear
-    supports_not :cloud_object_store_container_create
-    supports_not :cloud_volume
-    supports_not :cloud_volume_create
-    supports_not :cloud_volume_snapshots
-    supports_not :object_storage
-    supports_not :smartstate_analysis
-    supports_not :storage_services
-    supports_not :volume_multiattachment
-    supports_not :volume_resizing
 
     has_many :cloud_tenants, :foreign_key => :ems_id, :dependent => :destroy
     has_many :volume_availability_zones, :class_name => "AvailabilityZone", :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/metric/ci_mixin.rb
+++ b/app/models/metric/ci_mixin.rb
@@ -19,8 +19,6 @@ module Metric::CiMixin
     Metric::LongTermAverages::AVG_METHODS_WITHOUT_OVERHEAD.each do |vcol|
       virtual_column vcol, :type => :float, :uses => :vim_performance_operating_ranges
     end
-
-    supports_not :capture
   end
 
   def has_perf_data?

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -3,8 +3,6 @@ class MiqTemplate < VmOrTemplate
 
   default_scope { where(:template => true) }
 
-  supports_not :kickstart_provisioning
-
   virtual_column :display_type,                         :type => :string
   virtual_column :display_operating_system,             :type => :string
   virtual_column :display_platform,                     :type => :string

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -3,16 +3,16 @@ module MiqTemplate::Operations
 
   included do
     supports     :clone
-    supports_not :collect_running_processes, :reason => N_("Process Collection is not available for Images and VM Templates.")
-    supports_not :pause,                     :reason => N_("Pause Operation is not available for Images and VM Templates.")
-    supports_not :provisioning,              :reason => N_("Provisioning Operation is not available for Images and VM Templates.")
-    supports_not :reboot_guest,              :reason => N_("Reboot Guest Operation is not available for Images and VM Templates.")
-    supports_not :reset,                     :reason => N_("Reset Operation is not available for Images and VM Templates.")
-    supports_not :retire,                    :reason => N_("Retire Operation is not available for Images and VM Templates.")
-    supports_not :shutdown_guest,            :reason => N_("Shutdown Guest Operation is not available for Images and VM Templates.")
-    supports_not :standby_guest,             :reason => N_("Standby Guest Operation is not available for Images and VM Templates.")
-    supports_not :start,                     :reason => N_("Start Operation is not available for Images and VM Templates.")
-    supports_not :stop,                      :reason => N_("Stop Operation is not available for Images and VM Templates.")
-    supports_not :suspend,                   :reason => N_("Suspend Operation is not available for Images and VM Templates.")
+    supports_not :collect_running_processes
+    supports_not :pause
+    supports_not :provisioning
+    supports_not :reboot_guest
+    supports_not :reset
+    supports_not :retire
+    supports_not :shutdown_guest
+    supports_not :standby_guest
+    supports_not :start
+    supports_not :stop
+    supports_not :suspend
   end
 end

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -3,16 +3,5 @@ module MiqTemplate::Operations
 
   included do
     supports     :clone
-    supports_not :collect_running_processes
-    supports_not :pause
-    supports_not :provisioning
-    supports_not :reboot_guest
-    supports_not :reset
-    supports_not :retire
-    supports_not :shutdown_guest
-    supports_not :standby_guest
-    supports_not :start
-    supports_not :stop
-    supports_not :suspend
   end
 end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -56,10 +56,6 @@ module SupportsFeatureMixin
   # Whenever this mixin is included we define all features as unsupported by default.
   # This way we can query for every feature
   included do
-    COMMON_FEATURES.each do |feature|
-      supports_not(feature)
-    end
-
     private_class_method :unsupported
     private_class_method :unsupported_reason_add
     private_class_method :define_supports_feature_methods

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -32,9 +32,6 @@ class NetworkRouter < ApplicationRecord
   virtual_column :main_route_table     , :type => :boolean # :array
   virtual_column :high_availability    , :type => :boolean
 
-  supports_not :add_interface
-  supports_not :remove_interface
-
   # Define all getters and setters for extra_attributes related virtual columns
   %i(external_gateway_info distributed routes propagating_vgws main_route_table high_availability).each do |action|
     define_method("#{action}=") do |value|

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -21,8 +21,6 @@ class PhysicalServer < ApplicationRecord
     nil       => "Unknown",
   }.freeze
 
-  supports_not :console
-
   validates :vendor, :inclusion =>{:in => VENDOR_TYPES}
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_servers,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -32,10 +32,6 @@ class PhysicalStorage < ApplicationRecord
 
   supports :timeline
 
-  supports_not :create
-  supports_not :delete
-  supports_not :update_physical_storage
-  supports_not :validate
   acts_as_miq_taggable
 
   def my_zone

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -29,8 +29,6 @@ class SecurityGroup < ApplicationRecord
   virtual_total :total_security_policy_rules_as_source, :security_policy_rules_as_source, :uses => :security_policy_rules_as_source
   virtual_total :total_security_policy_rules_as_destination, :security_policy_rules_as_destination, :uses => :security_policy_rules_as_destination
 
-  supports_not :delete_security_group
-
   def self.non_cloud_network
     where(:cloud_network_id => nil)
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -82,9 +82,6 @@ class Storage < ApplicationRecord
 
   supports(:delete) { _("Only storage without VMs and Hosts can be removed") if vms_and_templates.any? || hosts.any? }
 
-  supports_not :evacuate
-  supports_not :iso_datastore
-
   def to_s
     name
   end

--- a/app/models/storage_service.rb
+++ b/app/models/storage_service.rb
@@ -12,10 +12,6 @@ class StorageService < ApplicationRecord
   has_many :cloud_volumes
 
   acts_as_miq_taggable
-  supports_not :create
-  supports_not :delete
-  supports_not :update
-  supports_not :check_compliant_resources
 
   def self.class_by_ems(ext_management_system)
     ext_management_system&.class_by_ems(:StorageService)

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -46,14 +46,6 @@ module Vm::Operations
 
       reason
     end
-
-    supports_not :evacuate
-    supports_not :reconfigure_disks
-    supports_not :reconfigure_disksize
-    supports_not :reconfigure_network_adapters
-    supports_not :reconfigure_cdroms
-    supports_not :remove_security_group
-    supports_not :resize
   end
 
   def ipv4_address

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -5,11 +5,6 @@ module Vm::Operations::Guest
     api_relay_method :shutdown_guest
     api_relay_method :reboot_guest
     api_relay_method :reset
-
-    supports_not :reboot_guest
-    supports_not :reset
-    supports_not :shutdown_guest
-    supports_not :standby_guest
   end
 
   def raw_shutdown_guest

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -10,8 +10,6 @@ module Vm::Operations::Lifecycle
       end
     end
 
-    supports_not :publish
-
     api_relay_method :retire do |options|
       options
     end

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -29,10 +29,6 @@ module Vm::Operations::Power
         _('The VM is not powered on')
       end
     end
-
-    supports_not :pause
-    supports_not :shelve
-    supports_not :shelve_offload
   end
 
   def vm_powered_on?

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1631,7 +1631,6 @@ class VmOrTemplate < ApplicationRecord
     MiqTemplate.where(:id => ids).exists?
   end
 
-  supports_not :snapshots
   supports :destroy
 
   # Stop showing Reconfigure VM task unless the subclass allows

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -140,10 +140,7 @@ module VmOrTemplate::Operations
         _("The VM is not connected to an active Provider")
       end
     end
-    supports_not :clone
-    supports_not :quick_stats
-    supports_not :rename
-    supports_not :terminate
+
     supports :vm_control_powered_on do
       if !supports?(:control)
         unsupported_reason_add(:vm_control_powered_on, unsupported_reason(:control))

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -1,14 +1,6 @@
 module VmOrTemplate::Operations::Relocation
   extend ActiveSupport::Concern
 
-  included do
-    supports_not :evacuate
-    supports_not :live_migrate
-    supports_not :migrate
-    supports_not :move_into_folder
-    supports_not :relocate
-  end
-
   def raw_live_migrate(_options = nil)
     raise NotImplementedError, _("raw_live_migrate must be implemented in a subclass")
   end

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -1,10 +1,6 @@
 module VmOrTemplate::Scanning
   extend ActiveSupport::Concern
 
-  included do
-    supports_not :smartstate_analysis
-  end
-
   # Call the VmScan Job and raise a "request" event
   def scan(userid = "system", options = {})
     # Check if there are any current scan jobs already waiting to run

--- a/app/models/volume_mapping.rb
+++ b/app/models/volume_mapping.rb
@@ -13,8 +13,6 @@ class VolumeMapping < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
 
-  supports_not :create
-  supports_not :delete
   acts_as_miq_taggable
 
   def my_zone

--- a/spec/models/manageiq/providers/regions_spec.rb
+++ b/spec/models/manageiq/providers/regions_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ManageIQ::Providers::Regions, :providers_common => true do
   describe ".regions" do
-    ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
+    ExtManagementSystem.supported_types_for_create.select { |klass| klass.supports?(:regions) }.each do |klass|
       context klass.description do
         it "returns regions" do
           expect(klass.module_parent::Regions.regions.count).not_to be_zero
@@ -23,7 +23,7 @@ RSpec.describe ManageIQ::Providers::Regions, :providers_common => true do
   end
 
   describe ".all" do
-    ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
+    ExtManagementSystem.supported_types_for_create.select { |klass| klass.supports?(:regions) }.each do |klass|
       context klass.description do
         it "returns regions" do
           expect(klass.module_parent::Regions.all.count).not_to be_zero
@@ -46,7 +46,7 @@ RSpec.describe ManageIQ::Providers::Regions, :providers_common => true do
   end
 
   describe ".names" do
-    ExtManagementSystem.supported_types_for_create.select(&:supports_regions?).each do |klass|
+    ExtManagementSystem.supported_types_for_create.select { |klass| klass.supports?(:regions) }.each do |klass|
       context klass.description do
         it "returns regions" do
           expect(klass.module_parent::Regions.all.count).not_to be_zero

--- a/spec/models/vm_or_template/operations/relocation_spec.rb
+++ b/spec/models/vm_or_template/operations/relocation_spec.rb
@@ -24,4 +24,10 @@ RSpec.describe VmOrTemplate::Operations::Relocation do
       )
     end
   end
+
+  context "supports" do
+    it "does not support migrate by default" do
+      expect(FactoryBot.build(:vm).supports?(:migrate)).to be false
+    end
+  end
 end


### PR DESCRIPTION
I rebased https://github.com/ManageIQ/manageiq/pull/21478 and due to `stale` needed to open a new PR. This moves that code over here.

# Goal

Since `supports?(:unknown_feature) == false`, we no longer need to define supports up front.

The only `supports_not` I kept was in automate manager - `supports_not :refresh_ems`.

update:
- rebased #21478
- removed a few more `supports_not` entries

# Tangents / future

I think we can drop many of the `:reason` values behind `supports_not`, especially around `this feature is not supported by this provider`. These details seem unnecessary.