### PR TITLE
base_class is now memoized via inherited hook so it must run first

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -7,13 +7,14 @@ module ArRegion
 
   module ClassMethods
     def inherited(other)
+      super
+
       if other == other.base_class
         other.class_eval do
           virtual_column :region_number,      :type => :integer # This method is defined in ActiveRecord::IdRegions
           virtual_column :region_description, :type => :string
         end
       end
-      super
     end
   end
 


### PR DESCRIPTION
Rails 7 made this change and our hack was causing us to call base_class before set_base_class was called so it was not yet set and therefore nil. We should really let the superclass set things up before we do our stuff.

See:
https://github.com/rails/rails/pull/41901/files

Extracted from https://github.com/ManageIQ/manageiq/pull/22873

Note, this is needed for rails 7 but is backwards compatible with 6.1.