### PR TITLE
Fix aggregate_cpu/memory utilization methods for Containers

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -55,6 +55,11 @@ module ManageIQ::Providers
     has_many :all_container_quotas, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerQuota"
 
     virtual_column :port_show, :type => :string
+    virtual_sum    :aggregate_cpu_speed,       :computer_system_hardwares, :aggregate_cpu_speed
+    virtual_sum    :aggregate_cpu_total_cores, :computer_system_hardwares, :cpu_total_cores
+    virtual_sum    :aggregate_disk_capacity,   :computer_system_hardwares, :disk_capacity
+    virtual_sum    :aggregate_memory,          :computer_system_hardwares, :memory_mb
+    virtual_sum    :aggregate_physical_cpus,   :computer_system_hardwares, :cpu_sockets
 
     supports     :authentication_status
     supports     :metrics


### PR DESCRIPTION
The default aggregate_cpu/memory utilization methods use Hosts not ContainerNodes which doesn't work for ContainerManagers.

These are the methods being used for the table, https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/aggregation_mixin.rb#L5 which use `:host_hardwares` which won't be valid for ContainerManagers.

Before:
![image](https://github.com/ManageIQ/manageiq/assets/12851112/6b672c4e-7e5f-4b9a-a619-7a44bb580762)

After:
![image](https://github.com/ManageIQ/manageiq/assets/12851112/6517e39e-79ad-439e-8e4f-94231d2f6c56)

Follow-up, ~~what do other providers without Hosts do (thinking PhysicalInfraManagers that have PhysicalServers)~~ It seems like Infra and Container are the only two manager types that show aggregate cpu/memory on the UI.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
