### PR TITLE
Add has_many for annotations custom attribute each summary page that contains labels

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -17,6 +17,10 @@ class ContainerGroup < ApplicationRecord
   has_many :containers, :dependent => :destroy
   has_many :container_images, -> { distinct }, :through => :containers
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
+  has_many :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -23,6 +23,10 @@ class ContainerNode < ApplicationRecord
   has_many   :container_services, -> { distinct }, :through => :container_groups
   has_many   :container_routes, -> { distinct }, :through => :container_services
   has_many   :container_replicators, -> { distinct }, :through => :container_groups
+  has_many   :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+             :class_name => "CustomAttribute",
+             :as         => :resource,
+             :inverse_of => :resource
   has_many   :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
              :class_name => "CustomAttribute",
              :as         => :resource,

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -10,6 +10,10 @@ class ContainerReplicator < ApplicationRecord
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :container_groups
   belongs_to :container_project
+  has_many :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,

--- a/app/models/container_route.rb
+++ b/app/models/container_route.rb
@@ -6,6 +6,10 @@ class ContainerRoute < ApplicationRecord
   belongs_to :container_service
   has_many :container_nodes, -> { distinct }, :through => :container_service
   has_many :container_groups, -> { distinct }, :through => :container_service
+  has_many :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -9,6 +9,10 @@ class ContainerService < ApplicationRecord
   has_many :container_routes
   has_many :container_service_port_configs, :dependent => :destroy
   belongs_to :container_project
+  has_many :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -6,6 +6,10 @@ class ContainerTemplate < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
   has_many :container_template_parameters, :dependent => :destroy
+  has_many :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent
+           :class_name => "CustomAttribute",
+           :as         => :resource,
+           :inverse_of => :resource
   has_many :labels, -> { where(:section => "labels") }, # rubocop:disable Rails/HasManyOrHasOneDependent
            :class_name => "CustomAttribute",
            :as         => :resource,


### PR DESCRIPTION
Relevant PRs:
Providers-Kubernetes: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/530
Providers-Openshift: https://github.com/ManageIQ/manageiq-providers-openshift/pull/262
Ui-Classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/9214

Cross-Repo Tests:
https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/879 
All passing except for known failing test cases in core ManageIQ
