### PR TITLE
Add a `deliver!` version of `GenericMailer.deliver`

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -2,19 +2,16 @@ require 'hamlit'
 class GenericMailer < ActionMailer::Base
   include Vmdb::Logging
 
-  def self.deliver(method, options = {})
+  def self.deliver!(method, options = {})
     _log.info("starting: method: #{method} options: #{options} ")
     options[:attachment] &&= blob_to_attachment(options[:attachment])
     options[:sent_on] = Time.now
 
     msg = send(method, options)
     begin
-      msg.deliver_now
-
-    # catch delivery errors if raised,
-    rescue Net::SMTPError => e
+      msg.deliver_now!
+    rescue Net::SMTPError => e # catch delivery errors if raised
       invalid = []
-
       # attempt to resend message to recipients individually
       rcpts = [msg.to].flatten
       rcpts.each do |rcpt|
@@ -22,28 +19,27 @@ class GenericMailer < ActionMailer::Base
           options[:to] = to
           individual = send(method, options)
           begin
-            individual.deliver_now
+            individual.deliver_now!
           rescue Net::SMTPError
             invalid << to
           end
         end
       end
-
       _log.error("method: #{method} options: #{options} delivery-error #{e} recipients #{invalid}")
-
-    # connection errors, and other if raised
-    rescue => e
+    rescue => e # connection errors, and other if raised
       _log.error("method: #{method} delivery-error: #{e} attempting to resend")
 
       # attempt to deliver one more time
-      begin
-        msg.deliver_now
-      rescue => e
-        _log.error("method: #{method} options: #{options} delivery-error #{e}")
-      end
+      msg.deliver_now!
     end
 
     msg
+  end
+
+  def self.deliver(method, options = {})
+    deliver!(method, options)
+  rescue => e # catch delivery errors if raised,
+    _log.error("method: #{method} options: #{options} delivery-error #{e}")
   end
 
   def self.deliver_queue(method, options = {}, queue_options = {})

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -52,7 +52,7 @@ class GenericMailer < ActionMailer::Base
       queue_options.reverse_merge(
         :service     => "notifier",
         :class_name  => name,
-        :method_name => 'deliver',
+        :method_name => 'deliver!',
         :args        => [method, options]
       )
     )

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -23,14 +23,14 @@ describe GenericMailer do
         expect(BinaryBlob.count).to eq(0)
         GenericMailer.deliver_queue(:generic_notification, @args)
         expect(BinaryBlob.count).to eq(1)
-        expect(MiqQueue.exists?(:method_name => 'deliver',
+        expect(MiqQueue.exists?(:method_name => 'deliver!',
                                 :class_name  => described_class.name,
                                 :role        => 'notifier')).to be_truthy
       end
 
       it "with automation_notification" do
         GenericMailer.deliver_queue(:automation_notification, @args)
-        expect(MiqQueue.exists?(:method_name => 'deliver',
+        expect(MiqQueue.exists?(:method_name => 'deliver!',
                                 :class_name  => described_class.name,
                                 :role        => 'notifier')).to be_truthy
       end
@@ -48,7 +48,7 @@ describe GenericMailer do
           :message => "Queued the action: [generic_notification]"
         )
         expect(BinaryBlob.count).to eq(1)
-        expect(MiqQueue.exists?(:method_name => 'deliver',
+        expect(MiqQueue.exists?(:method_name => 'deliver!',
                                 :class_name  => described_class.name,
                                 :role        => 'notifier')).to be_truthy
       end
@@ -60,7 +60,7 @@ describe GenericMailer do
           :status  => MiqTask::STATUS_OK,
           :message => "Queued the action: [automation_notification]"
         )
-        expect(MiqQueue.exists?(:method_name => 'deliver',
+        expect(MiqQueue.exists?(:method_name => 'deliver!',
                                 :class_name  => described_class.name,
                                 :role        => 'notifier')).to be_truthy
       end

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -92,7 +92,7 @@ describe GenericMailer do
       # raises error when delivered
       msg = @args.merge(:to => 'me@bedrock.gov, you@bedrock.gov')
       notification = GenericMailer.generic_notification(msg)
-      allow(notification).to receive(:deliver_now).and_raise(Net::SMTPFatalError.new("fake_response"))
+      allow(notification).to receive(:deliver_now!).and_raise(Net::SMTPFatalError.new("fake_response"))
 
       # send error msg first...
       expect(GenericMailer)
@@ -106,7 +106,7 @@ describe GenericMailer do
         .and_call_original
 
       # send message
-      GenericMailer.deliver(:generic_notification)
+      GenericMailer.deliver(:generic_notification, msg)
 
       # ensure individual messages were sent
       expect(ActionMailer::Base.deliveries.size).to eq(2)


### PR DESCRIPTION
Add a version of `GenericMailer.deliver` which raises exceptions on failure and have the "async" queue/task methods call this.  This should allow for us to get an error on the miq_task if delivery failed.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
