### PR TITLE
Fix Renovate PRs

### DIFF
--- a/bin/before_install
+++ b/bin/before_install
@@ -38,7 +38,7 @@ if [ -n "$CI" ]; then
   echo
 
   # Gemfile.lock.release only applies to non-master branches and PRs to non-master branches
-  if [[ "$GITHUB_REPOSITORY_OWNER" = "ManageIQ" && "$GITHUB_BASE_REF" != "master" && "$GITHUB_REF_NAME" != "master" && "$GITHUB_REF_NAME" != "dependabot/"* ]]; then
+  if [[ "$GITHUB_REPOSITORY_OWNER" = "ManageIQ" && "$GITHUB_BASE_REF" != "master" && "$GITHUB_REF_NAME" != "master" && "$GITHUB_REF_NAME" != "dependabot/"* && "$GITHUB_REF_NAME" != "renovate/"* ]]; then
     echo "== Setup Gemfile.lock.release =="
     cp -f "$APP_ROOT/Gemfile.lock.release" "$APP_ROOT/Gemfile.lock"
     echo

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -80,7 +80,8 @@ module ManageIQ
       return unless ENV["GITHUB_REPOSITORY_OWNER"] == "ManageIQ" &&
                     ENV["GITHUB_BASE_REF"] != "master" && # PR to non-master branch
                     ENV["GITHUB_REF_NAME"] != "master" && # A non-master branch
-                    !ENV["GITHUB_REF_NAME"].to_s.start_with?("dependabot/") # Dependabot makes branches in the core repo
+                    !ENV["GITHUB_REF_NAME"].to_s.start_with?("dependabot/") && # Dependabot makes branches in the core repo
+                    !ENV["GITHUB_REF_NAME"].to_s.start_with?("renovate/")      # Renovate makes branches in the core repo
 
       raise "Missing Gemfile.lock.release" unless APP_ROOT.join("Gemfile.lock.release").file?
 


### PR DESCRIPTION
Renovate PRs fail because they try to copy the Gemfile.lock.release when it doesn't exist, so we can ignore those branches.

@agrare Please review.

Example failing PR: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/494
Example failing test: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/actions/runs/8847743518/job/24296188020?pr=494#step:6:24