### PR TITLE
service reconfigure task needs a default request type

### DIFF
--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -37,7 +37,10 @@ FactoryBot.define do
   factory :automation_task, :parent => :miq_request_task, :class => "AutomationTask"
 
   # Services
-  factory :service_reconfigure_task,        :parent => :miq_request_task, :class => "ServiceReconfigureTask"
+  factory :service_reconfigure_task,        :parent => :miq_request_task, :class => "ServiceReconfigureTask" do
+    request_type { 'service_reconfigure' }
+  end
+
   factory :service_template_provision_task, :parent => :miq_request_task, :class => "ServiceTemplateProvisionTask" do
     state        { 'pending' }
     request_type { 'clone_to_service' }


### PR DESCRIPTION
factory out of the box does not run and states this request type must be this value

Also, all tests using this factory hard code this value

