### PR TITLE
Fixed issue where dialog values are not passed consistently

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -265,6 +265,6 @@ class MiqRequestTask < ApplicationRecord
   end
 
   def dialog_values
-    options[:dialog] || {}
+    {:dialog => options[:dialog] || {}}
   end
 end


### PR DESCRIPTION
This matches the way it's passed for the dynamic_dialog_field_value_processor i.e. https://github.com/ManageIQ/manageiq/blob/26b506a6d38634a454c5f0b77b2c043a7e35d83f/app/models/dynamic_dialog_field_value_processor.rb#L7

@agrare Please review.