### PR TITLE
Don't STI load via the descendants/subclasses hooks during code reload

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,8 @@ end
 
 module Vmdb
   class Application < Rails::Application
+    attr_accessor :reloading
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
@@ -191,6 +193,12 @@ module Vmdb
       # Reload Settings to get values from db now that it's safe to autoload
       ::Settings.reload!
       Vmdb::Loggers.apply_config(::Settings.log)
+
+      # The descendant_loader.rb hooks descendants and subclasses to do proper sti loading of
+      # subclasses and descendants. It should not be used when code reload is happening.
+      Vmdb::Application.reloading = false
+      Vmdb::Application.reloader.before_class_unload { Vmdb::Application.reloading = true }
+      Vmdb::Application.reloader.to_complete         { Vmdb::Application.reloading = false }
     end
 
     console do

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -278,7 +278,7 @@ class DescendantLoader
     #   "xxx/manageiq/app/models/vm_or_template.rb:15:in `<class:VmOrTemplate>'",
     #   "xxx/manageiq/app/models/vm_or_template.rb:6:in `<main>'",
     def descendants
-      if Vmdb::Application.instance.initialized? && !defined?(@loaded_descendants) && %w[__update_callbacks].exclude?(caller_locations(1..1).first.base_label)
+      if Vmdb::Application.instance.initialized? && !defined?(@loaded_descendants) && %w[__update_callbacks].exclude?(caller_locations(1..1).first.base_label) && !Vmdb::Application.reloading
         @loaded_descendants = true
         DescendantLoader.instance.load_subclasses(self)
       end
@@ -327,7 +327,7 @@ class DescendantLoader
     #   "xxx/gems/activesupport-7.0.8.4/lib/active_support/descendants_tracker.rb:89:in `descendants'",
     #   ...
     def subclasses
-      if Vmdb::Application.instance.initialized? && !defined?(@loaded_descendants) && %w[descendants reload_schema_from_cache subclasses].exclude?(caller_locations(1..1).first.base_label)
+      if Vmdb::Application.instance.initialized? && !defined?(@loaded_descendants) && %w[descendants reload_schema_from_cache subclasses].exclude?(caller_locations(1..1).first.base_label) && !Vmdb::Application.reloading
         @loaded_descendants = true
         DescendantLoader.instance.load_subclasses(self)
       end


### PR DESCRIPTION
The descendant_loader.rb hooks descendants and subclasses to do proper sti loading of subclasses and descendants. It should not be used when code reload is happening.

This fixes a bug when issuing reload! in rails console with rails 7.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
