### PR TITLE
Added --prune option to remove deleted branches from the remote repos…

### DIFF
--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -271,8 +271,8 @@ class GitWorktree
     end
   end
 
-  def pull
-    lock { fetch_and_merge }
+  def pull(prune: true)
+    lock { fetch_and_merge(:prune => prune) }
   end
 
   def with_remote_options
@@ -328,15 +328,20 @@ class GitWorktree
     "refs/heads/#{current_branch}"
   end
 
-  def fetch_and_merge
-    fetch
+  def fetch_and_merge(prune: true)
+    fetch(:prune => prune)
     commit = @repo.ref(upstream_ref).target
     merge(commit)
   end
 
-  def fetch
+  def fetch(prune: true)
     with_remote_options do |remote_options|
-      @repo.fetch(@remote_name, **remote_options)
+      if prune
+        fetch_options = remote_options.merge(:prune => prune)
+        @repo.fetch(@remote_name, **fetch_options)
+      else
+        @repo.fetch(@remote_name, **remote_options)
+      end
     end
   end
 


### PR DESCRIPTION
**PR raised for old branches cleanup for Git-based domain**
https://github.com/ManageIQ/manageiq/issues/23087

**Before**
We can see a lot of branches that no longer exist in our Git remote repository in the 'Refreshing Branch for Git-Based Domain' window
![348248414-19aeb41e-efb8-4861-92fd-05a51101f229](https://github.com/user-attachments/assets/cd36bb3c-6fd8-4a60-aeb1-951d650459b4)

**After**
It now removes deleted branches using prune, so it only shows the existing branches.
![image](https://github.com/user-attachments/assets/3ae284ce-fc04-476c-b923-655e96a0306f)
Branch branch_test10 and branch_test12 have been deleted from the remote.