### PR TITLE
Passing legacy binds was deprecated in 6.1 and removed in 7.

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -31,10 +31,15 @@ module ArPglogicalMigrationHelper
       end
 
       to_add.each do |v|
-        ActiveRecord::Base.connection.exec_insert("INSERT INTO schema_migrations_ran (version, created_at) VALUES ($1, $2)", "SQL", [[nil, v], [nil, Time.now.utc.iso8601(6)]])
+        binds = [
+          ActiveRecord::Relation::QueryAttribute.new("version", v, ActiveModel::Type::String.new),
+          ActiveRecord::Relation::QueryAttribute.new("created_at", Time.now.utc.iso8601(6), ActiveModel::Type::Value.new)
+        ]
+        ActiveRecord::Base.connection.exec_insert("INSERT INTO schema_migrations_ran (version, created_at) VALUES ($1, $2)", "SQL", binds, nil, nil)
       end
     else
-      ActiveRecord::Base.connection.exec_delete("DELETE FROM schema_migrations_ran WHERE version = $1", "SQL", [[nil, version]])
+      binds = [ActiveRecord::Relation::QueryAttribute.new("version", version, ActiveModel::Type::String.new)]
+      ActiveRecord::Base.connection.exec_delete("DELETE FROM schema_migrations_ran WHERE version = $1", "SQL", binds)
     end
   end
 


### PR DESCRIPTION
See: https://github.com/rails/rails/commit/92360e9ea3674c153adf2fa4c2cdcb6d9afd730b

Extracted from https://github.com/ManageIQ/manageiq/pull/22873

Note, this failed with rails 7 when running `RAILS_ENV=test bundle exec rails db:environment:set evm:db:reset`.  This is backward compatible with rails 6.1.
