### PR TITLE
Fix the class name for the storage_vmware factory

### DIFF
--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     sequence(:name) { |n| "storage_#{seq_padded_for_sorting(n)}" }
   end
 
-  factory :storage_vmware, :parent => :storage do
+  factory :storage_vmware, :parent => :storage, :class => "ManageIQ::Providers::Vmware::InfraManager::Storage" do
     store_type { "VMFS" }
     sequence(:ems_ref) { |n| "datastore-#{n}" }
   end

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ManageIQ::Providers::InfraManager::MetricsCapture do
     it "finds enabled targets" do
       targets = described_class.new(nil, ems).capture_ems_targets
       assert_infra_targets_enabled targets
-      expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host Storage])
+      expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Storage])
     end
 
     it "finds enabled targets excluding storages" do


### PR DESCRIPTION
The class for Vmware Storage was missing from the factory so code which depends on having the correct class was failing.
It isn't great that we have provider specific factories here but especially for vmware that is quite common in core specs already.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
