### PR TITLE
Bump vcr to 6.1 for ruby 3.1 finalizer fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -303,7 +303,7 @@ group :test do
   gem "factory_bot",                    "~>5.1",             :require => false
   gem "simplecov",                      ">=0.21.2",          :require => false
   gem "timecop",                        "~>0.9", "!= 0.9.7", :require => false
-  gem "vcr",                            "~>5.0",             :require => false
+  gem "vcr",                            "~>6.1",             :require => false
   gem "webmock",                        "~>3.7",             :require => false
 end
 


### PR DESCRIPTION
Fix the rspec finalizer throwing an ArgumentError on ruby 3.1

Ref:
* https://github.com/vcr/vcr/pull/907


```
Finished in 10.73 seconds (files took 4.2 seconds to load)
152 examples, 0 failures

Randomized with seed 15029

/home/grare/adam/.gem/ruby/3.1.0/bin/rspec: warning: Exception in finalizer #<Proc:0x00007fb226bec708 /home/grare/adam/.gem/ruby/3.1.0/gems/vcr-5.1.0/lib/vcr/library_hooks/webmock.rb:36 (lambda)>
/home/grare/adam/.gem/ruby/3.1.0/gems/vcr-5.1.0/lib/vcr/library_hooks/webmock.rb:36:in `block in global_hook_disabled_requests': wrong number of arguments (given 1, expected 0) (ArgumentError)
```