### PR TITLE
Add url,url= to EMS default_endpoint delegates

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -225,6 +225,8 @@ class ExtManagementSystem < ApplicationRecord
            :hostname=,
            :port,
            :port=,
+           :url,
+           :url=,
            :security_protocol,
            :security_protocol=,
            :verify_ssl,


### PR DESCRIPTION
Noticed that this was missing while working on https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/107
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
