### PR TITLE
Replace Container ENV var EMS_IDS->_ID

### DIFF
--- a/app/models/miq_worker/deployment_per_worker.rb
+++ b/app/models/miq_worker/deployment_per_worker.rb
@@ -5,7 +5,7 @@ class MiqWorker
     def create_container_objects
       ContainerOrchestrator.new.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition, 1)
-        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_IDS", :value => Array.wrap(self.class.ems_id_from_queue_name(queue_name)).join(",")}
+        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_ID", :value => self.class.ems_id_from_queue_name(queue_name)}
       end
     end
 


### PR DESCRIPTION
Workers having a comma separated list of EMS IDs has been replaced with moving child-manager refresh logic into the parent-manager refresher.

I noticed this while investigating the OpentofuWorker, it is also odd that deployment-per-worker also assumes that it is an EMS worker which isn't necessarily the case.

I think a better approach would be to move the environment variable logic out of how the workers are managed by kubernetes, and unify it with how systemd handles environment variables per-worker with the `unit_environment_variables` method (which already handles EMS_ID).

Co-depends:
* https://github.com/ManageIQ/manageiq-pods/pull/1170
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
