### PR TITLE
Drop Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
         test-suite:
         - vmdb
@@ -43,7 +42,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ matrix.ruby-version }}"
-        rubygems: "${{ matrix.ruby-version == '2.7' && 'latest' || 'default' }}"
         bundler-cache: true
       timeout-minutes: 30
     - name: Prepare tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-raise "Ruby versions < 2.7.0 are unsupported!" if RUBY_VERSION < "2.7.0"
+raise "Ruby versions < 3.0.0 are unsupported!" if RUBY_VERSION < "3.0.0"
 raise "Ruby versions >= 3.1.0 are unsupported!" if RUBY_VERSION >= "3.1.0"
 
 source 'https://rubygems.org'

--- a/spec/models/custom_attribute_spec.rb
+++ b/spec/models/custom_attribute_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe CustomAttribute do
   end
 
   it "returns the value type of Integer custom attributes" do
-    # TODO: Ruby 2.4 unifies fixnum and bignum into integer, we shouldn't be
-    # returnings ruby types like this.
-    expected = RUBY_VERSION >= "2.4.0" ? :integer : :fixnum
-    expect(int_custom_attribute.value_type).to eq(expected)
+    expect(int_custom_attribute.value_type).to eq(:integer)
   end
 end


### PR DESCRIPTION
@jrafanie Please review.

Note that Ruby 2.7 is already removed on quinteros, so there's nothing to backport.

- [x] https://github.com/ManageIQ/amazon_ssa_support/pull/105
- [x] https://github.com/ManageIQ/dbus_api_service/pull/38
- [x] https://github.com/ManageIQ/manageiq-api/pull/1242
- [x] https://github.com/ManageIQ/manageiq-appliance-build/pull/558
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/223
- [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/534
- [x] https://github.com/ManageIQ/manageiq-consumption/pull/212
- [x] https://github.com/ManageIQ/manageiq-content/pull/739
- [x] https://github.com/ManageIQ/manageiq-decorators/pull/97
- [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/567
- [x] https://github.com/ManageIQ/manageiq-pods/pull/1007
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/836
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/300
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/240
- [x] https://github.com/ManageIQ/manageiq-providers-awx/pull/21
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/544
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/101
- [x] https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/101
- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/122
- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/255
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/42
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/477
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/150
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/98
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/100
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/511
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/225
- [x] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/397
- [x] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/95
- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/301
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/252
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/864
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/94
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/654
- [x] https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization/pull/38
- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/183
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/888
- [x] https://github.com/ManageIQ/manageiq-providers-workflows/pull/58
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/425
- [x] https://github.com/ManageIQ/manageiq-schema/pull/709
- [x] https://github.com/ManageIQ/manageiq-smartstate/pull/178
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8949
- [x] https://github.com/ManageIQ/guides/pull/531