### PR TITLE
ReadOnly models respond false to supports?(:update)

### DIFF
--- a/app/models/mixins/read_only_mixin.rb
+++ b/app/models/mixins/read_only_mixin.rb
@@ -3,6 +3,8 @@ module ReadOnlyMixin
 
   included do
     before_destroy :reject_if_read_only
+    supports(:update) { _("Can not edit read only model") if read_only? }
+    supports(:delete) { _("Can not delete read only model") if read_only? }
   end
 
   private


### PR DESCRIPTION
Extracted from https://github.com/ManageIQ/manageiq/pull/23140

# Goal

When asking a read only model `Model#supports?(:delete) (or `update) it will correctly respond no.

Yes, we did have 2 false positives adding `read_only` behavior to models that used that column for another meaning. But these were resolved a long time ago.

Previous PRs that addressed `ReadOnly` concerns

- #22232
- #22857
- #22493
