### PR TITLE
Replace "some" default_value_for usage

### DIFF
--- a/app/models/assigned_server_role.rb
+++ b/app/models/assigned_server_role.rb
@@ -2,7 +2,7 @@ class AssignedServerRole < ApplicationRecord
   belongs_to :miq_server
   belongs_to :server_role
 
-  default_value_for :active, false
+  attribute :active, :default => false
 
   delegate :master_supported?, :name, :to => :server_role
 

--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -2,7 +2,7 @@ class BlacklistedEvent < ApplicationRecord
   belongs_to        :ext_management_system, :foreign_key => "ems_id"
 
   attribute :enabled, :default => true
-  after_validation  :log_enabling, :if => :enabled_changed?
+  after_validation  :log_enabling, :if => :enabled_changed?, :unless => :new_record?
   after_create      :audit_creation
   after_destroy     :reload_all_server_settings, :audit_deletion
   after_save        :reload_all_server_settings

--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -1,7 +1,7 @@
 class BlacklistedEvent < ApplicationRecord
   belongs_to        :ext_management_system, :foreign_key => "ems_id"
 
-  default_value_for :enabled, true
+  attribute :enabled, :default => true
   after_save        :reload_all_server_settings
   after_destroy     :reload_all_server_settings, :audit_deletion
   after_create      :audit_creation

--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -2,9 +2,10 @@ class BlacklistedEvent < ApplicationRecord
   belongs_to        :ext_management_system, :foreign_key => "ems_id"
 
   attribute :enabled, :default => true
-  after_save        :reload_all_server_settings
-  after_destroy     :reload_all_server_settings, :audit_deletion
+  after_validation  :log_enabling, :if => :enabled_changed?
   after_create      :audit_creation
+  after_destroy     :reload_all_server_settings, :audit_deletion
+  after_save        :reload_all_server_settings
 
   def audit_deletion
     $audit_log.info("Blacklisted event [#{event_name}] for provider [#{provider_model}] with ID [#{ems_id}] has been deleted by user [#{self.class.current_userid}]")
@@ -14,11 +15,8 @@ class BlacklistedEvent < ApplicationRecord
     $audit_log.info("Creating blacklisted event [#{event_name}] for provider [#{provider_model}] with ID [#{ems_id}] by user [#{self.class.current_userid}]")
   end
 
-  def enabled=(value)
-    return if enabled == value
-
-    super
-    $audit_log.info("Blacklisted event [#{event_name}] for provider [#{provider_model}] with ID [#{ems_id}] had enabled changed to #{value} by user [#{self.class.current_userid}]")
+  def log_enabling
+    $audit_log.info("Blacklisted event [#{event_name}] for provider [#{provider_model}] with ID [#{ems_id}] had enabled changed to #{enabled} by user [#{self.class.current_userid}]")
   end
 
   def self.seed

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -35,10 +35,10 @@ class Classification < ApplicationRecord
 
   DEFAULT_NAMESPACE = "/managed".freeze
 
-  default_value_for :read_only,    false
-  default_value_for :syntax,       "string"
-  default_value_for :single_value, false
-  default_value_for :show,         true
+  attribute :read_only,    :default => false
+  attribute :syntax,       :default => "string"
+  attribute :single_value, :default => false
+  attribute :show,         :default => true
 
   FIXTURE_FILE = FIXTURE_DIR.join("classifications.yml")
 

--- a/app/models/cloud_database_flavor.rb
+++ b/app/models/cloud_database_flavor.rb
@@ -8,7 +8,7 @@ class CloudDatabaseFlavor < ApplicationRecord
 
   virtual_total :total_cloud_databases, :cloud_databases
 
-  default_value_for :enabled, true
+  attribute :enabled, :default => true
 
   scope :active, -> { where(:enabled => true) }
 end

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -4,7 +4,7 @@ class Dialog < ApplicationRecord
   # The following gets around a glob symbolic link issue
   YAML_FILES_PATTERN = "{,*/**/}*.{yaml,yml}".freeze
 
-  default_value_for :system, false
+  attribute :system, :default => false
   has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy
   validate :validate_children
 

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -29,10 +29,10 @@ class DialogField < ApplicationRecord
   validates :name, :exclusion => {:in      => %w(action controller),
                                   :message => "Field Name %{value} is reserved."}
 
-  default_value_for :required, false
-  default_value_for(:visible) { true }
+  attribute :required, :default => false
+  attribute :visible,  :default => true
   validates :visible, inclusion: { in: [ true, false ] }
-  default_value_for :load_values_on_init, true
+  attribute :load_values_on_init, :default => true
 
   serialize :values
   serialize :values_method_options,   Hash

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -3,7 +3,7 @@ require 'openssl'
 class Endpoint < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
-  default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
+  attribute :verify_ssl, :default => OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
   validates :port, :numericality => {:only_integer => true, :allow_nil => true, :greater_than => 0}
   validates :url, :uniqueness_when_changed => true, :allow_blank => true, :unless => :allow_duplicate_url?

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -294,7 +294,7 @@ class ExtManagementSystem < ApplicationRecord
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
   alias_attribute :to_s, :name
 
-  default_value_for :enabled, true
+  attribute :enabled, :default => true
 
   # Move ems to maintenance zone and backup current one
   # @param orig_zone [Integer] because of zone of child manager can be changed by parent manager's ensure_managers() callback

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -12,7 +12,7 @@ class Flavor < ApplicationRecord
 
   virtual_total :total_vms, :vms
 
-  default_value_for :enabled, true
+  attribute :enabled, :default => true
 
   alias_attribute :cpus, :cpu_total_cores
   alias_attribute :cpu_cores, :cpu_cores_per_socket

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -11,7 +11,7 @@ class GitRepository < ApplicationRecord
 
   validates :url, :format => Regexp.union(URI.regexp(%w[http https file ssh]), /\A[-\w:.]+@.*:/), :allow_nil => false
 
-  default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
+  attribute :verify_ssl, :default => OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
 
   has_many :git_branches, :dependent => :destroy

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
-  default_value_for :cloud, true
+  attribute :cloud, :default => true
 
   virtual_column :image?, :type => :boolean
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -26,7 +26,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
 
   has_many   :host_aggregates,        :through => :host
 
-  default_value_for :cloud, true
+  attribute :cloud, :default => true
 
   virtual_column :ipaddresses, :type => :string_set, :uses => {:network_ports => :ipaddresses}
   virtual_column :floating_ip_addresses, :type => :string_set, :uses => {:network_ports => :floating_ip_addresses}

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -11,8 +11,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
   validates :scm_type,   :presence => true, :inclusion => {:in => %w[git]}
   validates :scm_branch, :presence => true
 
-  default_value_for :scm_type,   "git"
-  default_value_for :scm_branch, "master"
+  attribute :scm_type, :default => "git"
+  attribute :scm_branch, :default => "master"
 
   belongs_to :git_repository, :autosave => true, :dependent => :destroy
   before_validation :sync_git_repository

--- a/app/models/manageiq/providers/infra_manager/template.rb
+++ b/app/models/manageiq/providers/infra_manager/template.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::InfraManager::Template < MiqTemplate
-  default_value_for :cloud, false
+  attribute :cloud, :default => false
 
   def self.display_name(number = 1)
     n_('Template', 'Templates', number)

--- a/app/models/manageiq/providers/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/infra_manager/vm.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::InfraManager::Vm < ::Vm
-  default_value_for :cloud, false
+  attribute :cloud, :default => false
 
   # Show certain non-generic charts
   def cpu_mhz_available?

--- a/app/models/manageiq/providers/physical_infra_manager/vm.rb
+++ b/app/models/manageiq/providers/physical_infra_manager/vm.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::PhysicalInfraManager::Vm < ::Vm
-  default_value_for :cloud, false
+  attribute :cloud, :default => false
 
   def self.display_name(number = 1)
     n_('Virtual Machine', 'Virtual Machines', number)

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -5,7 +5,7 @@ class MiqAeMethod < ApplicationRecord
   include MiqAeYamlImportExportMixin
   include RelativePathMixin
 
-  default_value_for(:embedded_methods) { [] }
+  attribute :embedded_methods, :default => -> { [] }
   # switch back to validates :exclusion once rails 6.1 issue is fixed
   # https://github.com/rails/rails/issues/41051
   validate :embedded_methods_not_nil

--- a/app/models/miq_approval.rb
+++ b/app/models/miq_approval.rb
@@ -3,7 +3,7 @@ class MiqApproval < ApplicationRecord
   belongs_to :stamper,  :class_name => "User"
   belongs_to :miq_request
 
-  default_value_for :state, "pending"
+  attribute :state, :default => "pending"
 
   def approver=(approver)
     super

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -32,9 +32,8 @@ class MiqGroup < ApplicationRecord
 
   serialize :settings
 
-  default_value_for :group_type, USER_GROUP
-  default_value_for(:sequence) { next_sequence }
-
+  attribute :group_type, :default => USER_GROUP
+  attribute :sequence, :default => -> { next_sequence }
   acts_as_miq_taggable
   include CustomAttributeMixin
   include ActiveVmAggregationMixin
@@ -81,7 +80,7 @@ class MiqGroup < ApplicationRecord
     #   https://github.com/rails/rails/pull/35280
     #
     # This was an attempt to fix "leaking scopes", however, in our case, we use
-    # this method both for our +default_value_for(:sequence)+, and it will get
+    # this method both for our default value of :sequence, and it will get
     # used as part of +.create_tenant_group+.
     #
     # As such, we need both +.current_scope+ for when we want to scope down the

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -35,9 +35,9 @@ class MiqPolicy < ApplicationRecord
   include YamlImportExportMixin
   before_validation :default_name_to_guid, :on => :create
 
-  default_value_for :towhat, 'Vm'
-  default_value_for :active, true
-  default_value_for :mode,   'control'
+  attribute :towhat, :default => 'Vm'
+  attribute :active, :default => true
+  attribute :mode,   :default => 'control'
 
   # NOTE: If another class references MiqPolicy through an ActiveRecord association,
   #   particularly has_one and belongs_to, calling .conditions will result in

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -16,7 +16,6 @@ class MiqProvisionRequest < MiqRequest
   validates :source, :presence => true
   validate               :must_have_user
 
-  default_value_for :options,      :number_of_vms => 1
   default_value_for(:source_id)    { |r| r.get_option(:src_vm_id) || r.get_option(:source_id) }
   attribute :source_type, :default => "VmOrTemplate"
 
@@ -24,6 +23,11 @@ class MiqProvisionRequest < MiqRequest
 
   include MiqProvisionMixin
   include MiqProvisionQuotaMixin
+
+  # Setup default coming back from the default serialized Hash
+  def options
+    super.tap { |s| s[:number_of_vms] = 1 unless s.key?(:number_of_vms) }
+  end
 
   def self.request_task_class_from(attribs)
     source_id = MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -18,7 +18,7 @@ class MiqProvisionRequest < MiqRequest
 
   default_value_for :options,      :number_of_vms => 1
   default_value_for(:source_id)    { |r| r.get_option(:src_vm_id) || r.get_option(:source_id) }
-  default_value_for :source_type,  "VmOrTemplate"
+  attribute :source_type, :default => "VmOrTemplate"
 
   virtual_column :provision_type, :type => :string
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -26,10 +26,10 @@ class MiqRequest < ApplicationRecord
 
   default_value_for(:message)       { |r| "#{r.class::TASK_DESCRIPTION} - Request Created" }
   default_value_for :options,       {}
-  default_value_for :request_state, 'pending'
+  attribute :request_state, :default => 'pending'
   default_value_for(:request_type)  { |r| r.request_types.first }
-  default_value_for :status,        'Ok'
-  default_value_for :process,       true
+  attribute :status,  :default => 'Ok'
+  attribute :process, :default => true
 
   validates_inclusion_of :approval_state, :in => %w(pending_approval approved denied), :message => "should be 'pending_approval', 'approved' or 'denied'"
   validates_inclusion_of :status,         :in => %w(Ok Warn Error Timeout Denied)

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -25,7 +25,6 @@ class MiqRequest < ApplicationRecord
   serialize   :options, Hash
 
   default_value_for(:message)       { |r| "#{r.class::TASK_DESCRIPTION} - Request Created" }
-  default_value_for :options,       {}
   attribute :request_state, :default => 'pending'
   default_value_for(:request_type)  { |r| r.request_types.first }
   attribute :status,  :default => 'Ok'

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -15,8 +15,8 @@ class MiqRequestTask < ApplicationRecord
 
   default_value_for :phase_context, {}
   default_value_for :options,       {}
-  default_value_for :state,         'pending'
-  default_value_for :status,        'Ok'
+  attribute :state, :default => 'pending'
+  attribute :status, :default => 'Ok'
 
   delegate :request_class, :task_description, :to => :class
 

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -13,8 +13,6 @@ class MiqRequestTask < ApplicationRecord
   serialize   :phase_context, Hash
   serialize   :options,       Hash
 
-  default_value_for :phase_context, {}
-  default_value_for :options,       {}
   attribute :state, :default => 'pending'
   attribute :status, :default => 'Ok'
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -44,8 +44,8 @@ class MiqSchedule < ApplicationRecord
   ALLOWED_CLASS_METHOD_ACTIONS = %w[automation_request].freeze
   IMPORT_CLASS_NAMES = %w[MiqSchedule].freeze
 
-  default_value_for :userid,  "system"
-  default_value_for :enabled, true
+  attribute :userid, :default => "system"
+  attribute :enabled, :default => true
   default_value_for(:zone_id) { MiqServer.my_server.zone_id }
 
   def set_start_time_and_prod_default

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -46,7 +46,7 @@ class MiqSchedule < ApplicationRecord
 
   attribute :userid, :default => "system"
   attribute :enabled, :default => true
-  default_value_for(:zone_id) { MiqServer.my_server.zone_id }
+  attribute :zone_id, :default => -> { MiqServer.my_server.zone_id }
 
   def set_start_time_and_prod_default
     run_at # Internally this will correct :start_time to UTC

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -26,7 +26,7 @@ class MiqServer < ApplicationRecord
   after_destroy           :destroy_linked_events_queue
 
   attribute :name, :default => "EVM"
-  default_value_for(:zone) { Zone.default_zone }
+  attribute :zone, :default => -> { Zone.default_zone }
 
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
   scope :recently_active,    -> { where(:last_heartbeat => 10.minutes.ago.utc...Time.now.utc) }

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -25,7 +25,7 @@ class MiqServer < ApplicationRecord
   before_destroy          :validate_is_deleteable
   after_destroy           :destroy_linked_events_queue
 
-  default_value_for(:name, "EVM")
+  attribute :name, :default => "EVM"
   default_value_for(:zone) { Zone.default_zone }
 
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -14,7 +14,7 @@ class MiqUserRole < ApplicationRecord
 
   serialize :settings
 
-  default_value_for :read_only, false
+  attribute :read_only, :default => false
 
   FIXTURE_PATH = File.join(FIXTURE_DIR, table_name)
   FIXTURE_YAML = "#{FIXTURE_PATH}.yml"

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -4,8 +4,8 @@
 class MiqWidget < ApplicationRecord
   include ReadOnlyMixin
 
-  default_value_for :enabled, true
-  default_value_for :read_only, false
+  attribute :enabled, :default => true
+  attribute :read_only, :default => false
 
   DEFAULT_ROW_COUNT = 5
   IMPORT_CLASS_NAMES = %w(MiqWidget).freeze

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -16,7 +16,6 @@ class Notification < ApplicationRecord
   before_save :backup_subject_name
 
   serialize :options, Hash
-  default_value_for(:options) { Hash.new }
 
   validate :complete_bindings
 

--- a/app/models/notification_recipient.rb
+++ b/app/models/notification_recipient.rb
@@ -1,7 +1,7 @@
 class NotificationRecipient < ApplicationRecord
   belongs_to :notification
   belongs_to :user
-  default_value_for :seen, false
+  attribute :seen, :default => false
   virtual_column :details, :type => :string
 
   scope :unseen, -> { where(:seen => false) }

--- a/app/models/orchestration_stack_retire_task.rb
+++ b/app/models/orchestration_stack_retire_task.rb
@@ -1,5 +1,5 @@
 class OrchestrationStackRetireTask < MiqRetireTask
-  default_value_for :request_type, "orchestration_stack_retire"
+  attribute :request_type, :default => "orchestration_stack_retire"
 
   def self.base_model
     OrchestrationStackRetireTask

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -7,8 +7,8 @@ class OrchestrationTemplate < ApplicationRecord
   has_many :stacks, :class_name => "OrchestrationStack"
   has_one :picture, :dependent => :destroy, :as => :resource, :autosave => true
 
-  default_value_for :draft, false
-  default_value_for :orderable, true
+  attribute :draft, :default => false
+  attribute :orderable, :default => true
 
   validates :md5,
             :uniqueness_when_changed => {:scope => :draft, :message => "of content already exists (content must be unique)"},

--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -5,7 +5,7 @@ class PxeServer < ApplicationRecord
 
   alias_attribute :description, :name
 
-  default_value_for :customization_directory, ""
+  attribute :customization_directory, :default => ""
 
   serialize :visibility
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -89,10 +89,10 @@ class Service < ApplicationRecord
 
   validates :name, :presence => true
 
-  default_value_for :visible, false
-  default_value_for :initiator, 'user'
-  default_value_for :lifecycle_state, 'unprovisioned'
-  default_value_for :retired, false
+  attribute :visible, :default => false
+  attribute :initiator, :default => 'user'
+  attribute :lifecycle_state, :default => 'unprovisioned'
+  attribute :retired, :default => false
 
   validates :visible, :inclusion => { :in => [true, false] }
   validates :retired, :inclusion => { :in => [true, false] }

--- a/app/models/service_reconfigure_request.rb
+++ b/app/models/service_reconfigure_request.rb
@@ -9,7 +9,7 @@ class ServiceReconfigureRequest < MiqRequest
   virtual_has_one :provision_dialog
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
-  default_value_for :source_type,  SOURCE_CLASS_NAME
+  attribute :source_type, :default => SOURCE_CLASS_NAME
 
   def my_role(_action = nil)
     'ems_operations'

--- a/app/models/service_resource.rb
+++ b/app/models/service_resource.rb
@@ -10,10 +10,10 @@ class ServiceResource < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :source,   :polymorphic => true
 
-  default_value_for :group_idx, 0
-  default_value_for :scaling_min, 1
-  default_value_for :scaling_max, -1
-  default_value_for :provision_index, 0
+  attribute :group_idx,       :default => 0
+  attribute :scaling_min,     :default => 1
+  attribute :scaling_max,     :default => -1
+  attribute :provision_index, :default => 0
 
   virtual_column :resource_name,        :type => :string
   virtual_column :resource_description, :type => :string

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -1,5 +1,5 @@
 class ServiceRetireTask < MiqRetireTask
-  default_value_for :request_type, "service_retire"
+  attribute :request_type, :default => "service_retire"
 
   def self.base_model
     ServiceRetireTask

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -59,8 +59,8 @@ class ServiceTemplate < ApplicationRecord
   virtual_column   :archived,                     :type => :boolean
   virtual_column   :active,                       :type => :boolean
 
-  default_value_for :internal, false
-  default_value_for :service_type, SERVICE_TYPE_ATOMIC
+  attribute :internal, :default => false
+  attribute :service_type, :default => SERVICE_TYPE_ATOMIC
   default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }
 
   virtual_has_one :config_info, :class_name => "Hash"

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -17,8 +17,8 @@ class ServiceTemplateProvisionRequest < MiqRequest
   virtual_has_one :user
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
-  default_value_for :source_type,  SOURCE_CLASS_NAME
-  default_value_for :process,      false
+  attribute :source_type, :default => SOURCE_CLASS_NAME
+  attribute :process, :default => false
 
   delegate :picture, :to => :service_template, :allow_nil => true
 

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -11,7 +11,7 @@ class Share < ApplicationRecord
   validates :tenant,               :presence => true
   validates :user,                 :presence => true
 
-  default_value_for :allow_tenant_inheritance, false
+  attribute :allow_tenant_inheritance, :default => false
 
   scope :by_tenant_inheritance, ->(tenant) do
     where(:tenant => tenant.accessible_tenant_ids(:ancestor_ids),

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -2,7 +2,7 @@ class SystemConsole < ApplicationRecord
   belongs_to :vm
   belongs_to :user
 
-  default_value_for :opened, false
+  attribute :opened, :default => false
 
   validates :url_secret, :uniqueness_when_changed => true
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -12,10 +12,10 @@ class Tenant < ApplicationRecord
 
   acts_as_miq_taggable
 
-  default_value_for :name,        "My Company"
-  default_value_for :description, "Tenant for My Company"
-  default_value_for :divisible,   true
-  default_value_for :use_config_for_attributes, false
+  attribute :name,        :default => "My Company"
+  attribute :description, :default => "Tenant for My Company"
+  attribute :divisible,   :default => true
+  attribute :use_config_for_attributes, :default => false
 
   before_destroy :ensure_can_be_destroyed
 

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -4,8 +4,6 @@ class TimeProfile < ApplicationRecord
   DEFAULT_TZ = "UTC".freeze
 
   serialize :profile
-  default_value_for :days,  ALL_DAYS
-  default_value_for :hours, ALL_HOURS
 
   has_many  :miq_reports
   has_many  :metric_rollups
@@ -75,7 +73,7 @@ class TimeProfile < ApplicationRecord
   end
 
   def days
-    profile[:days]
+    profile.fetch(:days, ALL_DAYS)
   end
 
   def days=(arr)
@@ -85,7 +83,7 @@ class TimeProfile < ApplicationRecord
   end
 
   def hours
-    profile[:hours]
+    profile.fetch(:hours, ALL_HOURS)
   end
 
   def hours=(arr)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ApplicationRecord
   serialize     :settings, Hash   # Implement settings column as a hash
   default_value_for(:settings) { Hash.new }
 
-  default_value_for :failed_login_attempts, 0
+  attribute :failed_login_attempts, :default => 0
 
   scope :in_all_regions, ->(id) { where(:userid => User.default_scoped.where(:id => id).select(:userid)) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,6 @@ class User < ApplicationRecord
   alias_method :authenticate_bcrypt, :authenticate
 
   serialize     :settings, Hash   # Implement settings column as a hash
-  default_value_for(:settings) { Hash.new }
 
   attribute :failed_login_attempts, :default => 0
 

--- a/app/models/vm_migrate_task.rb
+++ b/app/models/vm_migrate_task.rb
@@ -2,7 +2,7 @@ class VmMigrateTask < MiqRequestTask
   alias_attribute :vm, :source
 
   validate :validate_request_type, :validate_state
-  default_value_for :request_type, "vm_migrate"
+  attribute :request_type, :default => "vm_migrate"
 
   AUTOMATE_DRIVES = true
 

--- a/app/models/vm_retire_request.rb
+++ b/app/models/vm_retire_request.rb
@@ -4,7 +4,7 @@ class VmRetireRequest < MiqRetireRequest
   ACTIVE_STATES     = %w(retired) + base_class::ACTIVE_STATES
 
   default_value_for(:source_id)    { |r| r.get_option(:src_ids) }
-  default_value_for :source_type,  SOURCE_CLASS_NAME
+  attribute :source_type, :default => SOURCE_CLASS_NAME
 
   def my_zone
     vm = Vm.find_by(:id => options[:src_ids])

--- a/app/models/vm_retire_task.rb
+++ b/app/models/vm_retire_task.rb
@@ -1,6 +1,6 @@
 class VmRetireTask < MiqRetireTask
   alias_attribute :vm, :source
-  default_value_for :request_type, "vm_retire"
+  attribute :request_type, :default => "vm_retire"
 
   def self.base_model
     VmRetireTask

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -43,7 +43,7 @@ class Zone < ApplicationRecord
   include ConfigurationManagementMixin
 
   scope :visible, -> { where(:visible => true) }
-  default_value_for :visible, true
+  attribute :visible, :default => true
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)

--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -1,8 +1,8 @@
 module UuidMixin
   extend ActiveSupport::Concern
   included do
-    default_value_for(:guid) { SecureRandom.uuid }
-    validates :guid,  :uniqueness_when_changed => true, :presence => true
+    attribute :guid, :default => -> { SecureRandom.uuid }
+    validates :guid, :uniqueness_when_changed => true, :presence => true
   end
 
   def dup

--- a/spec/lib/extensions/ar_yaml_spec.rb
+++ b/spec/lib/extensions/ar_yaml_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActiveRecord::AttributeAccessorThatYamls do
     inst = Vm.new
     inst.access1 = 1
     inst.access2 = 2
-    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Type::String])
+    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Attribute::UserProvidedDefault, ActiveModel::Type::String])
     expect(result.access1).to eq(1)
     expect(result.access2).to eq(2)
   end
@@ -18,14 +18,14 @@ RSpec.describe ActiveRecord::AttributeAccessorThatYamls do
   it "attr_reader_that_yamls" do
     inst = Vm.new
     inst.instance_variable_set("@read1", 1)
-    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Type::String])
+    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Attribute::UserProvidedDefault, ActiveModel::Type::String])
     expect(result.read1).to eq(1)
   end
 
   it "attr_writer_that_yamls" do
     inst = Vm.new
     inst.write1 = 1
-    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Type::String])
+    result = YAML.safe_load(YAML.dump(inst), :permitted_classes => [Vm, ActiveModel::Attribute.const_get(:FromDatabase), ActiveModel::Attribute::const_get(:FromUser), ActiveModel::Attribute::UserProvidedDefault, ActiveModel::Type::String])
     expect(result.instance_variable_get("@write1")).to eq(1)
   end
 end

--- a/spec/lib/uniqueness_when_changed_validator_spec.rb
+++ b/spec/lib/uniqueness_when_changed_validator_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe UniquenessWhenChangedValidator do
   describe "#uniqueness_when_changed" do
     it "queries for a new record" do
       alert = FactoryBot.build(:miq_alert)
-      expect { alert.valid? }.to make_database_queries(:count => 1)
+      expect { alert.valid? }.to make_database_queries(:count => 2)
     end
 
     it "queries for a changed record" do

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -47,17 +47,27 @@ RSpec.describe BlacklistedEvent do
       expect(f.enabled).to be_falsey
     end
 
+    it "log creation" do
+      expect($audit_log).to receive(:info).with(a_string_including("Creating")).once
+      FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
+    end
+
+    it "doesn't log changed on creation" do
+      expect($audit_log).to receive(:info).with(a_string_including("changed")).never
+      FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
+    end
+
     it 'logs a message when changed' do
       f = FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
 
-      expect($audit_log).to receive(:info)
+      expect($audit_log).to receive(:info).with(a_string_including("changed")).once
       f.update(:enabled => false)
     end
 
     it 'does not log a message when unchanged' do
       f = FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
 
-      expect($audit_log).to_not receive(:info)
+      expect($audit_log).to receive(:info).with(a_string_including("changed")).never
       f.update(:enabled => f.enabled)
     end
 

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -30,12 +30,21 @@ RSpec.describe BlacklistedEvent do
     end
   end
 
-  it '#enabled=' do
-    User.current_user = FactoryBot.create(:user)
-    f = FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
-    expect(f.enabled).to be_truthy
+  context "#enabled=" do
+    it 'new record' do
+      f = FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
+      expect(f.enabled).to be_truthy
 
-    f.enabled = false
-    expect(f.enabled).to be_falsey
+      f.enabled = false
+      expect(f.enabled).to be_falsey
+    end
+
+    it 'persisted' do
+      f = FactoryBot.build(:blacklisted_event, :event_name => 'event_1')
+      expect(f.enabled).to be_truthy
+
+      f.enabled = false
+      expect(f.enabled).to be_falsey
+    end
   end
 end

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -46,5 +46,20 @@ RSpec.describe BlacklistedEvent do
       f.enabled = false
       expect(f.enabled).to be_falsey
     end
+
+    it 'logs a message when changed' do
+      f = FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
+
+      expect($audit_log).to receive(:info)
+      f.update(:enabled => false)
+    end
+
+    it 'does not log a message when unchanged' do
+      f = FactoryBot.create(:blacklisted_event, :event_name => 'event_1')
+
+      expect($audit_log).to_not receive(:info)
+      f.update(:enabled => f.enabled)
+    end
+
   end
 end


### PR DESCRIPTION
tldr;  I think these are mostly safe changes that gets us closer to not depending on `default_value_for`.  There's more to do but we can tackle that later if we really want to not use it anymore.

From research in [upgrading default_value_for](https://github.com/FooBarWidget/default_value_for/issues/92#issuecomment-1946564359), it seems reasonable to replace it and not have to deal with getting this gem to work with rails as we upgrade.  Currently, the gem's master branch supports rails 7 but hasn't been released so we need to ride master to work with rails 7 or fork it.

I've found the attributes API is mostly a replacement but it is different than default_value_for in the following ways:
1) You can't override the getter/setter methods for the attribute in the same way you could with this gem.  I think this revolves around how it's hard to detect if the `super` method's return is `nil` (`{}` serialize as hash attributes) explicitly or coming from the defaults from rails.  I suspect there's a way to do it correctly but it's less obvious.
2) The default value block format doesn't yield the instance, so you can't derive defaults based on the current instance.  We definitely use this and the remaining usages are those.
3) There doesn't seem to be a way to set multiple default values all at once.  You have to set them individually.  I don't think we use this feature.
4) Default values make new objects look changed, unlike default_value_for.
5) Attributes API default value doesn't support `allow_nil: false` so if a `nil` is provided as a value for an attribute, the default value will not be used. NOTE: I don't see much usage of this.

EDIT:

This PR avoids the more complicated changes where we used a block and the corresponding instance in the block.  The remaining ones in core should probably be done in a followup PR.  Either way, we can choose to keep default_value_for, but I thought it made sense to switch to vanilla rails for the more basic cases.  This is what remains in core (note, there's also usage in providers/plugins):

```
app/models/miq_provision_request.rb:  default_value_for(:source_id)    { |r| r.get_option(:src_vm_id) || r.get_option(:source_id) }
app/models/miq_request.rb:  default_value_for(:message)       { |r| "#{r.class::TASK_DESCRIPTION} - Request Created" }
app/models/miq_request.rb:  default_value_for(:request_type)  { |r| r.request_types.first }
app/models/miq_retire_request.rb:  default_value_for(:source_id)    { |r| r.get_option(:src_id) }
app/models/service_reconfigure_request.rb:  default_value_for(:source_id)    { |r| r.get_option(:src_id) }
app/models/service_template.rb:  default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }
app/models/service_template_provision_request.rb:  default_value_for(:source_id)    { |r| r.get_option(:src_id) }
app/models/vm_retire_request.rb:  default_value_for(:source_id)    { |r| r.get_option(:src_ids) }
```


