### PR TITLE
[WIP] Generate secret key and JWT token for API auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN echo "# This file intentionally left blank. ManageIQ maintains its own SSL c
       memcached               \
       postgresql-server       \
       mod_ssl                 \
-      libsodium               \
       &&                      \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN echo "# This file intentionally left blank. ManageIQ maintains its own SSL c
       memcached               \
       postgresql-server       \
       mod_ssl                 \
+      libsodium               \
       &&                      \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.1",             :require => false
+gem "jwt"
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      "~>3.0",             :require => false
 gem "listen",                           "~>3.2",             :require => false
@@ -82,9 +83,7 @@ gem "sprockets",                        "~>3.7.2",           :require => false
 gem "sync",                             "~>0.5",             :require => false
 gem "sys-filesystem",                   "~>1.4.3"
 gem "terminal",                                              :require => false
-gem "jwt"
 gem "wim_parser",                       "~>1.0",             :require => false
-
 
 # gems to resolve security issues
 # CVE-2021-33621 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-vc47-6rqg-c7f5

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem "sync",                             "~>0.5",             :require => false
 gem "sys-filesystem",                   "~>1.4.3"
 gem "terminal",                                              :require => false
 gem "wim_parser",                       "~>1.0",             :require => false
+gem "jwt"
 
 # gems to resolve security issues
 # CVE-2021-33621 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-vc47-6rqg-c7f5

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.1",             :require => false
+gem "jwt"
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      "~>3.0",             :require => false
 gem "listen",                           "~>3.2",             :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -82,8 +82,9 @@ gem "sprockets",                        "~>3.7.2",           :require => false
 gem "sync",                             "~>0.5",             :require => false
 gem "sys-filesystem",                   "~>1.4.3"
 gem "terminal",                                              :require => false
-gem "wim_parser",                       "~>1.0",             :require => false
 gem "jwt"
+gem "wim_parser",                       "~>1.0",             :require => false
+
 
 # gems to resolve security issues
 # CVE-2021-33621 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-vc47-6rqg-c7f5

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.1",             :require => false
-gem "jwt"
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      "~>3.0",             :require => false
 gem "listen",                           "~>3.2",             :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.1",             :require => false
-gem "jwt"
+gem "jwt",                                                   :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      "~>3.0",             :require => false
 gem "listen",                           "~>3.2",             :require => false

--- a/bin/before_install
+++ b/bin/before_install
@@ -8,6 +8,7 @@ if [ -n "$CI" ]; then
   echo "== Installing system packages =="
   sudo apt-get update
   sudo apt-get install -y libcurl4-openssl-dev
+  sudo apt-get install -y libsodium-dev
   echo
 
   # Install gettext for I18n msgfmt specs

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -195,7 +195,7 @@ class ContainerOrchestrator
       }
       JWT.encode(payload, secret_key, 'HS256')
     end
-    
+
     def database_environment
       [
         {:name => "DATABASE_SSL_MODE", :value => ENV["DATABASE_SSL_MODE"]},

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -178,14 +178,13 @@ class ContainerOrchestrator
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp/worker.hb").to_s},
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
         {:name => "TERRAFORM_RUNNER_URL",    :value => "https://opentofu-runner:6000"},
-        {:name => "SECRET_KEY", :value => opentofu_runner_secret_key},
         {:name => "TERRAFORM_RUNNER_TOKEN", :value => opentofu_runner_token},
       ] + database_environment + memcached_environment + messaging_environment
     end
 
     SECRET_KEY_FILE = "/run/secrets/manageiq/application/encryption_key".freeze
     def opentofu_runner_secret_key
-      @opentofu_runner_secret_key ||= File.exist?(file_path) ? File.read(SECRET_KEY_FILE) : "opentofu_runner_key"
+      @opentofu_runner_secret_key ||= File.exist?(SECRET_KEY_FILE) ? File.read(SECRET_KEY_FILE) : "opentofu_runner_key"
     end
 
     def opentofu_runner_token

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -194,7 +194,7 @@ class ContainerOrchestrator
       @opentofu_runner_secret_key ||= File.exist?(SECRET_KEY_FILE) ? File.read(SECRET_KEY_FILE) : "opentofu_runner_key"
     end
 
-    TERRAFORM_RUNNER_TOKEN_FILE = File.join(Dir.home, "TERRAFORM_RUNNER_TOKEN").freeze
+    TERRAFORM_RUNNER_TOKEN_FILE = Rails.root.join("TERRAFORM_RUNNER_TOKEN").freeze
     def opentofu_runner_token
       secret_key = opentofu_runner_secret_key
       payload = {

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -182,12 +182,12 @@ class ContainerOrchestrator
         {:name => "TERRAFORM_RUNNER_TOKEN", :value => opentofu_runner_token},
       ] + database_environment + memcached_environment + messaging_environment
     end
-    
+
     SECRET_KEY_FILE = "/run/secrets/manageiq/application/encryption_key".freeze
     def opentofu_runner_secret_key
       @opentofu_runner_secret_key ||= File.exist?(file_path) ? File.read(SECRET_KEY_FILE) : "opentofu_runner_key"
     end
-    
+
     def opentofu_runner_token
       secret_key = opentofu_runner_secret_key
       payload = {

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -194,7 +194,7 @@ class ContainerOrchestrator
       @opentofu_runner_secret_key ||= File.exist?(SECRET_KEY_FILE) ? File.read(SECRET_KEY_FILE) : "opentofu_runner_key"
     end
 
-    TERRAFORM_RUNNER_TOKEN_FILE = File.join(Dir.home, 'TERRAFORM_RUNNER_TOKEN').freeze
+    TERRAFORM_RUNNER_TOKEN_FILE = File.join(Dir.home, "TERRAFORM_RUNNER_TOKEN").freeze
     def opentofu_runner_token
       secret_key = opentofu_runner_secret_key
       payload = {
@@ -204,6 +204,7 @@ class ContainerOrchestrator
       File.open(TERRAFORM_RUNNER_TOKEN_FILE, "wb") do |file|
         file.sync = true
         file.write(jwtToken)
+      end  
       @opentofu_runner_token ||=  TERRAFORM_RUNNER_TOKEN_FILE
     end
 

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -182,7 +182,7 @@ class ContainerOrchestrator
         {:name => "TERRAFORM_RUNNER_TOKEN", :value => opentofu_runner_token},
       ] + database_environment + memcached_environment + messaging_environment
     end
-
+    
     SECRET_KEY_FILE = "/run/secrets/manageiq/application/encryption_key".freeze
     def opentofu_runner_secret_key
       @opentofu_runner_secret_key ||= File.exist?(file_path) ? File.read(SECRET_KEY_FILE) : "opentofu_runner_key"
@@ -191,9 +191,9 @@ class ContainerOrchestrator
     def opentofu_runner_token
       secret_key = opentofu_runner_secret_key
       payload = {
-        Username: 'opentofu-runner'
+        'Username' => 'opentofu-runner'
       }
-      return JWT.encode(payload, secret_key, 'HS256')
+      JWT.encode(payload, secret_key, 'HS256')
     end
     
     def database_environment

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe ContainerOrchestrator do
 
       deployment_definition = subject.send(:deployment_definition, "test")
 
-      expect(deployment_definition.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts).length).to eq(3)
-      expect(deployment_definition.fetch_path(:spec, :template, :spec, :volumes).length).to eq(3)
+      expect(deployment_definition.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts).length).to eq(4)
+      expect(deployment_definition.fetch_path(:spec, :template, :spec, :volumes).length).to eq(4)
     end
 
     it "mounts the database root certificate" do


### PR DESCRIPTION
Generating Secret Key and Token During Worker Deployment

- To generate a secret key, I am using the encryption key from the secret app-secrets. 
- If this secret is not mounted on the path /run/secrets/manageiq/application/encryption_key, then I am using a static value 'opentofu-runner' as the secret key.
- Using this secret, I am generating the token with the jwt.encode API.

The same secret and token are mounted as environment variables to the worker pod.