### PR TITLE
Pluggable credential types

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -1,6 +1,10 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < ManageIQ::Providers::EmbeddedAutomationManager::Authentication
   FRIENDLY_NAME = "Embedded Ansible Credential".freeze
 
+  def self.credential_type
+    "embedded_ansible_credential_types"
+  end
+
   private_class_method def self.queue_role
     "embedded_ansible"
   end

--- a/app/models/manageiq/providers/external_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/external_automation_manager/authentication.rb
@@ -1,3 +1,6 @@
 class ManageIQ::Providers::ExternalAutomationManager::Authentication <
   ManageIQ::Providers::AutomationManager::Authentication
+  def self.credential_type
+    "external_credential_types"
+  end
 end


### PR DESCRIPTION
Originally credential types were hard coded in the `Authentication` class. With this change we can define credential types in the respective classes and then pull the info for the OPTIONS call from the new `Authentication.credential_types` method

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1259
- [x] https://github.com/ManageIQ/manageiq-providers-workflows/pull/77
- [x] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/13

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_labels enhancement