### PR TITLE
Use named arguments for psych 4 support

### DIFF
--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -11,7 +11,7 @@ class DialogImportValidator
   end
 
   def determine_validity(import_file_upload)
-    potential_dialogs = YAML.safe_load(import_file_upload.uploaded_content, [Symbol])
+    potential_dialogs = YAML.safe_load(import_file_upload.uploaded_content, :permitted_classes => [Symbol])
     raise BlankFileError unless potential_dialogs
 
     check_dialogs_for_validity(potential_dialogs)

--- a/spec/lib/task_helpers/exports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/exports/custom_buttons_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
       TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
       file_contents = File.read("#{export_dir}/CustomButtons.yaml")
 
-      expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_export_test)
+      expect(YAML.safe_load(file_contents, :permitted_classes => [Symbol])).to contain_exactly(*custom_button_export_test)
       expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
       TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
       file_contents = File.read("#{export_dir}/CustomButtons.yaml")
 
-      expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*multi_custom_button_export_test)
+      expect(YAML.safe_load(file_contents, :permitted_classes => [Symbol])).to contain_exactly(*multi_custom_button_export_test)
       expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
     end
   end
@@ -284,7 +284,7 @@ RSpec.describe TaskHelpers::Exports::CustomButtons do
       TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
       file_contents = File.read("#{export_dir}/CustomButtons.yaml")
 
-      expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_with_dialogs_export_test)
+      expect(YAML.safe_load(file_contents, :permitted_classes => [Symbol])).to contain_exactly(*custom_button_with_dialogs_export_test)
       expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
     end
   end

--- a/spec/lib/task_helpers/exports/widgets_spec.rb
+++ b/spec/lib/task_helpers/exports/widgets_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe TaskHelpers::Exports::Widgets do
     resource_type: MiqReport
     enabled: true
     read_only: false
-    ", [Symbol], %i(col_order row_count roles)))
+    ", :permitted_classes => [Symbol]))
     MiqWidget.sync_from_hash(YAML.safe_load("
     description: Test Widget 2
     title: Test Widget 2
@@ -43,7 +43,7 @@ RSpec.describe TaskHelpers::Exports::Widgets do
     resource_type: MiqReport
     enabled: true
     read_only: false
-    ", [Symbol], %i(col_order row_count roles)))
+    ", :permitted_classes => [Symbol]))
   end
 
   after do

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe MiqWidgetSet do
       let(:dashboard_name) { "Dashboard for Group" }
       before do
         @yml_file = Tempfile.new('default_dashboard_for_group.yaml')
-        yml_data = YAML.safe_load(<<~DOC, [Symbol])
+        yml_data = YAML.safe_load(<<~DOC, :permitted_classes => [Symbol])
           ---
           name: #{dashboard_name}
           read_only: t


### PR DESCRIPTION
pulled out of https://github.com/ManageIQ/manageiq/pull/22698

See: https://www.ctrl.blog/entry/ruby-psych4.html
