### PR TITLE
Opt-in to the new rails connection handling

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -91,6 +91,10 @@ module Vmdb
     config.action_cable.allow_same_origin_as_host = true
     config.action_cable.mount_path = '/ws/notifications'
 
+    # In Rails 6.1+, Active Record provides a new internal API for connection management
+    # and the legacy connection handling is deprecated.
+    config.active_record.legacy_connection_handling = false
+
     # Rails 6.1.7+ has a protection to not lookup values by a large number.
     # A lookup/comparison with a large number (bigger than bigint)
     # needs to cast the db column to a double/numeric.


### PR DESCRIPTION
Rails began warnings about legacy connection handling being deprecated:
```
[----] D, [2024-09-03T09:25:16.211243#11476:87dc] DEBUG -- development: PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 1, in use: 0, waiting_in_queue: 0
[----] W, [2024-09-03T09:25:27.211621#11594:87c8]  WARN -- development: DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <main> at /home/grare/adam/src/manageiq/manageiq/config/environment.rb:5)
```

https://guides.rubyonrails.org/v7.0/active_record_multiple_databases.html#migrate-to-the-new-connection-handling

I don't see us using the deprecated `#connection_handlers` anywhere (except the archived 11yr old rails fork) https://github.com/search?q=org%3AManageIQ+connection_handler&type=code so it looks like we're safe to opt-in to the new connection handlers.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
