### PR TITLE
Ignore brakeman progress on CI (non-tty)

### DIFF
--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -22,11 +22,12 @@ class TestSecurityHelper
     # See all possible options here:
     #   https://brakemanscanner.org/docs/brakeman_as_a_library/#using-options
     options = {
-      :app_path     => app_path,
-      :engine_paths => engine_paths,
-      :quiet        => false,
-      :pager        => false,
-      :print_report => true
+      :app_path        => app_path,
+      :engine_paths    => engine_paths,
+      :pager           => false,
+      :print_report    => true,
+      :quiet           => false,
+      :report_progress => $stderr.tty?
     }
     if format == "json"
       options[:output_files] = [


### PR DESCRIPTION
On CI, we get every progress update line-by-line and it overwhelms the output. More specifically, since CI doesn't have a tty, we can use that as a more accurate indicator.

Before:

```
Processing libs...                    
 0/2080 files processed
 1/2080 files processed
 2/2080 files processed
 3/2080 files processed
 4/2080 files processed
 5/2080 files processed
 6/2080 files processed
 7/2080 files processed
... (2000+ more lines of output)
Processing routes...                  
Processing templates...               
 0/1638 templates processed
 1/1638 templates processed
 2/1638 templates processed
 3/1638 templates processed
 4/1638 templates processed
... (1600+ more lines of output)
```

After:

```
Processing libs...                    
Processing routes...                  
Processing templates...               
```
