### PR TITLE
Allow null values in worker_settings for unit_config_file

### DIFF
--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -116,16 +116,22 @@ class MiqWorker
     end
 
     def unit_config_file
-      # Override this in a sub-class if the specific instance needs
-      # any additional config
       <<~UNIT_CONFIG_FILE
         [Service]
-        MemoryHigh=#{worker_settings[:memory_threshold].bytes}
-        TimeoutStartSec=#{worker_settings[:starting_timeout]}
-        TimeoutStopSec=#{worker_settings[:stopping_timeout]}
-        WatchdogSec=#{worker_settings[:heartbeat_timeout]}
+        #{unit_config_hash.compact.map { |key, value| "#{key}=#{value}" }.join("\n")}
         #{unit_environment_variables.map { |env_var| "Environment=#{env_var}" }.join("\n")}
       UNIT_CONFIG_FILE
+    end
+
+    # Override this in a sub-class if the specific instance needs
+    # any additional config
+    def unit_config_hash
+      {
+        "MemoryHigh"      => worker_settings[:memory_threshold]&.bytes,
+        "TimeoutStartSec" => worker_settings[:starting_timeout],
+        "TimeoutStopSec"  => worker_settings[:stopping_timeout],
+        "WatchdogSec"     => worker_settings[:heartbeat_timeout]
+      }
     end
 
     def unit_environment_variables

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -118,14 +118,14 @@ class MiqWorker
     def unit_config_file
       <<~UNIT_CONFIG_FILE
         [Service]
-        #{unit_config_hash.compact.map { |key, value| "#{key}=#{value}" }.join("\n")}
-        #{unit_environment_variables.map { |env_var| "Environment=#{env_var}" }.join("\n")}
+        #{unit_settings.compact.map              { |key, value| "#{key}=#{value}" }.join("\n")}
+        #{unit_environment_variables.compact.map { |key, value| "Environment=#{key}=#{value}" }.join("\n")}
       UNIT_CONFIG_FILE
     end
 
     # Override this in a sub-class if the specific instance needs
-    # any additional config
-    def unit_config_hash
+    # any additional configuration settings
+    def unit_settings
       {
         "MemoryHigh"      => worker_settings[:memory_threshold]&.bytes,
         "TimeoutStartSec" => worker_settings[:starting_timeout],
@@ -134,9 +134,9 @@ class MiqWorker
       }
     end
 
+    # Override this in a child class to add environment variables
     def unit_environment_variables
-      # Override this in a child class to add env vars
-      []
+      {}
     end
   end
 end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -127,6 +127,6 @@ module PerEmsWorkerMixin
   end
 
   def unit_environment_variables
-    super << "EMS_ID=#{ems_id}"
+    super.merge("EMS_ID" => ems_id)
   end
 end


### PR DESCRIPTION
Allow subclasses to "drop" a worker_setting from the systemd unit_config.  For example if a worker doesn't have a heartbeat a worker can set the setting to nil and the HeartbeatTimeout property won't be set in the unit_config file for the systemd unit.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
