### PR TITLE
Don't reject AdvancedSetting#destroy if read-only

### DIFF
--- a/app/models/advanced_setting.rb
+++ b/app/models/advanced_setting.rb
@@ -1,6 +1,4 @@
 class AdvancedSetting < ApplicationRecord
-  include ReadOnlyMixin
-
   belongs_to :resource, :polymorphic => true
 
   def self.add_elements(parent, xml_node)


### PR DESCRIPTION
Read-only advanced_settings are created during refresh and prevent vms from being destroyed

For example Google uses advanced settings to store the "preemptible" property:
```
(byebug) ems.vms.first
#<ManageIQ::Providers::Google::CloudManager::Vm id: 26000000000517, vendor: "google", format: nil, version: nil, name: "instance-group-1-gvej", description: nil, location: "unknown", config_xml: nil, autostart: nil, host_id: nil, last_sync_on: nil, created_on: "2024-01-26 16:04:34.783414000 +0000", updated_on: "2024-01-26 16:04:35.009943000 +0000", storage_id: nil, guid: "1975b987-4001-4857-b70b-6306d798c2c5", ems_id: 26000000000096, last_scan_on: nil, last_scan_attempt_on: nil, uid_ems: "9028819323520596299", retires_on: nil, retired: nil, boot_time: nil, tools_status: nil, standby_action: nil, power_state: "on", state_changed_on: "2024-01-26 16:04:34.780444000 +0000", previous_state: nil, connection_state: "connected", last_perf_capture_on: nil, registered: nil, busy: nil, smart: nil, memory_reserve: nil, memory_reserve_expand: nil, memory_limit: nil, memory_shares: nil, memory_shares_level: nil, cpu_reserve: nil, cpu_reserve_expand: nil, cpu_limit: nil, cpu_shares: nil, cpu_shares_level: nil, cpu_affinity: nil, ems_created_on: nil, template: false, evm_owner_id: nil, miq_group_id: 26000000000033, linked_clone: nil, fault_tolerance: nil, type: "ManageIQ::Providers::Google::CloudManager::Vm", ems_ref: "9028819323520596299", ems_cluster_id: nil, retirement_warn: nil, retirement_last_warn: nil, vnc_port: nil, flavor_id: 26000000000109, availability_zone_id: 26000000000150, cloud: true, retirement_state: nil, cloud_network_id: nil, cloud_subnet_id: nil, cloud_tenant_id: nil, raw_power_state: "RUNNING", publicly_available: nil, orchestration_stack_id: nil, retirement_requester: nil, tenant_id: 26000000000031, resource_group_id: nil, deprecated: nil, storage_profile_id: nil, cpu_hot_add_enabled: nil, cpu_hot_remove_enabled: nil, memory_hot_add_enabled: nil, memory_hot_add_limit: nil, memory_hot_add_increment: nil, hostname: nil, ems_ref_type: nil, restart_needed: nil, ancestry: "26000000000469", placement_group_id: nil>
(byebug) ems.vms.first.advanced_settings
#<ActiveRecord::Associations::CollectionProxy [#<AdvancedSetting id: 26000000000046, name: "preemptible?", display_name: "Is VM Preemptible", description: "Whether or not the VM is 'preemptible'. See https:...", value: "false", default_value: nil, min: nil, max: nil, read_only: true, resource_type: "VmOrTemplate", resource_id: 26000000000517, created_on: "2024-01-26 16:04:34.998356000 +0000", updated_on: "2024-01-26 16:04:34.998356000 +0000">]>
(byebug) ems.vms.first.destroy!
*** ActiveRecord::RecordNotDestroyed Exception: Failed to destroy the record

nil
```

This appears to have been introduced by https://github.com/ManageIQ/manageiq/pull/22232