### PR TITLE
Expose the new yarn_audit task via rake -T

### DIFF
--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -65,6 +65,7 @@ namespace :test do
       exit $?.exitstatus unless system(cmd)
     end
 
+    desc "Run yarn npm audit with the specified report format ('human' or 'json')"
     task :yarn_audit, :format do |_, args|
       format = args.fetch(:format, "human")
 


### PR DESCRIPTION
I missed exposing the new yarn_audit task to `rake -T` in #23098 , so this adds it.