### PR TITLE
Add region count to audit reporting

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -598,6 +598,7 @@ class MiqServer < ApplicationRecord
       :arch                    => MiqEnvironment.arch.to_s,
       :services                => {:active => Service.active.count, :inactive => Service.inactive.count},
       :service_catalog_items   => {:active => ServiceTemplate.active.count, :archived => ServiceTemplate.archived.count},
+      :region_count            => MiqRegion.count,
     }
   end
 


### PR DESCRIPTION
We should include how many regions the user has in our audit reports

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_labels enhancement, radjabov/yes?