### PR TITLE
define supports :action

### DIFF
--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -2,13 +2,7 @@ module Vm::Operations::Lifecycle
   extend ActiveSupport::Concern
 
   included do
-    supports :retire do
-      if orphaned?
-        _("Retire not supported because VM is orphaned")
-      elsif archived?
-        _("Retire not supported because VM is archived")
-      end
-    end
+    supports(:retire) { unsupported_reason(:action) }
 
     api_relay_method :retire do |options|
       options

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1699,13 +1699,10 @@ class VmOrTemplate < ApplicationRecord
     self.class.calculate_power_state(raw_power_state)
   end
 
+  # deprecated, use unsupported_reason(:action) instead
   def check_feature_support(message_prefix)
-    if archived?
-      return [false, nil]
-    elsif orphaned?
-      return [false, _("%{action} cannot be performed on orphaned VM.") % {:action => message_prefix}]
-    end
-    [true, nil]
+    reason = unsupported_reason(:action)
+    [!reason, reason]
   end
 
   def create_notification(type, options)

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -125,6 +125,14 @@ module VmOrTemplate::Operations
   #
 
   included do
+    supports :action do
+      if orphaned?
+        _("The VM is orphaned")
+      elsif archived?
+        _("The VM is archived")
+      end
+    end
+
     supports :control do
       if retired?
         _('The VM is retired')


### PR DESCRIPTION
blocks:
- [ ] https://github.com/ManageIQ/manageiq/pull/22883 (in order to drop `unsupported_reason_add`)

Drop `check_feature_support`

## Before

We are removing `unsupported_reason_add`. 6 providers have this code:

```ruby
supports :smart_state_analysis do
  feature_supported, reason = check_feature_support('smartstate_analysis')
  unless feature_supported
    unsupported_reason_add(:smartstate_analysis, reason)
  end
  # [...]
end
```

## After

```ruby
supports(:smart_state_analysis) { unuspported_reason(:action) }
```

## Changes

- `check_feature_support` return a reason for all unsupported cases (`archived?` was returning `nil`)
- introduced `supports :action` which represents this logic in a reusable way

## Details

```ruby
supports :smart_state_analysis do
  feature_supported, reason = check_feature_support('smartstate_analysis')
  unless feature_supported
    unsupported_reason_add(:smartstate_analysis, reason)
  end
  # [...]
end

# dropping unuspported_reason_add:
supports :smart_state_analysis do
  feature_supported, reason = check_feature_support('smartstate_analysis')
  reason unless feature_supported
end

supports :smart_state_analysis do
  feature_supported, reason = check_feature_support('smartstate_analysis')
  reason
end

supports(:smart_state_analysis) { check_feature_support('smartstate_analysis').last }

# ...
supports(:smart_state_analysis) { unuspported_reason(:action) }

```
