### PR TITLE
CP4AIOPS-3113 Introduce configurable delimiter for LDAP group names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -290,7 +290,7 @@ end
 
 group :appliance, :optional => true do
   gem "irb",                            "=1.4.1",            :require => false # Locked to same version as the installed RPM rubygem-irb-1.4.1-142.module_el9+787+b20bfeee.noarch so that we don't bundle our own
-  gem "manageiq-appliance_console",     "~>9.1", ">=9.1.1",  :require => false
+  gem "manageiq-appliance_console",     "~>10.0",            :require => false
   gem "rdoc",                                                :require => false # Needed for rails console
 end
 

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -4,6 +4,11 @@ module Authenticator
       'External httpd'
     end
 
+    # @return group delimiter defined in settings
+    def self.group_delimiter
+      ::Settings.authentication.group_delimiter.presence
+    end
+
     def authorize_queue(username, request, options, *_args)
       log_auth_debug("authorize_queue(username=#{username}, options=#{options})")
 
@@ -146,7 +151,8 @@ module Authenticator
         user_headers.each { |k, v| log_auth_debug("  %-24{key} = \"%{val}\"" % {:key => k, :val => v}) }
       end
 
-      groups     = CGI.unescape(user_headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:,]/)
+      delimiter  = self.class.group_delimiter || /[;:,]/
+      groups     = CGI.unescape(user_headers['X-REMOTE-USER-GROUPS'] || '').split(delimiter)
       user_attrs = {:username  => username,
                     :fullname  => user_headers['X-REMOTE-USER-FULLNAME'],
                     :firstname => user_headers['X-REMOTE-USER-FIRSTNAME'],

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -151,7 +151,7 @@ module Authenticator
         user_headers.each { |k, v| log_auth_debug("  %-24{key} = \"%{val}\"" % {:key => k, :val => v}) }
       end
 
-      delimiter  = self.class.group_delimiter || /[;:,]/
+      delimiter  = self.class.group_delimiter || user_headers['X-REMOTE-USER-GROUP-DELIMITER'].presence || /[;:,]/
       groups     = CGI.unescape(user_headers['X-REMOTE-USER-GROUPS'] || '').split(delimiter)
       user_attrs = {:username  => username,
                     :fullname  => user_headers['X-REMOTE-USER-FULLNAME'],
@@ -172,6 +172,7 @@ module Authenticator
         X-REMOTE-USER-EMAIL
         X-REMOTE-USER-DOMAIN
         X-REMOTE-USER-GROUPS
+        X-REMOTE-USER-GROUP-DELIMITER
       ].each_with_object({}) do |k, h|
         h[k] = request.headers[k]&.force_encoding("UTF-8")
       end.delete_nils

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@
   :ldaphost:
   :ldapport: '389'
   :mode: database
+  :group_delimiter:
   :max_failed_login_attempts: 3
   :locked_account_timeout: 2.minutes
   :search_timeout: 30

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -172,6 +172,17 @@ RSpec.describe Authenticator::Httpd do
       }
     end
 
+    let(:user_attrs) do
+      {
+        :username  => "testuser",
+        :fullname  => "Test User",
+        :firstname => "Alice",
+        :lastname  => "Aardvark",
+        :email     => "testuser@example.com",
+        :domain    => "example.com"
+      }
+    end
+
     context "with user details" do
       let!(:alice) { FactoryBot.create(:user, :userid => 'alice') }
 
@@ -707,14 +718,6 @@ RSpec.describe Authenticator::Httpd do
         let(:headers) do
           super().merge('X-Remote-User-Groups' => 'wibble@fqdn,bubble@fqdn')
         end
-        let(:user_attrs) do
-          {:username  => "testuser",
-            :fullname  => "Test User",
-            :firstname => "Alice",
-            :lastname  => "Aardvark",
-            :email     => "testuser@example.com",
-            :domain    => "example.com"}
-        end
 
         it "handles a comma separated grouplist" do
           expect(subject).to receive(:find_external_identity).with(username, user_attrs, ["wibble@fqdn", "bubble@fqdn"])
@@ -726,14 +729,6 @@ RSpec.describe Authenticator::Httpd do
         let(:config) { {:httpd_role => true} }
         let(:headers) do
           super().merge('X-Remote-User-Groups' => CGI.escape('spécial_char@fqdn:moré@fqdn'))
-        end
-        let(:user_attrs) do
-          {:username  => "testuser",
-            :fullname  => "Test User",
-            :firstname => "Alice",
-            :lastname  => "Aardvark",
-            :email     => "testuser@example.com",
-            :domain    => "example.com"}
         end
 
         it "handles group names with escaped special characters" do
@@ -754,14 +749,6 @@ RSpec.describe Authenticator::Httpd do
             'X-Remote-User-Domain'    => 'example.com',
             'X-Remote-User-Groups'    => nil,
           }
-        end
-        let(:user_attrs) do
-          {:username  => "testuser",
-            :fullname  => "Test User",
-            :firstname => "Alice",
-            :lastname  => "Aardvark",
-            :email     => "testuser@example.com",
-            :domain    => "example.com"}
         end
 
         it "handles nil group names" do


### PR DESCRIPTION
## Overview

|Auth Server|Interface|Delimiter|
|-----------|---------|---------|
| Liberty   |     oicd|      `,`|
|           |     saml|      `;`|
|ipa        |     sssd|      `:`|
|ldap       |     sssd|      `:`|

## Goal

Allow users to have a `:` in group names.

Since the group can come in with 3 possible delimiters, we treat `:`, `,`, and `;` as possible delimiters.

This works fine if groups do not have one of those characters in it.

Liberty uses a `,` as a delimiter and allows `:` in the group name.
If a liberty server sends groups value of `'group1,people:fun,people:sad'`, we treat this as groups `'group1'`, `'people'`, `'fun'`, `'people'`, and `'sad'`.

If a configuration references `group1`, then it works fine, but configuration that references `people:fun` will not find the group and not work as expected.

## Solution

1. Allow apache to pass the delimiter used to ruby.
2. Allow the admin to override this delimiter in advanced settings.

The various configurations use different delimiters, so it makes sense to allow each of those configurations to specify the delimiter that is being used.

If an oidc server uses a different delimiter, then allow the admin to configure the correct delimiter in settings.

## See Also

blocked:

- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/265
- [x] https://github.com/ManageIQ/manageiq-appliance/pull/389
- [x] Release of appliance_console gem version 10.0.0 

dependent:

- [x] https://github.com/ManageIQ/manageiq-pods/pull/1155

ref:

- https://github.com/ManageIQ/manageiq/pull/32
- update: https://github.com/ManageIQ/httpd_configmap_generator


## Next steps

We could change the configuration for `LookupUserGroup` and `mod_auth_mellon` to just use a `,` as a delimiter, but that felt like too much change.