### PR TITLE
Update provider generator supports :create/DDFv2

### DIFF
--- a/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%.rb
+++ b/lib/generators/manageiq/provider/templates/app/models/%plugin_path%/%manager_path%.rb
@@ -1,4 +1,6 @@
 class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_type %>
+  supports :create
+
   # Form schema for creating/editing a provider, it should follow the DDF specification
   # For more information check the DDF documentation at: https://data-driven-forms.org
   #
@@ -15,11 +17,6 @@ class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_
     {
       :fields => [
         {
-          :component => "text-field",
-          :name      => "provider_region",
-          :label     => _("Provider Region"),
-        },
-        {
           :component => 'sub-form',
           :name      => 'endpoints-subform',
           :title     => _('Endpoints'),
@@ -31,24 +28,23 @@ class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_
               :validationDependencies => %w[type zone_id provider_region],
               :fields                 => [
                 {
-                  :component  => "select-field",
-                  :name       => "endpoints.default.security_protocol",
-                  :label      => _("Security Protocol"),
-                  :isRequired => true,
-                  :validate   => [{:type => "required-validator"}],
-                  :options    => [
+                  :component    => "select",
+                  :id           => "endpoints.default.verify_ssl",
+                  :name         => "endpoints.default.verify_ssl",
+                  :label        => _("SSL verification"),
+                  :dataType     => "integer",
+                  :isRequired   => true,
+                  :validate     => [{:type => "required"}],
+                  :initialValue => OpenSSL::SSL::VERIFY_PEER,
+                  :options      => [
                     {
-                      :label => _("SSL without validation"),
-                      :value => "ssl-no-validation"
+                      :label => _('Do not verify'),
+                      :value => OpenSSL::SSL::VERIFY_NONE,
                     },
                     {
-                      :label => _("SSL"),
-                      :value => "ssl-with-validation"
+                      :label => _('Verify'),
+                      :value => OpenSSL::SSL::VERIFY_PEER,
                     },
-                    {
-                      :label => _("Non-SSL"),
-                      :value => "non-ssl"
-                    }
                   ]
                 },
                 {
@@ -56,7 +52,7 @@ class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_
                   :name       => "endpoints.default.hostname",
                   :label      => _("Hostname (or IPv4 or IPv6 address)"),
                   :isRequired => true,
-                  :validate   => [{:type => "required-validator"}],
+                  :validate   => [{:type => "required"}],
                 },
                 {
                   :component    => "text-field",
@@ -65,14 +61,14 @@ class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_
                   :type         => "number",
                   :initialValue => 12345,
                   :isRequired   => true,
-                  :validate     => [{:type => "required-validator"}],
+                  :validate     => [{:type => "required"}]
                 },
                 {
                   :component  => "text-field",
                   :name       => "authentications.default.userid",
                   :label      => "Username",
                   :isRequired => true,
-                  :validate   => [{:type => "required-validator"}],
+                  :validate   => [{:type => "required"}]
                 },
                 {
                   :component  => "password-field",
@@ -80,7 +76,7 @@ class <%= class_name %>::<%= manager_type %> < ManageIQ::Providers::<%= manager_
                   :label      => "Password",
                   :type       => "password",
                   :isRequired => true,
-                  :validate   => [{:type => "required-validator"}],
+                  :validate   => [{:type => "required"}]
                 },
               ]
             }


### PR DESCRIPTION
Update the provider generator to include `supports :create` since that is now what is used to build the list of providers that can be added, as well as update the default params_for_create for DDF v2 similar to https://github.com/ManageIQ/manageiq-providers-vmware/pull/612

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
