### PR TITLE
Don't attempt to load SettingsChange too early

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -168,8 +168,9 @@ module Vmdb
     end
 
     initializer :load_vmdb_settings, :before => :load_config_initializers do
+      # Setup the Settings constant before the app and engine intializers run.
+      # They could be wrong values since we're not connected to the db yet.
       Vmdb::Settings.init
-      Vmdb::Loggers.apply_config(::Settings.log)
     end
 
     initializer :eager_load_all_the_things, :after => :load_config_initializers do
@@ -187,6 +188,10 @@ module Vmdb
       puts "** #{Vmdb::Appliance.BANNER}" unless Rails.env.production?
 
       YamlPermittedClasses.initialize_app_yaml_permitted_classes
+
+      # Reload Settings to get values from db now that it's safe to autoload
+      ::Settings.reload!
+      Vmdb::Loggers.apply_config(::Settings.log)
     end
 
     console do

--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -75,7 +75,7 @@ module Vmdb
       end
 
       def resource_queryable?
-        ActiveRecord::Base.connectable? && ::SettingsChange.table_exists?
+        ActiveRecord::Base.connectable? && defined?(::SettingsChange) && ::SettingsChange.table_exists?
       end
     end
   end


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/22052

This is an attempt to reimplement #22853 since that was reverted in #23038.

- [x] [Cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/881)

High level: We have plugins that expect the `Settings` constant to be defined.

These will have to use the defaults from the filesystem as we don't have access to the database this early.

We can then use a rails 7 friendly location to start autoloading, the after_initialize.

Using the test from #23038, I was able to verify this on the rails7 branch and on master with rails 6.1:

```
joerafaniello@Joes-MBP manageiq % bin/rails c
Loading development environment (Rails 6.1.7.8)
irb(main):001:0> SettingsChange.first
=> nil
irb(main):002:0>  Settings.log.level
=> "info"
irb(main):003:0>  Settings.log.level = "debug"
=> "debug"
irb(main):004:0> Vmdb::Settings.save!(MiqServer.my_server, Settings.to_h)
=> []
irb(main):005:0>  Settings.log.level
=> "debug"
irb(main):006:0> SettingsChange.first
=> #<SettingsChange:0x00000001183e5648 id: 99000000000005, resource_type: "MiqServer", resource_id: 99000000000002, key: "/log/level", value: "debug", created_at: Thu, 18 Jul 2024 19:15:50.513221000 UTC +00:00, updated_at: Thu, 18 Jul 2024 19:15:50.513221000 UTC +00:00>
irb(main):007:0> exit
joerafaniello@Joes-MBP manageiq % bin/rails c
Loading development environment (Rails 6.1.7.8)
irb(main):001:0>  Settings.log.level
=> "debug"
```

Note, this was extracted from #22873