### PR TITLE
BinaryBlob was changed in #22861 do this check, so use it

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -255,10 +255,8 @@ class MiqTask < ApplicationRecord
     # support legacy task that saved results in the results column
     return Marshal.load(Base64.decode64(results.split("\n").join)) unless results.nil?
     return miq_report_result.report_results unless miq_report_result.nil?
-    unless binary_blob.nil?
-      serializer_name = binary_blob.data_type
-      serializer = serializer_name.constantize
-      result = serializer.respond_to?(:unsafe_load) ? serializer.unsafe_load(binary_blob.binary) : serializer.load(binary_blob.binary)
+    if binary_blob
+      result = binary_blob.data
       return result.kind_of?(String) ? result.force_encoding("UTF-8") : result
     end
     nil


### PR DESCRIPTION
BinaryBlob already handles the serializer type and had this unsafe_load check added so we can greatly simplify this by letting BinaryBlob do this work this.

Follow up from @Fryguy's comment here: https://github.com/ManageIQ/manageiq/pull/22861/files#r1472038438