### PR TITLE
Recently active is active within past 10 minutes

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -29,7 +29,7 @@ class MiqServer < ApplicationRecord
   default_value_for(:zone) { Zone.default_zone }
 
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
-  scope :recently_active,    -> { where(:last_heartbeat => 10.minutes.ago.utc...Time.now.utc) }
+  scope :recently_active,    -> { where(:last_heartbeat => 10.minutes.ago.utc..) }
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
   virtual_delegate :description, :to => :zone, :prefix => true, :allow_nil => true, :type => :string
 


### PR DESCRIPTION
Changes query of recently active from:

```sql
-- MiqServer.where(:last_heartbeat => 10.minutes.ago.utc...Time.now.utc).first

SELECT "miq_servers".*
FROM "miq_servers"
WHERE "miq_servers"."last_heartbeat" >= $1
  AND "miq_servers"."last_heartbeat" < $2
ORDER BY "miq_servers"."id" ASC
LIMIT $3
```

to

```sql
-- MiqServer.where(:last_heartbeat => 10.minutes.ago.utc..).first

SELECT "miq_servers".*
FROM "miq_servers"
WHERE "miq_servers"."last_heartbeat" >= $1
ORDER BY "miq_servers"."id" ASC
LIMIT $2
```

Implications
============

This makes development environments (rails s) easier since we can set the heartbeat in the future.
This is necessary to run workflows with rails console / simulate_queue_worker
because 

```ruby
MiqServer.last.update(:last_heartbeat => 1.day.from_now.utc)

before:

MiqServer.where(:last_heartbeat => 10.minutes.ago.utc...Time.now.utc).exist?
=> false
MiqRegion.my_region.remote_ws_url
=> nil

after:

MiqServer.where(:last_heartbeat => 10.minutes.ago.utc..).exist?
=> true

MiqRegion.my_region.remote_ws_url
=> http://localhost:4000/
```