### PR TITLE
Add warning for local settings changes

### DIFF
--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -27,6 +27,7 @@ module Vmdb
     def self.init
       ::Config.overwrite_arrays = true
       ::Config.merge_nil_values = false
+      warn_on_local_changes
       reset_settings_constant(for_resource(:my_server))
     end
 
@@ -179,6 +180,13 @@ module Vmdb
       end
     end
     private_class_method :local_sources
+
+    def self.warn_on_local_changes
+      local_sources.select { |p| p.end_with?("settings.local.yml") }.each do |path|
+        warn "\e[1;33m** WARN: Local changes are present in #{path}\e[0m" if File.size?(path)
+      end
+    end
+    private_class_method :warn_on_local_changes
 
     def self.replace_magic_values!(settings, resource)
       parent_settings = nil


### PR DESCRIPTION
This PR adds a warning when any settings.local.yml file has changes in it.  Because these changes aren't necessarily expected, they can break things if the user is not aware.

In my case, I had a settings.local.yml file present and had forgotten about it, and then test cases kept failing and I couldn't figure out why.  This file is intentionally ignored by .gitignore, so locally it looked like nothing was changed.

@agrare Please review.  Not sure about the wording.

Example screenshots:

With changes to `config/settings.local.yml`:
![__dev_manageiq](https://github.com/user-attachments/assets/12f74081-3bb4-4788-921e-75d389a2388f)
