### PR TITLE
Seed workflows from plugins' content/workflows

### DIFF
--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -51,7 +51,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
   end
 
   def git_repository
-    (super || (ensure_git_repository && super)).tap { |r| sync_git_repository(r) }
+    (super || (ensure_git_repository && super))&.tap { |r| sync_git_repository(r) }
   end
 
   def verify_ssl=(val)
@@ -86,6 +86,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
   end
 
   def checkout_git_repository(target_directory)
+    return if git_repository.nil?
+
     git_repository.update_repo
     git_repository.checkout(scm_branch, target_directory)
   end
@@ -93,6 +95,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
   private
 
   def ensure_git_repository
+    return if scm_url.blank?
+
     transaction do
       repo = GitRepository.create!(attrs_for_sync_git_repository)
       if new_record?
@@ -108,6 +112,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
     return unless name_changed? || scm_url_changed? || authentication_id_changed? || @verify_ssl_changed
 
     git_repository ||= self.git_repository
+    return if git_repository.nil?
+
     git_repository.attributes = attrs_for_sync_git_repository
   end
 

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -80,6 +80,14 @@ module Vmdb
       end
     end
 
+    def embedded_workflows_content
+      @embedded_workflows_content ||= begin
+        flat_map do |engine|
+          Dir.glob(engine.root.join("content", "workflows", "**", "*.asl"))
+        end
+      end
+    end
+
     def automate_domains
       @automate_domains ||= begin
         require_relative 'plugins/automate_domain'

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -83,7 +83,7 @@ module Vmdb
     def embedded_workflows_content
       @embedded_workflows_content ||= begin
         flat_map do |engine|
-          Dir.glob(engine.root.join("content", "workflows", "**", "*.asl"))
+          engine.root.join("content", "workflows").glob("**/*.asl")
         end
       end
     end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -81,7 +81,7 @@ module Vmdb
     end
 
     def embedded_workflows_content
-      @embedded_workflows_content ||= flat_map do |engine|
+      @embedded_workflows_content ||= index_with do |engine|
         engine.root.join("content", "workflows").glob("**/*.asl")
       end
     end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -81,10 +81,8 @@ module Vmdb
     end
 
     def embedded_workflows_content
-      @embedded_workflows_content ||= begin
-        flat_map do |engine|
-          engine.root.join("content", "workflows").glob("**/*.asl")
-        end
+      @embedded_workflows_content ||= flat_map do |engine|
+        engine.root.join("content", "workflows").glob("**/*.asl")
       end
     end
 


### PR DESCRIPTION
Required for:
* https://github.com/ManageIQ/manageiq-providers-workflows/pull/57

TODO:
- [x] `ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource` won't create without a git_repository