### PR TITLE
Add rdoc for rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -283,7 +283,9 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
+  gem "irb",                            "=1.4.1",            :require => false # Locked to same version as the installed RPM rubygem-irb-1.4.1-142.module_el9+787+b20bfeee.noarch so that we don't bundle our own
   gem "manageiq-appliance_console",     "~>8.1",             :require => false
+  gem "rdoc",                                                :require => false # Needed for rails console
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues


### PR DESCRIPTION
Also include irb so that it is in the bundle

Without rdoc, we get the following error:
```
[root@localhost vmdb]# rails c
/opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require': cannot load such file -- rdoc (LoadError)
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require'
	from /usr/share/gems/gems/irb-1.4.1/lib/irb/input-method.rb:17:in `<main>'
	from /usr/share/gems/gems/irb-1.4.1/lib/irb/context.rb:14:in `require_relative'
	from /usr/share/gems/gems/irb-1.4.1/lib/irb/context.rb:14:in `<main>'
	from /usr/share/ruby/irb.rb:16:in `require_relative'
	from /usr/share/ruby/irb.rb:16:in `<main>'
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/commands/console/console_command.rb:3:in `<main>'
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command/behavior.rb:44:in `block (2 levels) in lookup'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command/behavior.rb:40:in `each'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command/behavior.rb:40:in `block in lookup'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command/behavior.rb:39:in `each'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command/behavior.rb:39:in `lookup'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command.rb:74:in `find_by_namespace'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/command.rb:46:in `invoke'
	from /opt/manageiq/manageiq-gemset/gems/railties-6.1.7.6/lib/rails/commands.rb:18:in `<main>'
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /opt/manageiq/manageiq-gemset/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
```