### PR TITLE
Add workflow_dispatch to allow manually triggering monolithic builds

### DIFF
--- a/.github/workflows/build_monolith.yaml
+++ b/.github/workflows/build_monolith.yaml
@@ -3,6 +3,7 @@ on:
   repository_dispatch:
     types:
     - build
+  workflow_dispatch:
 jobs:
   build_monolith:
     if: github.repository_owner == 'ManageIQ'


### PR DESCRIPTION
I can't manually trigger the quinteros-1 build and something didn't work on the repository_dispatch