### PR TITLE
Worker EMS_ID can no longer be an array

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -362,9 +362,8 @@ class MiqWorker < ApplicationRecord
     cmd = "nice -n #{nice_increment} #{cmd}" if ENV["APPLIANCE"]
 
     options = {:guid => guid, :heartbeat => nil}
-    if ems_id
-      options[:ems_id] = ems_id.kind_of?(Array) ? ems_id.join(",") : ems_id
-    end
+    options[:ems_id] = ems_id if ems_id
+
     "#{AwesomeSpawn::CommandLineBuilder.new.build(cmd, options)} #{name}"
   end
 

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -29,7 +29,7 @@ opt_parser = OptionParser.new do |opts|
     options[:guid] = val
   end
 
-  opts.on("-e=ems_id", "--ems-id=ems_id,ems_id", Array, "Provide a list of ems ids (without spaces) to a provider worker. This requires, at least one argument.") do |val|
+  opts.on("-e=ems_id", "--ems-id=ems_id", "Provide a list of ems ids (without spaces) to a provider worker. This requires, at least one argument.") do |val|
     options[:ems_id] = val
   end
 
@@ -81,7 +81,7 @@ end
 # Skip heartbeating with single worker
 ENV["DISABLE_MIQ_WORKER_HEARTBEAT"] ||= options[:heartbeat] ? nil : '1'
 
-options[:ems_id] ||= ENV["EMS_ID"].try(:split, ',')
+options[:ems_id] ||= ENV.fetch("EMS_ID", nil)
 
 if options[:roles].present?
   MiqServer.my_server.server_role_names += options[:roles]
@@ -102,8 +102,8 @@ unless options[:dry_run]
   create_options[:system_uid] = options[:system_uid] if options[:system_uid]
 
   if options[:ems_id]
-    create_options[:queue_name] = options[:ems_id].length == 1 ? "ems_#{options[:ems_id].first}" : options[:ems_id].collect { |id| "ems_#{id}" }
-    runner_options[:ems_id]     = options[:ems_id].length == 1 ? options[:ems_id].first : options[:ems_id].collect { |id| id }
+    create_options[:queue_name] = "ems_#{options[:ems_id]}"
+    runner_options[:ems_id]     = options[:ems_id]
   end
 
   update_options = create_options.dup


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/20345 dropped queue_name having multiple ems_ids but run_single_worker still had logic to handle this.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
