### PR TITLE
Fix non rails worker starting on podified

### DIFF
--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -6,9 +6,7 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
 
   def sync_starting_workers
     sync_from_system
-    MiqWorker.find_all_starting.each do |worker|
-      next if worker.class.rails_worker?
-
+    MiqWorker.find_all_starting.reject(&:rails_worker?).each do |worker|
       systemd_worker = miq_services_by_unit[worker[:system_uid]]
       next if systemd_worker.nil?
 
@@ -20,7 +18,7 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
 
   def sync_stopping_workers
     sync_from_system
-    MiqWorker.find_all_stopping.reject { |w| w.class.rails_worker? }.each do |worker|
+    MiqWorker.find_all_stopping.reject(&:rails_worker?).each do |worker|
       # If the worker record is "stopping" and the systemd unit is gone then the
       # worker has successfully exited.
       next if miq_services_by_unit[worker[:system_uid]].present?

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -71,6 +71,7 @@ class MiqWorker < ApplicationRecord
 
     true
   end
+  delegate :rails_worker?, :to => :class
 
   def self.scalable?
     maximum_workers_count.nil? || maximum_workers_count > 1

--- a/spec/models/miq_server/worker_management/kubernetes_spec.rb
+++ b/spec/models/miq_server/worker_management/kubernetes_spec.rb
@@ -210,6 +210,128 @@ RSpec.describe MiqServer::WorkerManagement::Kubernetes do
     end
   end
 
+  describe "#sync_starting_workers" do
+    before { MiqWorkerType.seed }
+
+    context "podified" do
+      let(:rails_worker) { true }
+      let(:pod_name)     { "1-generic-abcd" }
+      let(:pod_running)  { true }
+      let(:worker)       { FactoryBot.create(:miq_generic_worker, :miq_server => server, :status => status, :system_uid => pod_name) }
+      let(:current_pods) { {pod_name => {:label_name => pod_label, :last_state_terminated => false, :container_restarts => 0, :running => pod_running}} }
+
+      before do
+        allow(worker.class).to receive(:rails_worker?).and_return(rails_worker)
+        server.worker_manager.current_pods = current_pods
+      end
+
+      after do
+        server.worker_manager.current_pods.clear
+      end
+
+      context "with no starting workers" do
+        let(:status) { MiqWorker::STATUS_STARTED }
+
+        it "returns an empty array" do
+          expect(server.worker_manager.sync_starting_workers).to be_empty
+        end
+      end
+
+      context "with a starting worker" do
+        let(:status) { MiqWorker::STATUS_STARTING }
+
+        it "returns the starting worker" do
+          expect(server.worker_manager.sync_starting_workers).to include(worker)
+        end
+
+        context "non-rails worker" do
+          let(:rails_worker) { false }
+
+          context "without a pod" do
+            let(:current_pods) { {} }
+
+            it "returns the worker as still starting" do
+              expect(server.worker_manager.sync_starting_workers).to include(worker)
+            end
+          end
+
+          context "with a pod that is running" do
+            let(:pod_running) { true }
+
+            it "marks the worker as running and returns an empty array" do
+              expect(server.worker_manager.sync_starting_workers).to be_empty
+            end
+          end
+
+          context "with a pod that isn't running yet" do
+            let(:pod_running) { false }
+
+            it "returns the starting worker" do
+              expect(server.worker_manager.sync_starting_workers).to include(worker)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#sync_stopping_workers" do
+    before { MiqWorkerType.seed }
+
+    context "podified" do
+      let(:rails_worker) { true }
+      let(:pod_name)     { "1-generic-abcd" }
+      let(:pod_running)  { true }
+      let(:worker)       { FactoryBot.create(:miq_generic_worker, :miq_server => server, :status => status, :system_uid => pod_name) }
+      let(:current_pods) { {pod_name => {:label_name => pod_label, :last_state_terminated => false, :container_restarts => 0, :running => pod_running}} }
+
+      before do
+        allow(worker.class).to receive(:rails_worker?).and_return(rails_worker)
+        server.worker_manager.current_pods = current_pods
+      end
+
+      after do
+        server.worker_manager.current_pods.clear
+      end
+
+      context "with no stopping workers" do
+        let(:status) { MiqWorker::STATUS_STARTED }
+
+        it "returns an empty array" do
+          expect(server.worker_manager.sync_stopping_workers).to be_empty
+        end
+      end
+
+      context "with a stopping worker" do
+        let(:status) { MiqWorker::STATUS_STOPPING }
+
+        it "returns the stopping worker" do
+          expect(server.worker_manager.sync_stopping_workers).to include(worker)
+        end
+
+        context "non-rails worker" do
+          let(:rails_worker) { false }
+
+          context "without a pod" do
+            let(:current_pods) { {} }
+
+            it "marks the worker as stopped and returns an empty array" do
+              expect(server.worker_manager.sync_stopping_workers).to be_empty
+            end
+          end
+
+          context "with a pod that is still running" do
+            let(:pod_running) { true }
+
+            it "returns the stopping worker" do
+              expect(server.worker_manager.sync_stopping_workers).to include(worker)
+            end
+          end
+        end
+      end
+    end
+  end
+
   context "#cleanup_orphaned_worker_rows" do
     context "podified" do
       let(:server2) { EvmSpecHelper.remote_miq_server }


### PR DESCRIPTION
The current_pods Concurrent::Hash doesn't have the full pod object so we have to move the logic for checking if a pod is running down into save_pod

~~WIP pending tests covering more of these methods specifically sync_starting_workers~~

Dependents:
* https://github.com/ManageIQ/manageiq/pull/23117
* https://github.com/ManageIQ/manageiq/pull/23112
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
