### PR TITLE
Add default_authentication delegates

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -235,6 +235,16 @@ class ExtManagementSystem < ApplicationRecord
            :allow_nil => true
   delegate :path, :path=, :to => :default_endpoint, :prefix => "endpoint", :allow_nil => true
 
+  delegate :userid,
+           :userid=,
+           :password,
+           :password=,
+           :auth_key,
+           :auth_key=,
+           :to        => :default_authentication,
+           :allow_nil => true,
+           :prefix    => :default
+
   alias_method :address, :hostname # TODO: Remove all callers of address
 
   virtual_column :ipaddress,               :type => :string,  :uses => :endpoints

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -458,6 +458,10 @@ class ExtManagementSystem < ApplicationRecord
     emstype.downcase
   end
 
+  def default_authentication
+    authentication_type(default_authentication_type) || authentications.build(:authtype => default_authentication_type)
+  end
+
   def default_endpoint
     default = endpoints.detect { |e| e.role == "default" }
     default || endpoints.build(:role => "default")


### PR DESCRIPTION
Add delegates similar to the ones for the default endpoint simplifying accessing and assigning the default credentials

This allows for easier assignment of authentications when building an EMS record just like e.g. `:hostname`

Before:

```ruby
ManageIQ::Providers::Vmware::InfraManager.create!(
  :name     => "test",
  :hostname => "test",
  :zone     => Zone.default_zone
).tap { |ems|
  ems.update_authentication(:default => {:userid => "root", :password => "vmware"})
}
```

After:

```ruby
ManageIQ::Providers::Vmware::InfraManager.create!(
  :name             => "test",
  :hostname         => "test",
  :default_userid   => "root",
  :default_password => "vmware",
  :zone             => Zone.default_zone
)
```
