### PR TITLE
Set the minimum appliance_console to 9.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -290,7 +290,7 @@ end
 
 group :appliance, :optional => true do
   gem "irb",                            "=1.4.1",            :require => false # Locked to same version as the installed RPM rubygem-irb-1.4.1-142.module_el9+787+b20bfeee.noarch so that we don't bundle our own
-  gem "manageiq-appliance_console",     "~>9.1",             :require => false
+  gem "manageiq-appliance_console",     "~>9.1", ">=9.1.1",  :require => false
   gem "rdoc",                                                :require => false # Needed for rails console
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.1",             :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
-gem "linux_admin",                      "~>3.0",             :require => false
+gem "linux_admin",                      ">=3.0", "<5",       :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "manageiq-api-client",              "~>0.5.0",           :require => false
 gem "manageiq-loggers",                 "~>1.0", ">=1.1.1",  :require => false


### PR DESCRIPTION
For: https://github.com/ManageIQ/manageiq-appliance-build/pull/573

Requires:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/746