### PR TITLE
Fix ensure_kube_monitors_started alive?

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -134,7 +134,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
 
     monitor_started = Concurrent::Event.new
 
-    Thread.new do
+    thread = Thread.new do
       _log.info("Starting new #{resource} monitor thread of #{Thread.list.length} total")
       begin
         send(:"monitor_#{resource}", monitor_started)
@@ -151,6 +151,8 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
     monitor_started.wait
 
     _log.info("Starting new #{resource} monitor thread...Complete")
+
+    thread
   end
 
   def ensure_kube_monitors_started


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq/pull/23097 I didn't realize the Thread.new return was intentionally the return of the method

```
[NoMethodError]: undefined method `alive?' for true:TrueClass\n\n      if thread.nil? || !thread.alive?
                                   ^^^^^^^  Method:[block (2 levels) in <class:LogProxy>]"}
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:160:in `block in ensure_kube_monitors_started'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:157:in `each'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:157:in `ensure_kube_monitors_started'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:13:in `sync_from_system'\n/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:19:in `monitor_workers'
/var/www/miq/vmdb/app/models/miq_server.rb:210:in `block in monitor'
```

TODO:
* Need to write specs that cover this the actual method calls are all stubbed out currently

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
