### PR TITLE
statemachine_task_status

### DIFF
--- a/app/models/automation_task.rb
+++ b/app/models/automation_task.rb
@@ -10,6 +10,10 @@ class AutomationTask < MiqRequestTask
     AutomationTask
   end
 
+  def statemachine_task_status
+    state == "finished" ? status.to_s.downcase : "retry"
+  end
+
   def do_request
     args = {}
     args[:object_type]      = self.class.name

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -38,6 +38,14 @@ class MiqProvision < MiqProvisionTask
     MiqProvision
   end
 
+  def statemachine_task_status
+    if %w[finished provisioned].include?(state)
+      status.to_s.downcase == "error" || vm.nil? ? "error" : "ok"
+    else
+      "retry"
+    end
+  end
+
   def set_template_and_networking
     self.source = get_source
 

--- a/app/models/miq_provision_task.rb
+++ b/app/models/miq_provision_task.rb
@@ -10,6 +10,14 @@ class MiqProvisionTask < MiqRequestTask
     MiqProvisionTask
   end
 
+  def statemachine_task_status
+    if %w[finished provisioned].include?(state)
+      status.to_s.downcase == "error" || vm.nil? ? "error" : "ok"
+    else
+      "retry"
+    end
+  end
+
   def do_request
     signal :run_provision
   end

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -11,6 +11,10 @@ class ServiceReconfigureTask < MiqRequestTask
     "#{request_class::TASK_DESCRIPTION} for: #{req_obj.source.name}"
   end
 
+  def statemachine_task_status
+    state == "finished" ? status.to_s.downcase : "retry"
+  end
+
   def after_request_task_create
     update(:description => get_description)
   end

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -9,6 +9,14 @@ class ServiceRetireTask < MiqRetireTask
     Service
   end
 
+  def statemachine_task_status
+    if state == "finished"
+      status.to_s.downcase == "error" ? "error" : "ok"
+    else
+      "retry"
+    end
+  end
+
   def update_and_notify_parent(*args)
     prev_state = state
     super

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -9,6 +9,10 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     ServiceTemplateProvisionTask
   end
 
+  def statemachine_task_status
+    %w[finished provisioned].include?(state) ? status.to_s.downcase : "retry"
+  end
+
   def my_zone
     dialog_zone || source.my_zone || MiqServer.my_zone
   end

--- a/app/models/vm_migrate_task.rb
+++ b/app/models/vm_migrate_task.rb
@@ -36,6 +36,14 @@ class VmMigrateTask < MiqRequestTask
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end
 
+  def statemachine_task_status
+    if %w[finished migrated].include?(state)
+      status.to_s.downcase == "error" ? "error" : "ok"
+    else
+      "retry"
+    end
+  end
+
   def after_request_task_create
     update_attribute(:description, get_description)
   end

--- a/app/models/vm_retire_task.rb
+++ b/app/models/vm_retire_task.rb
@@ -9,4 +9,12 @@ class VmRetireTask < MiqRetireTask
   def self.model_being_retired
     Vm
   end
+
+  def statemachine_task_status
+    if state == "finished"
+      status.to_s.downcase == "error" ? "error" : "ok"
+    else
+      "retry"
+    end
+  end
 end


### PR DESCRIPTION
transfer automate status methods over to core

see also: https://github.com/ManageIQ/manageiq-automation_engine/pull/547

We are transferring "check status" over from automate to floe, so we need to roll this value into core.

Not exactly sure how retry will work, so that part may be a little different

Transferred from:

- [automation_task.rb:5](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_automation_task.rb#L5)
- [vm_retire_task.rb:3](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_vm_retire_task.rb#L3)
- [service_retire_task.rb:3](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_service_retire_task.rb#L3)
- [miq_provision_task.rb:3](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_task.rb#L3)
- [vm_migrate_task.rb:3](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_vm_migrate_task.rb#L3)
- [service_reconfigure_task.rb:19](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_service_reconfigure_task.rb#L19)
- [service_template_provision_task.rb:25](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb#L25)
- [miq_provision.rb:37](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb#L37)

