### PR TITLE
Use config option in 6.1.7+ instead of an initializer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -89,6 +89,14 @@ module Vmdb
     config.action_cable.allow_same_origin_as_host = true
     config.action_cable.mount_path = '/ws/notifications'
 
+    # Rails 6.1.7+ has a protection to not lookup values by a large number.
+    # A lookup/comparison with a large number (bigger than bigint)
+    # needs to cast the db column to a double/numeric.
+    # and that casting skips the index and forces a table scan
+    #
+    # https://discuss.rubyonrails.org/t/cve-2022-44566-possible-denial-of-service-vulnerability-in-activerecords-postgresql-adapter/82119
+    config.active_record.raise_int_wider_than_64bit = false
+
     # Use yaml_unsafe_load for column serialization to handle Symbols
     config.active_record.use_yaml_unsafe_load = true
 

--- a/config/initializers/postgres_bigints.rb
+++ b/config/initializers/postgres_bigints.rb
@@ -1,8 +1,0 @@
-# Rails has a protection to not lookup values by a large number.
-# A lookup/comparison with a large number (bigger than bigint)
-# needs to cast the db column to a double/numeric.
-# and that casting skips the index and forces a table scan
-#
-# https://discuss.rubyonrails.org/t/cve-2022-44566-possible-denial-of-service-vulnerability-in-activerecords-postgresql-adapter/82119
-#
-ActiveRecord::Base.raise_int_wider_than_64bit = false


### PR DESCRIPTION
In Rails 6.1.7, the config option sets:
`ActiveRecord::Base.raise_int_wider_than_64bit`

In Rails 7.0.8, the same option sets:
`ActiveRecord.raise_int_wider_than_64bit`

This change hides the internals and uses the public interface via the configuration option.

See the change that landed in 6.1.7 here:
https://github.com/rails/rails/commit/4f44aa9d514e701ada92b5cf08beccf566eeaebf

and 7.0 here:
https://github.com/rails/rails/commit/82bcdc011e2ff674e7dd8fd8cee3a831c908d29b