### PR TITLE
Link MiqWorker record to a running pod when not created using run_single_worker.rb

### DIFF
--- a/spec/models/miq_server/worker_management/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/kubernetes_spec.rb
@@ -215,9 +215,10 @@ RSpec.describe MiqServer::WorkerManagement::Kubernetes do
 
     context "podified" do
       let(:rails_worker) { true }
-      let(:pod_name)     { "1-generic-abcd" }
+      let(:pod_name)     { "#{server.compressed_id}-generic-abcd" }
       let(:pod_running)  { true }
-      let(:worker)       { FactoryBot.create(:miq_generic_worker, :miq_server => server, :status => status, :system_uid => pod_name) }
+      let(:worker)       { FactoryBot.create(:miq_generic_worker, :miq_server => server, :status => status, :system_uid => system_uid) }
+      let(:system_uid)   { pod_name }
       let(:current_pods) { {pod_name => {:label_name => pod_label, :last_state_terminated => false, :container_restarts => 0, :running => pod_running}} }
 
       before do
@@ -268,6 +269,36 @@ RSpec.describe MiqServer::WorkerManagement::Kubernetes do
 
             it "returns the starting worker" do
               expect(server.worker_manager.sync_starting_workers).to include(worker)
+            end
+          end
+
+          context "with a worker that doesn't have a system_uid yet" do
+            let(:system_uid) { nil }
+
+            context "without a pod" do
+              let(:current_pods) { {} }
+
+              it "returns the worker as still starting" do
+                expect(server.worker_manager.sync_starting_workers).to include(worker)
+              end
+            end
+
+            context "with a pod that is running" do
+              let(:pod_running) { true }
+
+              it "sets the worker's system_uid and marks the worker started" do
+                expect(server.worker_manager.sync_starting_workers).to be_empty
+                expect(worker.reload.system_uid).to eq(pod_name)
+              end
+            end
+
+            context "with a pod that isn't running" do
+              let(:pod_running) { false }
+
+              it "sets the worker's system_uid and but doesn't mark the worker started" do
+                expect(server.worker_manager.sync_starting_workers).to include(worker)
+                expect(worker.reload.system_uid).to eq(pod_name)
+              end
             end
           end
         end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23116
- [x] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/68

Fixes https://github.com/ManageIQ/manageiq-providers-embedded_terraform/issues/67
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
