### PR TITLE
[WIP] Use config.load_defaults for rails 7 with overrides

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -118,9 +118,6 @@ module Vmdb
     # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
     config.load_defaults 7.0
 
-    # TODO: this is the only change we had from defaults in 7.0.  See secure_headers.rb.  It's 0 in defaults.
-    config.action_dispatch.default_headers["X-XSS-Protection"] = "1; mode=block"
-
     # TODO: Find and fixed any deprecated behavior.  Opt in later.
     config.active_support.remove_deprecated_time_with_zone_name = false
     config.active_support.disable_to_s_conversion = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,6 +86,10 @@ module Vmdb
 
     # Disable ActionCable's request forgery protection
     # This is basically matching a set of allowed origins which is not good for us
+    # Note, similarly named forgery protections in action controller are set to true
+    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L115C12-L115C69
+    # 5.0 sets: action_controller.forgery_protection_origin_check = true
+    # 5.2 sets: action_controller.default_protect_from_forgery = true
     config.action_cable.disable_request_forgery_protection = false
     # Matching the origin against the HOST header is much more convenient
     config.action_cable.allow_same_origin_as_host = true
@@ -110,8 +114,23 @@ module Vmdb
 
     config.autoload_paths += config.eager_load_paths
 
-    # config.load_defaults 6.1
-    # Disable defaults as ActiveRecord::Base.belongs_to_required_by_default = true causes MiqRegion.seed to fail validation on belongs_to maintenance zone
+    # FYI, this is where load_defaults is defined as of 7.2:
+    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
+    config.load_defaults 7.0
+
+    # TODO: this is the only change we had from defaults in 7.0.  See secure_headers.rb.  It's 0 in defaults.
+    config.action_dispatch.default_headers["X-XSS-Protection"] = "1; mode=block"
+
+    # TODO: Find and fixed any deprecated behavior.  Opt in later.
+    config.active_support.remove_deprecated_time_with_zone_name = false
+    config.active_support.disable_to_s_conversion = false
+
+    # TODO: If disabled, causes cross repo test failures in content, ui-classic and amazon provider
+    config.active_record.partial_inserts = true
+
+    # Disable this setting as it causes MiqRegion.seed to fail validation on belongs_to maintenance zone.
+    # TODO: We should fix this so we don't need to carry this override.
+    config.active_record.belongs_to_required_by_default = false
 
     # NOTE:  If you are going to make changes to autoload_paths, please make
     # sure they are all strings.  Rails will push these paths into the

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,6 +10,10 @@ if defined?(SecureHeaders)
     config.x_content_type_options = "nosniff"
     # X-XSS-Protection
     # X-Permitted-Cross-Domain-Policies
+
+    #FYI, this was deprecated and disabled in rails 7.  Using content security policy is the desired behavior going forward:
+    # https://github.com/rails/rails/commit/1f4714c3f798df227222f531141880b8e1b4170a
+    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L227
     config.x_xss_protection = "1; mode=block"
     config.referrer_policy = "no-referrer-when-downgrade"
     # Content-Security-Policy

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -14,7 +14,9 @@ if defined?(SecureHeaders)
     #FYI, this was deprecated and disabled in rails 7.  Using content security policy is the desired behavior going forward:
     # https://github.com/rails/rails/commit/1f4714c3f798df227222f531141880b8e1b4170a
     # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L227
-    config.x_xss_protection = "1; mode=block"
+    # Disable x-xss-protection as it's being dropped by other big stakeholders for legitimate security reasons:
+    # https://github.com/github/secure_headers/issues/439
+    config.x_xss_protection = "0"
     config.referrer_policy = "no-referrer-when-downgrade"
     # Content-Security-Policy
     # Need google fonts in fonts_src for https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed%7CIBM+Plex+Sans:400,600&display=swap (For carbon-charts download)


### PR DESCRIPTION
As far as I can see, belongs_to_required_by_default, is the only override in load_defaults that we manually override.  See:
https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92

This change makes the override explicit.

Fixes #23172

- [x] [Cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/909)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
