### PR TITLE
Remove tags from entitlement filters from the deleted tag's region

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -160,7 +160,7 @@ class Tag < ApplicationRecord
   private
 
   def remove_from_managed_filters
-    Entitlement.remove_tag_from_all_managed_filters(name)
+    Entitlement.with_region(self.class.id_to_region(id)) { Entitlement.remove_tag_from_all_managed_filters(name) }
   end
 
   def name_path


### PR DESCRIPTION
The before_destroy callback wasn't previously scoped to the tag's region. From the global region, usually 99, you could delete a tag from region 1 with value "/managed/costcenter/004".  We would then remove that value from filters with that tag from entitlements in region 99, even though we deleted a region 1 tag. The same named tag could still exist in region 99.

This commit ensures that if you delete a region 99 tag, we'll only update filters in entitlements in region 99.