### PR TITLE
Change messaging-health-check to manageiq.liveness-check 

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -623,8 +623,8 @@ class MiqServer < ApplicationRecord
     broker = MiqQueue.messaging_client("health_check")
     return if broker.nil?
 
-    broker.publish_message(:service => "messaging-health-check", :message => "health check", :payload => {})
-    broker.subscribe_messages(:service => "messaging-health-check") { break }
+    broker.publish_message(:service => "manageiq.liveness-check", :message => "test message", :payload => {})
+    broker.subscribe_messages(:service => "manageiq.liveness-check") { break }
   rescue => err
     _log.error("Messaging health check failed: #{err}")
     shutdown_and_exit(1)


### PR DESCRIPTION
The server health check was using the wrong topic, should be `manageiq.liveness-check` similar to how its done in the messaging ready script https://github.com/ManageIQ/manageiq-appliance/blob/master/COPY/usr/bin/manageiq-messaging-ready#L33-L35

@miq-bot add_label bug
@miq-bot assign @agrare 