### PR TITLE
Method List dialog

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -30,6 +30,12 @@ class MiqAeMethod < ApplicationRecord
   AVAILABLE_SCOPES     = ["class", "instance"]
   validates_inclusion_of  :scope,     :in => AVAILABLE_SCOPES
 
+  # finds by name or namespace. not domain
+  # @param [nil,String] search
+  scope :name_path_search, lambda { |search|
+    search.present? ? where(arel_table[:relative_path].matches("%#{search}%")) : where({})
+  }
+
   def self.available_languages
     AVAILABLE_LANGUAGES
   end

--- a/spec/factories/miq_ae_method.rb
+++ b/spec/factories/miq_ae_method.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "miq_ae_method#{seq_padded_for_sorting(n)}" }
     language { "ruby" }
     location { "inline" }
+    scope { "instance" }
 
     transient do
       params { {} }

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -170,4 +170,34 @@ RSpec.describe MiqAeMethod do
     expect(keys.exclude?('options')).to be_truthy
     expect(keys.exclude?('embedded_methods')).to be_truthy
   end
+
+  describe ".name_path_search" do
+    it "matches name" do
+      m1 = FactoryBot.create(:miq_ae_method, "name" => "match", :class_id => sub_class.id)
+      FactoryBot.create(:miq_ae_method, "name" => "nope", :class_id => sys_class.id)
+
+      expect(MiqAeMethod.name_path_search("match")).to eq([m1])
+    end
+
+    it "matches a name with a %" do
+      m1 = FactoryBot.create(:miq_ae_method, "name" => "10_is_bigger", :class_id => sub_class.id)
+      FactoryBot.create(:miq_ae_method, "name" => "nope", :class_id => sys_class.id)
+
+      expect(MiqAeMethod.name_path_search("10%_big")).to eq([m1])
+    end
+
+    it "matches path" do
+      m1 = FactoryBot.create(:miq_ae_method, "name" => "match", :class_id => sub_class.id)
+      FactoryBot.create(:miq_ae_method, "name" => "nope", :class_id => sys_class.id)
+
+      expect(MiqAeMethod.name_path_search(sub_domain.name)).to eq([m1])
+    end
+
+    it "searches all when blank" do
+      m1 = FactoryBot.create(:miq_ae_method, "name" => "match", :class_id => sub_class.id)
+      m2 = FactoryBot.create(:miq_ae_method, "name" => "nope", :class_id => sys_class.id)
+
+      expect(MiqAeMethod.name_path_search(nil)).to match_array([m1, m2])
+    end
+  end
 end


### PR DESCRIPTION
## Overview

Part of https://github.com/ManageIQ/manageiq-ui-classic/pull/9047

Adds scopes for: https://github.com/ManageIQ/manageiq-ui-classic/pull/9059

This PR is an RnD work related to the search feature for the selection of the method.

Alternative to #22921

---

First commit deletes a bunch of code from the spec
Second commit is method and specs

Discussion: do we want to have conditional ids logic here or over in the ui?