### PR TITLE
Use "traditional chinese" for human locale name, not Mandarin

### DIFF
--- a/config/human_locale_names.yaml
+++ b/config/human_locale_names.yaml
@@ -9,4 +9,4 @@ human_locale_names:
   ko: 한국어
   pt_BR: Português (Brasil)
   zh_CN: 简体中文
-  zh_TW: 國語
+  zh_TW: 繁體中文


### PR DESCRIPTION
Originally added as Mandarin (in Traditional Chinese characters): https://github.com/ManageIQ/manageiq/pull/20719

We're changing this to the written language "Traditional Chinese".

Settings, application settings, server tab, default locale

**Before**
![image (40)](https://github.com/ManageIQ/manageiq/assets/19339/e1932079-42cb-4b62-9a45-576d5fc16cd6)

**After**
![image (39)](https://github.com/ManageIQ/manageiq/assets/19339/cc49fbd9-59e8-4b85-8600-276213fd1d51)

EDIT:
My brain blew up trying to sort written languages in different languages.  I'll trust the computers.