### PR TITLE
Close Kafka broker client connection after health check

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -629,6 +629,7 @@ class MiqServer < ApplicationRecord
 
     broker.publish_message(:service => "manageiq.liveness-check", :message => "test message", :payload => {})
     broker.subscribe_messages(:service => "manageiq.liveness-check") { break }
+    broker.close
   rescue => err
     _log.error("Messaging health check failed: #{err}")
     shutdown_and_exit(1)


### PR DESCRIPTION
The Kafka client should be closed after a successful health check. This was causing the manageiq-messaging-ready script to hang in the case of multiple Kafka appliances, since there were multiple consumers active on the same topic. As a result, the consumer on the health check of the running evmserver of the first appliance, was consuming all the health check messages being produced by all appliances. 

Related:
- [ ] https://github.com/ManageIQ/manageiq-appliance/pull/384

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_label bug
