### PR TITLE
Remove HasInfra/MonitoringManagerMixin from core

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class ContainerManager < BaseManager
-    include HasMonitoringManagerMixin
-    include HasInfraManagerMixin
     include SupportsFeatureMixin
 
     has_many :container_nodes, -> { active }, # rubocop:disable Rails/HasManyOrHasOneDependent
@@ -55,12 +53,6 @@ module ManageIQ::Providers
     has_many :all_container_images, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerImage"
     has_many :all_container_nodes, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerNode"
     has_many :all_container_quotas, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerQuota"
-
-    has_one :infra_manager,
-            :foreign_key => :parent_ems_id,
-            :class_name  => "ManageIQ::Providers::Kubevirt::InfraManager",
-            :autosave    => true,
-            :dependent   => :destroy
 
     virtual_column :port_show, :type => :string
 


### PR DESCRIPTION
These mixins should only be included in specific provider classes as not all container managers will have kubevirt/prometheus_alerts

TODO:
- [x] Remove the [`has_one :infra_manager`](https://github.com/ManageIQ/manageiq/pull/22926/files#diff-ddbb7767ddad963e09e945c64111801035077d8fbdb8f1f5a2112b04433de77fR57-R61) (kubernetes specs currently failing if I move this out of core and into the Kubernetes::ContainerManager)

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/231

Co-Depends:
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/518
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/257

Follow-ups:
* https://github.com/ManageIQ/manageiq-schema/pull/722

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
