### PR TITLE
Miq expression subst

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -82,11 +82,11 @@ class Condition < ApplicationRecord
   # similar to MiqExpression#evaluate
   # @return [Boolean] true if the expression matches the record
   def self.subst_matches?(expr, rec)
-    do_eval(subst(expr, rec))
+    do_eval(subst(expr, rec), rec)
   end
 
-  def self.do_eval(expr)
-    !!eval(expr)
+  def self.do_eval(expr, rec)
+    !!eval(expr, binding)
   end
   private_class_method :do_eval
 
@@ -167,7 +167,7 @@ class Condition < ApplicationRecord
       value = MiqExpression.quote(obj.send(attr), opts[:type]&.to_sym)
       value = value.gsub("\\", '\&\&') if value.kind_of?(String)
       e = search.gsub(/<value[^>]*>.+<\/value>/im, value.to_s)
-      obj if do_eval(e)
+      obj if do_eval(e, obj)
     end.compact
 
     MiqPolicy.logger.debug("MIQ(condition-_subst_find): Search Expression returned: [#{list.length}] records")
@@ -207,7 +207,7 @@ class Condition < ApplicationRecord
       e = check.gsub(/<value[^>]*>.+<\/value>/im, value.to_s)
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Check Expression after substitution: [#{e}]")
 
-      result = do_eval(e)
+      result = do_eval(e, obj)
 
       return true if result && checkmode == "any"
       return false if !result && checkmode == "all"

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -206,14 +206,14 @@ class CustomButton < ApplicationRecord
     return true unless enablement_expression
     return false if enablement_expression && !object # list
 
-    enablement_expression.lenient_evaluate(object)
+    enablement_expression.evaluate(object, :lenient => true)
   end
 
   def evaluate_visibility_expression_for(object)
     return true unless visibility_expression
     return false if visibility_expression && !object # object == nil, method is called for list of objects
 
-    visibility_expression.lenient_evaluate(object)
+    visibility_expression.evaluate(object, :lenient => true)
   end
 
   # End - Helper methods to support moving automate columns to resource_actions table

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -52,7 +52,7 @@ module MiqReport::Generator::Trend
 
     if conditions
       tz = User.lookup_by_userid(options[:userid]).get_timezone if options[:userid]
-      results = results.reject { |obj| conditions.lenient_evaluate(obj, tz) }
+      results = results.reject { |obj| conditions.evaluate(obj, tz, :lenient => true) }
     end
     results = results[0...options[:limit]] if options[:limit]
     [results]

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -575,13 +575,10 @@ class MiqExpression
     }
   end
 
-  def lenient_evaluate(obj, timezone = nil, prune_sql: false)
+  def evaluate(obj, timezone = nil, prune_sql: false, lenient: false)
     ruby_exp = to_ruby(timezone, :prune_sql => prune_sql)
-    ruby_exp.nil? || Condition.subst_matches?(ruby_exp, obj)
-  end
+    return lenient if ruby_exp.nil? && lenient
 
-  def evaluate(obj, tz = nil)
-    ruby_exp = to_ruby(tz)
     Condition.subst_matches?(ruby_exp, obj)
   end
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -190,7 +190,7 @@ class MiqExpression
     end
   end
 
-  def self._to_ruby(exp, context_type, tz)
+  def self._to_ruby(exp, context_type, tz, obj_name: :rec)
     return exp unless exp.kind_of?(Hash)
 
     operator = exp.keys.first
@@ -200,29 +200,29 @@ class MiqExpression
 
     case operator
     when "equal", "=", "<", ">", ">=", "<=", "!="
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "before"
       col_type = Target.parse(col_name).column_type if col_name
-      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type, :obj_name => obj_name)
       val = op_args["value"]
       clause = ruby_for_date_compare(col_ruby, col_type, tz, "<", val)
     when "after"
       col_type = Target.parse(col_name).column_type if col_name
-      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type, :obj_name => obj_name)
       val = op_args["value"]
       clause = ruby_for_date_compare(col_ruby, col_type, tz, nil, nil, ">", val)
     when "includes all"
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
       clause = "(#{operands[0]} & #{operands[1]}) == #{operands[1]}"
     when "includes any"
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
       clause = "(#{operands[1]} - #{operands[0]}) != #{operands[1]}"
     when "includes only", "limited to"
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
       clause = "(#{operands[0]} - #{operands[1]}) == []"
     when "like", "not like", "starts with", "ends with", "includes"
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
       operands[1] =
         case operator
         when "starts with"
@@ -235,7 +235,7 @@ class MiqExpression
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
       clause = "!(" + clause + ")" if operator == "not like"
     when "regular expression matches", "regular expression does not match"
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
 
       # If it looks like a regular expression, sanitize from forward
       # slashes and interpolation
@@ -255,11 +255,11 @@ class MiqExpression
       end
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "and", "or"
-      clause = "(" + op_args.collect { |operand| _to_ruby(operand, context_type, tz) }.join(" #{normalize_ruby_operator(operator)} ") + ")"
+      clause = "(" + op_args.collect { |operand| _to_ruby(operand, context_type, tz, :obj_name => obj_name) }.join(" #{normalize_ruby_operator(operator)} ") + ")"
     when "not", "!"
-      clause = normalize_ruby_operator(operator) + "(" + _to_ruby(op_args, context_type, tz) + ")"
+      clause = normalize_ruby_operator(operator) + "(" + _to_ruby(op_args, context_type, tz, :obj_name => obj_name) + ")"
     when "is null", "is not null", "is empty", "is not empty"
-      operands = operands2rubyvalue(operator, op_args, context_type)
+      operands = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "contains"
       op_args["tag"] ||= col_name
@@ -294,14 +294,14 @@ class MiqExpression
 
       check =~ /^check(.*)$/
       mode = $1.downcase
-      clause = "<find><search>" + _to_ruby(op_args["search"], context_type, tz) + "</search>" \
-               "<check mode=#{mode}>" + _to_ruby(op_args[check], context_type, tz) + "</check></find>"
+      clause = "<find><search>" + _to_ruby(op_args["search"], context_type, tz, :obj_name => nil) + "</search>" \
+               "<check mode=#{mode}>" + _to_ruby(op_args[check], context_type, tz, :obj_name => nil) + "</check></find>"
     when "key exists"
-      clause, = operands2rubyvalue(operator, op_args, context_type)
+      clause, = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
     when "value exists"
-      clause, = operands2rubyvalue(operator, op_args, context_type)
+      clause, = operands2rubyvalue(operator, op_args, context_type, :obj_name => obj_name)
     when "is"
-      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type, :obj_name => obj_name)
       col_type = Target.parse(col_name).column_type
       value = op_args["value"]
       clause = if col_type == :date && !RelativeDatetime.relative?(value)
@@ -310,7 +310,7 @@ class MiqExpression
                  ruby_for_date_compare(col_ruby, col_type, tz, ">=", value, "<=", value)
                end
     when "from"
-      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      col_ruby, _value = operands2rubyvalue(operator, {"field" => col_name}, context_type, :obj_name => obj_name)
       col_type = Target.parse(col_name).column_type
 
       start_val, end_val = op_args["value"]
@@ -705,7 +705,7 @@ class MiqExpression
     end
   end
 
-  def self.operands2rubyvalue(operator, ops, context_type)
+  def self.operands2rubyvalue(operator, ops, context_type, obj_name: nil)
     if ops["field"]
       if ops["field"] == "<count>"
         ["<count>", quote(ops["value"], :integer)]
@@ -715,6 +715,9 @@ class MiqExpression
 
         [if context_type == "hash"
            "<value type=#{col_type}>#{ops["field"].split(".").last.split("-").join(".")}</value>"
+         elsif obj_name && !virtual_custom_attribute?(target.column) && target.associations.empty?
+          # TODO: handle value for fields with associations (they could be habtm, has_one, has_many, belongs_to)
+           "#{obj_name}.#{target.column}"
          else
            "<value ref=#{target.model.to_s.downcase}, type=#{col_type}>#{target.tag_path_with}</value>"
          end, quote_by(operator, ops["value"], col_type)]
@@ -838,6 +841,10 @@ class MiqExpression
   # Escape any unescaped forward slashes and/or interpolation
   def self.sanitize_regular_expression(string)
     string.gsub(%r{\\*/}, "\\/").gsub(/\\*#/, "\\#")
+  end
+
+  def self.virtual_custom_attribute?(attribute)
+    attribute.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
   end
 
   def self.escape_virtual_custom_attribute(attribute)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -919,7 +919,7 @@ module Rbac
     end
 
     def matches_search_filters?(obj, filter, timezone, prune_sql: true)
-      filter.nil? || filter.lenient_evaluate(obj, timezone, :prune_sql => prune_sql)
+      filter.nil? || filter.evaluate(obj, timezone, :prune_sql => prune_sql, :lenient => true)
     end
   end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1105,7 +1105,7 @@ RSpec.describe MiqExpression do
     end
   end
 
-  describe "#lenient_evaluate" do
+  describe "#evaluate with lenient" do
     describe "integration" do
       it "with a find/checkany expression" do
         host1, host2, host3, host4, host5, host6, host7, host8 = FactoryBot.create_list(:host, 8)
@@ -1122,7 +1122,7 @@ RSpec.describe MiqExpression do
             "checkany" => {"FROM" => {"field" => "Host.vms-last_scan_on",
                                       "value" => ["2011-01-08 17:00", "2011-01-09 23:30:59"]}},
             "search"   => {"IS NOT NULL" => {"field" => "Host.vms-description"}}})
-        result = Host.all.to_a.select { |rec| filter.lenient_evaluate(rec) }
+        result = Host.all.to_a.select { |rec| filter.evaluate(rec, :lenient => true) }
         expect(result).to contain_exactly(host3, host5)
       end
 
@@ -1148,7 +1148,7 @@ RSpec.describe MiqExpression do
                                       "value" => ["2011-01-08 17:00", "2011-01-09 23:30:59"]}},
             "checkall" => {"IS NOT NULL" => {"field" => "Host.vms-description"}}}
         )
-        result = Host.all.to_a.select { |rec| filter.lenient_evaluate(rec) }
+        result = Host.all.to_a.select { |rec| filter.evaluate(rec, :lenient => true) }
         expect(result).to eq([host2])
       end
 
@@ -1156,7 +1156,7 @@ RSpec.describe MiqExpression do
         vm = FactoryBot.create(:vm_vmware)
 
         expect do
-          described_class.new("=" => {"field" => "Vm-destroy", "value" => true}).lenient_evaluate(vm)
+          described_class.new("=" => {"field" => "Vm-destroy", "value" => true}).evaluate(vm, :lenient => true)
         end.not_to change(Vm, :count)
       end
     end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe MiqExpression do
       it "!(ruby) => keep all expressions" do
         exp1 = {"=" => {"field" => "Vm-platform", "value" => "foo"}}
         ruby = MiqExpression.new("NOT" => exp1).to_ruby(:prune_sql => true)
-        expect(ruby).to eq("!(<value ref=vm, type=string>/virtual/platform</value> == \"foo\")")
+        expect(ruby).to eq("!(rec.platform == \"foo\")")
       end
 
       it "!(sql OR ruby) => (!(sql) AND !(ruby)) => !(ruby)" do
@@ -1285,7 +1285,7 @@ RSpec.describe MiqExpression do
 
     it "generates the ruby for a LIKE expression with field" do
       actual = described_class.new("LIKE" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /foo/"
+      expected = "rec.name =~ /foo/"
       expect(actual).to eq(expected)
     end
 
@@ -1303,7 +1303,7 @@ RSpec.describe MiqExpression do
 
     it "generates the ruby for a NOT LIKE expression with field" do
       actual = described_class.new("NOT LIKE" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
-      expected = "!(<value ref=vm, type=string>/virtual/name</value> =~ /foo/)"
+      expected = "!(rec.name =~ /foo/)"
       expect(actual).to eq(expected)
     end
 
@@ -1463,7 +1463,7 @@ RSpec.describe MiqExpression do
 
     it "generates the SQL for a != expression" do
       actual = described_class.new("!=" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> != \"foo\""
+      expected = "rec.name != \"foo\""
       expect(actual).to eq(expected)
     end
 
@@ -1475,7 +1475,7 @@ RSpec.describe MiqExpression do
 
     it "detects value empty array" do
       exp = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "[]"})
-      expect(exp.to_ruby).to eq("<value ref=vm, type=string>/virtual/name</value> =~ /\\[\\]/")
+      expect(exp.to_ruby).to eq("rec.name =~ /\\[\\]/")
     end
 
     it "raises error if expression contains ruby script" do
@@ -1485,115 +1485,115 @@ RSpec.describe MiqExpression do
 
     it "ignores invalid values for a numeric_set in an = expression" do
       actual = described_class.new("=" => {"field" => "Host-enabled_inbound_ports", "value" => "22, 427, 5988, 5989, foo, `echo 1000`.to_i, abc..123, 1..4"}).to_ruby
-      expected = "<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> == [1,2,3,4,22,427,5988,5989]"
+      expected = "rec.enabled_inbound_ports == [1,2,3,4,22,427,5988,5989]"
       expect(actual).to eq(expected)
     end
 
     it "ignores invalid values for a numeric_set in an INCLUDES ALL expression" do
       actual = described_class.new("INCLUDES ALL" => {"field" => "Host-enabled_inbound_ports", "value" => "22, 427, 5988, 5989, foo, `echo 1000`.to_i, abc..123, 1..4"}).to_ruby
-      expected = "(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> & [1,2,3,4,22,427,5988,5989]) == [1,2,3,4,22,427,5988,5989]"
+      expected = "(rec.enabled_inbound_ports & [1,2,3,4,22,427,5988,5989]) == [1,2,3,4,22,427,5988,5989]"
       expect(actual).to eq(expected)
     end
 
     it "ignores invalid values for a numeric_set in an INCLUDES ANY expression" do
       actual = described_class.new("INCLUDES ANY" => {"field" => "Host-enabled_inbound_ports", "value" => "22, 427, 5988, 5989, foo, `echo 1000`.to_i, abc..123, 1..4"}).to_ruby
-      expected = "([1,2,3,4,22,427,5988,5989] - <value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value>) != [1,2,3,4,22,427,5988,5989]"
+      expected = "([1,2,3,4,22,427,5988,5989] - rec.enabled_inbound_ports) != [1,2,3,4,22,427,5988,5989]"
       expect(actual).to eq(expected)
     end
 
     it "ignores invalid values for a numeric_set in an INCLUDES ONLY expression" do
       actual = described_class.new("INCLUDES ONLY" => {"field" => "Host-enabled_inbound_ports", "value" => "22, 427, 5988, 5989, foo, `echo 1000`.to_i, abc..123, 1..4"}).to_ruby
-      expected = "(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [1,2,3,4,22,427,5988,5989]) == []"
+      expected = "(rec.enabled_inbound_ports - [1,2,3,4,22,427,5988,5989]) == []"
       expect(actual).to eq(expected)
     end
 
     it "ignores invalid values for a numeric_set in an LIMITED TO expression" do
       actual = described_class.new("LIMITED TO" => {"field" => "Host-enabled_inbound_ports", "value" => "22, 427, 5988, 5989, foo, `echo 1000`.to_i, abc..123, 1..4"}).to_ruby
-      expected = "(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [1,2,3,4,22,427,5988,5989]) == []"
+      expected = "(rec.enabled_inbound_ports - [1,2,3,4,22,427,5988,5989]) == []"
       expect(actual).to eq(expected)
     end
 
     it "escapes forward slashes for values in REGULAR EXPRESSION MATCHES expressions" do
       value = "//; puts 'Hi, mom!';//"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/; puts 'Hi, mom!';\\//"
+      expected = "rec.name =~ /\\/; puts 'Hi, mom!';\\//"
       expect(actual).to eq(expected)
     end
 
     it "preserves the delimiters when escaping forward slashes in case-insensitive REGULAR EXPRESSION MATCHES expressions" do
       value = "//; puts 'Hi, mom!';//i"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/; puts 'Hi, mom!';\\//i"
+      expected = "rec.name =~ /\\/; puts 'Hi, mom!';\\//i"
       expect(actual).to eq(expected)
     end
 
     it "escapes forward slashes for non-Regexp literal values in REGULAR EXPRESSION MATCHES expressions" do
       value = ".*/; puts 'Hi, mom!';/.*"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /.*\\/; puts 'Hi, mom!';\\/.*/"
+      expected = "rec.name =~ /.*\\/; puts 'Hi, mom!';\\/.*/"
       expect(actual).to eq(expected)
     end
 
     it "does not escape escaped forward slashes for values in REGULAR EXPRESSION MATCHES expressions" do
       value = "/foo/bar"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/foo\\/bar/"
+      expected = "rec.name =~ /\\/foo\\/bar/"
       expect(actual).to eq(expected)
     end
 
     it "handles arbitarily long escaping of forward " do
       value = "\\\\\\/foo\\\\\\/bar"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/foo\\/bar/"
+      expected = "rec.name =~ /\\/foo\\/bar/"
       expect(actual).to eq(expected)
     end
 
     it "escapes interpolation in REGULAR EXPRESSION MATCHES expressions" do
       value = "/\#{puts 'Hi, mom!'}/"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\\#{puts 'Hi, mom!'}/"
+      expected = "rec.name =~ /\\\#{puts 'Hi, mom!'}/"
       expect(actual).to eq(expected)
     end
 
     it "handles arbitrarily long escaping of interpolation in REGULAR EXPRESSION MATCHES expressions" do
       value = "/\\\\\#{puts 'Hi, mom!'}/"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\\#{puts 'Hi, mom!'}/"
+      expected = "rec.name =~ /\\\#{puts 'Hi, mom!'}/"
       expect(actual).to eq(expected)
     end
 
     it "escapes interpolation in non-Regexp literal values in REGULAR EXPRESSION MATCHES expressions" do
       value = "\#{puts 'Hi, mom!'}"
       actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\\#{puts 'Hi, mom!'}/"
+      expected = "rec.name =~ /\\\#{puts 'Hi, mom!'}/"
       expect(actual).to eq(expected)
     end
 
     it "escapes forward slashes for values in REGULAR EXPRESSION DOES NOT MATCH expressions" do
       value = "//; puts 'Hi, mom!';//"
       actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /\\/; puts 'Hi, mom!';\\//"
+      expected = "rec.name !~ /\\/; puts 'Hi, mom!';\\//"
       expect(actual).to eq(expected)
     end
 
     it "preserves the delimiters when escaping forward slashes in case-insensitive REGULAR EXPRESSION DOES NOT MATCH expressions" do
       value = "//; puts 'Hi, mom!';//i"
       actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /\\/; puts 'Hi, mom!';\\//i"
+      expected = "rec.name !~ /\\/; puts 'Hi, mom!';\\//i"
       expect(actual).to eq(expected)
     end
 
     it "escapes forward slashes for non-Regexp literal values in REGULAR EXPRESSION DOES NOT MATCH expressions" do
       value = ".*/; puts 'Hi, mom!';/.*"
       actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /.*\\/; puts 'Hi, mom!';\\/.*/"
+      expected = "rec.name !~ /.*\\/; puts 'Hi, mom!';\\/.*/"
       expect(actual).to eq(expected)
     end
 
     it "does not escape escaped forward slashes for values in REGULAR EXPRESSION DOES NOT MATCH expressions" do
       value = "/foo/bar"
       actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /\\/foo\\/bar/"
+      expected = "rec.name !~ /\\/foo\\/bar/"
       expect(actual).to eq(expected)
     end
 
@@ -1609,7 +1609,7 @@ RSpec.describe MiqExpression do
           field: Host-enabled_inbound_ports
           value: 22, 427, 5988, 5989, 1..4
       '
-      expected = "(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> & [1,2,3,4,22,427,5988,5989]) == [1,2,3,4,22,427,5988,5989]"
+      expected = "(rec.enabled_inbound_ports & [1,2,3,4,22,427,5988,5989]) == [1,2,3,4,22,427,5988,5989]"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1621,7 +1621,7 @@ RSpec.describe MiqExpression do
           value: 22, 427, 5988, 5989, 1..4
       '
 
-      expected = "([1,2,3,4,22,427,5988,5989] - <value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value>) != [1,2,3,4,22,427,5988,5989]"
+      expected = "([1,2,3,4,22,427,5988,5989] - rec.enabled_inbound_ports) != [1,2,3,4,22,427,5988,5989]"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1633,7 +1633,7 @@ RSpec.describe MiqExpression do
           value: 22, 427, 5988, 5989, 1..4
       '
 
-      expected = "(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [1,2,3,4,22,427,5988,5989]) == []"
+      expected = "(rec.enabled_inbound_ports - [1,2,3,4,22,427,5988,5989]) == []"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1645,7 +1645,7 @@ RSpec.describe MiqExpression do
           value: 22, 427, 5988, 5989, 1..4
       '
 
-      expected = "(<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> - [1,2,3,4,22,427,5988,5989]) == []"
+      expected = "(rec.enabled_inbound_ports - [1,2,3,4,22,427,5988,5989]) == []"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1657,7 +1657,7 @@ RSpec.describe MiqExpression do
           value: "ntpd, sshd, vmware-vpxa, vmware-webAccess"
       '
 
-      expected = "<value ref=host, type=string_set>/virtual/service_names</value> == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
+      expected = "rec.service_names == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1669,7 +1669,7 @@ RSpec.describe MiqExpression do
           value: "ntpd, sshd, vmware-vpxa, vmware-webAccess"
       '
 
-      expected = "(<value ref=host, type=string_set>/virtual/service_names</value> & ['ntpd','sshd','vmware-vpxa','vmware-webAccess']) == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
+      expected = "(rec.service_names & ['ntpd','sshd','vmware-vpxa','vmware-webAccess']) == ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1681,7 +1681,7 @@ RSpec.describe MiqExpression do
           value: "ntpd, sshd, vmware-vpxa, vmware-webAccess"
       '
 
-      expected = "(['ntpd','sshd','vmware-vpxa','vmware-webAccess'] - <value ref=host, type=string_set>/virtual/service_names</value>) != ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
+      expected = "(['ntpd','sshd','vmware-vpxa','vmware-webAccess'] - rec.service_names) != ['ntpd','sshd','vmware-vpxa','vmware-webAccess']"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1693,7 +1693,7 @@ RSpec.describe MiqExpression do
           value: "ntpd, sshd, vmware-vpxa"
       '
 
-      expected = "(<value ref=host, type=string_set>/virtual/service_names</value> - ['ntpd','sshd','vmware-vpxa']) == []"
+      expected = "(rec.service_names - ['ntpd','sshd','vmware-vpxa']) == []"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1705,7 +1705,7 @@ RSpec.describe MiqExpression do
           value: "ntpd, sshd, vmware-vpxa"
       '
 
-      expected = "(<value ref=host, type=string_set>/virtual/service_names</value> - ['ntpd','sshd','vmware-vpxa']) == []"
+      expected = "(rec.service_names - ['ntpd','sshd','vmware-vpxa']) == []"
       expect(filter.to_ruby).to eq(expected)
     end
 
@@ -1734,7 +1734,7 @@ RSpec.describe MiqExpression do
           field: Host-name
           value: /^[^.]*\.galaxy\..*$/
       '
-      expect(filter.to_ruby).to eq('<value ref=host, type=string>/virtual/name</value> =~ /^[^.]*\.galaxy\..*$/')
+      expect(filter.to_ruby).to eq('rec.name =~ /^[^.]*\.galaxy\..*$/')
     end
 
     it "should test regexp with string literal" do
@@ -1744,7 +1744,7 @@ RSpec.describe MiqExpression do
           field: Host-name
           value: ^[^.]*\.galaxy\..*$
       '
-      expect(filter.to_ruby).to eq('<value ref=host, type=string>/virtual/name</value> =~ /^[^.]*\.galaxy\..*$/')
+      expect(filter.to_ruby).to eq('rec.name =~ /^[^.]*\.galaxy\..*$/')
     end
 
     it "should test regexp as part of a FIND/checkany expression" do
@@ -1799,7 +1799,7 @@ RSpec.describe MiqExpression do
           field: Vm-memory_shares
           value: 25.kilobytes
       '
-      expect(filter.to_ruby).to eq('<value ref=vm, type=integer>/virtual/memory_shares</value> >= 25600')
+      expect(filter.to_ruby).to eq('rec.memory_shares >= 25600')
     end
 
     it "should test numbers with commas with methods" do
@@ -1810,74 +1810,74 @@ RSpec.describe MiqExpression do
           field: Vm-used_disk_storage
           value: 1,000.megabytes
       '
-      expect(filter.to_ruby).to eq('<value ref=vm, type=integer>/virtual/used_disk_storage</value> >= 1048576000')
+      expect(filter.to_ruby).to eq('rec.used_disk_storage >= 1048576000')
     end
 
     it "generates the ruby for a STARTS WITH expression" do
       actual = described_class.new("STARTS WITH" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /^foo/"
+      expected = "rec.name =~ /^foo/"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an ENDS WITH expression" do
       actual = described_class.new("ENDS WITH" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /foo$/"
+      expected = "rec.name =~ /foo$/"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an AND expression" do
       actual = described_class.new("AND" => [{"=" => {"field" => "Vm-name", "value" => "foo"}},
                                              {"=" => {"field" => "Vm-vendor", "value" => "bar"}}]).to_ruby
-      expected = "(<value ref=vm, type=string>/virtual/name</value> == \"foo\" and <value ref=vm, type=string>/virtual/vendor</value> == \"bar\")"
+      expected = "(rec.name == \"foo\" and rec.vendor == \"bar\")"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an OR with a count" do
       actual = described_class.new("OR" => [{"=" => {"field" => "Vm-name", "value" => "foo"}}, {"=" => {"count" => "Vm.snapshots", "value" => "1"}}]).to_ruby
-      expected = "(<value ref=vm, type=string>/virtual/name</value> == \"foo\" or <count ref=vm>/virtual/snapshots</count> == 1)"
+      expected = "(rec.name == \"foo\" or <count ref=vm>/virtual/snapshots</count> == 1)"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an OR expression" do
       actual = described_class.new("OR" => [{"=" => {"field" => "Vm-name", "value" => "foo"}},
                                             {"=" => {"field" => "Vm-vendor", "value" => "bar"}}]).to_ruby
-      expected = "(<value ref=vm, type=string>/virtual/name</value> == \"foo\" or <value ref=vm, type=string>/virtual/vendor</value> == \"bar\")"
+      expected = "(rec.name == \"foo\" or rec.vendor == \"bar\")"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for a NOT expression" do
       actual = described_class.new("NOT" => {"=" => {"field" => "Vm-name", "value" => "foo"}}).to_ruby
-      expected = "!(<value ref=vm, type=string>/virtual/name</value> == \"foo\")"
+      expected = "!(rec.name == \"foo\")"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for a ! expression" do
       actual = described_class.new("!" => {"=" => {"field" => "Vm-name", "value" => "foo"}}).to_ruby
-      expected = "!(<value ref=vm, type=string>/virtual/name</value> == \"foo\")"
+      expected = "!(rec.name == \"foo\")"
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an IS NULL expression" do
       actual = described_class.new("IS NULL" => {"field" => "Vm-name"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> == \"\""
+      expected = "rec.name == \"\""
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an IS NOT NULL expression" do
       actual = described_class.new("IS NOT NULL" => {"field" => "Vm-name"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> != \"\""
+      expected = "rec.name != \"\""
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an IS EMPTY expression" do
       actual = described_class.new("IS EMPTY" => {"field" => "Vm-name"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> == \"\""
+      expected = "rec.name == \"\""
       expect(actual).to eq(expected)
     end
 
     it "generates the ruby for an IS NOT EMPTY expression" do
       actual = described_class.new("IS NOT EMPTY" => {"field" => "Vm-name"}).to_ruby
-      expected = "<value ref=vm, type=string>/virtual/name</value> != \"\""
+      expected = "rec.name != \"\""
       expect(actual).to eq(expected)
     end
 
@@ -1974,27 +1974,27 @@ RSpec.describe MiqExpression do
       context "static dates and times with no timezone" do
         it "generates the ruby for an AFTER expression with date value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val > Time.utc(2011,1,10,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val > Time.utc(2011,1,10,23,59,59)")
         end
 
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val < Time.utc(2011,1,10,0,0,0)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val < Time.utc(2011,1,10,0,0,0)")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val > Time.utc(2011,1,10,9,0,0)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val > Time.utc(2011,1,10,9,0,0)")
         end
 
         it "generates the ruby for a IS expression with date value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,10,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
         end
 
         it "generates the ruby for a IS expression with datetime value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,10,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
         end
 
         it "generates the ruby for a IS expression with hash context" do
@@ -2005,22 +2005,22 @@ RSpec.describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,9,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,9,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
         end
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,9,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,9,0,0,0) and val <= Time.utc(2011,1,10,23,59,59)")
         end
 
         it "generates the ruby for a FROM expression with datetime values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,8,0,0) and val <= Time.utc(2011,1,10,17,0,0)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,10,8,0,0) and val <= Time.utc(2011,1,10,17,0,0)")
         end
 
         it "generates the ruby for a FROM expression with identical datetime values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,0,0,0) and val <= Time.utc(2011,1,10,0,0,0)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,10,0,0,0) and val <= Time.utc(2011,1,10,0,0,0)")
         end
 
         it "generates the ruby for a FROM expression with hash context" do
@@ -2038,42 +2038,42 @@ RSpec.describe MiqExpression do
 
         it "generates the ruby for a AFTER expression with date value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val > Time.utc(2011,1,11,4,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val > Time.utc(2011,1,11,4,59,59)")
         end
 
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val < Time.utc(2011,1,10,5,0,0)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val < Time.utc(2011,1,10,5,0,0)")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val > Time.utc(2011,1,10,14,0,0)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val > Time.utc(2011,1,10,14,0,0)")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val > Time.utc(2011,1,10,14,0,0)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val > Time.utc(2011,1,10,14,0,0)")
         end
 
         it "generates the ruby for a IS expression wtih date value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,5,0,0) and val <= Time.utc(2011,1,11,4,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,10,5,0,0) and val <= Time.utc(2011,1,11,4,59,59)")
         end
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,9,5,0,0) and val <= Time.utc(2011,1,11,4,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,9,5,0,0) and val <= Time.utc(2011,1,11,4,59,59)")
         end
 
         it "generates the ruby for a FROM expression with datetime values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 8:00", "2011-01-10 17:00"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,13,0,0) and val <= Time.utc(2011,1,10,22,0,0)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,10,13,0,0) and val <= Time.utc(2011,1,10,22,0,0)")
         end
 
         it "generates the ruby for a FROM expression with identical datetime values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,5,0,0) and val <= Time.utc(2011,1,10,5,0,0)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,10,5,0,0) and val <= Time.utc(2011,1,10,5,0,0)")
         end
       end
     end
@@ -2085,72 +2085,72 @@ RSpec.describe MiqExpression do
         it "generates the SQL for a AFTER expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("AFTER" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val > Time.utc(2011,1,11,16,59,59)")
+          expect(ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val > Time.utc(2011,1,11,16,59,59)")
         end
 
         it "generates the RUBY for a BEFORE expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val < Time.utc(2011,1,10,17,0,0)")
+          expect(ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val < Time.utc(2011,1,10,17,0,0)")
         end
 
         it "generates the RUBY for an IS expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,17,0,0) and val <= Time.utc(2011,1,11,16,59,59)")
+          expect(ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,10,17,0,0) and val <= Time.utc(2011,1,11,16,59,59)")
         end
 
         it "generates the RUBY for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
           exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w[Yesterday Today]})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,10,17,0,0) and val <= Time.utc(2011,1,12,16,59,59)")
+          expect(ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,10,17,0,0) and val <= Time.utc(2011,1,12,16,59,59)")
         end
       end
 
       context "relative dates with no time zone" do
         it "generates the ruby for an AFTER expression with date value of n Days Ago" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val > Time.utc(2011,1,9,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val > Time.utc(2011,1,9,23,59,59)")
         end
 
         it "generates the ruby for an AFTER expression with datetime value of n Days ago" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val > Time.utc(2011,1,9,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val > Time.utc(2011,1,9,23,59,59)")
         end
 
         it "generates the ruby for a BEFORE expression with date value of n Days Ago" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val < Time.utc(2011,1,9,0,0,0)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val < Time.utc(2011,1,9,0,0,0)")
         end
 
         it "generates the ruby for a BEFORE expression with datetime value of n Days Ago" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-last_scan_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val < Time.utc(2011,1,9,0,0,0)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val < Time.utc(2011,1,9,0,0,0)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last/This Hour" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,16,0,0) and val <= Time.utc(2011,1,11,17,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,11,16,0,0) and val <= Time.utc(2011,1,11,17,59,59)")
         end
 
         it "generates the ruby for a FROM expression with date values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of n Months Ago/Last Month" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2010,11,1,0,0,0) and val <= Time.utc(2010,12,31,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2010,11,1,0,0,0) and val <= Time.utc(2010,12,31,23,59,59)")
         end
 
         it "generates the ruby for an IS expression with datetime value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "Last Week"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
         end
 
         it "generates the ruby for an IS expression with relative date with hash context" do
@@ -2161,22 +2161,22 @@ RSpec.describe MiqExpression do
 
         it "generates the ruby for an IS expression with date value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,3,0,0,0) and val <= Time.utc(2011,1,9,23,59,59)")
         end
 
         it "generates the ruby for a IS expression with date value of Today" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,0,0,0) and val <= Time.utc(2011,1,11,23,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,11,0,0,0) and val <= Time.utc(2011,1,11,23,59,59)")
         end
 
         it "generates the ruby for an IS expression with date value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
         end
 
         it "generates the ruby for a IS expression with datetime value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
+          expect(exp.to_ruby).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
         end
       end
 
@@ -2185,47 +2185,47 @@ RSpec.describe MiqExpression do
 
         it "generates the ruby for a FROM expression with datetime value of Last/This Hour" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Hour", "This Hour"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,16,0,0) and val <= Time.utc(2011,1,11,17,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,11,16,0,0) and val <= Time.utc(2011,1,11,17,59,59)")
         end
 
         it "generates the ruby for a FROM expression with date values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of n Months Ago/Last Month" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-last_scan_on", "value" => ["2 Months Ago", "Last Month"]})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2010,11,1,10,0,0) and val <= Time.utc(2011,1,1,9,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2010,11,1,10,0,0) and val <= Time.utc(2011,1,1,9,59,59)")
         end
 
         it "generates the ruby for an IS expression with datetime value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "Last Week"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
         end
 
         it "generates the ruby for an IS expression with date value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,3,10,0,0) and val <= Time.utc(2011,1,10,9,59,59)")
         end
 
         it "generates the ruby for an IS expression with date value of Today" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,10,0,0) and val <= Time.utc(2011,1,12,9,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,11,10,0,0) and val <= Time.utc(2011,1,12,9,59,59)")
         end
 
         it "generates the ruby for an IS expression with date value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/retires_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.retires_on&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
         end
 
         it "generates the ruby for an IS expression with datetime value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-last_scan_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby(tz)).to eq("!(val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
+          expect(exp.to_ruby(tz)).to eq("!(val=rec.last_scan_on&.to_time).nil? and val >= Time.utc(2011,1,11,14,0,0) and val <= Time.utc(2011,1,11,14,59,59)")
         end
       end
     end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Condition do
 
       it "evaluates custom attribute on right side and integer column of VmOrTemplate on left side" do
         condition_to_evaluate = Condition.send(:subst, @filter_2.to_ruby(nil), vm)
-        expect(condition_to_evaluate).to eq('10 > 30')
+        expect(condition_to_evaluate).to eq('rec.memory_reserve > 30')
       end
 
       it "evaluates custom attribute on left side and integer column of VmOrTemplate on right side" do
@@ -216,11 +216,19 @@ RSpec.describe Condition do
 
   describe ".do_eval" do
     it "detects true" do
-      expect(Condition.send(:do_eval, "true")).to be_truthy
+      expect(Condition.send(:do_eval, "true", nil)).to be_truthy
     end
 
     it "detects false" do
-      expect(Condition.send(:do_eval, "false")).not_to be_truthy
+      expect(Condition.send(:do_eval, "false", nil)).not_to be_truthy
+    end
+
+    it "references object passed - happy" do
+      expect(Condition.send(:do_eval, "rec == 1", 1)).to be_truthy
+    end
+
+    it "references object passed - sad" do
+      expect(Condition.send(:do_eval, "rec == 1", 2)).not_to be_truthy
     end
   end
 


### PR DESCRIPTION
## Overview

This is only enabled for simple expressions like `Host-name` and not `Vm.host-name`.
It is also enabled for `<find>` clauses.

```ruby
exp = MiqExpression.new(...)
tmp_ruby_exp = exp.to_ruby
records.select do |rec|
  ruby_exp = Condition.subst(tmp_ruby_exp, rec)
  Condition.do_eval(ruby_exp, rec)
end
```

## Before

- Up front, `to_ruby` produces `<value ...>/virtual/total_hosts</value> == 5`
- For each record, `subst` runs `ruby_exp.gsub(/<value/>/, rec.total_hosts).
- For the `select`, `do_eval` evaluates `3 == 5` returning `false` (each record has a different expression)

## After

- Up front, `to_ruby` produces `rec.total_hosts == 5`
- For each record, `subst` is a no-op.
- For the `select`, `do_eval` returns `false`
