### PR TITLE
Refactor inventory syndication to persister

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -98,7 +98,6 @@ module ManageIQ
           inventory = nil # clear to help GC
 
           Benchmark.realtime_block(:save_inventory) { save_inventory(ems, target, parsed) }
-          Benchmark.realtime_block(:publish_inventory) { publish_inventory(ems, target, parsed) }
 
           _log.info "#{log_header} Refreshing target #{target.class} [#{target.name}] id [#{target.id}]...Complete"
         end
@@ -140,42 +139,8 @@ module ManageIQ
       # @param ems [ManageIQ::Providers::BaseManager]
       # @param target [ManageIQ::Providers::BaseManager or InventoryRefresh::Target or InventoryRefresh::TargetCollection]
       # @param parsed [Array<Hash> or ManageIQ::Providers::Inventory::Persister]
-      def save_inventory(ems, _target, persister)
-        InventoryRefresh::SaveInventory.save_inventory(ems, persister.inventory_collections)
-      end
-
-      def publish_inventory(ems, target, persister)
-        return unless publish_inventory?
-
-        ems_identifier = "#{ems.emstype}__#{ems.id}"
-
-        messaging_client = MiqQueue.messaging_client(ems_identifier)
-        return if messaging_client.nil?
-
-        persister.collections.each_value do |collection|
-          inventory_objects = collection.to_hash[:data].to_a
-
-          payloads = inventory_objects.map do |inventory_object_hash|
-            reference         = inventory_object_hash.values_at(*collection.manager_ref).join("__")
-            target_identifier = "#{ems_identifier}__#{collection.name}__#{reference}"
-
-            {
-              :service => "manageiq.ems-inventory",
-              :sender  => ems_identifier,
-              :event   => target_identifier,
-              :payload => {
-                :ems_id         => ems.id,
-                :ems_identifier => ems_identifier,
-                :collection     => collection.name,
-                :data           => inventory_object_hash
-              }
-            }
-          end
-
-          messaging_client.publish_topic(payloads) if payloads.present?
-        end
-      rescue => err
-        _log.warn("Failed to publish inventory for target #{target.class} [#{target.name}] id [#{target.id}]: #{err}")
+      def save_inventory(_ems, _target, persister)
+        persister.persist!
       end
 
       def post_refresh_ems_cleanup(_ems, _targets)
@@ -207,10 +172,6 @@ module ManageIQ
       def inventory_class_for(klass)
         provider_module = ManageIQ::Providers::Inflector.provider_module(klass)
         "#{provider_module}::Inventory".constantize
-      end
-
-      def publish_inventory?
-        options[:syndicate_inventory] && MiqQueue.messaging_type != "miq_queue"
       end
 
       def group_targets_by_ems(targets)

--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::Inventory::Persister
   attr_reader :manager, :target, :collections, :tag_mapper
 
   include ::ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
+  include Vmdb::Logging
 
   # @param manager [ManageIQ::Providers::BaseManager] A manager object
   # @param target [Object] A refresh Target object
@@ -21,6 +22,7 @@ class ManageIQ::Providers::Inventory::Persister
   # Persists InventoryCollection objects into the DB
   def persist!
     InventoryRefresh::SaveInventory.save_inventory(manager, inventory_collections)
+    publish_inventory(manager, target)
   end
 
   # Returns Persister object loaded from a passed JSON
@@ -117,6 +119,46 @@ class ManageIQ::Providers::Inventory::Persister
 
   def self.provider_module
     ManageIQ::Providers::Inflector.provider_module(self).name
+  end
+
+  def publish_inventory(ems, target)
+    return unless publish_inventory?
+
+    ems_identifier = "#{ems.emstype}__#{ems.id}"
+
+    messaging_client = MiqQueue.messaging_client(ems_identifier)
+    return if messaging_client.nil?
+
+    collections.each_value do |collection|
+      inventory_objects = collection.to_hash[:data].to_a
+
+      payloads = inventory_objects.map do |inventory_object_hash|
+        reference         = inventory_object_hash.values_at(*collection.manager_ref).join("__")
+        target_identifier = "#{ems_identifier}__#{collection.name}__#{reference}"
+
+        {
+          :service => "manageiq.ems-inventory",
+          :sender  => ems_identifier,
+          :event   => target_identifier,
+          :payload => {
+            :ems_id         => ems.id,
+            :ems_identifier => ems_identifier,
+            :collection     => collection.name,
+            :data           => inventory_object_hash
+          }
+        }
+      end
+
+      messaging_client.publish_topic(payloads) if payloads.present?
+    end
+  rescue => err
+    _log.warn("Failed to publish inventory for target #{target.class} [#{target.name}] id [#{target.id}]: #{err}")
+  end
+
+  private
+
+  def publish_inventory?
+    Settings.ems_refresh.syndicate_inventory && MiqQueue.messaging_type != "miq_queue"
   end
 
   protected

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
       it "doesn't publish anything" do
         expect(messaging_client).not_to receive(:publish_topic)
 
-        refresher = described_class.new([ems])
-        refresher.publish_inventory(ems, ems, persister)
+        persister.publish_inventory(ems, ems)
       end
     end
 
@@ -129,8 +128,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
           )
         )
 
-        refresher = described_class.new([ems])
-        refresher.publish_inventory(ems, ems, persister)
+        persister.publish_inventory(ems, ems)
       end
     end
 
@@ -177,8 +175,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
           )
         )
 
-        refresher = described_class.new([ems])
-        refresher.publish_inventory(ems, ems, persister)
+        persister.publish_inventory(ems, ems)
       end
     end
   end


### PR DESCRIPTION
- Currently streaming refresh providers (vmware infra, kubernetes) are unable to syndicate inventory because they do not go through the base manager (where inventory syndication is handled)
- Therefore move inventory syndication to a common location hit by all providers i.e. the persister

@miq-bot add_labels bug, refactoring, providers/inventory, quinteros/yes?
@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 