### PR TITLE
Don't send a 0.minute timeout for EmbeddedAnsible Playbook run if execution_ttl is not passed

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -18,8 +18,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < Manage
     credentials = collect_credentials(vars)
 
     kwargs = {:become_enabled => vars[:become_enabled]}
-    kwargs[:timeout]   = vars[:execution_ttl].to_i.minutes
-    kwargs[:verbosity] = vars[:verbosity].to_i if vars[:verbosity].present?
+    kwargs[:timeout]   = vars[:execution_ttl].to_i.minutes if vars[:execution_ttl].present?
+    kwargs[:verbosity] = vars[:verbosity].to_i             if vars[:verbosity].present?
 
     workflow.create_job({}, extra_vars, playbook_vars, vars[:hosts], credentials, **kwargs).tap(&:signal_start)
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook
       expect(job.options[:verbosity]).to eq(5)
     end
 
+    it "defaults to timeout 1.hour with execution_ttl is not passed" do
+      job = playbook.run
+
+      expect(job).to be_a(ManageIQ::Providers::AnsiblePlaybookWorkflow)
+      expect(job.options[:timeout]).to eq(1.hour)
+    end
+
     it "passes become_enabled to the job when specified" do
       job = playbook.run(:become_enabled => true)
 


### PR DESCRIPTION
AnsibleRunnerWorkflow has a default timeout of `1.hour` but if the `:execution_ttl` isn't passed it will set `:timeout => 0.minutes` because of `vars[:execution_ttl].to_i.minutes`
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
