### PR TITLE
Add tenancy scoping to Switches

### DIFF
--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -1,6 +1,7 @@
 class Switch < ApplicationRecord
   include NewWithTypeStiMixin
   include CustomActionsMixin
+  extend TenancyCommonMixin
 
   belongs_to :host, :inverse_of => :host_virtual_switches
   has_one :ext_management_system, :through => :host
@@ -14,6 +15,22 @@ class Switch < ApplicationRecord
 
   scope :shareable, ->     { where(:shared => true) }
   scope :with_id,   ->(id) { where(:id => id) }
+
+  has_one :tenant, :through => :ext_management_system
+
+  def self.scope_by_tenant?
+    true
+  end
+
+  def self.tenant_id_clause_format(tenant_ids)
+    {:ext_management_systems => {:tenant_id => tenant_ids}}
+  end
+
+  # in a perfect world, all of this would be in tenant_clause
+  # and that would not return a hash but a scope
+  def self.tenant_join_clause
+    left_outer_joins(:tenant)
+  end
 
   acts_as_miq_taggable
 end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -155,6 +155,7 @@ module Rbac
       'SecurityGroup'          => :descendant_ids,
       'SecurityPolicy'         => :descendant_ids,
       'SecurityPolicyRule'     => :descendant_ids,
+      'Switch'                 => :descendant_ids,
       'Tenant'                 => :descendant_ids,
       'User'                   => :descendant_ids,
       'Vm'                     => :descendant_ids
@@ -622,7 +623,9 @@ module Rbac
       klass = scope.respond_to?(:klass) ? scope.klass : scope
       user_or_group = user || miq_group
       tenant_id_clause = klass.tenant_id_clause(user_or_group)
-      tenant_id_clause ? scope.where(tenant_id_clause) : scope
+      scope = scope.where(tenant_id_clause) if tenant_id_clause
+      scope = scope.tenant_join_clause if scope.respond_to?(:tenant_join_clause)
+      scope
     end
 
     def scope_to_cloud_tenant(scope, user, miq_group)


### PR DESCRIPTION
This adds tenant filtering to Switches

aside
=====

Unfortunately, switches do not have a tenant_id
so we needed to add a little extra code to find the tenant through the ems (which is through the host)
