### PR TITLE
Fix locale update all from GitHub actions

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -10,10 +10,4 @@ if Rails.application.config.autoloader == :zeitwerk && Rails.autoloaders.main
   Rails.autoloaders.main.collapse(Rails.root.join("lib/manageiq/reporting/charting"))
   Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
   Rails.autoloaders.main.collapse(Rails.root.join("lib/pdf_generator"))
-
-  # requires qpid, which is an optional dependency because LOL mac
-  if RUBY_PLATFORM.include?("darwin")
-    message_handler_path = Pathname.new(Vmdb::Plugins.paths[ManageIQ::Providers::Nuage::Engine]).join("app/models/manageiq/providers/nuage/network_manager/event_catcher/messaging_handler.rb")
-    Rails.autoloaders.main.ignore(message_handler_path)
-  end
 end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -133,7 +133,7 @@ namespace :locale do
   end
 
   desc "Extract model attribute names and virtual column names"
-  task "store_model_attributes" do
+  task "store_model_attributes" => :environment do
     require 'gettext_i18n_rails/model_attributes_finder'
     require_relative 'model_attribute_override.rb'
 


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq/pull/22752

Upgrading to zeitwerk meant that when locale:update_all tried to eager load the app, it tried to load a file that required qpid_proton be installed.  This wasn't configured in the github action that was being done for locale:update_all.  This change makes qpid_proton not necessary to run update_all.

Should be merged with https://github.com/ManageIQ/manageiq-providers-nuage/pull/299