### PR TITLE
Update authentications supports to reflect update and delete

### DIFF
--- a/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager::Authentication < ManageIQ:
   after_create :set_manager_ref
 
   supports :create
+  supports :update
+  supports :delete
 
   COMMON_ATTRIBUTES = {}.freeze
   EXTRA_ATTRIBUTES = {}.freeze

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -2,6 +2,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
   include ManageIQ::Providers::EmbeddedAutomationManager::CrudCommon
 
   supports :create
+  supports :update
+  supports :delete
 
   virtual_attribute :verify_ssl, :integer
 


### PR DESCRIPTION
Fixes
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1220

Before
======

The api checked `respond_to? :{create, update, delete}_in_provider_queue` to determine support for those methods.

`CrudCommon` defines all 3 of these methods, so any class that `includes CrudCommon` supports all. All children do as well.

After
=====

Using `support` to reflect what actions are supported.

Notes
===

- [ ] We could add these supports via an `included do` block an `included do`, but just adding where this was included seemed more explicit.
- [ ] We want these supports in `EmbeddedAutomationManager/Authentication`, but not sure if we want it in `ConfigurationScriptSource`
- [ ] Alternatively, we can add the `supports` to each of the leaf nodes. (all child of `EmbeddedAutomationManager/Authentication`). Defining in the leaf nodes tends to work better.
