### PR TITLE
Add a GenericMailer method that creates a MiqTask

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -52,14 +52,14 @@ class GenericMailer < ActionMailer::Base
     _log.info("starting: method: #{method} args: #{options} ")
     options[:attachment] &&= attachment_to_blob(options[:attachment])
 
-    queue_options.reverse_merge!(
-      :service     => "notifier",
-      :class_name  => name,
-      :method_name => 'deliver',
-      :args        => [method, options]
+    MiqQueue.submit_job(
+      queue_options.reverse_merge(
+        :service     => "notifier",
+        :class_name  => name,
+        :method_name => 'deliver',
+        :args        => [method, options]
+      )
     )
-
-    MiqQueue.submit_job(**queue_options)
   end
 
   def self.deliver_task(method, options = {})

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -17,28 +17,72 @@ describe GenericMailer do
       @miq_server.save!
     end
 
-    it "call deliver_queue for generic_notification" do
-      @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
-      expect(BinaryBlob.count).to eq(0)
-      GenericMailer.deliver_queue(:generic_notification, @args)
-      expect(BinaryBlob.count).to eq(1)
-      expect(MiqQueue.exists?(:method_name => 'deliver',
-                              :class_name  => described_class.name,
-                              :role        => 'notifier')).to be_truthy
+    describe ".deliver_queue" do
+      it "with generic_notification" do
+        @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
+        expect(BinaryBlob.count).to eq(0)
+        GenericMailer.deliver_queue(:generic_notification, @args)
+        expect(BinaryBlob.count).to eq(1)
+        expect(MiqQueue.exists?(:method_name => 'deliver',
+                                :class_name  => described_class.name,
+                                :role        => 'notifier')).to be_truthy
+      end
+
+      it "with automation_notification" do
+        GenericMailer.deliver_queue(:automation_notification, @args)
+        expect(MiqQueue.exists?(:method_name => 'deliver',
+                                :class_name  => described_class.name,
+                                :role        => 'notifier')).to be_truthy
+      end
     end
 
-    it "call deliver_queue for automation_notification" do
-      GenericMailer.deliver_queue(:automation_notification, @args)
-      expect(MiqQueue.exists?(:method_name => 'deliver',
-                              :class_name  => described_class.name,
-                              :role        => 'notifier')).to be_truthy
+    describe ".deliver_task" do
+      it "with generic_notification" do
+        @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
+
+        expect(BinaryBlob.count).to eq(0)
+        task = GenericMailer.deliver_task(:generic_notification, @args)
+        expect(task).to have_attributes(
+          :state   => MiqTask::STATE_QUEUED,
+          :status  => MiqTask::STATUS_OK,
+          :message => "Queued the action: [generic_notification]"
+        )
+        expect(BinaryBlob.count).to eq(1)
+        expect(MiqQueue.exists?(:method_name => 'deliver',
+                                :class_name  => described_class.name,
+                                :role        => 'notifier')).to be_truthy
+      end
+
+      it "with automation_notification" do
+        task = GenericMailer.deliver_task(:automation_notification, @args)
+        expect(task).to have_attributes(
+          :state   => MiqTask::STATE_QUEUED,
+          :status  => MiqTask::STATUS_OK,
+          :message => "Queued the action: [automation_notification]"
+        )
+        expect(MiqQueue.exists?(:method_name => 'deliver',
+                                :class_name  => described_class.name,
+                                :role        => 'notifier')).to be_truthy
+      end
     end
   end
 
   context 'without a notifier within a region' do
-    it 'does not queue any mail notifications' do
-      @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
-      expect { GenericMailer.deliver_queue(:generic_notification, @args) }.not_to(change { MiqQueue.count })
+    describe ".deliver_queue" do
+      it 'does not queue any mail notifications' do
+        @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
+        expect { GenericMailer.deliver_queue(:generic_notification, @args) }.not_to(change { MiqQueue.count })
+      end
+    end
+
+    describe ".deliver_task" do
+      it "sets the miq_task to status error" do
+        task = GenericMailer.deliver_task(:generic_notification, @args)
+        expect(task).to have_attributes(
+          :status  => MiqTask::STATUS_ERROR,
+          :message => "No server with notifier role in region"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
There is currently a `GenericMailer.deliver_queue` which puts the deliver request on the queue but no task is created for tracking the state/status of the request.

This adds a `GenericMailer.deliver_task` method that wraps `.deliver_queue` but creates a `MiqTask` and adds a queue callback to the `MiqQueue` options.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
