### PR TITLE
Provision workflow

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -97,6 +97,10 @@ class MiqProvision < MiqProvisionTask
     end
   end
 
+  def workflow_inputs
+    options
+  end
+
   def self.get_description(prov_obj, vm_name)
     request_type = prov_obj.options[:request_type]
     title = case request_type

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -10,7 +10,7 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
         req_task.miq_request_id = service_task.miq_request.id
         req_task.userid         = service_task.userid
 
-        task_options     = req_task.options.merge(service_options(parent_svc, template_service_resource))
+        task_options     = req_task.options.merge(service_options(parent_svc, service_task, template_service_resource))
         task_options     = task_options.merge(owner_options(service_task))
         req_task.options = task_options
       end
@@ -37,12 +37,15 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
 
   private
 
-  def service_options(parent_svc, template_service_resource)
+  def service_options(parent_svc, service_task, template_service_resource)
+    parent_service_task = MiqRequestTask.find(service_task.options[:parent_task_id])
+
     {
-      :miq_force_unique_name    => [true, 1],
-      :service_guid             => parent_svc.guid,
-      :service_resource_id      => template_service_resource.id,
-      :service_template_request => false
+      :miq_force_unique_name           => [true, 1],
+      :service_guid                    => parent_svc.guid,
+      :service_resource_id             => template_service_resource.id,
+      :service_template_request        => false,
+      :configuration_script_payload_id => parent_service_task&.resource_action&.configuration_script_payload&.id
     }
   end
 

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -38,7 +38,7 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
   private
 
   def service_options(parent_svc, service_task, template_service_resource)
-    parent_service_task = MiqRequestTask.find(service_task.options[:parent_task_id])
+    parent_service_task = get_parent_task(service_task)
 
     {
       :miq_force_unique_name           => [true, 1],

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -140,12 +140,12 @@ class MiqRequestTask < ApplicationRecord
 
     _log.info("Queuing #{request_class::TASK_DESCRIPTION}: [#{description}]...")
 
-    if resource_action&.configuration_script_payload
-      workflow = resource_action.configuration_script_payload
+    workflow = ConfigurationScriptPayload.find(options[:configuration_script_payload_id]) if options[:configuration_script_payload_id]
+    if workflow
       miq_task_id = workflow.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone, :object => self)
 
       options[:miq_task_id]                     = miq_task_id
-      options[:configuration_script_payload_id] = resource_action.configuration_script_payload.id
+      options[:configuration_script_payload_id] = workflow.id
       options[:configuration_script_id]         = MiqTask.find(miq_task_id).context_data[:workflow_instance_id]
       save!
     elsif self.class::AUTOMATE_DRIVES

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -142,7 +142,7 @@ class MiqRequestTask < ApplicationRecord
 
     workflow = ConfigurationScriptPayload.find(options[:configuration_script_payload_id]) if options[:configuration_script_payload_id]
     if workflow
-      miq_task_id = workflow.run(:inputs => dialog_values, :userid => get_user.userid, :zone => zone, :object => self)
+      miq_task_id = workflow.run(:inputs => workflow_inputs, :userid => get_user.userid, :zone => zone, :object => self)
 
       options[:miq_task_id]                     = miq_task_id
       options[:configuration_script_payload_id] = workflow.id
@@ -263,6 +263,10 @@ class MiqRequestTask < ApplicationRecord
 
   def valid_states
     %w[pending finished] + request_class::ACTIVE_STATES
+  end
+
+  def workflow_inputs
+    dialog_values
   end
 
   def dialog_values

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -138,10 +138,18 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     ra = resource_action
 
     unless ra.nil?
-      args[:namespace]        = ra.ae_namespace if ra.ae_namespace.present?
-      args[:class_name]       = ra.ae_class     if ra.ae_class.present?
-      args[:instance_name]    = ra.ae_instance  if ra.ae_instance.present?
-      args[:automate_message] = ra.ae_message   if ra.ae_message.present?
+      if ra.configuration_script_payload
+        args[:namespace]        = "Service/Provisioning/StateMachines"
+        args[:class_name]       = "ServiceProvision_Template"
+        args[:instance_name]    = "CatalogItemInitialization"
+        args[:automate_message] = nil
+      else
+        args[:namespace]        = ra.ae_namespace if ra.ae_namespace.present?
+        args[:class_name]       = ra.ae_class     if ra.ae_class.present?
+        args[:instance_name]    = ra.ae_instance  if ra.ae_instance.present?
+        args[:automate_message] = ra.ae_message   if ra.ae_message.present?
+      end
+
       args[:attrs].merge!(ra.ae_attributes)
     end
 

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ServiceTemplateProvisionTask do
             zone               = FactoryBot.create(:zone, :name => "special")
             automation_manager = FactoryBot.create(:ems_workflows_automation, :zone => zone)
             payload            = FactoryBot.create(:embedded_workflow, :manager => automation_manager)
-            @task_0.source     = FactoryBot.create(
+            @task_1.source     = FactoryBot.create(
               :service_template_generic,
               :name             => "Provision",
               :resource_actions => [
@@ -129,11 +129,17 @@ RSpec.describe ServiceTemplateProvisionTask do
               ]
             )
 
-            @task_0.deliver_queue
+            @task_1_1.update(
+              :options => {
+                :configuration_script_payload_id => payload.id,
+                :parent_task_id                  => @task_1.id
+              }
+            )
+            @task_1_1.deliver_queue
 
-            expect(@task_0.reload.options.keys).to include(:miq_task_id, :configuration_script_id, :configuration_script_payload_id)
+            expect(@task_1_1.reload.options.keys).to include(:miq_task_id, :configuration_script_id, :configuration_script_payload_id)
 
-            configuration_script = ConfigurationScript.find(@task_0.options[:configuration_script_id])
+            configuration_script = ConfigurationScript.find(@task_1_1.options[:configuration_script_id])
 
             expect(configuration_script).to have_attributes(:manager => automation_manager, :run_by_userid => @admin.userid, :status => "pending")
             expect(MiqQueue.first).to       have_attributes(
@@ -142,7 +148,7 @@ RSpec.describe ServiceTemplateProvisionTask do
               :method_name => "run",
               :queue_name  => "automate",
               :role        => "automate",
-              :args        => [hash_including(:object_type => "ServiceTemplateProvisionTask", :object_id => @task_0.id)]
+              :args        => [hash_including(:object_type => "ServiceTemplateProvisionTask", :object_id => @task_1_1.id)]
             )
           end
         end


### PR DESCRIPTION
first commit is squashed:
- https://github.com/ManageIQ/manageiq/pull/23034

This adds a change that provisions send all options to dialog.
This is required for asl to properly modify requests

Fixes #23034
(or rather replaces it but... yea)