### PR TITLE
Use Rails 7 way to set yaml permitted classes

### DIFF
--- a/lib/yaml_permitted_classes.rb
+++ b/lib/yaml_permitted_classes.rb
@@ -30,11 +30,7 @@ class YamlPermittedClasses
 
   def self.initialize_app_yaml_permitted_classes
     @initialize_app_yaml_permitted_classes ||= begin
-      if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
-        ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes
-      else
-        ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes
-      end
+      ActiveRecord.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes
       true
     end
   end


### PR DESCRIPTION
Drops the rails 6.1 compatibility from:
https://github.com/ManageIQ/manageiq/pull/22887

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
