### PR TITLE
Fix dashboard accessibility issues

### DIFF
--- a/app/models/miq_widget/report_content.rb
+++ b/app/models/miq_widget/report_content.rb
@@ -28,10 +28,12 @@ class MiqWidget::ReportContent < MiqWidget::ContentGeneration
       end
     end
 
+    empty_row = "<tr><td>#{_("No records found")}</td>#{"<td></td>" * (headers.length - 1)}</tr>"
+
     rows = "<table class='table table-striped table-bordered table-hover'><thead><tr>"
     headers.each { |h| rows << "<th>#{h}</th>" }
     rows << "</tr></thead><tbody>"
-    rows << (body.blank? ? "<tr><td colspan='5'>" + _("No records found") + "</td></tr>" : body)
+    rows << (body.presence || empty_row)
     rows << "</tbody></table>"
   end
 end


### PR DESCRIPTION
Fixed dashboard accessibility violations by adding empty columns into dashboard report widget tables. This change will only apply when the dashboard is generating new report widgets. Any report widgets already created will not be affected by this change.

Before:
<img width="574" alt="Screenshot 2023-12-14 at 11 14 42 AM" src="https://github.com/ManageIQ/manageiq/assets/32444791/43c978dd-eec9-47ed-bfbd-4759d0e463c9">

After:
<img width="638" alt="Screenshot 2023-12-14 at 11 33 00 AM" src="https://github.com/ManageIQ/manageiq/assets/32444791/3b4f1daf-f0fc-4665-ae57-f0c783779917">
