### PR TITLE
Switch to Ruby argument forwarding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem "rails",                            "~>6.1.7", ">=6.1.7.7"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false
-gem "ripper_ruby_parser",               "~>1.5.1",           :require => false
+gem "ripper_ruby_parser",               "~>1.11",            :require => false
 gem "ruby-progressbar",                 "~>1.7.0",           :require => false
 gem "rubyzip",                          "~>2.0.0",           :require => false
 gem "rugged",                           "~>1.5.0",           :require => false

--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -164,9 +164,9 @@ module FileDepotMixin
   end
   alias_method :directory_delete, :file_delete
 
-  def file_open(*args, &block)
+  def file_open(...)
     with_depot do
-      mnt.open(*args, &block)
+      mnt.open(...)
     end
   end
 

--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -4,8 +4,8 @@ module Vmdb
       @instance ||= ActiveSupport::Deprecation.new("T-release", "ManageIQ").tap { |d| d.behavior = default_behavior }
     end
 
-    def self.method_missing(method_name, *args, &block)
-      instance.respond_to?(method_name) ? instance.send(method_name, *args, &block) : super
+    def self.method_missing(method_name, ...)
+      instance.respond_to?(method_name) ? instance.send(method_name, ...) : super
     end
 
     def self.respond_to_missing?(method, _include_private = false)

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -7,8 +7,8 @@ module Vmdb
 
     include Enumerable
 
-    def self.method_missing(m, *args, &block)
-      instance.respond_to?(m) ? instance.send(m, *args, &block) : super
+    def self.method_missing(m, ...)
+      instance.respond_to?(m) ? instance.send(m, ...) : super
     end
 
     def self.respond_to_missing?(*args)


### PR DESCRIPTION
This fixes the rubocop Style/ArgumentsForwarding cop as well.

@jrafanie Please review.  I'm labeling this as Ruby3, because the ripper_ruby_parser change is really for Ruby3

If I didn't update the gem, then this argument forwarding syntax fails with errors like:

```
  1) Vmdb::Plugins .automate_domains
     Failure/Error: parsed = RipperRubyParser::Parser.new.parse(content, filename)

     SexpTypeError:
       exp must be a Sexp, was Symbol::&
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:221:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/blocks.rb:196:in `handle_block_argument'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/blocks.rb:26:in `process_params'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:135:in `process_paren'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:13:in `block in process_def'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:79:in `in_method'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/methods.rb:12:in `process_def'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:145:in `process_comment'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:56:in `block in map_process_list'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp.rb:73:in `map'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp.rb:73:in `map'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:56:in `map_process_list'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:52:in `map_process_list_compact'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/blocks.rb:89:in `process_bodystmt'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:258:in `class_or_module_body'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:60:in `process_module'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:145:in `process_comment'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:56:in `block in map_process_list'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:56:in `map'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:56:in `map_process_list'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_handlers/helper_methods.rb:52:in `map_process_list_compact'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:78:in `process_stmts'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/sexp_processor.rb:53:in `process_program'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:269:in `block (2 levels) in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:324:in `error_handler'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:268:in `block in process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:388:in `in_context'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/sexp_processor-4.17.1/lib/sexp_processor.rb:245:in `process'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/ripper_ruby_parser-1.5.1/lib/ripper_ruby_parser/parser.rb:21:in `parse'
     # ./lib/extensions/descendant_loader.rb:75:in `classes_in'
     # ./lib/extensions/descendant_loader.rb:207:in `classes_in'
     # ./lib/extensions/descendant_loader.rb:223:in `block in class_inheritance_relationships'
     # ./lib/extensions/descendant_loader.rb:222:in `class_inheritance_relationships'
     # ./lib/extensions/descendant_loader.rb:246:in `load_subclasses'
     # ./lib/extensions/descendant_loader.rb:268:in `descendants'
     # ./app/models/event_stream.rb:56:in `clear_event_groups_cache'
     # /Users/jfrey/.gem/ruby/3.1.4/gems/webmock-3.23.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'
```
