### PR TITLE
Creating environment varaible for TERRAFORM_RUNNER_URL

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -175,6 +175,7 @@ class ContainerOrchestrator
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp/worker.hb").to_s},
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
+        {:name => "TERRAFORM_RUNNER_URL",    :value => "https://opentofu-runner:6000"},
       ] + database_environment + memcached_environment + messaging_environment
     end
 


### PR DESCRIPTION
Creating environment variable TERRAFORM_RUNNER_URL.
Like name suggest this is the URL to access opentofu runner pod.