### PR TITLE
Remove return value sync_workers/sync_starting_workers

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -5,7 +5,7 @@ class MiqServer::WorkerManagement
   include Heartbeat
   include Monitor
 
-  attr_reader :my_server
+  attr_reader :my_server, :workers
 
   def self.build(my_server)
     klass = if podified?

--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -21,19 +21,15 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
   end
 
   def sync_starting_workers
-    starting = MiqWorker.find_all_starting.to_a
-    starting.each do |worker|
+    MiqWorker.find_all_starting.each do |worker|
       next if worker.class.rails_worker?
 
       worker_pod = get_pod(worker[:system_uid])
       container_status = worker_pod.status.containerStatuses.find { |container| container.name == worker.worker_deployment_name }
       if worker_pod.status.phase == "Running" && container_status.ready && container_status.started
         worker.update!(:status => "started")
-        starting.delete(worker)
       end
     end
-
-    starting
   end
 
   def enough_resource_to_start_worker?(_worker_class)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -38,9 +38,9 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def sync_workers
-    MiqWorkerType.worker_classes.each_with_object({}) do |klass, result|
-      result[klass.name] = klass.sync_workers
-      result[klass.name][:adds].each { |pid| worker_add(pid) unless pid.nil? }
+    MiqWorkerType.worker_classes.each do |klass|
+      result = klass.sync_workers
+      result[:adds].each { |pid| worker_add(pid) unless pid.nil? }
     rescue => error
       _log.error("Failed to sync_workers for class: #{klass.name}: #{error}")
       _log.log_backtrace(error)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -37,8 +37,8 @@ module MiqServer::WorkerManagement::Monitor
 
   def sync_workers
     MiqWorkerType.worker_classes.each do |klass|
-      result = klass.sync_workers
-      result[:adds].each { |pid| worker_add(pid) unless pid.nil? }
+      synced_workers = klass.sync_workers
+      synced_workers[:adds].each { |pid| worker_add(pid) unless pid.nil? }
     rescue => error
       _log.error("Failed to sync_workers for class: #{klass.name}: #{error}")
       _log.log_backtrace(error)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -23,8 +23,6 @@ module MiqServer::WorkerManagement::Monitor
     # Sync the workers after sync'ing the child worker settings
     sync_workers
 
-    sync_starting_workers
-
     MiqWorker.status_update_all
 
     cleanup_failed_workers
@@ -46,6 +44,8 @@ module MiqServer::WorkerManagement::Monitor
       _log.log_backtrace(error)
       next
     end
+
+    sync_starting_workers
   end
 
   def cleanup_failed_workers

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -11,6 +11,8 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
       next if worker.class.rails_worker?
 
       systemd_worker = miq_services_by_unit[worker[:system_uid]]
+      next if systemd_worker.nil?
+
       if systemd_worker[:load_state] == "loaded" && systemd_worker[:active_state] == "active" && systemd_worker[:sub_state] == "running"
         worker.update!(:status => "started")
         starting.delete(worker)

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -40,7 +40,10 @@ RSpec.describe MiqServer::WorkerManagement::Monitor do
         allow(MiqWorkerType).to receive(:worker_class_names).and_return(%w[MiqGenericWorker MiqPriorityWorker])
         allow(MiqGenericWorker).to receive(:sync_workers).and_raise
         expect(MiqPriorityWorker).to receive(:sync_workers).and_return(:adds => [123])
-        expect(server.worker_manager.sync_workers).to eq("MiqPriorityWorker"=>{:adds=>[123]})
+
+        server.worker_manager.sync_workers
+
+        expect(server.worker_manager.workers.keys).to include(12345, 123)
       end
     end
   end

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe MiqServer::WorkerManagement::Monitor do
 
         server.worker_manager.sync_workers
 
-        expect(server.worker_manager.workers.keys).to include(12345, 123)
+        expect(server.worker_manager.workers.keys).to include(123)
       end
     end
   end

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -53,6 +53,88 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     end
   end
 
+  context "#sync_starting_workers" do
+    let!(:worker) { FactoryBot.create(:miq_generic_worker, :status => status, :miq_server => server, :system_uid => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service") }
+
+    context "with no starting workers" do
+      let(:status) { MiqWorker::STATUS_STARTED }
+
+      it "doesn't update the worker record" do
+        expect(worker).not_to receive(:update!)
+
+        server.worker_manager.sync_starting_workers
+      end
+    end
+
+    context "with a starting worker" do
+      let(:status) { MiqWorker::STATUS_STARTING }
+
+      before { allow(worker.class).to receive(:rails_worker?).and_return(rails_worker) }
+
+      context "with a rails worker" do
+        let(:rails_worker) { true }
+
+        it "doesn't update the worker record" do
+          expect(worker).not_to receive(:update!)
+
+          server.worker_manager.sync_starting_workers
+        end
+      end
+
+      context "with a non-rails worker" do
+        let(:rails_worker) { false }
+
+        context "with no systemd unit" do
+          it "doesn't update the worker record" do
+            expect(worker).not_to receive(:update!)
+
+            server.worker_manager.sync_starting_workers
+          end
+        end
+
+        context "with a systemd unit" do
+          context "that isn't active yet" do
+            let(:units) do
+              [
+                {
+                  :name         => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service",
+                  :load_state   => "loaded",
+                  :active_state => "active",
+                  :sub_state    => "start-pre"
+                }
+              ]
+            end
+
+            it "doesn't update the worker record" do
+              server.worker_manager.sync_starting_workers
+
+              expect(worker.reload.status).to eq(MiqWorker::STATUS_STARTING)
+            end
+          end
+
+          context "that is running" do
+            let(:units) do
+              [
+                {
+                  :name         => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service",
+                  :load_state   => "loaded",
+                  :active_state => "active",
+                  :sub_state    => "running"
+                }
+              ]
+            end
+
+            it "sets the worker record to started" do
+              server.worker_manager.sync_starting_workers
+
+              expect(worker.reload.status).to eq(MiqWorker::STATUS_STARTED)
+            end
+          end
+        end
+      end
+    end
+  end
+
   context "#failed_miq_services (private)" do
     before { server.worker_manager.sync_from_system }
 


### PR DESCRIPTION
These return values don't appear to be used anywhere and make the code slightly more complicated.

Related to: https://github.com/ManageIQ/manageiq/pull/22941

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
