### PR TITLE
Change URL for the OpenSSF Best Practices badge to the current one

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Translate](https://img.shields.io/badge/translate-transifex-blue.svg)](https://www.transifex.com/manageiq/manageiq/dashboard/)
 [![Open Source Helpers](https://www.codetriage.com/manageiq/manageiq/badges/users.svg)](https://www.codetriage.com/manageiq/manageiq)
 
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4282/badge)](https://bestpractices.coreinfrastructure.org/projects/4282)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/4282/badge)](https://www.bestpractices.dev/projects/4282)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ManageIQ/manageiq/badge)](https://api.securityscorecards.dev/projects/github.com/ManageIQ/manageiq)
 
 [![Build history for master branch](https://buildstats.info/github/chart/ManageIQ/manageiq?branch=master&buildCount=50&includeBuildsFromPullRequest=false&showstats=false)](https://github.com/ManageIQ/manageiq/actions?query=branch%3Amaster)


### PR DESCRIPTION
[skip ci]

The old URL doesn't seem to update properly, where the current URL does.

Before:

![ManageIQ_manageiq__ManageIQ_Open-Source_Management_Platform](https://github.com/ManageIQ/manageiq/assets/52120/acc42a20-de91-440d-8174-acb2398d9407)

After:

![manageiq_README_md_at_2ce231c9728170631f490f1ad080bfa1ac0326c6_·_ManageIQ_manageiq](https://github.com/ManageIQ/manageiq/assets/52120/194c2a74-9519-486b-ba9d-fc1121d88220)
