### PR TITLE
Add OpenShift Virtualization vendor types for VMs and hosts

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -21,6 +21,7 @@ class Host < ApplicationRecord
     "kubevirt"        => "KubeVirt",
     "vmware"          => "VMware",
     "openstack_infra" => "OpenStack Infrastructure",
+    "openshift_infra" => "OpenShift Virtualization",
     "ibm_power_hmc"   => "IBM Power HMC",
     "unknown"         => "Unknown",
     nil               => "Unknown",

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -36,25 +36,26 @@ class VmOrTemplate < ApplicationRecord
 
   VENDOR_TYPES = {
     # DB            Displayed
-    "azure"         => "Azure",
-    "azure_stack"   => "AzureStack",
-    "vmware"        => "VMware",
-    "microsoft"     => "Microsoft",
-    "xen"           => "XenSource",
-    "parallels"     => "Parallels",
-    "amazon"        => "Amazon",
-    "redhat"        => "Red Hat",
-    "ovirt"         => "oVirt",
-    "openstack"     => "OpenStack",
-    "oracle"        => "Oracle",
-    "google"        => "Google",
-    "kubevirt"      => "KubeVirt",
-    "ibm_cloud"     => "IBM Cloud",
-    "ibm_power_vs"  => "IBM Power Systems Virtual Server",
-    "ibm_power_vc"  => "IBM PowerVC",
-    "ibm_power_hmc" => "IBM Power HMC",
-    "ibm_z_vm"      => "IBM Z/VM",
-    "unknown"       => "Unknown"
+    "azure"           => "Azure",
+    "azure_stack"     => "AzureStack",
+    "vmware"          => "VMware",
+    "microsoft"       => "Microsoft",
+    "xen"             => "XenSource",
+    "parallels"       => "Parallels",
+    "amazon"          => "Amazon",
+    "redhat"          => "Red Hat",
+    "ovirt"           => "oVirt",
+    "openstack"       => "OpenStack",
+    "openshift_infra" => "OpenShift Virtualization",
+    "oracle"          => "Oracle",
+    "google"          => "Google",
+    "kubevirt"        => "KubeVirt",
+    "ibm_cloud"       => "IBM Cloud",
+    "ibm_power_vs"    => "IBM Power Systems Virtual Server",
+    "ibm_power_vc"    => "IBM PowerVC",
+    "ibm_power_hmc"   => "IBM Power HMC",
+    "ibm_z_vm"        => "IBM Z/VM",
+    "unknown"         => "Unknown"
   }
 
   POWER_OPS = %w[start stop suspend reset shutdown_guest standby_guest reboot_guest]


### PR DESCRIPTION
These will be needed after the introduction of the OSV provider as its own separate provider

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/264

@miq-bot assign @agrare 
@miq-bot add_label enhancement, providers, radjabov/yes?
@miq-bot add_reviewer @agrare
