### PR TITLE
Change ems refresh task complete messaging

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -168,9 +168,8 @@ module EmsRefresh
   end
 
   def self.create_refresh_task(ems, targets)
-    targets = targets.collect { |target_class, target_id| [target_class.demodulize, target_id] }
     task_options = {
-      :action => "EmsRefresh(#{ems.name}) [#{targets}]".truncate(255),
+      :action => "EmsRefresh(#{ems.name}) Refreshing relationships and power states",
       :userid => "system"
     }
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -148,27 +148,6 @@ RSpec.describe EmsRefresh do
         expect(task_ids.length).to eq(2)
       end
     end
-
-    context "task name" do
-      let(:vm1) { FactoryBot.create(:vm_vmware, :ext_management_system => @ems) }
-      let(:vm2) { FactoryBot.create(:vm_vmware, :ext_management_system => @ems) }
-      it "uses targets' short classnames to compose task name" do
-        task_ids = described_class.queue_refresh_task([vm1, vm2])
-        task_name = MiqTask.find(task_ids.first).name
-        expect(task_name).to include([vm1.class.name.demodulize, vm1.id].to_s)
-        expect(task_name).to include([vm2.class.name.demodulize, vm1.id].to_s)
-      end
-    end
-
-    describe ".create_refresh_task" do
-      it "create refresh task and trancates task name to 255 symbols" do
-        vm = FactoryBot.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => @ems)
-        targets = Array.new(500) { [vm.class.name, vm.id] }
-        task_name = described_class.send(:create_refresh_task, @ems, targets).name
-        expect(task_name.include?(@ems.name)).to eq true
-        expect(task_name.length).to eq 255
-      end
-    end
   end
 
   def queue_refresh_and_assert_queue_item(target, expected_targets)


### PR DESCRIPTION
taken from:
- https://github.com/ManageIQ/manageiq/pull/22465
- https://github.com/ManageIQ/manageiq-providers-autosde/pull/228

Instead of displaying target information, this now displays a user friendly message in the ui

This was marked as stale and I liked the change by @galoiring so I put this together

Before
------

<img width="1192" alt="a93b3af1-f7cb-4a64-ad4d-3b5b87161e8c" src="https://user-images.githubusercontent.com/74841666/232780831-481d98cb-d573-419e-b2da-06c3059b4eca.png">

After
-----

<img width="1506" alt="Screenshot 2023-04-18 at 15 43 35" src="https://user-images.githubusercontent.com/74841666/232781106-a8b37d14-1afd-4428-b6db-b55085aabe38.png">
