### PR TITLE
Psych 4 won't allow unpermitted classes by default

### DIFF
--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -108,7 +108,7 @@ class BinaryBlob < ApplicationRecord
   end
 
   def data
-    serializer.load(binary)
+    serializer.respond_to?(:unsafe_load) ? serializer.unsafe_load(binary) : serializer.load(binary)
   end
 
   def store_data(data_type, the_data)

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -257,9 +257,8 @@ class MiqTask < ApplicationRecord
     return miq_report_result.report_results unless miq_report_result.nil?
     unless binary_blob.nil?
       serializer_name = binary_blob.data_type
-      serializer_name = "Marshal" unless serializer_name == "YAML" # YAML or Marshal, for now
       serializer = serializer_name.constantize
-      result = serializer.load(binary_blob.binary)
+      result = serializer.respond_to?(:unsafe_load) ? serializer.unsafe_load(binary_blob.binary) : serializer.load(binary_blob.binary)
       return result.kind_of?(String) ? result.force_encoding("UTF-8") : result
     end
     nil

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -85,6 +85,15 @@ RSpec.describe BinaryBlob do
       expect(bb.data).to eq(data)
     end
 
+    it "can store and load data as YAML with unpermitted classes" do
+      bb = FactoryBot.build(:binary_blob)
+      data = {:a => User}
+
+      bb.store_data("YAML", data)
+
+      expect(bb.data).to eq(data)
+    end
+
     it "can store and load Marshaled data" do
       bb = FactoryBot.build(:binary_blob)
       data = "foo"

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -134,6 +134,13 @@ RSpec.describe MiqTask do
       expect(miq_task.task_results).to eq(results)
     end
 
+    it "should get/set task_results with not normally permitted classes properly" do
+      results = {:a => 1, :b => User}
+      miq_task.task_results = results
+      miq_task.save
+      expect(miq_task.task_results).to eq(results)
+    end
+
     it "should queue callback properly" do
       state   = MiqTask::STATE_QUEUED
       message = 'Message for testing: queue_callback'


### PR DESCRIPTION
Use unsafe_load to load unpersisted objects for psych versions supporting unsafe_load.

Note, we haven't used Marshal binary blob serializer since before open sourcing. It should be safe to assume we're using YAML.

cc @DavidResende0 