### PR TITLE
Use DDF style parameters for Host verify_credentials

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -629,8 +629,8 @@ class Host < ApplicationRecord
   def verify_credentials?(auth_type = nil, options = {})
     # Prevent the connection details, including the password, from being leaked into the logs
     # and MiqQueue by only returning true/false
-    auth = options.delete(:credentials)
-    update_authentication(auth, :save => false) if auth.present?
+    auth = options.delete("authentications")
+    update_authentication(auth.deep_symbolize_keys, :save => false) if auth.present?
 
     !!verify_credentials(auth_type, options)
   end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -232,10 +232,10 @@ RSpec.describe Host do
 
       it "passes the new credentials" do
         @host.update_authentication(old_creds)
-        @host.verify_credentials_task(FactoryBot.create(:user).userid, :default, :credentials => default_creds)
+        @host.verify_credentials_task(FactoryBot.create(:user).userid, :default, "authentications" => default_creds.deep_stringify_keys)
 
         expect(MiqQueue.last).to have_attributes(
-          :args        => [:default, {:credentials => default_creds}],
+          :args        => [:default, {"authentications" => default_creds.deep_stringify_keys}],
           :method_name => "verify_credentials?",
           :instance_id => @host.id,
           :class_name  => @host.class.name,
@@ -277,7 +277,7 @@ RSpec.describe Host do
 
       it "updates credentials via validate_credential options" do
         @host.update_authentication(old_creds)
-        assert_default_credentials_validated(:credentials => default_creds)
+        assert_default_credentials_validated("authentications" => default_creds)
       end
     end
 


### PR DESCRIPTION
Replace the `:credentials =>` style with ddf parameters which has `"authentications" => {"auth_type" => {}}`

Required for:
* https://github.com/ManageIQ/manageiq-api/pull/1244