### PR TITLE
Replace RipperRubyParser with Prism for DescendantLoader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-raise "Ruby versions < 3.0.0 are unsupported!"  if RUBY_VERSION < "3.0.0"
+raise "Ruby versions < 3.0.1 are unsupported!"  if RUBY_VERSION < "3.0.1"
 raise "Ruby versions >= 3.2.0 are unsupported!" if RUBY_VERSION >= "3.2.0"
 
 source 'https://rubygems.org'
@@ -29,7 +29,7 @@ gem "awesome_spawn",                    "~>1.6",             :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load
-gem "bundler",                          "~> 2.1", ">= 2.1.4", "!= 2.2.10", :require => false
+gem "bundler",                          "~> 2.2", ">= 2.2.15", *("!= 2.5.0".."!= 2.5.9"), :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
 gem "pg",                               ">=1.4.1",           :require => false
 gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
+gem "prism",                            ">=0.25.0",          :require => false # Used by DescendantLoader
 gem "psych",                            ">=3.1",             :require => false # 3.1 safe_load changed positional to kwargs like aliases: true: https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.6.4",         :require => false
@@ -71,7 +72,6 @@ gem "rails",                            "~>6.1.7", ">=6.1.7.7"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false
-gem "ripper_ruby_parser",               "~>1.11",            :require => false
 gem "ruby-progressbar",                 "~>1.7.0",           :require => false
 gem "rubyzip",                          "~>2.0.0",           :require => false
 gem "rugged",                           "~>1.5.0",           :require => false

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -67,12 +67,11 @@ class DescendantLoader
   # be defined in [depending on runtime details], the name of the class,
   # and the name of its superclass), given a path to a ruby script file.
   module Parser
-    autoload :RipperRubyParser, 'ripper_ruby_parser'
+    autoload :Prism, 'prism'
 
     def classes_in(filename)
-      content = File.read(filename)
       begin
-        parsed = RipperRubyParser::Parser.new.parse(content, filename)
+        parsed = Prism::Translation::RubyParser.parse_file(filename)
       rescue => e
         warn "\nError parsing classes in #{filename}:\n#{e.class.name}: #{e}\n\n"
         raise


### PR DESCRIPTION
RipperRubyParser isn't really maintained anymore whereas Prism is soon becoming the replacement official Ruby parser. Prism already has a RubyParser translation layer internally, which is fully maintained. Additionally, the performance of Prism is much faster than Ripper.

Performance testing DescendantLoader:

Cached sti_loader? | Measurement            | Time (s)
------------------ | ---------------------- | ---------------------
(Ripper) No cache  | Vm.descendants         | 15.303
(Prism)  No cache  | Vm.descendants         |  4.093 (73% faster)
(Ripper) No cache  | evm:compile_sti_loader | 20.120
(Prism)  No cache  | evm:compile_sti_loader |  8.216 (59% faster)
(Ripper) Cached    | Vm.descendants         |  0.554
(Prism)  Cached    | Vm.descendants         |  0.583 (same)
(Ripper) Cached    | evm:compile_sti_loader |  3.271
(Prism)  Cached    | evm:compile_sti_loader |  3.138 (same)

---

The second commit updates bundler to deal with this new gem and some bugs found in bundler itself.

In rubygems/rubygems#7607, this bundler bug presented itself with respect to adding the prism gem and was fixed in 2.5.10. As such, we want to avoid loading 2.5.0 to 2.5.9.

Separately, the application will still work with older versions of bundler. While we could change the bundler minimum to ">= 2.5.10", and call it a day, this actually causes unnecessary overhead for developers and CI, where we are forced to install that minimum version and can't just use what comes with Ruby, which is the most convenient option. In CI, the setup-ruby action will try to use the version of bundler that comes with Ruby, and we'd like to avoid overriding that if possible, because it requires changes to ci.yaml files in every repo. Again, using what comes with Ruby is the most convenient option.

So, to summarize, the goal is to support as many versions of Ruby and bundler as possible, avoid CI and developer overhead, while simultaneous not allowing specific versions of bundler, namely 2.2.10 (which has a bug that breaks our application) and 2.5.0-2.5.9, while also keeping the Gemfile line as succinct as possible.

So, the changes in this commit:
1. Bump the minimum version of bundler to 2.2. This is because the application only supports Ruby 3.0+ and the version of bundler that shipped with Ruby 3.0.0 was bundler 2.2.3.
2. Bump Ruby minimum to 3.0.1 and thus further bump the bundler minimum to 2.2.15. This avoids the bundler 2.2.10 problem. It's unlikely anyone is actually using Ruby 3.0.0 since 3.0.7 is the current version of Ruby, so changing this Ruby minimum shouldn't affect many developers, and it does not affect CI at all.
3. Prevent bundler 2.5.0 through 2.5.9. The only way to do this in bundler while keeping 2.2 as the minimum is to enumerate each version. For cleanliness, this commit uses a simple map.

---

@jrafanie Please review.

Will likely depend on https://github.com/rubygems/rubygems/issues/7585, so we may not be able to merge until we change the bundler minimum.