### PR TITLE
Setup Settings constant before the database is connected

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -159,7 +159,7 @@ module Vmdb
       Vmdb::Plugins.init
     end
 
-    initializer :load_vmdb_settings, :before => :load_config_initializers do
+    initializer :load_vmdb_settings, :before => "active_record.initialize_database" do
       Vmdb::Settings.init
       Vmdb::Loggers.apply_config(::Settings.log)
     end


### PR DESCRIPTION
In rails 7, the loading order is changed, so we need to make sure we're running Vmdb Settings init before the database connection is initialized. We can do this with the correct hook in both rails 6 and 7.