### PR TITLE
Use default_value_for 4.0 with rails 7+ support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false
 gem "connection_pool",                                       :require => false # For Dalli
 gem "dalli",                            "~>3.2.3",           :require => false
-gem "default_value_for",                "~>3.3"
+gem "default_value_for",                "~>4.0"
 gem "docker-api",                       "~>1.33.6",          :require => false
 gem "elif",                             "=0.1.0",            :require => false
 gem "fast_gettext",                     "~>2.0.1"


### PR DESCRIPTION
Extracted from #22873

- [x] [cross repo test](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/880)