### PR TITLE
Deprecate and remove usage of include_concern and require_nested

### DIFF
--- a/app/models/advanced_setting.rb
+++ b/app/models/advanced_setting.rb
@@ -1,5 +1,5 @@
 class AdvancedSetting < ApplicationRecord
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   belongs_to :resource, :polymorphic => true
 

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -3,7 +3,7 @@ class AuditEvent < ApplicationRecord
   validates :status, :inclusion => { :in => %w(success failure) }
   validates :severity, :inclusion => { :in => %w(fatal error warn info debug) }
 
-  include_concern 'Purging'
+  include Purging
 
   def self.generate(attrs)
     attrs = {

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,6 +1,6 @@
 class Authentication < ApplicationRecord
   acts_as_miq_taggable
-  include_concern 'ImportExport'
+  include ImportExport
   include YamlImportExportMixin
   include SupportsFeatureMixin
   include NewWithTypeStiMixin

--- a/app/models/automation_worker.rb
+++ b/app/models/automation_worker.rb
@@ -1,8 +1,6 @@
 class AutomationWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.required_roles               = ["automate"]
   self.default_queue_name           = "automate"
   self.maximum_workers_count        = 1

--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -1,5 +1,5 @@
 class BinaryBlob < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
 
   belongs_to :resource, :polymorphic => true
   has_many :binary_blob_parts, -> { order(:id) }, :dependent => :delete_all

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,6 +1,6 @@
 class Classification < ApplicationRecord
   acts_as_tree
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   belongs_to :tag
 

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -12,7 +12,7 @@ class CloudObjectStoreContainer < ApplicationRecord
   include SupportsFeatureMixin
   include CustomActionsMixin
 
-  include_concern 'Operations'
+  include Operations
 
   alias_attribute :name, :key
 

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -11,7 +11,7 @@ class CloudObjectStoreObject < ApplicationRecord
   include ProcessTasksMixin
   include SupportsFeatureMixin
 
-  include_concern 'Operations'
+  include Operations
 
   alias_attribute :name, :key
 

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -6,8 +6,7 @@ class CloudVolume < ApplicationRecord
   include CloudTenancyMixin
   include CustomActionsMixin
   include EmsRefreshMixin
-
-  include_concern 'Operations'
+  include Operations
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
   belongs_to :availability_zone

--- a/app/models/compliance.rb
+++ b/app/models/compliance.rb
@@ -1,5 +1,5 @@
 class Compliance < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
   belongs_to  :resource,  :polymorphic => true
   has_many    :compliance_details, :dependent => :destroy
 

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,6 +1,6 @@
 class Condition < ApplicationRecord
   include UuidMixin
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   before_validation :default_name_to_guid, :on => :create
 

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -2,7 +2,7 @@ class Container < ApplicationRecord
   include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include ArchivedMixin
-  include_concern 'Purging'
+  include Purging
 
   belongs_to :container_group
   belongs_to :ext_management_system, :foreign_key => :ems_id

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -9,7 +9,7 @@ class ContainerGroup < ApplicationRecord
   include TenantIdentityMixin
   include ArchivedMixin
   include CustomActionsMixin
-  include_concern 'Purging'
+  include Purging
 
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :restart_policy, :dns_policy

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -11,8 +11,7 @@ class ContainerImage < ApplicationRecord
   include NewWithTypeStiMixin
   include CustomActionsMixin
   include Metric::CiMixin
-
-  include_concern 'Purging'
+  include Purging
 
   DOCKER_IMAGE_PREFIX = "docker://"
   DOCKER_PULLABLE_PREFIX = "docker-pullable://".freeze

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -9,7 +9,7 @@ class ContainerNode < ApplicationRecord
   include SupportsFeatureMixin
   include ArchivedMixin
   include CustomActionsMixin
-  include_concern 'Purging'
+  include Purging
 
   EXTERNAL_LOGGING_PATH = "/#/discover?_g=()&_a=(columns:!(hostname,level,kubernetes.pod_name,message),filters:!((meta:(disabled:!f,index:'%{index}',key:hostname,negate:!f),%{query})),index:'%{index}',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!(time,desc))".freeze
 

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -7,7 +7,7 @@ class ContainerProject < ApplicationRecord
   include MiqPolicyMixin
   include TenantIdentityMixin
   include CustomActionsMixin
-  include_concern 'Purging'
+  include Purging
   belongs_to :ext_management_system, :class_name => "ManageIQ::Providers::ContainerManager", :foreign_key => "ems_id", :inverse_of => :container_projects
   has_many :container_groups, -> { active }, :inverse_of => :container_project
   has_many :container_routes

--- a/app/models/container_quota.rb
+++ b/app/models/container_quota.rb
@@ -10,7 +10,7 @@ class ContainerQuota < ApplicationRecord
   # - ContainerQuotaItems can be added/deleted/changed, and we use archiving to
   #   record changes too!
   include ArchivedMixin
-  include_concern 'Purging'
+  include Purging
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project

--- a/app/models/container_quota_item.rb
+++ b/app/models/container_quota_item.rb
@@ -2,7 +2,7 @@ class ContainerQuotaItem < ApplicationRecord
   # This model is unusual in using archiving not only to record deletions but also changes in quota_desired, quota_enforced, quota_observed.
   # Instead of updating in-place, we archive the old record and create a new one.
   include ArchivedMixin
-  include_concern 'Purging'
+  include Purging
 
   belongs_to :container_quota
   has_many :container_quota_scopes, :through => :container_quota

--- a/app/models/drift_state.rb
+++ b/app/models/drift_state.rb
@@ -1,5 +1,5 @@
 class DriftState < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
 
   belongs_to :resource, :polymorphic => true
 

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -1,5 +1,5 @@
 class EmsEvent < EventStream
-  include_concern 'Automate'
+  include Automate
 
   CLONE_TASK_COMPLETE = "CloneVM_Task_Complete"
   SOURCE_DEST_TASKS = [

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -1,5 +1,5 @@
 class EventStream < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
   serialize :full_data
 
   belongs_to :target, :polymorphic => true

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -3,7 +3,7 @@ class ExtManagementSystem < ApplicationRecord
   include SupportsFeatureMixin
   include ExternalUrlMixin
   include VerifyCredentialsMixin
-  include_concern "SupportsAttribute"
+  include SupportsAttribute
 
   hide_attribute "aggregate_memory" # better to use total_memory (coin toss - they're similar)
 

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -1,7 +1,7 @@
 class FileDepot < ApplicationRecord
   include NewWithTypeStiMixin
   include AuthenticationMixin
-  include_concern 'ImportExport'
+  include ImportExport
   include YamlImportExportMixin
 
   has_many              :miq_schedules, :dependent => :nullify

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -1,6 +1,6 @@
 class GenericObjectDefinition < ApplicationRecord
   include YamlImportExportMixin
-  include_concern 'ImportExport'
+  include ImportExport
 
   TYPE_MAP = {
     :boolean  => ActiveModel::Type::Boolean.new,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,6 +1,4 @@
 class Job < ApplicationRecord
-  require_nested :Dispatcher
-
   include StateMachine
   include UuidMixin
   include FilterableMixin

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,7 +1,7 @@
 class Job < ApplicationRecord
   require_nested :Dispatcher
 
-  include_concern 'StateMachine'
+  include StateMachine
   include UuidMixin
   include FilterableMixin
 

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -1,13 +1,4 @@
 class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
-  require_nested :Authentication
-  require_nested :ConfigurationScript
-  require_nested :ConfigurationScriptPayload
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfiguredSystem
-  require_nested :InventoryGroup
-  require_nested :InventoryRootGroup
-  require_nested :OrchestrationStack
-
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class BaseManager < ExtManagementSystem
-    require_nested :Refresher
-
     include Inflector::Methods
 
     def self.metrics_collector_queue_name

--- a/app/models/manageiq/providers/base_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::BaseManager::EventCatcher < MiqWorker
-  require_nested :Runner
-
   include ProviderWorkerMixin
   include PerEmsWorkerMixin
 

--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
@@ -1,8 +1,5 @@
 class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
-
-  require_nested :Runner
-
   include ProviderWorkerMixin
   include PerEmsTypeWorkerMixin
 

--- a/app/models/manageiq/providers/base_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::BaseManager::OperationsWorker < MiqQueueWorkerBase
-  require_nested :Runner
-
   include ProviderWorkerMixin
   include PerEmsWorkerMixin
 

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
-  require_nested :Runner
-
   include ProviderWorkerMixin
   include PerEmsWorkerMixin
 

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -1,15 +1,5 @@
 module ManageIQ::Providers
   class CloudManager < BaseManager
-    require_nested :AuthKeyPair
-    require_nested :Template
-    require_nested :MetricsCapture
-    require_nested :Provision
-    require_nested :ProvisionWorkflow
-    require_nested :ResourcePool
-    require_nested :Vm
-    require_nested :OrchestrationStack
-    require_nested :VmOrTemplate
-
     class << model_name
       define_method(:route_key) { "ems_clouds" }
       define_method(:singular_route_key) { "ems_cloud" }

--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::Authentication
   has_and_belongs_to_many :vms, :join_table => :key_pairs_vms, :foreign_key => :authentication_id
   virtual_belongs_to :ext_management_system, :uses => :resource
 
-  include_concern 'Operations'
+  include Operations
 
   def self.class_by_ems(ext_management_system)
     ext_management_system&.class_by_ems(:AuthKeyPair)

--- a/app/models/manageiq/providers/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision.rb
@@ -1,10 +1,10 @@
 class ManageIQ::Providers::CloudManager::Provision < MiqProvision
-  include_concern 'Cloning'
-  include_concern 'OptionsHelper'
-  include_concern 'Placement'
-  include_concern 'StateMachine'
-  include_concern 'Configuration'
-  include_concern 'VolumeAttachment'
+  include Cloning
+  include OptionsHelper
+  include Placement
+  include StateMachine
+  include Configuration
+  include VolumeAttachment
 
   def destination_type
     "Vm"

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtWorkflow
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
   include CloudInitTemplateMixin
   include SysprepTemplateMixin
 

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -1,9 +1,5 @@
 module ManageIQ::Providers
   class ContainerManager < BaseManager
-    require_nested :ContainerTemplate
-    require_nested :MetricsCapture
-    require_nested :OrchestrationStack
-
     include HasMonitoringManagerMixin
     include HasInfraManagerMixin
     include SupportsFeatureMixin

--- a/app/models/manageiq/providers/embedded_ansible.rb
+++ b/app/models/manageiq/providers/embedded_ansible.rb
@@ -1,3 +1,3 @@
 module ManageIQ::Providers::EmbeddedAnsible
-  include_concern :Seeding
+  include Seeding
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -1,23 +1,4 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Providers::EmbeddedAutomationManager
-  require_nested :Credential
-  require_nested :AmazonCredential
-  require_nested :AzureCredential
-  require_nested :CloudCredential
-  require_nested :GoogleCredential
-  require_nested :MachineCredential
-  require_nested :NetworkCredential
-  require_nested :OpenstackCredential
-  require_nested :RhvCredential
-  require_nested :ScmCredential
-  require_nested :VaultCredential
-  require_nested :VmwareCredential
-
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfigurationWorkflow
-  require_nested :ConfiguredSystem
-  require_nested :Job
-  require_nested :Playbook
-
   supports_not :refresh_ems
 
   def self.ems_type

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -1,8 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::Providers::EmbeddedAutomationManager::OrchestrationStack
   include CiFeatureMixin
-
-  require_nested :Status
-
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::AutomationManager", :inverse_of => false
   belongs_to :playbook, :foreign_key => :configuration_script_base_id, :inverse_of => false
 

--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
-  include_concern 'DefaultAnsibleObjects'
+  include DefaultAnsibleObjects
 
   has_one :automation_manager,
           :foreign_key => "provider_id",

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -1,11 +1,4 @@
 class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::AutomationManager
-  require_nested :Authentication
-  require_nested :ConfigurationScript
-  require_nested :ConfigurationScriptPayload
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfiguredSystem
-  require_nested :OrchestrationStack
-
   supports :catalog
 
   def self.catalog_types

--- a/app/models/manageiq/providers/external_automation_manager.rb
+++ b/app/models/manageiq/providers/external_automation_manager.rb
@@ -1,8 +1,2 @@
 class ManageIQ::Providers::ExternalAutomationManager < ManageIQ::Providers::AutomationManager
-  require_nested :Authentication
-  require_nested :ConfigurationScript
-  require_nested :ConfigurationScriptPayload
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfiguredSystem
-  require_nested :OrchestrationStack
 end

--- a/app/models/manageiq/providers/image_import_job.rb
+++ b/app/models/manageiq/providers/image_import_job.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::ImageImportJob < ManageIQ::Providers::AnsiblePlaybookWorkflow
-  require_nested :Dispatcher
-
   # FIXME: As of now ManageIQ supports only IBM Power Virtual Servers <--> IBM PowerVC
   # image import workflows. Future releases might not be limited only to these
   # import directions. In next release we should therefore remove dependency on the

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -1,17 +1,5 @@
 module ManageIQ::Providers
   class InfraManager < BaseManager
-    require_nested :Cluster
-    require_nested :Datacenter
-    require_nested :Folder
-    require_nested :MetricsCapture
-    require_nested :ProvisionWorkflow
-    require_nested :ResourcePool
-    require_nested :Storage
-    require_nested :StorageCluster
-    require_nested :Template
-    require_nested :Vm
-    require_nested :VmOrTemplate
-
     include SupportsFeatureMixin
 
     has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system

--- a/app/models/manageiq/providers/inventory.rb
+++ b/app/models/manageiq/providers/inventory.rb
@@ -1,9 +1,5 @@
 module ManageIQ::Providers
   class Inventory
-    require_nested :Collector
-    require_nested :Parser
-    require_nested :Persister
-
     attr_accessor :collector, :parsers, :persister
 
     # Entry point for building inventory

--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -1,7 +1,6 @@
 class ManageIQ::Providers::Inventory::Persister
   require 'json'
   require 'yaml'
-  require_nested :Builder
 
   attr_reader :manager, :target, :collections, :tag_mapper
 

--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -6,14 +6,6 @@ module ManageIQ::Providers
 
       class NotSubclassedError < StandardError; end
 
-      require_nested :AutomationManager
-      require_nested :CloudManager
-      require_nested :InfraManager
-      require_nested :NetworkManager
-      require_nested :PhysicalInfraManager
-      require_nested :StorageManager
-      require_nested :PersisterHelper
-
       include ::ManageIQ::Providers::Inventory::Persister::Builder::Shared
 
       # Default options for builder

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class PhysicalInfraManager < BaseManager
-    require_nested :Vm
-
     include SupportsFeatureMixin
 
     has_many :physical_chassis,  :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system

--- a/app/models/metric/ci_mixin.rb
+++ b/app/models/metric/ci_mixin.rb
@@ -1,12 +1,12 @@
 module Metric::CiMixin
   extend ActiveSupport::Concern
 
-  include_concern 'Capture'
-  include_concern 'Processing'
-  include_concern 'Rollup'
-  include_concern 'Targets'
-  include_concern 'StateFinders'
-  include_concern 'LongTermAverages'
+  include Capture
+  include Processing
+  include Rollup
+  include Targets
+  include StateFinders
+  include LongTermAverages
 
   included do
     # TODO: Move in creation of has_many relations here from various classes?

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -4,7 +4,7 @@ class MetricRollup < ApplicationRecord
   self.primary_key = "id"
 
   include Metric::Common
-  include_concern 'Metric::ChargebackHelper'
+  include Metric::ChargebackHelper
 
   CHARGEBACK_METRIC_FIELDS = %w(derived_vm_numvcpus cpu_usagemhz_rate_average
                                 cpu_usage_rate_average disk_usage_rate_average

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -1,6 +1,6 @@
 class MiqAlert < ApplicationRecord
   include UuidMixin
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   SEVERITIES = [nil, "info", "warning", "error"]
 

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -1,5 +1,5 @@
 class MiqDialog < ApplicationRecord
-  include_concern "Seeding"
+  include Seeding
 
   validates :name, :description, :presence => true
   validates :name, :unique_within_region => { :scope => :dialog_type, :match_case => false }

--- a/app/models/miq_ems_metrics_processor_worker.rb
+++ b/app/models/miq_ems_metrics_processor_worker.rb
@@ -1,8 +1,6 @@
 class MiqEmsMetricsProcessorWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.required_roles       = ["ems_metrics_processor"]
   self.default_queue_name   = "ems_metrics_processor"
 

--- a/app/models/miq_event_handler.rb
+++ b/app/models/miq_event_handler.rb
@@ -1,8 +1,6 @@
 class MiqEventHandler < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.required_roles               = ["event"]
   self.default_queue_name           = "ems"
   self.miq_messaging_subscribe_mode = "topic"

--- a/app/models/miq_generic_worker.rb
+++ b/app/models/miq_generic_worker.rb
@@ -1,8 +1,6 @@
 class MiqGenericWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.default_queue_name = "generic"
 
   def self.kill_priority

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -1,7 +1,7 @@
 # TODO: Import/Export support
 
 class MiqPolicy < ApplicationRecord
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   TOWHAT_APPLIES_TO_CLASSES = %w(ContainerGroup
                                  ContainerImage
@@ -29,7 +29,7 @@ class MiqPolicy < ApplicationRecord
 
   acts_as_miq_taggable
   acts_as_miq_set_member
-  include_concern 'ImportExport'
+  include ImportExport
 
   include UuidMixin
   include YamlImportExportMixin

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -1,6 +1,6 @@
 class MiqPolicySet < ApplicationRecord
   acts_as_miq_set
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   before_validation :default_name_to_description, :on => :create
   before_destroy    :destroy_policy_tags

--- a/app/models/miq_priority_worker.rb
+++ b/app/models/miq_priority_worker.rb
@@ -1,8 +1,6 @@
 class MiqPriorityWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.default_queue_name   = "generic"
 
   def self.queue_priority

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -6,7 +6,7 @@ class MiqProductFeature < ApplicationRecord
   ALL_TASKS_FEATURE     = "miq_task_all_ui".freeze
   TENANT_ADMIN_FEATURE  = "rbac_tenant".freeze
 
-  include_concern "Seeding"
+  include Seeding
 
   acts_as_tree
 

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -1,20 +1,20 @@
 class MiqProvision < MiqProvisionTask
   include MiqProvisionMixin
-  include_concern 'Automate'
-  include_concern 'CustomAttributes'
-  include_concern 'Description'
-  include_concern 'Genealogy'
-  include_concern 'PostInstallCallback'
-  include_concern 'Helper'
-  include_concern 'Iso'
-  include_concern 'Naming'
-  include_concern 'OptionsHelper'
-  include_concern 'Ownership'
-  include_concern 'Pxe'
-  include_concern 'Retirement'
-  include_concern 'Service'
-  include_concern 'StateMachine'
-  include_concern 'Tagging'
+  include Automate
+  include CustomAttributes
+  include Description
+  include Genealogy
+  include PostInstallCallback
+  include Helper
+  include Iso
+  include Naming
+  include OptionsHelper
+  include Ownership
+  include Pxe
+  include Retirement
+  include Service
+  include StateMachine
+  include Tagging
 
   alias_attribute :miq_provision_request, :miq_request   # Legacy provisioning support
   alias_attribute :provision_type,        :request_type  # Legacy provisioning support

--- a/app/models/miq_provision_task.rb
+++ b/app/models/miq_provision_task.rb
@@ -1,6 +1,6 @@
 class MiqProvisionTask < MiqRequestTask
   include MiqProvisionQuotaMixin
-  include_concern 'Tagging'
+  include Tagging
 
   validates_inclusion_of :state, :in => %w(pending queued active provisioned finished), :message => "should be pending, queued, active, provisioned or finished"
 

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1,5 +1,5 @@
 class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
 
   def auto_placement_enabled?
     get_value(@values[:placement_auto])

--- a/app/models/miq_queue_worker_base.rb
+++ b/app/models/miq_queue_worker_base.rb
@@ -1,6 +1,4 @@
 class MiqQueueWorkerBase < MiqWorker
-  require_nested :Runner
-
   class_attribute :miq_messaging_subscribe_mode
 
   def self.queue_priority

--- a/app/models/miq_remote_console_worker.rb
+++ b/app/models/miq_remote_console_worker.rb
@@ -1,6 +1,4 @@
 class MiqRemoteConsoleWorker < MiqWorker
-  require_nested :Runner
-
   self.required_roles = ['remote_console']
 
   RACK_APPLICATION = RemoteConsole::RackServer

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -1,14 +1,14 @@
 class MiqReport < ApplicationRecord
   include ActiveRecord::AttributeAccessorThatYamls
 
-  include_concern 'Formatting'
-  include_concern 'Formatters'
-  include_concern 'Seeding'
-  include_concern 'ImportExport'
-  include_concern 'Generator'
-  include_concern 'Notification'
-  include_concern 'Schedule'
-  include_concern 'Search'
+  include Formatting
+  include Formatters
+  include Seeding
+  include ImportExport
+  include Generator
+  include Notification
+  include Schedule
+  include Search
   include YamlImportExportMixin
 
   serialize :cols

--- a/app/models/miq_report/formatters.rb
+++ b/app/models/miq_report/formatters.rb
@@ -1,9 +1,9 @@
 module MiqReport::Formatters
   extend ActiveSupport::Concern
 
-  include_concern 'Csv'
-  include_concern 'Graph'
-  include_concern 'Html'
-  include_concern 'Text'
-  include_concern 'Timeline'
+  include Csv
+  include Graph
+  include Html
+  include Text
+  include Timeline
 end

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -1,12 +1,12 @@
 module MiqReport::Generator
   extend ActiveSupport::Concern
 
-  include_concern 'Aggregation'
-  include_concern 'Async'
-  include_concern 'Html'
-  include_concern 'Sorting'
-  include_concern 'Trend'
-  include_concern 'Utilization'
+  include Aggregation
+  include Async
+  include Html
+  include Sorting
+  include Trend
+  include Utilization
 
   DATE_TIME_BREAK_SUFFIXES = [
     [N_("Hour"),              "hour"],

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -1,6 +1,6 @@
 class MiqReportResult < ApplicationRecord
-  include_concern 'Purging'
-  include_concern 'ResultSetOperations'
+  include Purging
+  include ResultSetOperations
 
   belongs_to :miq_report
   belongs_to :miq_group

--- a/app/models/miq_reporting_worker.rb
+++ b/app/models/miq_reporting_worker.rb
@@ -1,8 +1,6 @@
 class MiqReportingWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.required_roles       = ["reporting"]
   self.default_queue_name   = "reporting"
 

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -1,7 +1,7 @@
 class MiqRequestTask < ApplicationRecord
-  include_concern 'Dumping'
-  include_concern 'PostInstallCallback'
-  include_concern 'StateMachine'
+  include Dumping
+  include PostInstallCallback
+  include StateMachine
 
   belongs_to :miq_request
   belongs_to :source,            :polymorphic => true

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 
 class MiqRequestWorkflow
   include Vmdb::Logging
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
 
   # We rely on MiqRequestWorkflow's descendants to be comprehensive
   singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -1,7 +1,7 @@
 class MiqSchedule < ApplicationRecord
   include DeprecationMixin
-  include_concern 'ImportExport'
-  include_concern 'Filters'
+  include ImportExport
+  include Filters
 
   include YamlImportExportMixin
   deprecate_attribute :towhat, :resource_type, :type => :string

--- a/app/models/miq_schedule_worker.rb
+++ b/app/models/miq_schedule_worker.rb
@@ -1,9 +1,6 @@
 class MiqScheduleWorker < MiqWorker
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Jobs
-  require_nested :Runner
-
   self.workers = 1
 
   def self.kill_priority

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -1,7 +1,7 @@
 class MiqSearch < ApplicationRecord
   serialize :options
   serialize :filter
-  include_concern 'ImportExport'
+  include ImportExport
   include YamlImportExportMixin
 
   validates :name, :uniqueness_when_changed => {:scope => "db"}

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -1,14 +1,14 @@
 require 'resolv'
 
 class MiqServer < ApplicationRecord
-  include_concern 'AtStartup'
-  include_concern 'ServerSmartProxy'
-  include_concern 'ConfigurationManagement'
-  include_concern 'EnvironmentManagement'
-  include_concern 'LogManagement'
-  include_concern 'QueueManagement'
-  include_concern 'RoleManagement'
-  include_concern 'StatusManagement'
+  include AtStartup
+  include ServerSmartProxy
+  include ConfigurationManagement
+  include EnvironmentManagement
+  include LogManagement
+  include QueueManagement
+  include RoleManagement
+  include StatusManagement
 
   require_nested :ServerMonitor
   require_nested :WorkerManagement

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -9,10 +9,6 @@ class MiqServer < ApplicationRecord
   include QueueManagement
   include RoleManagement
   include StatusManagement
-
-  require_nested :ServerMonitor
-  require_nested :WorkerManagement
-
   include UuidMixin
   acts_as_miq_taggable
   include MiqPolicyMixin

--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -5,9 +5,9 @@ class MiqServer::WorkerManagement
   require_nested :Process
   require_nested :Systemd
 
-  include_concern 'Dequeue'
-  include_concern 'Heartbeat'
-  include_concern 'Monitor'
+  include Dequeue
+  include Heartbeat
+  include Monitor
 
   attr_reader :my_server
 

--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -1,10 +1,6 @@
 class MiqServer::WorkerManagement
   include Vmdb::Logging
 
-  require_nested :Kubernetes
-  require_nested :Process
-  require_nested :Systemd
-
   include Dequeue
   include Heartbeat
   include Monitor

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -1,15 +1,15 @@
 module MiqServer::WorkerManagement::Monitor
   extend ActiveSupport::Concern
 
-  include_concern 'Kill'
-  include_concern 'Quiesce'
-  include_concern 'Reason'
-  include_concern 'Settings'
-  include_concern 'Start'
-  include_concern 'Status'
-  include_concern 'Stop'
-  include_concern 'SystemLimits'
-  include_concern 'Validation'
+  include Kill
+  include Quiesce
+  include Reason
+  include Settings
+  include Start
+  include Status
+  include Stop
+  include SystemLimits
+  include Validation
 
   def monitor_workers
     # Reload my_server so we can detect role and possibly other changes faster

--- a/app/models/miq_smart_proxy_worker.rb
+++ b/app/models/miq_smart_proxy_worker.rb
@@ -1,8 +1,6 @@
 class MiqSmartProxyWorker < MiqQueueWorkerBase
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.required_roles       = ["smartproxy"]
   self.default_queue_name   = "smartproxy"
 

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -1,5 +1,5 @@
 class MiqTask < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
 
   serialize :context_data
   STATE_INITIALIZED = N_('Initialized').freeze

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -10,7 +10,7 @@ class MiqTemplate < VmOrTemplate
   virtual_column :display_deprecated,                   :type => :string
   virtual_column :display_memory,                       :type => :integer
 
-  include_concern 'Operations'
+  include Operations
 
   def self.base_model
     MiqTemplate

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -1,6 +1,4 @@
 class MiqUiWorker < MiqWorker
-  require_nested :Runner
-
   self.required_roles = ['user_interface']
 
   STARTING_PORT = 3000

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -1,5 +1,5 @@
 class MiqUserRole < ApplicationRecord
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   DEFAULT_TENANT_ROLE_NAME = "EvmRole-tenant_administrator"
 

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -1,6 +1,4 @@
 class MiqWebServiceWorker < MiqWorker
-  require_nested :Runner
-
   self.required_roles = ['web_services']
 
   STARTING_PORT = 4000

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -2,7 +2,7 @@
 #
 
 class MiqWidget < ApplicationRecord
-  include_concern "ReadOnlyMixin"
+  include ReadOnlyMixin
 
   default_value_for :enabled, true
   default_value_for :read_only, false
@@ -29,7 +29,7 @@ class MiqWidget < ApplicationRecord
 
   scope :with_content_type, ->(type) { where(:content_type => type) }
 
-  include_concern 'ImportExport'
+  include ImportExport
   include UuidMixin
   include YamlImportExportMixin
   acts_as_miq_set_member

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -1,5 +1,5 @@
 class MiqWidgetSet < ApplicationRecord
-  include_concern 'SetData'
+  include SetData
 
   acts_as_miq_set
 

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -1,8 +1,8 @@
 require 'io/wait'
 
 class MiqWorker < ApplicationRecord
-  include_concern 'ContainerCommon'
-  include_concern 'SystemdCommon'
+  include ContainerCommon
+  include SystemdCommon
   include UuidMixin
 
   before_destroy :error_out_tasks_with_active_queue_message, :log_destroy_of_worker_messages

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
 
   belongs_to :notification_type
   belongs_to :initiator, :class_name => "User", :foreign_key => 'user_id'

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -1,8 +1,6 @@
 require 'ancestry'
 
 class OrchestrationStack < ApplicationRecord
-  require_nested :Status
-
   include NewWithTypeStiMixin
   include AsyncDeleteMixin
   include ProcessTasksMixin

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -11,8 +11,7 @@ class PhysicalServer < ApplicationRecord
   include EmsRefreshMixin
   include CustomActionsMixin
 
-
-  include_concern 'Operations'
+  include Operations
 
   VENDOR_TYPES = {
     # DB        Displayed

--- a/app/models/physical_server/operations.rb
+++ b/app/models/physical_server/operations.rb
@@ -1,10 +1,10 @@
 module PhysicalServer::Operations
   extend ActiveSupport::Concern
 
-  include_concern 'Power'
-  include_concern 'Led'
-  include_concern 'ConfigPattern'
-  include_concern 'Lifecycle'
+  include Power
+  include Led
+  include ConfigPattern
+  include Lifecycle
 
   def remote_console_acquire_resource_queue(userid)
     task_opts = {

--- a/app/models/physical_server_firmware_update_task.rb
+++ b/app/models/physical_server_firmware_update_task.rb
@@ -1,5 +1,5 @@
 class PhysicalServerFirmwareUpdateTask < MiqRequestTask
-  include_concern 'StateMachine'
+  include StateMachine
 
   validates :state, :inclusion => {
     :in      => %w[pending queued active firmware_updated finished],

--- a/app/models/physical_server_profile.rb
+++ b/app/models/physical_server_profile.rb
@@ -8,7 +8,7 @@ class PhysicalServerProfile < ApplicationRecord
   include ProviderObjectMixin
   include EmsRefreshMixin
 
-  include_concern 'Operations'
+  include Operations
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_server_profiles,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"

--- a/app/models/physical_server_profile/operations.rb
+++ b/app/models/physical_server_profile/operations.rb
@@ -1,5 +1,5 @@
 module PhysicalServerProfile::Operations
   extend ActiveSupport::Concern
 
-  include_concern 'Assignment'
+  include Assignment
 end

--- a/app/models/physical_server_provision_task.rb
+++ b/app/models/physical_server_provision_task.rb
@@ -1,5 +1,5 @@
 class PhysicalServerProvisionTask < MiqProvisionTask
-  include_concern 'StateMachine'
+  include StateMachine
 
   def description
     'Provision Physical Server'

--- a/app/models/policy_event.rb
+++ b/app/models/policy_event.rb
@@ -1,5 +1,5 @@
 class PolicyEvent < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
 
   belongs_to  :miq_event_definition
   belongs_to  :miq_policy

--- a/app/models/provider_tag_mapping.rb
+++ b/app/models/provider_tag_mapping.rb
@@ -20,8 +20,6 @@
 class ProviderTagMapping < ApplicationRecord
   belongs_to :tag
 
-  require_nested :Mapper
-
   TAG_PREFIXES = ExtManagementSystem.label_mapping_prefixes.map { |name| "/managed/#{name}:" }.freeze
   validate :validate_tag_prefix
 

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -1,5 +1,5 @@
 class ScanItem < ApplicationRecord
-  include_concern "Seeding"
+  include Seeding
 
   serialize :definition
   acts_as_miq_set_member

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -74,10 +74,10 @@ class Service < ApplicationRecord
 
   extend InterRegionApiMethodRelay
 
-  include_concern 'Aggregation'
-  include_concern 'Operations'
-  include_concern 'ResourceLinking'
-  include_concern 'RetirementManagement'
+  include Aggregation
+  include Operations
+  include ResourceLinking
+  include RetirementManagement
 
   hide_attribute "display"
 

--- a/app/models/service/dialog_properties.rb
+++ b/app/models/service/dialog_properties.rb
@@ -1,7 +1,5 @@
 class Service
   class DialogProperties
-    require_nested :Retirement
-
     def initialize(options, user)
       @options = options || {}
       @user = user

--- a/app/models/service/operations.rb
+++ b/app/models/service/operations.rb
@@ -1,5 +1,5 @@
 module Service::Operations
   extend ActiveSupport::Concern
 
-  include_concern 'Lifecycle'
+  include Lifecycle
 end

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -1,7 +1,7 @@
 class ServiceOrchestration < Service
   include ServiceOrchestrationMixin
   include ServiceOrchestrationOptionsMixin
-  include_concern 'ProvisionTagging'
+  include ProvisionTagging
 
   # read from DB or parse from dialog
   def stack_name

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -29,8 +29,8 @@ class ServiceTemplate < ApplicationRecord
   include TenancyMixin
   include ArchivedMixin
   include CiFeatureMixin
-  include_concern 'Filter'
-  include_concern 'Copy'
+  include Filter
+  include Copy
 
   validates :name, :presence => true
   belongs_to :tenant

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -1,5 +1,5 @@
 class VimPerformanceState < ApplicationRecord
-  include_concern 'Purging'
+  include Purging
 
   serialize :state_data
 

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -8,7 +8,7 @@ class Vm < VmOrTemplate
   include ExternalUrlMixin
   include AuthenticationMixin
 
-  include_concern 'Operations'
+  include Operations
 
   def self.base_model
     Vm

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -1,9 +1,9 @@
 module Vm::Operations
   extend ActiveSupport::Concern
 
-  include_concern 'Guest'
-  include_concern 'Power'
-  include_concern 'Lifecycle'
+  include Guest
+  include Power
+  include Lifecycle
 
   included do
     supports :html5_console do

--- a/app/models/vm_migrate_workflow.rb
+++ b/app/models/vm_migrate_workflow.rb
@@ -1,5 +1,5 @@
 class VmMigrateWorkflow < MiqRequestWorkflow
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
 
   def self.base_model
     VmMigrateWorkflow

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -13,11 +13,11 @@ class VmOrTemplate < ApplicationRecord
   self.table_name = 'vms'
   has_ancestry
 
-  include_concern 'Operations'
-  include_concern 'RetirementManagement'
-  include_concern 'RightSizing'
-  include_concern 'Scanning'
-  include_concern 'Snapshotting'
+  include Operations
+  include RetirementManagement
+  include RightSizing
+  include Scanning
+  include Snapshotting
 
   attr_accessor :surrogate_host
   @surrogate_host = nil

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -1,10 +1,10 @@
 module VmOrTemplate::Operations
   extend ActiveSupport::Concern
 
-  include_concern 'Configuration'
-  include_concern 'Power'
-  include_concern 'Relocation'
-  include_concern 'Snapshot'
+  include Configuration
+  include Power
+  include Relocation
+  include Snapshot
 
   alias_method :ruby_clone, :clone
 

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -1,6 +1,4 @@
 class VmScan < Job
-  require_nested :Dispatcher
-
   #
   # TODO: until we get location/offset read capability for OpenStack
   # image data, OpenStack fleecing is prone to timeout (based on image size).

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -3,7 +3,7 @@ autoload(:KubeException, 'kubeclient')
 
 class ContainerOrchestrator
   include Vmdb::Logging
-  include_concern 'ObjectDefinition'
+  include ObjectDefinition
 
   TOKEN_FILE   = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
   CA_CERT_FILE = "/run/secrets/kubernetes.io/serviceaccount/ca.crt".freeze

--- a/lib/extensions/as_include_concern.rb
+++ b/lib/extensions/as_include_concern.rb
@@ -56,6 +56,7 @@ module ActiveSupport
         end
         include to_include.constantize
       end
+      Vmdb::Deprecation.deprecate_methods(self, :include_concern)
     end
   end
 end

--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -37,6 +37,7 @@ module RequireNested
       Object.require_nested name
     end
   end
+  Vmdb::Deprecation.deprecate_methods(self, :require_nested)
 end
 
 Module.include RequireNested

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%.rb
@@ -1,10 +1,4 @@
 class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_type %>
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Vm
-
   # Form schema for creating/editing a provider, it should follow the DDF specification
   # For more information check the DDF documentation at: https://data-driven-forms.org
   #

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/event_catcher.rb
@@ -1,3 +1,2 @@
 class <%= class_name %>::<%= manager_type %>::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_collector_worker.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class <%= class_name %>::<%= manager_type %>::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "<%= provider_name %>"
 
   def friendly_name

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresh_worker.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%/refresh_worker.rb
@@ -1,3 +1,2 @@
 class <%= class_name %>::<%= manager_type %>::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory.rb
@@ -1,5 +1,2 @@
 class <%= class_name %>::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/collector.rb
@@ -1,6 +1,4 @@
 class <%= class_name %>::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :<%= manager_type %>
-
   def connection
     @connection ||= manager.connect
   end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/parser.rb
@@ -1,6 +1,4 @@
 class <%= class_name %>::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :<%= manager_type %>
-
   def parse
     vms
   end

--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/inventory/persister.rb
@@ -1,6 +1,4 @@
 class <%= class_name %>::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :<%= manager_type %>
-
   def initialize_inventory_collections
     add_cloud_collection(:vms)
   end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -5,7 +5,6 @@ class MiqExpression
   MODE_SQL  = 2
   MODE_BOTH = MODE_RUBY | MODE_SQL
 
-  require_nested :Tag
   include Vmdb::Logging
   attr_accessor :exp, :context_type, :preprocess_options
 


### PR DESCRIPTION
Constants referenced within a namespace are already handled by zeitwerk, with the first lookup occurring relative to the current namespace.  This is what both of these methods did.

From: https://guides.rubyonrails.org/classic_to_zeitwerk_howto.html#delete-require-dependency-calls
"All known use cases of require_dependency have been eliminated with Zeitwerk. You should grep the project and delete them."

Prerequisites have already been merged for a while:

We've been running with zeitwerk by default since https://github.com/ManageIQ/manageiq/pull/22488, so that's the dependency.

We dropped support for the classic autoloader, removing the need for these methods, via https://github.com/ManageIQ/manageiq/pull/22801

Regarding `require_nested`, the only change in behavior is where we previously eagerly required the file, but this is only where `cache_classes` is false, which is dev mode.  

```
config/environments/development.rb:  config.cache_classes = false
config/environments/i18n.rb:  config.cache_classes = false
config/environments/production.rb:  config.cache_classes = true
config/environments/test.rb:  config.cache_classes = true
```

Test and production mode used [autoload before](https://github.com/ManageIQ/manageiq/blob/f479740793cdd30108c84943564c9a1a4f710d03/lib/extensions/require_nested.rb#L8-L10) and continue to use `autoload` but with zeitwerk.  

EDIT: Added prerequisites
EDIT2: Added explanation for require_nested