### PR TITLE
Add rake task for rebuilding the yarn audit pending list

### DIFF
--- a/lib/tasks/test_security.rake
+++ b/lib/tasks/test_security.rake
@@ -28,6 +28,11 @@ namespace :test do
     rescue TestSecurityHelper::SecurityTestFailed
       exit 1
     end
+
+    desc "Rebuild yarn audit pending list for an engine"
+    task :rebuild_yarn_audit_pending do
+      TestSecurityHelper.rebuild_yarn_audit_pending
+    end
   end
 
   desc "Run all security tests with the specified report format ('human' or 'json')"


### PR DESCRIPTION
Run from an engine, this will rebuild that yarn audit pending list in the .yarnrc.yml file. See https://github.com/ManageIQ/manageiq-ui-classic/pull/9241 for an example of the output generated.