### PR TITLE
Require uuidtools in MiqServer::EnvironmentManager

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -3,6 +3,8 @@ module MiqServer::EnvironmentManagement
 
   module ClassMethods
     def get_network_information
+      require "uuidtools"
+
       ipaddr = hostname = mac_address = nil
 
       begin


### PR DESCRIPTION
Prevent `NameError uninitialized constant UUIDTools` during MiqServer startup

This wasn't a new call, but I'm guessing when we dropped the LinuxAdmin require here 71fb7d24da80b1d0297183b54ec32cb8d7fff3c6 / https://github.com/ManageIQ/manageiq/pull/23118#issuecomment-2260591465 it caused this to fail sometimes.

```
INFO -- evm: MIQ(EvmServer#impersonate_server) Impersonating server - id: 1, guid: 421b8269-4509-4897-b600-b577940837eb
WARN -- evm: MIQ(MiqServer.get_network_information) Failed to get network information: uninitialized constant MiqServer::EnvironmentManagement::ClassMethods::UUIDTools
        mac_address = UUIDTools::UUID.mac_address.dup
                      ^^^^^^^^^
ERROR -- evm: [NameError]: uninitialized constant MiqServer::EnvironmentManagement::ClassMethods::UUIDTools
        mac_address = UUIDTools::UUID.mac_address.dup
                      ^^^^^^^^^  Method:[block (2 levels) in <class:LogProxy>]
ERROR -- evm: /var/www/miq/vmdb/app/models/miq_server/environment_management.rb:11:in `get_network_information'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:166:in `save_local_network_info'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:109:in `start_server'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:45:in `block in start_servers'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:273:in `block in as_each_server'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:271:in `each'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:271:in `as_each_server'/var/www/miq/vmdb/lib/workers/evm_server.rb:45:in `start_servers'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:30:in `start'
  /var/www/miq/vmdb/lib/workers/evm_server.rb:84:in `start'
  lib/workers/bin/evm_server.rb:4:in `<main>'
INFO -- evm: MIQ(EvmServer#log_server_info) Server IP Address: 10.2.2.24
INFO -- evm: MIQ(EvmServer#log_server_info) Server Hostname: manageiq.rb.nj.grare.com
INFO -- evm: MIQ(EvmServer#log_server_info) Server MAC Address: 52:54:00:e8:67:81
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
