### PR TITLE
Lock down ffi due to build issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "default_value_for",                "~>3.3"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false
 gem "fast_gettext",                     "~>2.0.1"
+gem "ffi",                              "< 1.17.0",          :require => false
 gem "gettext_i18n_rails",               "~>1.11"
 gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"


### PR DESCRIPTION
Error during `rake update:ui`:
```
➤ YN0000: · Done with warnings in 1m 12s
Webpacker is installed 🎉 🍰
Using /root/BUILD/manageiq-gemset-19.0.0/bundler/gems/manageiq-ui-classic-486e88a5c91a/config/webpacker.yml file for setting up webpack paths ASSERTION FAILURE: (!isvariadic) || (nfixedargs >= 1) at /home/lars/comcard/ffi/ext/ffi_c/libffi/src/prep_cif.c:121 /build_scripts/lib/manageiq/rpm_build/helper.rb:14:in `exit': no implicit conversion from nil to integer (TypeError)
	from /build_scripts/lib/manageiq/rpm_build/helper.rb:14:in `shell_cmd'
	from /build_scripts/lib/manageiq/rpm_build/generate_gemset.rb:82:in `block in populate_gem_home'
	from /build_scripts/lib/manageiq/rpm_build/generate_gemset.rb:58:in `chdir'
	from /build_scripts/lib/manageiq/rpm_build/generate_gemset.rb:58:in `populate_gem_home'
	from bin/build.rb:29:in `<main>'
```