### PR TITLE
Bump appliance_console for kafka client fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -288,7 +288,7 @@ end
 
 group :appliance, :optional => true do
   gem "irb",                            "=1.4.1",            :require => false # Locked to same version as the installed RPM rubygem-irb-1.4.1-142.module_el9+787+b20bfeee.noarch so that we don't bundle our own
-  gem "manageiq-appliance_console",     "~>9.0", ">= 9.0.2", :require => false
+  gem "manageiq-appliance_console",     "~>9.0", ">= 9.0.3", :require => false
   gem "rdoc",                                                :require => false # Needed for rails console
 end
 


### PR DESCRIPTION
Pull in fix for missing ca-cert when configuring an appliance as a messaging client.

https://github.com/ManageIQ/manageiq-appliance_console/pull/250

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
