### PR TITLE
Fix inconsistent dialog input for Workflows

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -267,7 +267,7 @@ class MiqRequestTask < ApplicationRecord
   end
 
   def workflow_inputs
-    dialog_values
+    {:dialog => dialog_values}
   end
 
   def dialog_values


### PR DESCRIPTION
Workflows run for a dynamic dialog have their dialog_values nested under a top-level `{:dialog => {}} ` key, workflows run as a Service Template Entrypoint should have the same format.

Before this the input from a dialog would be passed like:
`Running state: [CloneTemplate] with input [{"dialog_vm_name"=>"ag-prov-test", "dialog_provider"=>4, "dialog_verify_ssl"=>"false", "dialog_source_template"=>"vm-64"}]...`

Which would cause e.g. https://github.com/ManageIQ/workflows-examples/blob/master/provision-vm-service/provision-vm.asl#L19-L23 to fail to find the values.

This way the input format should be the same as workflows run via a dynamic dialog e.g. https://github.com/ManageIQ/workflows-examples/blob/master/provision-vm-service/list-providers.asl#L17

Related: https://github.com/ManageIQ/manageiq/pull/22849
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
