### PR TITLE
Fix dashboard missing chart

### DIFF
--- a/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
+++ b/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
@@ -27,7 +27,7 @@ graph:
   :type: Column
   :count: 10
   :other: true
-dims: 1
+dims: 2
 filename:
 file_mtime:
 categories: []


### PR DESCRIPTION
Fixes a bug where the number of nodes per CPU cores chart won't render despite data being contained in the report.

Before:
<img width="707" alt="Screenshot 2024-02-01 at 12 41 06 PM" src="https://github.com/ManageIQ/manageiq/assets/32444791/1317a873-e031-4e85-93a2-fec1d26adf5b">

After:
<img width="714" alt="Screenshot 2024-02-01 at 12 35 26 PM" src="https://github.com/ManageIQ/manageiq/assets/32444791/3f41d59d-ae38-4fcc-aeb3-fb47fc608349">
