### PR TITLE
Add referrer_policy to security headers to fix DAST scan

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,6 +11,7 @@ if defined?(SecureHeaders)
     # X-XSS-Protection
     # X-Permitted-Cross-Domain-Policies
     config.x_xss_protection = "1; mode=block"
+    config.referrer_policy = "no-referrer-when-downgrade"
     # Content-Security-Policy
     # Need google fonts in fonts_src for https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed%7CIBM+Plex+Sans:400,600&display=swap (For carbon-charts download)
     config.csp = {


### PR DESCRIPTION
**Before**

<details><summary>DAST Scan Results</summary>

| path | element | package | severity | threatClass | securityRisk | cause  | cvss | status | comment |
|---|---|---|---|---|---|---|---|---|---|
|/| ||Informational|Information Leakage|It is possible to persuade a naive user to supply sensitive information such as username, password, credit card number, social security number etc.|Insecure web application programming or configuration|0.0|Open||
</details>

`curl -I http://localhost:3000`


`Referrer-Policy: no-referrer-when-downgrade` was not available before

**After**
```
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Vary: Accept
ETag: W/"08d7ba3d47d6f6da91a6b2d7293e856b"
Cache-Control: max-age=0, private, must-revalidate
Set-Cookie: _vmdb_session=3361f6dd38cef8eb822fddf78d9234b2; path=/; expires=Thu, 25 Apr 2024 07:43:43 GMT; HttpOnly
X-Request-Id: 6d517b7d-2402-4f44-95ac-af34cedd1dcc
X-Runtime: 13.803666
Content-Security-Policy: default-src 'self'; child-src 'self'; connect-src 'self' fonts.gstatic.com ws://localhost:3000; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; script-src 'unsafe-eval' 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report
Referrer-Policy: no-referrer-when-downgrade
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-XSS-Protection: 1; mode=block
Content-Length: 0
```