### PR TITLE
Generalize the product feature for automation manager tagging of repos and credentials

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5176,9 +5176,9 @@
         :feature_type: control
         :identifier: embedded_configuration_script_source_refresh
       - :name: Edit Tags
-        :description: Edit Tags for the selected Ansible Repositories
+        :description: Edit Tags for the selected Automation Manager Repositories
         :feature_type: control
-        :identifier: ansible_repository_tag
+        :identifier: embedded_configuration_script_source_tag
   - :name: Playbooks
     :description: Everything under Playbooks
     :feature_type: node
@@ -5245,9 +5245,9 @@
         :feature_type: control
         :identifier: embedded_automation_manager_credentials_refresh
       - :name: Edit Tags
-        :description: Edit Tags for the selected Ansible Credentials
+        :description: Edit Tags for the selected Automation Manager Credentials
         :feature_type: control
-        :identifier: ansible_credential_tag
+        :identifier: embedded_automation_manager_credential_tag
 
 # Automation Manager
 - :name: Ansible Tower

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5141,7 +5141,7 @@
 
 # Embedded Automation Manager
 - :name: Embedded Automation Manager
-  :description: Everything under Ansible
+  :description: Everything under Automation Manager
   :feature_type: node
   :identifier: embedded_automation_manager
   :children:
@@ -5172,45 +5172,45 @@
         :feature_type: admin
         :identifier: embedded_configuration_script_source_delete
       - :name: Refresh Repositories
-        :description: Ansible Repositories Refresh
+        :description: Automation Manager Repositories Refresh
         :feature_type: control
         :identifier: embedded_configuration_script_source_refresh
       - :name: Edit Tags
         :description: Edit Tags for the selected Automation Manager Repositories
         :feature_type: control
         :identifier: embedded_configuration_script_source_tag
-  - :name: Playbooks
-    :description: Everything under Playbooks
+  - :name: Configuration Scripts
+    :description: Everything under Configuration Scripts
     :feature_type: node
     :identifier: embedded_configuration_script_payload
     :children:
     - :name: View
-      :description: View Playbooks
+      :description: View Configuration Script Payloads
       :feature_type: view
       :identifier: embedded_configuration_script_payload_view
     - :name: Modify
-      :description: Modify Playbooks
+      :description: Modify Configuration Script Payloads
       :feature_type: admin
       :identifier: embedded_configuration_script_payload_admin
       :children:
-      - :name: Add Playbook
-        :description: Add a Playbook
+      - :name: Add Configuration Script
+        :description: Add a Configuration Script Payload
         :feature_type: admin
         :identifier: embedded_configuration_script_payload_add
-      - :name: Edit Playbook
-        :description: Edit a Playbook
+      - :name: Edit Configuration Script
+        :description: Edit a Configuration Script Payload
         :feature_type: admin
         :identifier: embedded_configuration_script_payload_edit
       - :name: Map Credentials
-        :description: Map Credentials to Workflow
+        :description: Map Credentials to Configuration Script Payloads
         :feature_type: admin
         :identifier: embedded_configuration_script_payload_map_credentials
-      - :name: Refresh Playbooks
-        :description: Ansible Playbooks Refresh
+      - :name: Refresh Configuration Script Payloads
+        :description: Configuration Script Payload Refresh
         :feature_type: control
         :identifier: embedded_configuration_script_payload_refresh
       - :name: Edit Tags
-        :description: Edit Tags for the selected Ansible Playbooks
+        :description: Edit Tags for the selected Configuration Script Payloads
         :feature_type: control
         :identifier: embedded_configuration_script_payload_tag
 
@@ -5241,7 +5241,7 @@
         :feature_type: admin
         :identifier: embedded_automation_manager_credentials_delete
       - :name: Refresh Credentials
-        :description: Ansible Credentials Refresh
+        :description: Credentials Refresh
         :feature_type: control
         :identifier: embedded_automation_manager_credentials_refresh
       - :name: Edit Tags


### PR DESCRIPTION
We started with embedded ansible but with the addition of embedded terraform, it makes sense to generalize these common product features.

Related to https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/3

Related to: https://github.com/ManageIQ/manageiq/pull/22971

- [x] Depends on / UI changes being merged: https://github.com/ManageIQ/manageiq-ui-classic/pull/9117 (THIS PR includes that commit from the PR)
- [x] Green cross repo https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/864

Merge together:
- [ ] https://github.com/ManageIQ/manageiq/pull/22971
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/9142
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/731
- [ ] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/22

Followup work comments moved to https://github.com/ManageIQ/manageiq/issues/23005
