### PR TITLE
Run all security tests before failing any one of them

### DIFF
--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -92,11 +92,15 @@ class TestSecurityHelper
   end
 
   def self.all(format: "human")
-    brakeman(format: format)
-    puts
-    bundle_audit(format: format)
-    puts
-    yarn_audit(format: format)
-    true
+    success = %i[bundle_audit brakeman yarn_audit].map do |suite|
+      public_send(suite, format: format)
+      true
+    rescue SecurityTestFailed
+      false
+    ensure
+      puts
+    end.all?
+
+    raise SecurityTestFailed unless success
   end
 end


### PR DESCRIPTION
This change allows all of the security tests to run, then fails if any one fail. This allows us to get a fuller picture before failing.

@jrafanie Please review.