### PR TITLE
comments on a Switch

### DIFF
--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -3,6 +3,9 @@ class Switch < ApplicationRecord
   include CustomActionsMixin
   extend TenancyCommonMixin
 
+  # Note:
+  #   DistributedVirtualSwitch, PhysicalSwitch references ems through Switch#ems_id
+  #   HostVirtualSwitch references ems through Host
   belongs_to :host, :inverse_of => :host_virtual_switches
   has_one :ext_management_system, :through => :host
 


### PR DESCRIPTION
Document how a switch relates to an ems

Some models use `ems_id`, others use `HostVirtualSwitch`