### PR TITLE
Fix test rake task indentation

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,56 +1,56 @@
 require_relative './evm_test_helper'
 
 if defined?(RSpec)
-namespace :test do
-  task :initialize do
-    if ENV['RAILS_ENV'] && ENV["RAILS_ENV"] != "test"
-      warn "Warning: RAILS_ENV is currently set to '#{ENV["RAILS_ENV"]}'. Forcing to 'test' for this run."
-    end
-    ENV['RAILS_ENV'] = "test"
-    Rails.env = 'test' if defined?(Rails)
+  namespace :test do
+    task :initialize do
+      if ENV['RAILS_ENV'] && ENV["RAILS_ENV"] != "test"
+        warn "Warning: RAILS_ENV is currently set to '#{ENV["RAILS_ENV"]}'. Forcing to 'test' for this run."
+      end
+      ENV['RAILS_ENV'] = "test"
+      Rails.env = 'test' if defined?(Rails)
 
-    ENV['VERBOSE'] ||= "false"
-  end
-
-  desc "Verifies that the rails environment does not require DB access"
-  task :verify_no_db_access_loading_rails_environment do
-    if Rake::Task['environment'].already_invoked
-      raise "Failed to verify database access when loading rails because the 'environment' rake task has already been invoked!"
+      ENV['VERBOSE'] ||= "false"
     end
 
-    EvmRakeHelper.with_dummy_database_url_configuration do
-      begin
-        puts "** Confirming rails environment does not connect to the database"
-        Rake::Task['environment'].invoke
-      rescue ActiveRecord::NoDatabaseError
-        STDERR.write "Detected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n"
-        raise
+    desc "Verifies that the rails environment does not require DB access"
+    task :verify_no_db_access_loading_rails_environment do
+      if Rake::Task['environment'].already_invoked
+        raise "Failed to verify database access when loading rails because the 'environment' rake task has already been invoked!"
+      end
+
+      EvmRakeHelper.with_dummy_database_url_configuration do
+        begin
+          puts "** Confirming rails environment does not connect to the database"
+          Rake::Task['environment'].invoke
+        rescue ActiveRecord::NoDatabaseError
+          STDERR.write "Detected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n"
+          raise
+        end
       end
     end
+
+    task :setup_db => [:initialize, :setup_region] do
+      reset_task = defined?(ENGINE_ROOT) ? 'app:evm:db:reset' : 'evm:db:reset'
+      Rake::Task[reset_task].invoke
+    end
+
+    task :setup_region do
+      ENV["REGION"] ||= (rand(99) + 1).to_s # Ensure we have a random, non-0, region
+      puts "** Preparing database with REGION #{ENV["REGION"]}"
+    end
+
+    task :spec_deps => [:initialize, 'evm:compile_sti_loader']
+
+    task :setup do
+      test_suite = ENV["TEST_SUITE"] || "vmdb"
+      Rake::Task["test:#{test_suite}:setup"].invoke
+    end
   end
 
-  task :setup_db => [:initialize, :setup_region] do
-    reset_task = defined?(ENGINE_ROOT) ? 'app:evm:db:reset' : 'evm:db:reset'
-    Rake::Task[reset_task].invoke
-  end
+  task :default => :test
 
-  task :setup_region do
-    ENV["REGION"] ||= (rand(99) + 1).to_s # Ensure we have a random, non-0, region
-    puts "** Preparing database with REGION #{ENV["REGION"]}"
-  end
-
-  task :spec_deps => [:initialize, 'evm:compile_sti_loader']
-
-  task :setup do
+  task :test do
     test_suite = ENV["TEST_SUITE"] || "vmdb"
-    Rake::Task["test:#{test_suite}:setup"].invoke
+    Rake::Task["test:#{test_suite}"].invoke
   end
-end
-
-task :default => :test
-
-task :test do
-  test_suite = ENV["TEST_SUITE"] || "vmdb"
-  Rake::Task["test:#{test_suite}"].invoke
-end
 end # ifdef

--- a/lib/tasks/test_providers_common.rake
+++ b/lib/tasks/test_providers_common.rake
@@ -1,15 +1,15 @@
 require_relative './evm_test_helper'
 
 if defined?(RSpec)
-namespace :test do
-  desc "Run all specs tagged 'providers_common'"
-  RSpec::Core::RakeTask.new(:providers_common => :spec_deps) do |t|
-    EvmTestHelper.init_rspec_task(t, ['--tag', 'providers_common'])
+  namespace :test do
+    desc "Run all specs tagged 'providers_common'"
+    RSpec::Core::RakeTask.new(:providers_common => :spec_deps) do |t|
+      EvmTestHelper.init_rspec_task(t, ['--tag', 'providers_common'])
 
-    if defined?(ENGINE_ROOT)
-      t.rspec_opts += ["--exclude-pattern", "manageiq/spec/tools/**/*_spec.rb"]
-      t.pattern = "manageiq/spec/**/*_spec.rb"
+      if defined?(ENGINE_ROOT)
+        t.rspec_opts += ["--exclude-pattern", "manageiq/spec/tools/**/*_spec.rb"]
+        t.pattern = "manageiq/spec/**/*_spec.rb"
+      end
     end
   end
-end
 end

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -1,7 +1,9 @@
 require_relative "./evm_test_helper"
-require 'parallel_tests/tasks'
 
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
+
+require 'parallel_tests/tasks'
+
 namespace :test do
   namespace :vmdb do
     desc "Setup environment for vmdb specs"

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -2,23 +2,23 @@ require_relative "./evm_test_helper"
 
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 
-require 'parallel_tests/tasks'
+  require 'parallel_tests/tasks'
 
-namespace :test do
-  namespace :vmdb do
-    desc "Setup environment for vmdb specs"
-    task :setup => :initialize do |rake_task|
-      # in case we are called from an engine or plugin, the task might be namespaced under 'app:'
-      # i.e. it's 'app:test:vmdb:setup'. Then we have to call the tasks in here under the 'app:' namespace too
-      app_prefix = rake_task.name.chomp('test:vmdb:setup')
-      Rake::Task["#{app_prefix}test:setup_db"].invoke
+  namespace :test do
+    namespace :vmdb do
+      desc "Setup environment for vmdb specs"
+      task :setup => :initialize do |rake_task|
+        # in case we are called from an engine or plugin, the task might be namespaced under 'app:'
+        # i.e. it's 'app:test:vmdb:setup'. Then we have to call the tasks in here under the 'app:' namespace too
+        app_prefix = rake_task.name.chomp('test:vmdb:setup')
+        Rake::Task["#{app_prefix}test:setup_db"].invoke
+      end
+    end
+
+    desc "Run all vmdb specs"
+    RSpec::Core::RakeTask.new(:vmdb => :spec_deps) do |t|
+      EvmTestHelper.init_rspec_task(t)
+      t.pattern = EvmTestHelper.vmdb_spec_directories
     end
   end
-
-  desc "Run all vmdb specs"
-  RSpec::Core::RakeTask.new(:vmdb => :spec_deps) do |t|
-    EvmTestHelper.init_rspec_task(t)
-    t.pattern = EvmTestHelper.vmdb_spec_directories
-  end
-end
 end # ifdef


### PR DESCRIPTION
Fix the indentation of rake tasks inside `if defined?(RSpec)` guards.

Built on https://github.com/ManageIQ/manageiq/pull/22831