### PR TITLE
Remove controller prefix from RHV delete disk list

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -76,13 +76,8 @@ class Hardware < ApplicationRecord
                    .select(:id, :device_type, :location, :address)
                    .collect { |rec| [rec.id, [rec.device_type, rec.location, rec.address]] }
 
-    if parent.vendor == "redhat"
-      deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
-                     .collect { |rec| [rec.id, [rec.device_type, "0:#{rec.location}"]] }
-    else
-      deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
-                     .collect { |rec| [rec.id, [rec.device_type, rec.location]] }
-    end
+    deletes[:disk] = parent.hardware.disks.select(:id, :device_type, :location)
+                           .collect { |rec| [rec.id, [rec.device_type, rec.location]] }
 
     xmlNode.root.each_recursive do |e|
       begin


### PR DESCRIPTION
Since we are now persisting RHV disk locations in a `controller:unit` format (see dependent PR), we don't need to tack on an extra `"0:#{rec.location}"` when dealing with RHV SSA scans. Otherwise this will lead to incorrectly comparing `0:0:x` with the XML disk location `0:x` https://github.com/ManageIQ/manageiq/blob/master/app/models/hardware.rb#L205 and have the disks deleted after a SSA scan

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/662

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_labels bug, radjabov/yes?