### PR TITLE
[WIP] Fix non-rails workers not restarting for settings changes

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -20,6 +20,8 @@ module MiqServer::WorkerManagement::Monitor
 
     sync_monitor
 
+    sync_config
+
     # Sync the workers after sync'ing the child worker settings
     sync_workers
 


### PR DESCRIPTION
Our typical Rails based workers have their own [`MiqWorker::Runner#sync_config` ](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_worker/runner.rb#L260-L278) which reloads the settings.

For a non-rails worker that doesn't run this heartbeat method we added a check on the settings changes to see if we should restart the worker: https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_server/worker_management/monitor/settings.rb#L27 https://github.com/ManageIQ/manageiq/pull/22329

The issue is that in MiqServer the sync_config method is only called on startup: https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_server/worker_management.rb#L42

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
