### PR TITLE
Move `GitWorktree#pull` to a public method

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -114,7 +114,7 @@ class GitRepository < ApplicationRecord
     with_worktree do |worktree|
       message = "Updating #{url} in #{directory_name}..."
       _log.info(message)
-      worktree.send(:pull)
+      worktree.pull
       _log.info("#{message}...Complete")
     end
     @updated_repo = true

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -263,6 +263,10 @@ class GitWorktree
     end
   end
 
+  def pull
+    lock { fetch_and_merge }
+  end
+
   def with_remote_options
     if @ssh_private_key
       @ssh_private_key_file = Tempfile.new
@@ -326,10 +330,6 @@ class GitWorktree
     with_remote_options do |remote_options|
       @repo.fetch(@remote_name, **remote_options)
     end
-  end
-
-  def pull
-    lock { fetch_and_merge }
   end
 
   def merge_and_push(commit)

--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe GitWorktree do
       expect(c_repo.file_list).to match_array(@ae_db.file_list)
       @ae_db.mv_file_with_new_contents('A/File1.YamL', 'A/File11.YamL', "Hello")
       @ae_db.save_changes("file renamed in master")
-      c_repo.send(:pull)
+      c_repo.pull
       expect(c_repo.file_list).to match_array(@ae_db.file_list)
       FileUtils.rm_rf(dirname) if Dir.exist?(dirname)
     end
@@ -247,14 +247,14 @@ RSpec.describe GitWorktree do
         end
       end
 
-      describe "#pull (private)" do
+      describe "#pull" do
         it "fetches the repo with proxy options" do
           _dir, worktree = clone(@master_url)
           expect(worktree.instance_variable_get(:@repo)).to receive(:fetch).with("origin", hash_including(:proxy_url => proxy_url))
 
           worktree.instance_variable_set(:@proxy_url, proxy_url)
 
-          worktree.send(:pull)
+          worktree.pull
         end
       end
     end


### PR DESCRIPTION
Pull isn't called internally and there doesn't appear to be another public way to update an existing cloned git repo.

Ref: https://github.com/ManageIQ/manageiq/pull/22972#discussion_r1556108231

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
