### PR TITLE
Drop needless method put at the module scope

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -65,8 +65,4 @@ module ManageIQ::Providers
       {}
     end
   end
-
-  def self.display_name(number = 1)
-    n_('Manager', 'Managers', number)
-  end
 end


### PR DESCRIPTION
The parent class, ems, already has this method with the same value.  We're currently using it because the deleted method was on the ManageIQ::Providers module, not on the BaseManager class.

```
irb(main):001:0> ManageIQ::Providers.display_name
=> "Manager"
irb(main):002:0> ManageIQ::Providers.method(:display_name)
=> #<Method: ManageIQ::Providers.display_name(number=...) /Users/joerafaniello/Code/manageiq/app/models/manageiq/providers/base_manager.rb:69>

irb(main):003:0> ManageIQ::Providers::BaseManager.method(:display_name)
=> #<Method: ManageIQ::Providers::BaseManager (call 'ManageIQ::Providers::BaseManager.connection' to establish a connection)(ExtManagementSystem (call 'ExtManagementSystem.connection' to establish a connection)).display_name(number=...) /Users/joerafaniello/Code/manageiq/app/models/ext_management_system.rb:985>
irb(main):004:0> ManageIQ::Providers::BaseManager.display_name
=> "Manager"
```

This was added to a bunch of files in cfdd29b405b86faa2e9bcc3d4d3a0ea72082f8e1 and looks like a mistake as it wasn't obvious where the module vs class scope is.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
