### PR TITLE
Upgrading ruby to 3.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '3.0'
         - '3.1'
-        - '3.2'
         - '3.3'
         test-suite:
         - vmdb

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
-raise "Ruby versions < 3.0.1 are unsupported!"  if RUBY_VERSION < "3.0.1"
-warn "Ruby versions >= 3.2.0 are untested!" if RUBY_VERSION >= "3.2.0"
-raise "Ruby versions >= 3.4.0 are unsupported!" if RUBY_VERSION >= "3.4.0"
-
+ruby ">= 3.1.1", "< 3.5.0"
+warn "Ruby versions >= 3.4.0 are untested!" if RUBY_VERSION >= "3.4.0"
 source 'https://rubygems.org'
 
 plugin "bundler-inject", "~> 2.0"


### PR DESCRIPTION
# 3.2 [ref](https://rubyreferences.github.io/rubychanges/3.2.html)

Highlights:

- [x] optional: `Regexp.timeout = 1.0` or `Regexp.new('^a*b?a*()\1$', timeout: Float::INFINITY)`
- [x] All methods wishing to delegate keyword arguments through *args must now be marked with ruby2_keywords, with no exception.
- [x] Hash#shift (empty returns nil instead of default)
- [x] `Struct` no longer needs `keyword_init`
- [x] removed: `Fixnum`, `Bignum` `Random::DEFAULT`, `Struct::Group`, `Struct::Passwd`
- [x] removed: `Dir.exists?`, `File.exists?`
- [x] removed: `Kernel#=~`, `Kernel#taint`, `Kernel#untaint`, `Kernel#tainted?`, `Kernel#trust`, `Kernel#untrust`, `Kernel#untrusted?`
- [x] lib no longer included: `libyaml`. (was in `psych`. May need `libyaml-dev` on ubuntu)
- [x] lib no longer included: `libffi`. (was in `fiddle` - only used on windows)
- [x] add `Queue#pop`, `SizedQueue#push`, `SizedQueue#pop` added param `timeout:`

# 3.3
- 

punt:
- `ERB::Util.html_escape` is made faster than `CGI.escapeHTML`
- no longer need `require "set"` (supporting older ruby versions)
  - this is not hurting anyone, and this change is not compatible for ruby <3.2 - which we still support

# External PRs

These were changed in external libraries and make using them easier, but are not required for our upgrade.
- [ ] https://github.com/oVirt/ovirt-engine-sdk-ruby/pull/19
- [x] https://github.com/oVirt/ovirt-engine-sdk-ruby/pull/17
- [ ] https://github.com/ruby/ruby/pull/11649 

Related PRs
---

- [x] https://github.com/oVirt/ovirt-engine-sdk-ruby/pull/17
- [x] https://github.com/ManageIQ/activerecord-virtual_attributes/pull/171
- [x] https://github.com/ManageIQ/linux_admin/pull/256
- [x] https://github.com/ManageIQ/manageiq/pull/23203
- [x] https://github.com/ManageIQ/manageiq/pull/23204
- [x] https://github.com/ManageIQ/manageiq/pull/23205
- [x] https://github.com/ManageIQ/manageiq/pull/23219
- [x] https://github.com/ManageIQ/manageiq/pull/23232
- [x] https://github.com/ManageIQ/manageiq/pull/23234
- [x] https://github.com/ManageIQ/manageiq-appliance-build/pull/577
- [x] https://github.com/ManageIQ/manageiq-appliance-build/pull/578
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/269
- [x] https://github.com/ManageIQ/manageiq-api/pull/1270
- [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/559
- [x] https://github.com/ManageIQ/manageiq-content/pull/754
- [x] https://github.com/ManageIQ/manageiq-consumption/pull/223
- [x] https://github.com/ManageIQ/manageiq-cross_repo/pull/111
- [x] https://github.com/ManageIQ/manageiq-decorators/pull/108
- [x] https://github.com/ManageIQ/manageiq-decorators/pull/109
- [x] https://github.com/ManageIQ/manageiq-schema/pull/755
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9277
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9286
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9293
- [x] https://github.com/ManageIQ/manageiq-password/pull/45
- [x] https://github.com/ManageIQ/manageiq-pods/pull/1184
- [x] https://github.com/ManageIQ/manageiq-ssh-util/pull/27
- [x] https://github.com/ManageIQ/manageiq-smartstate/pull/199
- [x] https://github.com/ManageIQ/manageiq-smartstate/pull/208
- [x] https://github.com/ManageIQ/manageiq-schema/pull/765
- [x] https://github.com/ManageIQ/more_core_extensions/pull/124
- [x] https://github.com/ManageIQ/more_core_extensions/pull/125
- [x] https://github.com/ManageIQ/multi_repo/pull/35
- [x] https://github.com/ManageIQ/ovirt_metrics/pull/58
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/517

providers:

- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/870
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/315
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/252
- [x] https://github.com/ManageIQ/manageiq-providers-awx/pull/38
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/562
- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/111
- [x] https://github.com/ManageIQ/manageiq-providers-dummy_provider/pull/65
- [x] https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/85
- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/133
- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/270
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/506
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/163
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/119
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/111
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/540
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/253
- [x] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/417
- [x] https://github.com/ManageIQ/manageiq-providers-nsxt/pull/129
- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/322
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/270
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/891
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/107
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/678
- [x] https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization/pull/56
- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/207
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/923
- [x] https://github.com/ManageIQ/manageiq-providers-workflows/pull/120

current solution
---
```
gem install --verbose ovirt-engine-sdk -v4.6.0 -- --with-cflags="-Wno-error=incompatible-function-pointer-types -Wno-error=implicit-function-declaration"
```
