### PR TITLE
Remove in_my_region calls from audit report

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -592,7 +592,7 @@ class MiqServer < ApplicationRecord
     {
       :vms                     => Vm.active.count,
       :hosts                   => Host.active.count,
-      :aggregate_physical_cpus => Host.active.in_my_region.sum(:aggregate_physical_cpus),
+      :aggregate_physical_cpus => Host.active.sum(:aggregate_physical_cpus),
       :providers               => ExtManagementSystem.group(:type).count,
       :deployment              => MiqEnvironment::Command.is_podified? ? "containers" : "appliance",
       :arch                    => MiqEnvironment.arch.to_s,


### PR DESCRIPTION
Audit reporting will be done on global regions only and so these calls need to be removed

Related:
- https://github.com/ManageIQ/manageiq/pull/22958

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @jrafanie, @Fryguy 
@miq-bot add_labels bug, radjabov/yes?