### PR TITLE
Drop eth0 from MiqServer.get_network_information

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -1,24 +1,17 @@
-require 'linux_admin'
-
 module MiqServer::EnvironmentManagement
   extend ActiveSupport::Concern
 
   module ClassMethods
     def get_network_information
       ipaddr = hostname = mac_address = nil
-      begin
-        if MiqEnvironment::Command.is_appliance?
-          eth0 = LinuxAdmin::NetworkInterface.new("eth0")
 
-          ipaddr      = eth0.address || eth0.address6
-          hostname    = LinuxAdmin::Hosts.new.hostname
-          mac_address = eth0.mac_address
-        else
-          ipaddr      = MiqEnvironment.local_ip_address
-          hostname    = MiqEnvironment.fully_qualified_domain_name
-          mac_address = UUIDTools::UUID.mac_address.dup
-        end
-      rescue
+      begin
+        ipaddr      = MiqEnvironment.local_ip_address
+        hostname    = MiqEnvironment.fully_qualified_domain_name
+        mac_address = UUIDTools::UUID.mac_address.dup
+      rescue => err
+        _log.warn("Failed to get network information: #{err}")
+        _log.log_backtrace(err)
       end
 
       [ipaddr, hostname, mac_address]


### PR DESCRIPTION
Don't depend on having an interface named eth0 for the get_network_information method.

MiqEnvironment already has logic for finding a non-loopback interface with an ipv4 or ipv6 address.  This doesn't work great with multiple interfaces but it does work on our default appliances with a single non lo iface.

Related:
* https://github.com/ManageIQ/manageiq-appliance-build/pull/573
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
