### PR TITLE
 Fixed ansible tower templates title

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1484,6 +1484,7 @@ en:
       ManageIQ::Providers::Workflows::AutomationManager::ScmCredential:                   Credential (SCM)
       ManageIQ::Providers::Workflows::AutomationManager::WorkflowCredential:              Credential (Workflow)
       ManageIQ::Providers::ExternalAutomationManager:                                     Automation Manager
+      ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript:                Template (Ansible Tower)
       ManageIQ::Providers::AutomationManager::Authentication:                             Credential
       ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential:             Credential (Amazon)
       ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential:              Credential (Microsoft Azure)


### PR DESCRIPTION
Fixed ansible tower templates title.

Before:
<img width="1414" alt="Screenshot 2024-05-10 at 8 57 11 AM" src="https://github.com/ManageIQ/manageiq/assets/32444791/4054146a-af7f-4a85-99a2-7d0cee70d84e">

After:
<img width="1409" alt="Screenshot 2024-05-10 at 8 56 53 AM" src="https://github.com/ManageIQ/manageiq/assets/32444791/b2a8c212-8a7e-47a1-9e3a-80f409f87aa4">
