### PR TITLE
Move to AS::DescendantsTracker.subclasses

### DIFF
--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe SupportsFeatureMixin do
   # this cleans out those values so future runs do not have bogus classes
   # this causes sporadic test failures.
   def cleanup_subclass(parent, children)
-    tracker = ActiveSupport::DescendantsTracker.class_variable_get(:@@direct_descendants)[parent]
+    tracker = ActiveSupport::DescendantsTracker.subclasses(parent)
     tracker&.reject! { |child| children.include?(child) }
   end
 


### PR DESCRIPTION
We were using a private class variable.  There's a public interface we can use and avoid a deprecation by switching from the variable to subclasses:

ActiveSupport::DescendantsTracker.direct_descendants is deprecated and will be removed in Rails 7.1. Use ActiveSupport::DescendantsTracker.subclasses instead.

extracted from https://github.com/ManageIQ/manageiq/pull/22873