### PR TITLE
Add back parallel_tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -308,6 +308,7 @@ group :test do
 end
 
 group :development, :test do
+  gem "parallel_tests",                 "~>4.4", :require => false
   gem "routes_lazy_routes"
   gem "rspec-rails",                    "~>4.0.1"
 end

--- a/config/database.pg.yml
+++ b/config/database.pg.yml
@@ -31,7 +31,7 @@ production:
 test:
   <<: *base
   pool: 3
-  database: vmdb_test
+  database: vmdb_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 i18n:
   <<: *base

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -1,4 +1,5 @@
 require_relative "./evm_test_helper"
+require 'parallel_tests/tasks'
 
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do


### PR DESCRIPTION
This adds back the parallel_tests gem and rake tasks that were dropped by https://github.com/ManageIQ/manageiq/pull/21976

The rationale was that it wasn't being used on CI after we moved to github actions, however particularly as local development machines become more and more powerful I think it makes sense to keep this even if we don't use it on CI.  Of course if we do allow creating 2x databases in our manageiq/postgresql service we could (aprox) halve the time it takes to run the CI suite.

For example locally running the whole core test suite:
```
$ time bundle exec rake

real	5m23.523s
user	4m22.581s
sys	0m9.156s
```

and 97% idle CPU
```
%Cpu(s):  2.5 us,  0.2 sy,  0.0 ni, 97.2 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
```

So 5mins to run the whole suite locally, also known as "I never actually do this"

When running with parallel_tests:
```
$ time bundle exec rake parallel:spec


real	0m47.115s
user	16m47.186s
sys	0m52.796s
```

And less than 5% idle CPU
```
%Cpu(s): 90.1 us,  4.0 sy,  0.0 ni,  4.5 id,  1.4 wa,  0.0 hi,  0.0 si,  0.0 st
```

When it takes ~45seconds to run everything I do this way more often, and it is faster than punting it up to GHA to run and checking back periodically to see if it finished.

I didn't do a full-revert of https://github.com/ManageIQ/manageiq/pull/21976 since it was simpler for me to just use `rake parallel:rake[test:vmdb:setup]` and `rake parallel:spec` instead of our own custom rake tasks, plus if reducing code was one of the original goals this doesn't add back that much.