### PR TITLE
Fix Socket.gethostbyname deprecation warning

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -9,7 +9,10 @@ module MiqEnvironment
   # Return the fully qualified hostname for the local host.
   #
   def self.fully_qualified_domain_name
-    Socket.gethostbyname(Socket.gethostname).first
+    hostname    = Socket.gethostname
+    addrinfo    = Addrinfo.getaddrinfo(hostname, nil).first
+    fqdn, _port = addrinfo.getnameinfo
+    fqdn
   end
 
   # Return the local IP v4 address of the local host

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -10,7 +10,7 @@ module MiqEnvironment
   #
   def self.fully_qualified_domain_name
     hostname    = Socket.gethostname
-    addrinfo    = Addrinfo.getaddrinfo(hostname, nil).first
+    addrinfo    = Addrinfo.getaddrinfo(hostname, nil, nil, :STREAM).first
     fqdn, _port = addrinfo.getnameinfo
     fqdn
   end

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -3,14 +3,14 @@ require 'socket'
 RSpec.describe "Server Environment Management" do
   context ".get_network_information" do
     let(:mac_address) { 'a:1:b:2:c:3:d:4' }
-    let(:hostname)    { "localhost.localdomain" }
+    let(:hostname)    { "localhost" }
     let(:ip_address)  { "10.1.2.3" }
 
     before do
       require "uuidtools"
       allow(UUIDTools::UUID).to receive(:mac_address).and_return(mac_address)
       allow(Socket).to receive(:gethostname).and_return("localhost")
-      allow(Socket).to receive(:gethostbyname).with("localhost").and_return([hostname])
+      allow(Addrinfo).to receive(:getaddrinfo).with("localhost", nil).and_return([Addrinfo.tcp("localhost", nil), Addrinfo.udp("localhost", nil)])
       allow(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip(ip_address)])
     end
 

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Server Environment Management" do
       require "uuidtools"
       allow(UUIDTools::UUID).to receive(:mac_address).and_return(mac_address)
       allow(Socket).to receive(:gethostname).and_return("localhost")
-      allow(Addrinfo).to receive(:getaddrinfo).with("localhost", nil).and_return([Addrinfo.tcp("localhost", nil), Addrinfo.udp("localhost", nil)])
+      allow(Addrinfo).to receive(:getaddrinfo).with("localhost", nil, nil, :STREAM).and_return([Addrinfo.tcp("localhost", nil)])
       allow(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip(ip_address)])
     end
 


### PR DESCRIPTION
Fixes:
```
lib/miq_environment.rb:12: warning: Socket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.
```