### PR TITLE
Supports feature attributes

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -7,6 +7,7 @@ class CloudVolume < ApplicationRecord
   include CustomActionsMixin
   include EmsRefreshMixin
   include Operations
+  include SupportsAttribute
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
   belongs_to :availability_zone
@@ -24,11 +25,7 @@ class CloudVolume < ApplicationRecord
   has_many   :host_initiators, :through => :volume_mappings
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
-  virtual_column :supports_safe_delete, :type => :boolean
-
-  def supports_safe_delete
-    supports?(:safe_delete)
-  end
+  supports_attribute :feature => :safe_delete
 
   acts_as_miq_taggable
 

--- a/app/models/mixins/supports_attribute.rb
+++ b/app/models/mixins/supports_attribute.rb
@@ -1,4 +1,4 @@
-module ExtManagementSystem::SupportsAttribute
+module SupportsAttribute
   extend ActiveSupport::Concern
 
   class_methods do

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -8,6 +8,7 @@ class VmOrTemplate < ApplicationRecord
   include RetirementMixin
   include ScanningMixin
   include SupportsFeatureMixin
+  include SupportsAttribute
   include EmsRefreshMixin
 
   self.table_name = 'vms'
@@ -199,6 +200,11 @@ class VmOrTemplate < ApplicationRecord
 
   delegate :connect_lans, :disconnect_lans, :to => :hardware, :allow_nil => true
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
+  supports_attribute :feature => :reconfigure_disks
+  supports_attribute :feature => :reconfigure_disksize
+  supports_attribute :feature => :reconfigure_cdroms
+  supports_attribute :feature => :reconfigure_network_adapters
 
   after_save :save_genealogy_information
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe VmOrTemplate do
+  include Spec::Support::SupportsHelper
+
   subject { vm }
 
   include_examples "MiqPolicyMixin"
@@ -720,6 +722,34 @@ RSpec.describe VmOrTemplate do
 
     it "returns true for a valid vm" do
       expect(vm.supports?(:control)).to be_truthy
+    end
+  end
+
+  context "virtual column :supports_reconfigure_network_adapters" do
+    it "returns false if reconfigure_network_adapters is not supported" do
+      ems = FactoryBot.create(:vm_infra)
+      stub_supports_not(ems.class, :reconfigure_network_adapters)
+      expect(ems.supports_reconfigure_network_adapters).to eq(false)
+    end
+
+    it "returns true if reconfigure_network_adapters is supported" do
+      ems = FactoryBot.create(:vm_infra)
+      stub_supports(ems.class, :reconfigure_network_adapters)
+      expect(ems.supports_reconfigure_network_adapters).to eq(true)
+    end
+  end
+
+  context "virtual column :supports_reconfigure_cdroms" do
+    it "returns false if reconfigure_cdroms is not supported" do
+      ems = FactoryBot.create(:vm_infra)
+      stub_supports_not(ems.class, :reconfigure_cdroms)
+      expect(ems.supports_reconfigure_cdroms).to eq(false)
+    end
+
+    it "returns true if reconfigure_cdroms is supported" do
+      ems = FactoryBot.create(:vm_infra)
+      stub_supports(ems.class, :reconfigure_cdroms)
+      expect(ems.supports_reconfigure_cdroms).to eq(true)
     end
   end
 


### PR DESCRIPTION
added `supports_` columns so the API can determine if the vm supports reconfiguration.

related to https://github.com/ManageIQ/manageiq/pull/22980

/cc @jeffibm FYI - for the reconfiguration API that is currently on hold