### PR TITLE
Improve the defaults for optional positional AnsibleRunnerWorkflow parameters

### DIFF
--- a/app/models/manageiq/providers/ansible_runner_workflow.rb
+++ b/app/models/manageiq/providers/ansible_runner_workflow.rb
@@ -1,7 +1,10 @@
 class ManageIQ::Providers::AnsibleRunnerWorkflow < Job
   def self.create_job(env_vars, extra_vars, role_or_playbook_options,
-                      hosts = ["localhost"], credentials = [],
+                      hosts = nil, credentials = nil,
                       timeout: 1.hour, poll_interval: 1.second, verbosity: 0, become_enabled: false)
+    hosts       ||= %w[localhost]
+    credentials ||= []
+
     super(role_or_playbook_options.merge(
       :become_enabled => become_enabled,
       :credentials    => credentials,


### PR DESCRIPTION
The `AnsibleRunnerWorkflow` optional positional parameters had their defaults in the method definition which doesn't work properly if a `nil` is passed in which it would have to be in order to specify e.g. credentials but not hosts.

The calling method (https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb#L24) passes `vars[:hosts], credentials` so it isn't possible for the `hosts = ["localhosts"]` to ever work when called from the `Playbook#run` method

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
