### PR TITLE
Psych 3.1 is required since we assert safe_load accepts kwargs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem "net-ldap",                         "~>0.16.1",          :require => false
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
+gem "psych",                            ">=3.1",             :require => false # 3.1 safe_load changed positional to kwargs like aliases: true: https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd
 gem "pg",                               ">=1.4.1",           :require => false
 gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "query_relation",                   "~>0.1.0",           :require => false

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -16,7 +16,5 @@ module YamlLoadAliases
   end
 end
 
-if Psych::VERSION >= "3.1"
-  require 'yaml'
-  YAML.singleton_class.prepend(YamlLoadAliases)
-end
+require 'yaml'
+YAML.singleton_class.prepend(YamlLoadAliases)


### PR DESCRIPTION
Followup to discussion in https://github.com/ManageIQ/manageiq-appliance_console/pull/234

3.1 safe_load changed positional to kwargs like aliases: true: https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd

Note, there are other changes to psych over time that ease the changes to the psych 4 defaults to safe_load but this is the absolute minimum we need.

safe_load_file was added in 3.2.1:
https://github.com/ruby/psych/commit/0210e310d04cbc9b236ccdde6caaf79aab4eb794

unsafe_load and unsafe_load_file was added in 3.3.2: https://github.com/ruby/psych/commit/cb50aa8d3fb8be01897becff77b4922b12a0ab4c

safe_load was added with positional arguments in 2.0.0: https://github.com/ruby/psych/commit/2c644e184192975b261a81f486a04defa3172b3f