### PR TITLE
Fix undefined method while getting database configuration

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -150,7 +150,7 @@ class EvmDatabase
   private_class_method :seed_classes
 
   def self.host
-    (ActiveRecord::Base.configurations[ENV['RAILS_ENV']] || {})['host']
+    ActiveRecord::Base.configurations.find_db_config(Rails.env).host
   end
 
   def self.local?


### PR DESCRIPTION
`ActiveRecord::Base.configurations` no longer responds to `[]` like a hash.

```
lib/evm_database.rb:153:in `host': undefined method `[]' lib/evm_database.rb:153:in `host': undefined method `[]'
(ActiveRecord::Base.configurations[ENV['RAILS_ENV']] || {})['host']
                                  ^^^^^^^^^^^^^^^^^^
lib/evm_database.rb:157:in `local?'
lib/workers/evm_server.rb:236:in `configure_server_roles'
lib/workers/evm_server.rb:127:in `start_server'
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
