### PR TITLE
[WIP] Use zeitwerk on load instead of hooking descendants subclasses

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -2,6 +2,11 @@ module Authenticator
   class Base
     include Vmdb::Logging
 
+    # Simulate being a STI table class for proper descendant class loading
+    def self.inheritance_column
+      "type"
+    end
+
     def self.validate_config(_config)
       []
     end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -4,9 +4,6 @@ class MiqRequestWorkflow
   include Vmdb::Logging
   include DialogFieldValidation
 
-  # We rely on MiqRequestWorkflow's descendants to be comprehensive
-  singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
-
   attr_accessor :requester, :values, :last_vm_id
   attr_writer :dialogs
 

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -9,3 +9,17 @@ end
 Rails.autoloaders.main.collapse(Rails.root.join("lib/manageiq/reporting/charting"))
 Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
 Rails.autoloaders.main.collapse(Rails.root.join("lib/pdf_generator"))
+
+DescendantLoader.instance.discovered_parent_child_classes.each do |parent, children|
+  puts "Registering on_load for class: #{parent}"
+  Rails.autoloaders.main.on_load(parent.to_s) do |klass, _abspath|
+    puts "Running on_load for class: #{klass} with children: #{children}"
+    children.each do |child|
+      begin
+        child.safe_constantize
+      rescue NameError
+        puts "!!! FAILED to load #{child} for parent: #{klass}"
+      end
+    end
+  end
+end

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -10,15 +10,25 @@ Rails.autoloaders.main.collapse(Rails.root.join("lib/manageiq/reporting/charting
 Rails.autoloaders.main.collapse(Rails.root.join("lib/ansible/runner/credential"))
 Rails.autoloaders.main.collapse(Rails.root.join("lib/pdf_generator"))
 
+excluded_from_eager_load = %w[
+  ApplicationRecord
+  MiqDecorator
+  OrchestrationStack::Status
+  ResourcePool
+]
+
 DescendantLoader.instance.discovered_parent_child_classes.each do |parent, children|
+  next if excluded_from_eager_load.include?(parent)
+
   puts "Registering on_load for class: #{parent}"
   Rails.autoloaders.main.on_load(parent.to_s) do |klass, _abspath|
     puts "Running on_load for class: #{klass} with children: #{children}"
     children.each do |child|
       begin
         child.safe_constantize
-      rescue NameError
-        puts "!!! FAILED to load #{child} for parent: #{klass}"
+      rescue NameError => err
+        puts "!!! FAILED to load #{child} for parent: #{klass} with inheritance column: #{klass.try(:inheritance_column)} reason: #{err}. Error class: #{err.class.name}"
+        raise
       end
     end
   end

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -26,6 +26,11 @@ class ActsAsArModel
     []
   end
 
+  # Simulate being a STI table class for proper descendant class loading
+  def self.inheritance_column
+    "type"
+  end
+
   class << self; alias_method :base_model, :base_class; end
 
   #


### PR DESCRIPTION
WIP - don't merge yet

Not practical.  This moves on demand calls of subclasses/descendants to eager loading of descendent classes when a class loads.  It's moving us more to eager loading but was causing other issues.  If we were to got this route, we should probably do vanilla eager load and try to resolve issues there instead of doing a modified eager load with complicated conditions for eager loading.