### PR TITLE
Add a generic EvmSpecHelper.add_role

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -21,11 +21,15 @@ module EvmSpecHelper
     end
   end
 
-  def self.assign_embedded_ansible_role(miq_server = nil)
+  def self.assign_role(role_name, miq_server: nil, create_options: {})
     MiqRegion.seed
     miq_server ||= local_miq_server
-    role = ServerRole.find_by(:name => "embedded_ansible") || FactoryBot.create(:server_role, :name => 'embedded_ansible', :max_concurrent => 0)
+    role = ServerRole.find_by(:name => role_name) || FactoryBot.create(:server_role, :name => role_name, **create_options)
     miq_server.assign_role(role).update(:active => true)
+  end
+
+  def self.assign_embedded_ansible_role(miq_server = nil)
+    assign_role("embedded_ansible", :miq_server => miq_server, :create_options => {:max_concurrent => 0})
   end
 
   # Clear all EVM caches


### PR DESCRIPTION
Make the `EvmSpecHelper.assign_embedded_ansible_role` more generic by taking a `role_name` argument allowing for other role types to be assigned.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
