### PR TITLE
Only run load_subclasses after app is initialized

### DIFF
--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -263,7 +263,7 @@ class DescendantLoader
 
   module ArDescendantsWithLoader
     def descendants
-      unless defined? @loaded_descendants
+      if Vmdb::Application.instance.initialized? && !defined? @loaded_descendants
         @loaded_descendants = true
         DescendantLoader.instance.load_subclasses(self)
       end
@@ -275,7 +275,7 @@ class DescendantLoader
     # https://github.com/rails/rails/commit/8f8aa857e084b76b1120edaa9bb9ce03ba1e6a19
     # We need to get in front of it, like we do for descendants.
     def subclasses
-      unless defined? @loaded_descendants
+      if Vmdb::Application.instance.initialized? && !defined? @loaded_descendants
         @loaded_descendants = true
         DescendantLoader.instance.load_subclasses(self)
       end


### PR DESCRIPTION
In rails 6.1, nothing was calling descendants or subclasses during the app initialization.

Rails changed in 7.0 to call subclasses from reload_schema_from_cache here: https://github.com/rails/rails/commit/6f30cc09a7ad21898d856059e498ab9ad2ae64a4

It also changed to call descendants on the callback class (self) insead of the ActiveSupport::DescendantsTracker here:
https://github.com/rails/rails/commit/ffae3bd8d69f9ed1ae185e960d7a38ec17118a4d

We are not expecting to be called from these locations.

We can make this rails 7 compatible by ensuring the descendant loader loading of subclasses until after the app is booted, which was the implicit behavior previously.


(Extracted from https://github.com/ManageIQ/manageiq/pull/22873)