### PR TITLE
Remove `Vmdb::Logger.progname_from_file`

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -81,10 +81,6 @@ module Vmdb
       nil
     end
 
-    private_class_method def self.progname_from_file(log_file_name)
-      File.basename(log_file_name, ".*")
-    end
-
     private_class_method def self.create_wrapper_logger(log_file, logger_class, wrapped_logger)
       log_file = Pathname.new(log_file) if log_file.kind_of?(String)
       log_file = ManageIQ.root.join("log", log_file) if log_file.try(:dirname).to_s == "."


### PR DESCRIPTION
This method is no longer used as of 3dcf261adc2964112bdea81a760d2efb26ce7524 and can be removed.  It seems like it was added and removed in the different commits in the same PR https://github.com/ManageIQ/manageiq/pull/21177

https://github.com/search?q=org%3AManageIQ%20progname_from_file&type=code

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
