### PR TITLE
Fix DRB dequeue_method spec

### DIFF
--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe EmsEvent do
         before do
           stub_settings_merge(
             :messaging => {:type => 'artemis'},
-            :workers   => {:worker_base => {:queue_worker_base => {:defaults => {:dequeue_method => "drb"}}}}
+            :workers   => {:worker_base => {:queue_worker_base => {:event_handler => {:dequeue_method => "drb"}}}}
           )
         end
 
@@ -197,7 +197,7 @@ RSpec.describe EmsEvent do
         before do
           stub_settings_merge(
             :messaging => {:type => 'kafka'},
-            :workers   => {:worker_base => {:queue_worker_base => {:defaults => {:dequeue_method => "drb"}}}}
+            :workers   => {:worker_base => {:queue_worker_base => {:event_handler => {:dequeue_method => "drb"}}}}
           )
         end
 


### PR DESCRIPTION
Since event handler dequeue method is no longer inherited from defaults https://github.com/ManageIQ/manageiq/blob/master/config/settings.yml#L1112, this check's behaviour was changed https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_event.rb#L107 and so the specs needed to be updated

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @jrafanie 
@miq-bot add_label bug, test