### PR TITLE
Fail providers on seeding failure

### DIFF
--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -43,11 +43,9 @@ RSpec.describe EvmDatabase do
       expect { described_class.seed(["VmOrTemplate"]) }.to raise_error(ArgumentError, /do not respond to seed/)
     end
 
-    # this spec takes about 30 seconds but is the only check that db:seed won't fail
-    it "doesn't fail" do
-      expect do
-        described_class.seed
-      end.not_to raise_error
+    # this spec takes about 20 seconds but is the only check that db:seed won't fail
+    it "doesn't fail", :providers_common => true do
+      described_class.seed
     end
   end
 


### PR DESCRIPTION
@agrare Please review.  This will add 20 seconds to the providers (sorry!), but we can catch seeding failures, such as invalid workflows in ootb provider plugins.

In fairness, we need a way to run tests for all _plugins_ as opposed to all providers, but this is our only mechanism.  I'll probably make a future PR to introduce a plugins_common and then make sure all plugins run those tests.