### PR TITLE
Rails7 friendly require during initializers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -160,6 +160,7 @@ module Vmdb
     # on the top to bottom order of initializer calls in the file.
     # Because this is easy to mess up, keep your initializers in order.
     initializer :load_inflections, :before => :init_vmdb_plugins do
+      require 'vmdb/inflections'
       Vmdb::Inflections.load_inflections
     end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,6 +63,7 @@ require "minitest"
 require "factory_bot"
 require "timecop"
 require "vcr"
+require "rspec"
 require "webmock/rspec"
 require "capybara"
 

--- a/config/initializers/active_metrics.rb
+++ b/config/initializers/active_metrics.rb
@@ -1,2 +1,3 @@
 # Note: The legacy Postgresql adapter ignores everything except the adapter name here, just stealing the current ActiveRecord connection.
+require 'active_metrics'
 ActiveMetrics::Base.establish_connection(:adapter => "miq_postgres", :database => "manageiq_metrics")

--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -10,6 +10,7 @@ begin
   load_paths.sort_by! { |p| File.basename(p) } # consistently sort en_foo.yml *after* en.yml
   I18n.load_path += load_paths
 
+  require 'vmdb/fast_gettext_helper'
   Vmdb::FastGettextHelper.register_locales
   Vmdb::FastGettextHelper.register_human_localenames
   gettext_options = %w[--sort-by-msgid --location --no-wrap]

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -6,4 +6,5 @@ session_store ||= case Settings.server.session_store
                   when "cache"  then :mem_cache_store
                   end
 
+require 'manageiq/session'
 ManageIQ::Session.store = session_store

--- a/lib/extensions/as_include_concern.rb
+++ b/lib/extensions/as_include_concern.rb
@@ -57,6 +57,7 @@ module ActiveSupport
         end
         include to_include.constantize
       end
+      require 'vmdb/deprecation'
       Vmdb::Deprecation.deprecate_methods(self, :include_concern)
     end
   end

--- a/lib/extensions/yaml_load_aliases.rb
+++ b/lib/extensions/yaml_load_aliases.rb
@@ -1,3 +1,5 @@
+require 'yaml_permitted_classes'
+
 module YamlLoadAliases
   # Psych 4 aliases load as safe_load.  Some loads happen early, like reading the database.yml so we don't want to load our
   # constants at that time, such as MiqExpression, Ruport, so we have two sets of permitted classes.

--- a/lib/manageiq/session.rb
+++ b/lib/manageiq/session.rb
@@ -96,3 +96,5 @@ module ManageIQ
     private_class_method :fetch_store_from_rails
   end
 end
+
+Dir.glob(File.join(__dir__, "session/*")).sort.each { |f| require f }

--- a/lib/manageiq/session/mem_cache_store_adapter.rb
+++ b/lib/manageiq/session/mem_cache_store_adapter.rb
@@ -6,6 +6,7 @@ module ManageIQ
       end
 
       def session_options
+        require 'miq_memcached'
         super.merge(MiqMemcached.default_client_options).merge(
           :expire_after    => 24.hours,
           :key             => "_vmdb_session",

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,4 +1,5 @@
 require "manageiq"
+require "vmdb/settings"
 
 module DatabaseConfigurationPatch
   def database_configuration


### PR DESCRIPTION
Extracted from: https://github.com/ManageIQ/manageiq/pull/22873

- [x] [Cross repo test](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/882)

These changes should be backward compatible with rails 6.1 and allows us to be rails 7 friendly by not trying to autoload during application initialization.  

See also: https://guides.rubyonrails.org/v7.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots

"While booting, applications can autoload from the autoload once paths, which are managed by the once autoloader. Please check the section config.autoload_once_paths above.
However, you cannot autoload from the autoload paths, which are managed by the main autoloader. This applies to code in config/initializers as well as application or engines initializers.
Why? Initializers only run once, when the application boots. If you reboot the server, they run again in a new process, but reloading does not reboot the server, and initializers don't run again."