### PR TITLE
Remove deletion of data/git_repos for EmbeddedAnsible tests

### DIFF
--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe GitRepository do
     let(:userid) { 'user' }
     let(:password) { 'password' }
 
+    after do
+      described_class::LOCKFILE_DIR.join(repo.id.to_s).unlink
+    rescue Errno::ENOENT
+      nil
+    end
+
     context "parameter check" do
       let(:args) do
         {

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Configur
     let(:clone_dir)          { Dir.mktmpdir }
     let(:local_repo)         { File.join(clone_dir, "hello_world_local") }
     let(:repo_dir)           { Pathname.new(Dir.mktmpdir) }
+    let(:locks_dir)          { Pathname.new(Dir.mktmpdir) }
     let(:repos)              { Dir.glob(File.join(repo_dir, "*")) }
     let(:repo_dir_structure) { %w[hello_world.yaml] }
 
@@ -26,6 +27,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Configur
 
       GitRepository
       stub_const("GitRepository::GIT_REPO_DIRECTORY", repo_dir)
+      stub_const("GitRepository::LOCKFILE_DIR", locks_dir)
 
       EvmSpecHelper.assign_embedded_ansible_role
     end
@@ -34,6 +36,7 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Configur
     after do
       FileUtils.rm_rf(repo_dir)
       FileUtils.rm_rf(clone_dir)
+      FileUtils.rm_rf(locks_dir)
     end
 
     def files_in_repository(git_repo_dir)


### PR DESCRIPTION
The data/git_repos directory doesn't appear to be used but it does leave local git changes when running the embedded_ansible_spec.rb

```
$ git status

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    data/git_repos/locks/.gitkeep
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
