### PR TITLE
Remove calls to supports and supports back to back

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -197,18 +197,18 @@ class Host < ApplicationRecord
 
   # if you change this, please check in on VmWare#start
   supports :start do
-    if !supports?(:ipmi)
-      unsupported_reason(:ipmi)
-    elsif power_state != "off"
+    if power_state != "off"
       _("The Host is not in power state off")
+    else
+      unsupported_reason(:ipmi)
     end
   end
 
   supports :stop do
-    if !supports?(:ipmi)
-      unsupported_reason(:ipmi)
-    elsif power_state != "on"
+    if power_state != "on"
       _("The Host is not in powered on")
+    else
+      unsupported_reason(:ipmi)
     end
   end
 

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -344,10 +344,10 @@ class Storage < ApplicationRecord
   end
 
   def scan(userid = "system", _role = "ems_operations")
-    unless supports?(:smartstate_analysis)
+    if (reason = unsupported_reason(:smartstate_analysis))
       raise(MiqException::MiqUnsupportedStorage,
             _("Action not supported for Datastore type [%{store_type}], [%{name}] with id: [%{id}] %{error}") %
-              {:store_type => store_type, :name => name, :id => id, :error => unsupported_reason(:smartstate_analysis)})
+              {:store_type => store_type, :name => name, :id => id, :error => reason})
     end
 
     task_name = "SmartState Analysis for [#{name}]"

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -118,9 +118,9 @@ class Vm < VmOrTemplate
 
   def supported_consoles
     {
-      :html5   => html5_support,
-      :vmrc    => vmrc_support,
-      :native  => native_support
+      :html5  => support_hash(:html5_console, :launch_html5_console),
+      :vmrc   => support_hash(:vmrc_console, :launch_vmrc_console),
+      :native => support_hash(:native_console, :launch_native_console)
     }
   end
 
@@ -144,27 +144,12 @@ class Vm < VmOrTemplate
 
   private
 
-  def html5_support
+  def support_hash(visible, launch)
+    reason = unsupported_reason(launch)
     {
-      :visible => supports?(:html5_console),
-      :enabled => supports?(:launch_html5_console),
-      :message => unsupported_reason(:launch_html5_console)
-    }
-  end
-
-  def vmrc_support
-    {
-      :visible => supports?(:vmrc_console),
-      :enabled => supports?(:launch_vmrc_console),
-      :message => unsupported_reason(:launch_vmrc_console)
-    }
-  end
-
-  def native_support
-    {
-      :visible => supports?(:native_console),
-      :enabled => supports?(:launch_native_console),
-      :message => unsupported_reason(:launch_native_console)
+      :visible => supports?(visible),
+      :enabled => !reason,
+      :message => reason
     }
   end
 

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -78,9 +78,9 @@ class Vm < VmOrTemplate
 
   def running_processes
     pl = {}
-    unless supports?(:collect_running_processes)
-      _log.warn(unsupported_reason(:collect_running_processes))
-      raise unsupported_reason(:collect_running_processes)
+    if (reason = unsupported_reason(:collect_running_processes))
+      _log.warn(reason)
+      raise reason
     end
 
     begin

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -7,26 +7,26 @@ module Vm::Operations::Power
     api_relay_method :suspend
 
     supports :suspend do
-      if !supports?(:control)
-        unsupported_reason(:control)
-      elsif !vm_powered_on?
+      if !vm_powered_on?
         _('The VM is not powered on')
+      else
+        unsupported_reason(:control)
       end
     end
 
     supports :start do
-      if !supports?(:control)
-        unsupported_reason(:control)
-      elsif vm_powered_on?
+      if vm_powered_on?
         _('The VM is powered on')
+      else
+        unsupported_reason(:control)
       end
     end
 
     supports :stop do
-      if !supports?(:control)
-        unsupported_reason(:control)
-      elsif !vm_powered_on?
+      if !vm_powered_on?
         _('The VM is not powered on')
+      else
+        unsupported_reason(:control)
       end
     end
   end

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -148,10 +148,10 @@ module VmOrTemplate::Operations
     end
 
     supports :vm_control_powered_on do
-      if !supports?(:control)
-        unsupported_reason(:control)
-      elsif current_state != "on"
+      if current_state != "on"
         "The VM is not powered on"
+      else
+        unsupported_reason(:control)
       end
     end
   end

--- a/app/models/vm_scan/dispatcher.rb
+++ b/app/models/vm_scan/dispatcher.rb
@@ -246,8 +246,7 @@ class VmScan
         return []
       end
 
-      unless @vm.supports?(:smartstate_analysis)
-        msg = @vm.unsupported_reason(:smartstate_analysis)
+      if (msg = @vm.unsupported_reason(:smartstate_analysis))
         queue_signal(job, {:args => [:abort, msg, "error"]})
         return []
       end


### PR DESCRIPTION
Part of (extracted from):
- [ ] https://github.com/ManageIQ/manageiq/pull/22898

No reason to call the same block twice.

This is probably pedantic.
Typically, the value of the first call would be cached for the second call.
But getting away from the duplicate calls is preferred.


This came about because I found a few supports calls that had a `return` and I saw these missing.