### PR TITLE
Mark the MiqTask as finished if GenericMailer fails due to missing notifier role

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -69,7 +69,7 @@ class GenericMailer < ActionMailer::Base
 
     # Fail the task if there is no server with the notifier role in this region
     unless MiqRegion.my_region.role_assigned?('notifier')
-      task.error(_("No server with notifier role in region"))
+      task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_ERROR, _("No server with notifier role in region"))
       return task
     end
 


### PR DESCRIPTION
If there is no notifier role and the MiqTask tracking the GenericMailer.deliver call fails mark the state as finished.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
