### PR TITLE
Vm.supports returns strings

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -143,9 +143,9 @@ module VmOrTemplate::Operations
 
     supports :vm_control_powered_on do
       if !supports?(:control)
-        unsupported_reason_add(:vm_control_powered_on, unsupported_reason(:control))
+        unsupported_reason(:control)
       elsif current_state != "on"
-        unsupported_reason_add(:vm_control_powered_on, "The VM is not powered on")
+        "The VM is not powered on"
       end
     end
   end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -295,4 +295,29 @@ RSpec.describe Vm do
       expect(vm.supported_consoles.keys).to match_array([:html5, :vmrc, :native])
     end
   end
+
+  context "#supports?(:vm_control_powered_on)" do
+    it "returns true for powered on vms with control" do
+      # need a vendor to properly specify the running state
+      vm = FactoryBot.create(:vm_vmware,
+                             :host                  => FactoryBot.create(:host),
+                             :ext_management_system => FactoryBot.create(:ext_management_system))
+      expect(vm.unsupported_reason(:control)).to eq(nil)
+      expect(vm.unsupported_reason(:vm_control_powered_on)).to eq(nil)
+    end
+
+    it "returns the control reason if vm is not properly controlled" do
+      vm = FactoryBot.create(:vm_vmware)
+      expect(vm.unsupported_reason(:control)).to match(/not connected to a Host/i)
+      expect(vm.unsupported_reason(:vm_control_powered_on)).to match(/not connected to a Host/i)
+    end
+
+    it "returns false for powered off vms with control" do
+      vm = FactoryBot.create(:vm_vmware,
+                             :raw_power_state       => "unknown",
+                             :host                  => FactoryBot.create(:host),
+                             :ext_management_system => FactoryBot.create(:ext_management_system))
+      expect(vm.unsupported_reason(:vm_control_powered_on)).to match(/not powered on/i)
+    end
+  end
 end


### PR DESCRIPTION
the unsupported_reason_add interface is being phased out.
Returning a string will do the same thing

Currently, this is the last reference to `unsupported_reason_add` in core