### PR TITLE
Fix qpid proton require under zeitwerk - resolves rake locale:update_all failure in CI

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -11,9 +11,8 @@ if Rails.application.config.autoloader == :zeitwerk && Rails.autoloaders.main
   Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
   Rails.autoloaders.main.collapse(Rails.root.join("lib/pdf_generator"))
 
-  # requires qpid, which is an optional dependency because LOL mac
-  if RUBY_PLATFORM.include?("darwin")
-    message_handler_path = Pathname.new(Vmdb::Plugins.paths[ManageIQ::Providers::Nuage::Engine]).join("app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb")
-    Rails.autoloaders.main.ignore(message_handler_path)
-  end
+  # The following file should not be eager loaded as it depends on being installed, which isn't possible on macs and isn't done by default
+  # in ci for other plugins, core, etc.
+  message_handler_path = Pathname.new(Vmdb::Plugins.paths[ManageIQ::Providers::Nuage::Engine]).join("app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb")
+  Rails.autoloaders.main.ignore(message_handler_path)
 end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -133,7 +133,7 @@ namespace :locale do
   end
 
   desc "Extract model attribute names and virtual column names"
-  task "store_model_attributes" do
+  task "store_model_attributes" => :environment do
     require 'gettext_i18n_rails/model_attributes_finder'
     require_relative 'model_attribute_override.rb'
 


### PR DESCRIPTION
* Don't eager load a class needing qpid_proton loaded at load time

```
This class can't be eager loaded because not all platforms install qpid_proton
and we need qpid_proton's class at load time.  We can't install qpid_proton on mac
but also don't want to install qpid's dependencies in CI in various providers, core,
etc.
```

* Ensure store_model_attributes loads rails environment first

Follow, this enables us to do an explicit require in the troublesome file before it tries to access a constant that is not auto-loadable as it's from a library: https://github.com/ManageIQ/manageiq-providers-nuage/pull/299
