### PR TITLE
[QUINTEROS] Bump appliance_console to 8.1 in Gemfile.lock.release

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -754,7 +754,7 @@ GEM
     hashdiff (1.1.0)
     hashie (5.0.0)
     high_voltage (3.0.0)
-    highline (1.6.21)
+    highline (2.1.0)
     http (5.1.1)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -869,13 +869,13 @@ GEM
       json (~> 2.3)
       more_core_extensions
       query_relation
-    manageiq-appliance_console (8.0.0)
-      activerecord (~> 6.1.6, >= 6.1.6.1)
-      activesupport (~> 6.1.6, >= 6.1.6.1)
-      awesome_spawn (~> 1.4)
+    manageiq-appliance_console (8.1.0)
+      activerecord (>= 6.1.7.6)
+      activesupport (>= 6.1.7.6)
+      awesome_spawn (~> 1.6)
       bcrypt (~> 3.1.10)
       bcrypt_pbkdf (>= 1.0, < 2.0)
-      highline (~> 1.6.21)
+      highline (~> 2.1)
       i18n (>= 0.8)
       linux_admin (~> 2.0)
       manageiq-password (< 2)
@@ -1366,7 +1366,7 @@ DEPENDENCIES
   listen (~> 3.2)
   manageiq-api!
   manageiq-api-client (~> 0.3.6)
-  manageiq-appliance_console (~> 8.0)
+  manageiq-appliance_console (~> 8.1)
   manageiq-automation_engine!
   manageiq-consumption!
   manageiq-content!


### PR DESCRIPTION
After backport of #22889 

@jrafanie or @agrare Please review.