### PR TITLE
Fix MiqServer WorkerManager Process with Non Rails workers

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -90,4 +90,12 @@ class MiqServer::WorkerManagement
     end
     miq_workers.reload
   end
+
+  private
+
+  def sync_starting_rails_workers
+  end
+
+  def sync_stopping_rails_workers
+  end
 end

--- a/app/models/miq_server/worker_management/process.rb
+++ b/app/models/miq_server/worker_management/process.rb
@@ -7,22 +7,18 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
 
   def sync_starting_workers
     sync_from_system
-    starting = MiqWorker.find_all_starting
-    starting.where(:pid => miq_processes_by_pid.keys)
-            .reject(&:rails_worker?)
-            .each { |w| w.update!(:status => MiqWorker::STATUS_STARTED) }
+    sync_starting_rails_workers
+    sync_starting_non_rails_workers
 
-    starting.reload
+    MiqWorker.find_all_starting.to_a
   end
 
   def sync_stopping_workers
     sync_from_system
-    stopping = MiqWorker.find_all_stopping
-    stopping.where(:pid => miq_processes_by_pid.keys)
-            .reject(&:rails_worker?)
-            .each { |w| w.update!(:status => MiqWorker::STATUS_STOPPED) }
+    sync_stopping_rails_workers
+    sync_stopping_non_rails_workers
 
-    stopping.reload
+    MiqWorker.find_all_stopping.to_a
   end
 
   def monitor_workers
@@ -88,4 +84,18 @@ class MiqServer::WorkerManagement::Process < MiqServer::WorkerManagement
   private
 
   attr_accessor :miq_processes, :miq_processes_by_pid
+
+  def sync_starting_non_rails_workers
+    starting = MiqWorker.find_all_starting
+    starting.where(:pid => miq_processes_by_pid.keys)
+            .reject(&:rails_worker?)
+            .each { |w| w.update!(:status => MiqWorker::STATUS_STARTED) }
+  end
+
+  def sync_stopping_non_rails_workers
+    stopping = MiqWorker.find_all_stopping
+    stopping.where(:pid => miq_processes_by_pid.keys)
+            .reject(&:rails_worker?)
+            .each { |w| w.update!(:status => MiqWorker::STATUS_STOPPED) }
+  end
 end

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
       it "doesn't update the worker record" do
         expect(worker).not_to receive(:update!)
 
-        server.worker_manager.sync_starting_workers
+        expect(server.worker_manager.sync_starting_workers).to be_empty
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
         it "doesn't update the worker record" do
           expect(worker).not_to receive(:update!)
 
-          server.worker_manager.sync_starting_workers
+          expect(server.worker_manager.sync_starting_workers).to include(worker)
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
           it "doesn't update the worker record" do
             expect(worker).not_to receive(:update!)
 
-            server.worker_manager.sync_starting_workers
+            expect(server.worker_manager.sync_starting_workers).to include(worker)
           end
         end
 
@@ -106,7 +106,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
             end
 
             it "doesn't update the worker record" do
-              server.worker_manager.sync_starting_workers
+              expect(server.worker_manager.sync_starting_workers).to include(worker)
 
               expect(worker.reload.status).to eq(MiqWorker::STATUS_STARTING)
             end
@@ -125,7 +125,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
             end
 
             it "sets the worker record to started" do
-              server.worker_manager.sync_starting_workers
+              expect(server.worker_manager.sync_starting_workers).to be_empty
 
               expect(worker.reload.status).to eq(MiqWorker::STATUS_STARTED)
             end
@@ -144,7 +144,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
       it "doesn't update the worker record" do
         expect(worker).not_to receive(:update!)
 
-        server.worker_manager.sync_stopping_workers
+        expect(server.worker_manager.sync_stopping_workers).to be_empty
       end
     end
 
@@ -159,7 +159,7 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
         it "doesn't update the worker record" do
           expect(worker).not_to receive(:update!)
 
-          server.worker_manager.sync_stopping_workers
+          expect(server.worker_manager.sync_stopping_workers).to include(worker)
         end
       end
 
@@ -181,13 +181,13 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
           it "doesn't update the worker record" do
             expect(worker).not_to receive(:update!)
 
-            server.worker_manager.sync_stopping_workers
+            expect(server.worker_manager.sync_stopping_workers).to include(worker)
           end
         end
 
         context "with a systemd unit that has exited" do
           it "sets the worker record to stopped" do
-            server.worker_manager.sync_stopping_workers
+            expect(server.worker_manager.sync_stopping_workers).to be_empty
 
             expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPED)
           end


### PR DESCRIPTION
We only added logic to set non-rails workers to started/stopped for kubernetes and systemd worker manager subclasses.  This meant if you ran `rake evm:start` locally with a non-rails worker it wouldn't ever be marked as started.

Also updated the systemd side to be consistent with kubernetes in not returning a worker that was just marked as started.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23116

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
