### PR TITLE
Start all automation runners in AutomationWorker

### DIFF
--- a/app/models/automation_worker/runner.rb
+++ b/app/models/automation_worker/runner.rb
@@ -1,2 +1,11 @@
 class AutomationWorker::Runner < MiqQueueWorkerBase::Runner
+  def do_before_work_loop
+    super
+    @automation_runners = Vmdb::Plugins.automation_runner_classes.map(&:runner)
+  end
+
+  def before_exit(*)
+    super
+    @automation_runners.each(&:stop)
+  end
 end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -95,6 +95,10 @@ module Vmdb
       end
     end
 
+    def automation_runner_classes
+      @automation_runner_classes ||= flat_map { |engine| engine.try(:automation_runners) }.compact
+    end
+
     def miq_widgets_content
       @miq_widgets_content ||= Dir.glob(Rails.root.join("product/dashboard/widgets/*")) + flat_map { |engine| content_directories(engine, "dashboard/widgets") }
     end


### PR DESCRIPTION
Add a way for plugins to register automation_runners, currently Workflows is the only one but embedded ansible / terraform could have dedicated runners in the future

Required for https://github.com/ManageIQ/manageiq-providers-workflows/pull/102
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
