### PR TITLE
Fix Build: handle awesome spawn update

### DIFF
--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Ansible::Runner do
   let(:env_vars)   { {"ENV1" => "VAL1", "ENV2" => "VAL2"} }
   let(:extra_vars) { {"id" => uuid} }
   let(:tags)       { "tag" }
-  let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", "0") }
+  let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", 100, "0") }
 
   let(:manageiq_venv_path)  { "/var/lib/manageiq/venv/python3.8/site-packages" }
   let(:ansible_python_path) { "/usr/local/lib64/python3.8/site-packages:/usr/local/lib/python3.8/site-packages:/usr/lib64/python3.8/site-packages:/usr/lib/python3.8/site-packages" }


### PR DESCRIPTION
handle change in attributes passed to `CommandResult#initialize`

```
  10) Ansible::Runner.run with special characters calls launch with expected arguments
      Failure/Error: let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", "0") }

      ArgumentError:
        wrong number of arguments (given 4, expected 5)
      # /Users/kbrock/.gem/ruby/3.0.6/gems/awesome_spawn-1.6.0/lib/awesome_spawn/command_result.rb:5:in `initialize'
      # ./spec/lib/ansible/runner_spec.rb:6:in `new'
      # ./spec/lib/ansible/runner_spec.rb:6:in `block (2 levels) in <main>'
```