### PR TITLE
Pass request_task_id to to workflows

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -141,7 +141,8 @@ class MiqRequestTask < ApplicationRecord
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 
     if resource_action&.configuration_script_payload
-      miq_task_id = resource_action.configuration_script_payload.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone, :object => self)
+      inputs = dialog_values.merge(:request_task_id => id)
+      miq_task_id = resource_action.configuration_script_payload.run(:inputs => inputs, :userid => get_user.userid, :zone => zone, :object => self)
 
       options[:miq_task_id]                     = miq_task_id
       options[:configuration_script_payload_id] = resource_action.configuration_script_payload.id


### PR DESCRIPTION
request_task (main object of interest for automate tasks) is now available to workflows.

The workflows can access this miq_request_task and call `execute` when the prework is done.
The workflow can then continue from there
