### PR TITLE
Rails 7 removed clear_association_cache

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -1010,10 +1010,5 @@ class ExtManagementSystem < ApplicationRecord
     update_authentication(creds, options)
   end
 
-  def clear_association_cache
-    @storages = nil
-    super
-  end
-
   define_method(:allow_duplicate_endpoint_url?) { false }
 end

--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -34,7 +34,6 @@ class PxeServer < ApplicationRecord
 
   def default_pxe_image_for_windows=(image)
     image.update(:default_for_windows => true)
-    clear_association_cache
   end
 
   def default_pxe_image_for_windows
@@ -44,7 +43,13 @@ class PxeServer < ApplicationRecord
   def synchronize_advertised_images
     pxe_menus.each(&:synchronize)
     sync_windows_images
-    clear_association_cache
+
+    advertised_pxe_images.reload
+    discovered_pxe_images.reload
+    pxe_images.reload
+    pxe_menus.reload
+    windows_images.reload
+
     update_attribute(:last_refresh_on, Time.now.utc)
   end
 
@@ -59,7 +64,8 @@ class PxeServer < ApplicationRecord
   def sync_images
     sync_pxe_images
     sync_windows_images
-    clear_association_cache
+    pxe_images.reload
+    windows_images.reload
     update_attribute(:last_refresh_on, Time.now.utc)
   end
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -154,8 +154,8 @@ class Tenant < ApplicationRecord
       end
       # Delete any quotas that were not passed in
       tenant_quotas.destroy_missing(updated_keys)
-      # unfortunatly, an extra scope is created in destroy_missing, so we need to reload the records
-      clear_association_cache
+      # unfortunately, an extra scope is created in destroy_missing, so we need to reload the records
+      tenant_quotas.reload
     end
 
     get_quotas

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -165,6 +165,30 @@ PXE
         end
       end
     end
+
+    context "#default_pxe_image_for_windows / #default_pxe_image_for_windows=" do
+      before { @pxe_server.sync_images }
+
+      it "when there is no default" do
+        expect(@pxe_server.default_pxe_image_for_windows).to be_nil
+      end
+
+      it "when setting the default" do
+        i = @pxe_server.pxe_images.detect { |pxe_image| pxe_image.name == "ubuntu-10.10-desktop-amd64" }
+        @pxe_server.default_pxe_image_for_windows = i
+
+        expect(@pxe_server.default_pxe_image_for_windows).to eq(i)
+      end
+
+      it "when setting the default with an image not from the collection directly" do
+        i = PxeImage.find_by(:name => "ubuntu-10.10-desktop-amd64")
+
+        @pxe_server.pxe_images.to_a # Preload the collection to ensure it's a different in-memory instance
+        @pxe_server.default_pxe_image_for_windows = i
+
+        expect(@pxe_server.default_pxe_image_for_windows).to eq(i)
+      end
+    end
   end
 
   context "ipxe depot" do

--- a/tools/fix_binary_blobs_and_parts_size_column.rb
+++ b/tools/fix_binary_blobs_and_parts_size_column.rb
@@ -26,5 +26,5 @@ BinaryBlob.where(:id => blob_ids).find_each do |bb|
   end
 
   # clear the binary_blob_parts from memory
-  bb.send(:clear_association_cache)
+  bb.reload
 end


### PR DESCRIPTION
In the event the association's objects are being changed outside
the in memory objects, we can do targetted reloads of the associations
to get similar results. Reloading the main object will blow up if the
object is not yet persisted and also discards any changes on that object.

In the case of ExtManagementSystem#clear_association_cache,
this was added when storages method wasn't a real association
so we manually built the ivar storages from the current hosts
so we needed to wrap the superclass clear_association_cache with
a clearing of our storages cache so it can be built clean.

With storages being an actual association on Ems, this is no longer
needed.

```
See:
commit dd5886d00a2d5f31ccf504c391aad93deb014eb8
Author: Ryuta Kamizono <kamipo@gmail.com>
Date:   Mon May 3 12:13:19 2021 +0900

    Remove unused `clear_association_cache`

    It is no longer used since #41112.
```