### PR TITLE
Use join to build an automate path

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -60,11 +60,7 @@ class ResourceAction < ApplicationRecord
   end
 
   def fqname
-    MiqAeEngine::MiqAePath.new(
-      :ae_namespace => ae_namespace,
-      :ae_class     => ae_class,
-      :ae_instance  => ae_instance
-    ).to_s
+    MiqAeEngine::MiqAePath.join(ae_namespace, ae_class, ae_instance)
   end
   alias_method :ae_path, :fqname
 


### PR DESCRIPTION
reducing surface area of automate
(saw this while reading the code)

`MiqAePath.new().to_s` is the same thing as `MiqAePath.join()`


both `to_s` and `join` can be found here:

https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb#L11-L38