### PR TITLE
Configure brakeman to use prism

### DIFF
--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -32,7 +32,8 @@ class TestSecurityHelper
       :pager           => false,
       :print_report    => true,
       :quiet           => false,
-      :report_progress => $stderr.tty?
+      :report_progress => $stderr.tty?,
+      :use_prism       => true,
     }
     if format == "json"
       options[:output_files] = [


### PR DESCRIPTION
Switching to prism dropped the brakeman time on my machine from 88s to 75s (15% faster). Eventually prism will be the Ruby default, so might as well get a jump on it where we can.

@jrafanie Please review.
