### PR TITLE
fix specs for Virtual attributes update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-session_store",       "~>2.0"
-gem "activerecord-virtual_attributes",  "~>6.1.1"
+gem "activerecord-virtual_attributes",  "~>6.1.2"
 gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                         "~>4.1.0",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3

--- a/spec/models/container_service_spec.rb
+++ b/spec/models/container_service_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe ContainerService do
   describe "#container_groups_count" do
     subject { service.tap { service.container_groups << group } }
 
-    # NOTE: virtual_total does not currently work with habtm
-    it_behaves_like "ruby only virtual_attribute", :container_groups_count, 1
+    it_behaves_like "sql friendly virtual_attribute", :container_groups_count, 1
   end
 end

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -105,9 +105,9 @@ shared_examples_for "OwnershipMixin" do
       it "usable as arel" do
         group_name = user.current_group.description.downcase
         sql        = <<-SQL.strip_heredoc.split("\n").join(' ')
-                       LOWER((SELECT "miq_groups"."description"
+                       LOWER(((SELECT "miq_groups"."description"
                        FROM "miq_groups"
-                       WHERE "miq_groups"."id" = "#{described_class.table_name}"."miq_group_id")) = '#{group_name}'
+                       WHERE "miq_groups"."id" = "#{described_class.table_name}"."miq_group_id"))) = '#{group_name}'
                      SQL
         attribute  = described_class.arel_table[:owned_by_current_ldap_group]
         expect(stringify_arel(attribute)).to eq ["(#{sql})"]
@@ -210,9 +210,9 @@ shared_examples_for "OwnershipMixin" do
       it "usable as arel" do
         userid = user.userid.downcase
         sql        = <<-SQL.strip_heredoc.split("\n").join(' ')
-                       LOWER((SELECT "users"."userid"
+                       LOWER(((SELECT "users"."userid"
                        FROM "users"
-                       WHERE "users"."id" = "#{described_class.table_name}"."evm_owner_id")) = '#{userid}'
+                       WHERE "users"."id" = "#{described_class.table_name}"."evm_owner_id"))) = '#{userid}'
                      SQL
         attribute  = described_class.arel_table[:owned_by_current_user]
         expect(stringify_arel(attribute)).to eq ["(#{sql})"]


### PR DESCRIPTION
Fixes Build after upgrading virtual attributes gem to 6.1.2

- virtual_total for habtm is now supported
- a few virtual_attributes got an extra set of parens

