### PR TITLE
Pluggable Server Roles

### DIFF
--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -10,9 +10,14 @@ class ServerRole < ApplicationRecord
 
   def self.seed
     server_roles = all.index_by(&:name)
-    CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/).each do |csv_row|
-      action = csv_row.to_hash
 
+    server_role_paths = [fixture_path] + Vmdb::Plugins.server_role_paths
+
+    csv_rows = server_role_paths.flat_map do |path|
+      CSV.foreach(path, :headers => true, :skip_lines => /^#/).map(&:to_hash)
+    end
+
+    csv_rows.each do |action|
       rec = server_roles[action['name']]
       if rec.nil?
         _log.info("Creating Server Role [#{action['name']}]")
@@ -25,6 +30,7 @@ class ServerRole < ApplicationRecord
         end
       end
     end
+
     @zone_scoped_roles = @region_scoped_roles = nil
   end
 

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -107,7 +107,7 @@ module Vmdb
     def server_role_paths
       @server_role_paths ||= filter_map do |engine|
         file = engine.root.join("content/server_roles.csv")
-        file if file.exist?
+        file if File.exist?(file.to_s)
       end
     end
 

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -104,6 +104,13 @@ module Vmdb
       end
     end
 
+    def server_role_paths
+      @server_role_paths ||= map do |engine|
+        file = engine.root.join("content/server_roles.csv")
+        file if file.exist?
+      end.compact
+    end
+
     def systemd_units
       @systemd_units ||= begin
         flat_map { |engine| engine.root.join("systemd").glob("*.*") }

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -107,7 +107,7 @@ module Vmdb
     def server_role_paths
       @server_role_paths ||= filter_map do |engine|
         file = engine.root.join("content/server_roles.csv")
-        file if File.exist?(file.to_s)
+        file if file.exist?
       end
     end
 

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -105,10 +105,10 @@ module Vmdb
     end
 
     def server_role_paths
-      @server_role_paths ||= map do |engine|
+      @server_role_paths ||= filter_map do |engine|
         file = engine.root.join("content/server_roles.csv")
         file if file.exist?
-      end.compact
+      end
     end
 
     def systemd_units

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -106,7 +106,7 @@ module Vmdb
 
     def server_role_paths
       @server_role_paths ||= filter_map do |engine|
-        file = engine.root.join("content/server_roles.csv")
+        file = engine.root.join("config/server_roles.csv")
         file if file.exist?
       end
     end

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ServerRole do
     end
 
     context "with a plugin" do
-      let(:plugin_server_role_path)  { ManageIQ::Api::Engine.root.join("content/server_roles.csv") }
+      let(:plugin_server_role_path)  { ManageIQ::Api::Engine.root.join("config/server_roles.csv") }
       let(:plugin_server_role_paths) { [plugin_server_role_path] }
 
       before do

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ServerRole do
         web_services,Web Services,0,false,region
       CSV
 
-      allow(File).to receive(:open).and_return(StringIO.new(@csv))
+      allow(File).to receive(:open).with(ServerRole.fixture_path, "r", any_args).and_return(StringIO.new(@csv))
       ServerRole.seed
     end
 

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe ServerRole do
         web_services,Web Services,0,false,region
       CSV
 
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(a_string_matching(/content\/server_roles.csv/)).and_return(false)
+
+      allow(File).to receive(:open).and_call_original
       allow(File).to receive(:open).with(ServerRole.fixture_path, "r", any_args).and_return(StringIO.new(@csv))
       ServerRole.seed
     end


### PR DESCRIPTION
Allow plugins to bring their own server_roles by adding a `content/server_roles.csv` file, for example if we extracted Embedded Ansible into a plugin we could move the embedded_ansible role to `manageiq-providers-embedded_ansible/content/server_roles.csv`:
```
name,description,max_concurrent,external_failover,role_scope
embedded_ansible,Embedded Ansible,0,false,region
```

https://github.com/ManageIQ/manageiq/issues/19440

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
