### PR TITLE
Add awesome_spawn gem directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "activerecord-session_store",       "~>2.0"
 gem "activerecord-virtual_attributes",  "~>6.1.2"
 gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                         "~>4.1.0",           :require => false
+gem "awesome_spawn",                    "~>1.6",             :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load


### PR DESCRIPTION
We were depending on it from manageiq-gems-pending, however there is a lot of code in core that depends on it directly, so it should live here.

Follow up to https://github.com/ManageIQ/manageiq/pull/22772#issuecomment-1791033562

@agrare Please review