### PR TITLE
Use Kernel system exception handling

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -312,10 +312,7 @@ namespace :locale do
       Dir.mkdir(combined_dir, 0o700)
       po_files.each do |locale, files|
         files.each do |file|
-          unless system "msgfmt --check #{file}"
-            puts "Fatal error running 'msgfmt --check' on file: #{file}.  Review the output above."
-            exit 1
-          end
+          system("msgfmt --check #{file}", :exception => true)
         end
 
         dir = File.join(combined_dir, locale)


### PR DESCRIPTION
This pattern can be used wherever we rolled our own exception handling like this one.

Found while working on https://github.com/ManageIQ/manageiq-ui-classic/pull/9263

### Before

WAT

```
Run bundle exec rake app:locale:po_to_json
** Using session_store: ActionDispatch::Session::MemoryStore
** ManageIQ master, codename: Spassky
Fatal error running 'msgmft --check on file: /home/runner/worker/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/locale/de/manageiq.po.  Review the output above.
Error: Process completed with exit code 1.
```


### After

It's very obvious I failed to install gettext for the msgfmt tool in this new github action:

```
Run bundle exec rake app:locale:po_to_json
** Using session_store: ActionDispatch::Session::MemoryStore
** ManageIQ master, codename: Spassky
rake aborted!
Errno::ENOENT: No such file or directory - msgfmt
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/lib/tasks/locale.rake:304:in `system'
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/lib/tasks/locale.rake:304:in `block (4 levels) in <main>'
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/lib/tasks/locale.rake:303:in `each'
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/lib/tasks/locale.rake:303:in `block (3 levels) in <main>'
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/lib/tasks/locale.rake:302:in `each'
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/spec/manageiq/lib/tasks/locale.rake:302:in `block (2 levels) in <main>'
/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/vendor/bundle/ruby/3.1.0/gems/rake-[13](https://github.com/jrafanie/manageiq-ui-classic/actions/runs/10854106197/job/30123837888#step:8:14).2.1/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.1.6/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.1.6/x64/bin/bundle:25:in `<main>'
Tasks: TOP => app:locale:po_to_json
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```
