### PR TITLE
Add a security test that runs yarn npm audit

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -103,6 +103,10 @@ module Vmdb
       @provider_plugins ||= select { |engine| engine.name.start_with?("ManageIQ::Providers::") }
     end
 
+    def ui_plugins
+      @ui_plugins ||= select { |engine| engine.root.join("package.json").exist? }
+    end
+
     def asset_paths
       @asset_paths ||= begin
         require_relative 'plugins/asset_path'


### PR DESCRIPTION
From the core repo, this will run yarn npm audit in each plugin that has UI content. If json output is requested, it will output into a log/yarn-audit-[plugin].json file. If run from a plugin, it will only run for that particular plugin.

Depends on 
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9227

Future work for future PRs
- If items are marked as pending but no longer exist, fail the run saying that the pending item needs to be removed.
- Allow all 3 security tests to regardless of failure, and then only report success if all 3 succeed.
- Move the coding logic into a helper Ruby file, and keep the rake task small.

@jrafanie Please review