### PR TITLE
Remove CVE-2024-26143 as rails 6.1 is not vulnerable

### DIFF
--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -55,9 +55,6 @@ namespace :test do
         }
       end
 
-      # See discussion in https://github.com/rails/rails/issues/51190
-      options << {:ignore => %w[CVE-2024-26143]}
-
       require "awesome_spawn"
       cmd = AwesomeSpawn.build_command_line("bundle-audit check", options)
       puts "** with command line: #{cmd}"


### PR DESCRIPTION
This mostly reverts #22909

Originally published as all versions as vulnerable, after review it was determined that rails 6.1 is not vulnerable to this CVE, the ruby advisory DB was updated and now we are green without excluding it.

See: https://discuss.rubyonrails.org/t/possible-xss-vulnerability-in-action-controller/84947?u=rafaelfranca https://github.com/rails/rails/issues 51190
https://github.com/rubysec/ruby-advisory-db/pull/753