### PR TITLE
Provide backward compatible way to globally set permitted classes

### DIFF
--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -30,7 +30,11 @@ class YamlPermittedClasses
 
   def self.initialize_app_yaml_permitted_classes
     @initialize_app_yaml_permitted_classes ||= begin
-      ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes
+      if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
+        ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes
+      else
+        ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes
+      end
       true
     end
   end


### PR DESCRIPTION
This was changed in rails 7 in the following commit:

https://github.com/rails/rails/commit/9529dc844e001c03931e3579a03b89713d9c236f

Note, there are ways to do per model permitted classes in rails 7.1, see: https://github.com/rails/rails/commit/4a075537dc0592753718b0f2d264ba56297ee4d3

Extracted from https://github.com/ManageIQ/manageiq/pull/22873