### PR TITLE
Bump to 6.1.7.8 for CVE-2024-28103 fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem "psych",                            ">=3.1",             :require => false #
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.6.4",         :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>6.1.7", ">=6.1.7.7"
+gem "rails",                            "~>6.1.7", ">=6.1.7.8"
 gem "rails-i18n",                       "~>6.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false


### PR DESCRIPTION
See also: https://rubyonrails.org/2024/6/4/Rails-Versions-6-1-7-8-7-0-8-4-and-7-1-3-4-have-been-released

Note, bundler audit wasn't detecting it but there's a advisory db PR opened so it's detected in the future. See: https://github.com/rubysec/ruby-advisory-db/pull/787