### PR TITLE
[WIP] Drop broadcast logger

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -59,6 +59,8 @@ module Vmdb
       return nil unless (logger = create_raw_container_logger)
 
       progname = progname_from_file(log_file_name)
+      logger.progname = progname
+
       create_wrapper_logger(progname, logger_class, logger)
     end
 
@@ -71,6 +73,8 @@ module Vmdb
       return nil unless (logger = create_raw_journald_logger)
 
       progname = progname_from_file(log_file_name)
+      logger.progname = progname
+
       create_wrapper_logger(progname, logger_class, logger)
     end
 
@@ -104,8 +108,6 @@ module Vmdb
         end
 
         logger.extend(ActiveSupport::Logger.broadcast(wrapped_logger))
-
-        wrapped_logger.progname = progname
       end
     end
 

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -49,8 +49,7 @@ module Vmdb
     end
 
     private_class_method def self.create_file_logger(log_file, logger_class)
-      log_file = Pathname.new(log_file) if log_file.kind_of?(String)
-      log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
+      log_file = log_path_from_file(log_file)
       progname = log_file.try(:basename, ".*").to_s
 
       logger_class.new(log_file, :progname => progname)
@@ -80,13 +79,18 @@ module Vmdb
       nil
     end
 
+    private_class_method def self.log_path_from_file(log_file)
+      log_file = Pathname.new(log_file) if log_file.kind_of?(String)
+      log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
+      log_file
+    end
+
     private_class_method def self.progname_from_file(log_file_name)
       File.basename(log_file_name, ".*")
     end
 
     private_class_method def self.create_wrapper_logger(log_file, logger_class, wrapped_logger)
-      log_file = Pathname.new(log_file) if log_file.kind_of?(String)
-      log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."
+      log_file = log_path_from_file(log_file)
       progname = log_file.try(:basename, ".*").to_s
 
       logger_class.new(nil, :progname => progname).tap do |logger|

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -56,33 +56,23 @@ module Vmdb
     end
 
     private_class_method def self.create_container_logger(log_file_name, logger_class)
-      return nil unless (logger = create_raw_container_logger)
+      require "manageiq/loggers/container"
+      logger = ManageIQ::Loggers::Container.new
 
       progname = progname_from_file(log_file_name)
       logger.progname = progname
 
       create_wrapper_logger(progname, logger_class, logger)
-    end
-
-    private_class_method def self.create_raw_container_logger
-      require "manageiq/loggers/container"
-      ManageIQ::Loggers::Container.new
     end
 
     private_class_method def self.create_journald_logger(log_file_name, logger_class)
-      return nil unless (logger = create_raw_journald_logger)
+      require "manageiq/loggers/journald"
+      logger = ManageIQ::Loggers::Journald.new
 
       progname = progname_from_file(log_file_name)
       logger.progname = progname
 
       create_wrapper_logger(progname, logger_class, logger)
-    end
-
-    private_class_method def self.create_raw_journald_logger
-      require "manageiq/loggers/journald"
-      ManageIQ::Loggers::Journald.new
-    rescue LoadError
-      nil
     end
 
     private_class_method def self.log_path_from_file(log_file)

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -93,15 +93,6 @@ module Vmdb
 
     private_class_method def self.create_wrapper_logger(progname, logger_class, wrapped_logger)
       logger_class.new(nil, :progname => progname).tap do |logger|
-        # HACK: In order to access the wrapped logger in test, we inject it as an instance var.
-        if Rails.env.test?
-          logger.instance_variable_set(:@wrapped_logger, wrapped_logger)
-
-          def logger.wrapped_logger
-            @wrapped_logger
-          end
-        end
-
         logger.extend(ActiveSupport::Logger.broadcast(wrapped_logger))
       end
     end

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -28,7 +28,7 @@ module Vmdb
       Vmdb::Plugins.each { |p| p.try(:apply_logger_config, config) }
     end
 
-    def self.create_logger(log_file_name, logger_class = ManageIQ::Loggers::Base)
+    def self.create_logger(log_file_name, logger_class = nil)
       if MiqEnvironment::Command.is_container?
         create_container_logger(log_file_name, logger_class)
       elsif MiqEnvironment::Command.supports_systemd?
@@ -52,6 +52,7 @@ module Vmdb
       log_file = log_path_from_file(log_file)
       progname = progname_from_file(log_file)
 
+      logger_class ||= ManageIQ::Loggers::Base
       logger_class.new(log_file, :progname => progname)
     end
 
@@ -62,6 +63,8 @@ module Vmdb
       progname = progname_from_file(log_file_name)
       logger.progname = progname
 
+      return logger if logger_class.nil?
+
       create_wrapper_logger(progname, logger_class, logger)
     end
 
@@ -71,6 +74,8 @@ module Vmdb
 
       progname = progname_from_file(log_file_name)
       logger.progname = progname
+
+      return logger if logger_class.nil?
 
       create_wrapper_logger(progname, logger_class, logger)
     end


### PR DESCRIPTION
When we were logging to both files and stdout / journald we needed every logger to be a broadcast logger, now that that is no longer the case we can return the "raw" logger.

This also will make it simpler for us to be able to create "ad-hoc" loggers with additional metadata like a logger for a specific MiqRequest with the request_id as a tag.

TODO
- [ ] Get tests passing with the raw logger
- [ ] What to do with the StringIO type?
- [ ] Convert the vmdb/loggers/ classes to modules to extend the journal/container loggers