### PR TITLE
[MORPHY] Lock down bundler to 2.4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be requi
 gem "ancestry",                         "~>3.0.7",           :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
-gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false
+gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", "< 2.5", :require => false # bundler 2.5 dropped support for Ruby 2.x
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false

--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -1168,7 +1168,7 @@ DEPENDENCIES
   ancestry (~> 3.0.7)
   aws-sdk-s3 (~> 1.0)
   bcrypt (~> 3.1.10)
-  bundler (~> 2.1, >= 2.1.4, != 2.2.10)
+  bundler (~> 2.1, >= 2.1.4, < 2.5, != 2.2.10)
   byebug
   color (~> 1.8)
   config (~> 2.2, >= 2.2.3)


### PR DESCRIPTION
bundler 2.5 dropped support for Ruby 2.x, so since morphy runs on 2.6, we need to lock down to bundler 2.4.x.

@agrare Please review
cc @bdunne @jrafanie 