### PR TITLE
Add attributes to user role

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -11,8 +11,10 @@ class MiqUserRole < ApplicationRecord
   virtual_column :service_template_restriction, :type => :string
 
   validates :name, :presence => true, :uniqueness_when_changed => {:case_sensitive => false}
+  validates :features_with_id, presence: true
 
   serialize :settings
+  serialize :features_with_id
 
   default_value_for :read_only, false
 


### PR DESCRIPTION
Add attributes to user role to allow for storing of checked features and unique ids for each product feature

Related: 
https://github.com/ManageIQ/manageiq-ui-classic/pull/9248

@miq-bot add-label enhancement
@miq-bot assign @Fryguy 

