### PR TITLE
Remove generic_ansible_playbook catalog_type from embedded automation manager

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Providers::EmbeddedAutomationManager
+  supports     :catalog
   supports_not :refresh_ems
 
   def self.ems_type
@@ -7,5 +8,9 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
 
   def self.description
     @description ||= "Embedded Ansible Automation".freeze
+  end
+
+  def self.catalog_types
+    {"generic_ansible_playbook" => N_("Ansible Playbook")}
   end
 end

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -1,7 +1,2 @@
 class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::AutomationManager
-  supports :catalog
-
-  def self.catalog_types
-    {"generic_ansible_playbook" => N_("Ansible Playbook")}
-  end
 end


### PR DESCRIPTION
This catalog type should only be implemented by the EmbeddedAnsible provider and not by the other embedded automation_managers that inherit from this (Embedded Workflows and Embedded Terraform)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
