### PR TITLE
Rework Kafka health check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "linux_admin",                      "~>2.0", ">=2.0.1",  :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "manageiq-api-client",              "~>0.3.6",           :require => false
 gem "manageiq-loggers",                 "~>1.0", ">=1.1.1",  :require => false
-gem "manageiq-messaging",               "~>1.0", ">=1.4.1",  :require => false
+gem "manageiq-messaging",               "~>1.0", ">=1.4.3",  :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.2",             :require => false
 gem "manageiq-ssh-util",                "~>0.1.1",           :require => false

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -629,6 +629,7 @@ class MiqServer < ApplicationRecord
 
     broker.publish_message(:service => "manageiq.liveness-check", :message => "test message", :payload => {})
     broker.subscribe_messages(:service => "manageiq.liveness-check") { break }
+    broker.close
   rescue => err
     _log.error("Messaging health check failed: #{err}")
     shutdown_and_exit(1)

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -627,11 +627,14 @@ class MiqServer < ApplicationRecord
     broker = MiqQueue.messaging_client("health_check")
     return if broker.nil?
 
-    broker.publish_message(:service => "manageiq.liveness-check", :message => "test message", :payload => {})
-    broker.subscribe_messages(:service => "manageiq.liveness-check") { break }
-    broker.close
-  rescue => err
-    _log.error("Messaging health check failed: #{err}")
-    shutdown_and_exit(1)
+    begin
+      # Fail health check if list of topics can't be retrieved
+      broker.topics
+    rescue => err
+      _log.error("Messaging health check failed: #{err}")
+      shutdown_and_exit(1)
+    ensure
+      broker.close
+    end
   end
 end # class MiqServer


### PR DESCRIPTION
- The push/pop approach for Kafka health checks is not ideal because this can lead to timing issues when dealing with multiple consumers (multiple appliances). Therefore using a simple call to retrieve metadata from the Kafka server, this will fail if the server is down which is ideal for a health check
- Kafka client connections should be closed to prevent issues with multiple consumers on the same topic

Depends on:
- [x] https://github.com/ManageIQ/manageiq-messaging/pull/88
- [x] https://github.com/ManageIQ/manageiq-appliance/pull/384

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_labels enhancement, bug

