### PR TITLE
Mark workers associated with failed systemd units as stopped

### DIFF
--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -32,6 +32,11 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
 
     _log.info("Disabling failed unit files: [#{service_names.join(", ")}]")
     systemd_stop_services(service_names)
+
+    _log.info("Stopping worker records for failed units: [#{service_names.join(", ")}]")
+    MiqWorker.find_current_or_starting.where(:system_uid => service_names).each do |w|
+      w.update!(:status => MiqWorker::STATUS_STOPPED)
+    end
   end
 
   private

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -27,7 +27,7 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   end
 
   def cleanup_failed_systemd_services
-    service_names = failed_miq_service_namees
+    service_names = failed_miq_service_names
     return if service_names.empty?
 
     _log.info("Disabling failed unit files: [#{service_names.join(", ")}]")
@@ -104,7 +104,7 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     miq_services.select { |service| service[:active_state] == "failed" }
   end
 
-  def failed_miq_service_namees
+  def failed_miq_service_names
     failed_miq_services.pluck(:name)
   end
 


### PR DESCRIPTION
If we start a systemd unit and it fails this can leave the miq_worker record associated with it in "creating" without ever being cleaned up.

When we stop and cleanup any failed systemd units we should also mark any associated miq-worker records as stopped so that they can be cleaned up by the `clean_worker_records` method.

```
INFO -- evm: MIQ(MiqServer::WorkerManagement::Systemd#cleanup_failed_systemd_services) Disabling failed unit files: [opentofu-runner.service]
INFO -- evm: MIQ(MiqServer::WorkerManagement::Systemd#cleanup_failed_systemd_services) Stopping worker records for failed units: [opentofu-runner.service]
INFO -- evm: MIQ(MiqServer::WorkerManagement::Systemd#clean_worker_records) SQL Record for Worker [OpentofuWorker] with ID: [71], PID: [], GUID: [46e4cdf4-22b8-426>
```

TODO
- [x] Live test on an appliance

Fixes https://github.com/ManageIQ/manageiq-providers-embedded_terraform/issues/59
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
