### PR TITLE
[WIP] Define modules separate from class

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1,5 +1,5 @@
 class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
-  include DialogFieldValidation
+  # include DialogFieldValidation
 
   def auto_placement_enabled?
     get_value(@values[:placement_auto])
@@ -1146,3 +1146,4 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
   end
 end
+require "miq_provision_virt_workflow/dialog_field_validation"

--- a/app/models/miq_provision_virt_workflow/dialog_field_validation.rb
+++ b/app/models/miq_provision_virt_workflow/dialog_field_validation.rb
@@ -1,5 +1,6 @@
 # These methods are available for dialog field validation, do not erase.
-module MiqProvisionVirtWorkflow::DialogFieldValidation
+class MiqProvisionVirtWorkflow
+module DialogFieldValidation
   def default_require_sysprep_enabled(_field, _values, dlg, fld, value)
     if value.blank? || value == "disabled"
       _("%{description} is required") % {:description => required_description(dlg, fld)}
@@ -63,3 +64,5 @@ module MiqProvisionVirtWorkflow::DialogFieldValidation
     _("%{description} is required") % {:description => required_description(dlg, fld)}
   end
 end
+end
+MiqProvisionVirtWorkflow.include(MiqProvisionVirtWorkflow::DialogFieldValidation)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 
 class MiqRequestWorkflow
   include Vmdb::Logging
-  include DialogFieldValidation
+  # include DialogFieldValidation
 
   # We rely on MiqRequestWorkflow's descendants to be comprehensive
   singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
@@ -1535,3 +1535,4 @@ class MiqRequestWorkflow
     source[:datacenter] ? array.reject { |i| find_datacenter_for_ci(i).id != source[:datacenter].id } : array
   end
 end
+require "miq_request_workflow/dialog_field_validation"

--- a/app/models/miq_request_workflow/dialog_field_validation.rb
+++ b/app/models/miq_request_workflow/dialog_field_validation.rb
@@ -1,5 +1,6 @@
 # These methods are available for dialog field validation, do not erase.
-module MiqRequestWorkflow::DialogFieldValidation
+class MiqRequestWorkflow
+  module DialogFieldValidation
   def validate_tags(field, values, _dlg, fld, _value)
     selected_tags_categories = Array.wrap(values[field].split('\n')).collect do |tag_id|
       Classification.find_by(:id => tag_id).parent.name.to_sym
@@ -54,3 +55,5 @@ module MiqRequestWorkflow::DialogFieldValidation
     end
   end
 end
+end
+MiqRequestWorkflow.include(MiqRequestWorkflow::DialogFieldValidation)


### PR DESCRIPTION
This resolves spec failures in manageiq-api, because they are not using zeitwerk.

This is the cause of the manageiq-api loader issues.

To define the `Workflow`, it needed to define the `DialogFieldValidation` first to then be able to `include`, but it couldn't define the `Validation` because it was inside the `Workflow` and needed the `Workflow` to be defined first.

Zeitwerk handles this but stock ruby can not.

## Outstanding

For this PR, I didn't define all of the validation classes, and didn't reindent them, but just put this in there to explain the issue.

I'm also concerned we have this issue elsewhere since this is a pretty common pattern that we follow.

## Reproducer

```
RSpec.describe :issue do
  # before: the constantize throws and error and the rescue nil => nil
  # after: a class comes back
  it { expect(MiqProvisionVirtWorkflow.new.worflow_class).not_to be_nil }
end
```

/cc @Fryguy wanted you to be aware of this issue, and wondered if you had an alternative solution.