### PR TITLE
Set system_uid for systemd workers

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -5,7 +5,8 @@ class MiqWorker < ApplicationRecord
   include SystemdCommon
   include UuidMixin
 
-  before_destroy :error_out_tasks_with_active_queue_message, :log_destroy_of_worker_messages
+  after_initialize :set_system_uid
+  before_destroy   :error_out_tasks_with_active_queue_message, :log_destroy_of_worker_messages
 
   belongs_to :miq_server
   has_many   :messages,           :as => :handler, :class_name => 'MiqQueue'
@@ -39,10 +40,6 @@ class MiqWorker < ApplicationRecord
   PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time proportional_set_size unique_set_size)
 
   PROCESS_TITLE_PREFIX = "MIQ:".freeze
-
-  after_initialize do |worker|
-    worker.system_uid = worker.unit_name if worker.systemd_worker?
-  end
 
   def self.atShutdown
     stop_workers
@@ -485,6 +482,10 @@ class MiqWorker < ApplicationRecord
       _log.warn("Message id: [#{m.id}] Setting state to 'error'")
       m.delivered_in_error('Clean Active Messages')
     end
+  end
+
+  private def set_system_uid
+    self.system_uid = unit_name if systemd_worker?
   end
 
   private def error_out_tasks_with_active_queue_message

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -40,6 +40,10 @@ class MiqWorker < ApplicationRecord
 
   PROCESS_TITLE_PREFIX = "MIQ:".freeze
 
+  after_initialize do |worker|
+    worker.system_uid = worker.unit_name if worker.systemd_worker?
+  end
+
   def self.atShutdown
     stop_workers
   end
@@ -288,9 +292,8 @@ class MiqWorker < ApplicationRecord
     params[:queue_name]     = default_queue_name unless params.key?(:queue_name) || default_queue_name.nil?
     params[:status]         = STATUS_CREATING
     params[:last_heartbeat] = Time.now.utc
-    server_scope.new(params).tap do |w|
-      w.system_uid = w.unit_name if systemd_worker?
-    end
+
+    server_scope.new(params)
   end
 
   def self.create_worker_record(*params)

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -288,8 +288,9 @@ class MiqWorker < ApplicationRecord
     params[:queue_name]     = default_queue_name unless params.key?(:queue_name) || default_queue_name.nil?
     params[:status]         = STATUS_CREATING
     params[:last_heartbeat] = Time.now.utc
-
-    server_scope.new(params)
+    server_scope.new(params).tap do |w|
+      w.system_uid = w.unit_name if systemd_worker?
+    end
   end
 
   def self.create_worker_record(*params)

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -7,6 +7,14 @@ class MiqWorker
         "manageiq-#{minimal_class_name.underscore.tr("/", "_")}"
       end
 
+      def service_file
+        "#{service_base_name}@.service"
+      end
+
+      def target_file
+        "#{service_base_name}.target"
+      end
+
       def systemd_unit_dir
         Pathname.new("/lib/systemd/system")
       end

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -12,6 +12,10 @@ class MiqWorker
       end
     end
 
+    def unit_name
+      "#{service_base_name}#{unit_instance}.service"
+    end
+
     def start_systemd_worker
       enable_systemd_unit
       write_unit_settings_file
@@ -75,10 +79,6 @@ class MiqWorker
 
     def service_base_name
       self.class.service_base_name
-    end
-
-    def unit_name
-      "#{service_base_name}#{unit_instance}.service"
     end
 
     def unit_instance

--- a/spec/models/miq_worker/systemd_common_spec.rb
+++ b/spec/models/miq_worker/systemd_common_spec.rb
@@ -8,12 +8,7 @@ RSpec.describe MiqWorker::SystemdCommon do
       expected_units -= %w[manageiq-db-ready.service manageiq-messaging-ready.service evmserverd.service manageiq.target]
 
       found_units = MiqWorkerType.worker_classes.flat_map do |worker_class|
-        service_base_name = worker_class.service_base_name
-
-        service_file = "#{service_base_name}@.service"
-        target_file  = "#{service_base_name}.target"
-
-        [service_file, target_file]
+        [worker_class.service_file, worker_class.target_file]
       end
 
       expect(found_units).to match_array(expected_units)


### PR DESCRIPTION
On podified the system_uid is set by the container entrypoint (https://github.com/ManageIQ/manageiq-pods/blob/master/images/manageiq-base-worker/container-assets/entrypoint#L7) but we were not setting it in systemd.

Since the worker record is created ahead of time on systemd we can set the system_uid in the worker record at create time that way we don't have to have access to the database from within the systemd unit to update the worker record.

Example:
```
>> MiqWorker.pluck(:system_uid)
The version of PostgreSQL being connected to (160002) is incompatible with ManageIQ (130000 / 13 required)                                       
The version of PostgreSQL being connected to (160002) is incompatible with ManageIQ (130000 / 13 required)                                       
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 1, waiting_in_queue: 0                                   
   (0.3ms)  SELECT "miq_workers"."system_uid" FROM "miq_workers"
=>                                           
["manageiq-generic@db0cfc9f-f3b6-41e1-97dd-666a50035d94.service",
 "manageiq-priority@8873602a-b864-49aa-bdc6-b8664d8dc6c8.service",
 "manageiq-ems_metrics_processor@d51f756f-7942-44ea-9b9b-538c319af904.service",
 "manageiq-ems_metrics_processor@a573a677-c73b-4034-8897-af9e701ee0b7.service",
 "manageiq-ui@cabc9ecc-792a-4049-aa5e-481c81799624.service",
 "manageiq-web_service@f349a1a0-168e-47ba-8d79-89bd4c438d90.service",
 "manageiq-priority@bb6e611c-54f2-47ee-998d-5f928bceddd6.service",
 "manageiq-web_service@4b709d73-6aa2-4c73-8a28-0eddfe278389.service",
 "manageiq-ui@4371faf2-e66b-4fd2-acea-471524835f09.service",
 "manageiq-automation@c1869097-35bb-426f-b07d-58236facaad9.service",
 "manageiq-event_handler@965e1f02-80c1-49d4-9090-80a972b8e54d.service",
 "manageiq-reporting@7c9c6b6f-2311-4a97-9098-25fc6d2b12cb.service",
 "manageiq-remote_console@6b5217f0-1225-4f68-8d46-adfbe1330078.service",
 "manageiq-generic@e61298ac-feb9-4702-8a2d-14ecb907c06f.service",
 "manageiq-schedule@f50f651e-5a30-41b6-bf68-4b48f7b15e40.service",
 "manageiq-reporting@62dd032f-b14e-4f95-978f-78f85b4820f5.service"]
```