### PR TITLE
Unify Worker Environment Variables systemd/k8s

### DIFF
--- a/app/models/automation_worker.rb
+++ b/app/models/automation_worker.rb
@@ -9,10 +9,13 @@ class AutomationWorker < MiqQueueWorkerBase
     MiqWorkerType::KILL_PRIORITY_GENERIC_WORKERS
   end
 
+  def container_environment_variables
+    super.merge("AUTOMATION_JOB_SERVICE_ACCOUNT" => ENV.fetch("WORKER_SERVICE_ACCOUNT"))
+  end
+
   def configure_worker_deployment(definition, replicas = 0)
     super
 
     definition[:spec][:template][:spec][:serviceAccountName] = "manageiq-automation"
-    definition[:spec][:template][:spec][:containers][0][:env] << {:name => "AUTOMATION_JOB_SERVICE_ACCOUNT", :value => ENV.fetch("WORKER_SERVICE_ACCOUNT")}
   end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -379,9 +379,15 @@ class MiqWorker < ApplicationRecord
     self.class.build_command_line(*worker_options.values_at(:guid, :ems_id))
   end
 
+  def environment_variables
+    {
+      "BUNDLER_GROUPS" => self.class.bundler_groups.join(",")
+    }
+  end
+
   def start_runner_via_spawn
     pid = Kernel.spawn(
-      {"BUNDLER_GROUPS" => self.class.bundler_groups.join(",")},
+      environment_variables,
       command_line,
       [:out, :err] => [Rails.root.join("log/evm.log"), "a"]
     )

--- a/app/models/miq_worker/deployment_per_worker.rb
+++ b/app/models/miq_worker/deployment_per_worker.rb
@@ -5,7 +5,6 @@ class MiqWorker
     def create_container_objects
       ContainerOrchestrator.new.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition, 1)
-        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_ID", :value => self.class.ems_id_from_queue_name(queue_name).to_s}
       end
     end
 

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -45,8 +45,6 @@ class MiqWorker
 
       container = definition[:spec][:template][:spec][:containers].first
       container[:ports] = [{:containerPort => SERVICE_PORT}, {:containerPort => HEALTH_PORT}]
-      container[:env] << {:name => "PORT", :value => container_port.to_s}
-      container[:env] << {:name => "BINDING_ADDRESS", :value => "0.0.0.0"}
       container[:volumeMounts] ||= []
       definition[:spec][:template][:spec][:volumes] ||= []
     end
@@ -67,6 +65,10 @@ class MiqWorker
 
     def container_image
       ENV["WEBSERVER_WORKER_IMAGE"] || default_image
+    end
+
+    def container_environment_variables
+      super.merge("PORT" => container_port.to_s, "BINDING_ADDRESS" => "0.0.0.0")
     end
   end
 end

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -116,10 +116,12 @@ class MiqWorker
     end
 
     def unit_config_file
+      environment = systemd_environment_variables.merge(environment_variables)
+
       <<~UNIT_CONFIG_FILE
         [Service]
-        #{unit_settings.compact.map              { |key, value| "#{key}=#{value}" }.join("\n")}
-        #{unit_environment_variables.compact.map { |key, value| "Environment=#{key}=#{value}" }.join("\n")}
+        #{unit_settings.compact.map { |key, value| "#{key}=#{value}" }.join("\n")}
+        #{environment.compact.map   { |key, value| "Environment=#{key}=#{value}" }.join("\n")}
       UNIT_CONFIG_FILE
     end
 
@@ -135,7 +137,7 @@ class MiqWorker
     end
 
     # Override this in a child class to add environment variables
-    def unit_environment_variables
+    def systemd_environment_variables
       {}
     end
   end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -126,7 +126,7 @@ module PerEmsWorkerMixin
     super.merge(:ems_id => ems_id)
   end
 
-  def unit_environment_variables
-    super.merge("EMS_ID" => ems_id)
+  def environment_variables
+    super.merge("EMS_ID" => ems_id.to_s)
   end
 end

--- a/systemd/manageiq-automation@.service
+++ b/systemd/manageiq-automation@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-automation.target
 WantedBy=manageiq-automation.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb AutomationWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-ems_metrics_processor@.service
+++ b/systemd/manageiq-ems_metrics_processor@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-ems_metrics_processor.target
 WantedBy=manageiq-ems_metrics_processor.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-event_handler@.service
+++ b/systemd/manageiq-event_handler@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-event_handler.target
 WantedBy=manageiq-event_handler.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-generic@.service
+++ b/systemd/manageiq-generic@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-generic.target
 WantedBy=manageiq-generic.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-priority@.service
+++ b/systemd/manageiq-priority@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-priority.target
 WantedBy=manageiq-priority.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-remote_console@.service
+++ b/systemd/manageiq-remote_console@.service
@@ -5,7 +5,6 @@ Wants=httpd.service
 WantedBy=manageiq-remote_console.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-reporting@.service
+++ b/systemd/manageiq-reporting@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-reporting.target
 WantedBy=manageiq-reporting.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-schedule@.service
+++ b/systemd/manageiq-schedule@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-schedule.target
 WantedBy=manageiq-schedule.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-smart_proxy@.service
+++ b/systemd/manageiq-smart_proxy@.service
@@ -4,7 +4,6 @@ PartOf=manageiq-smart_proxy.target
 WantedBy=manageiq-smart_proxy.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-ui@.service
+++ b/systemd/manageiq-ui@.service
@@ -5,7 +5,6 @@ Wants=httpd.service
 WantedBy=manageiq-ui.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i
 User=manageiq

--- a/systemd/manageiq-web_service@.service
+++ b/systemd/manageiq-web_service@.service
@@ -5,7 +5,6 @@ Wants=httpd.service
 WantedBy=manageiq-web_service.target
 [Service]
 WorkingDirectory=/var/www/miq/vmdb
-Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
 EnvironmentFile=/etc/default/manageiq*.properties
 ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i
 User=manageiq


### PR DESCRIPTION
Handling of worker environment variables was spread across a number of different locations and in a number of cases had to be duplicated for systemd/kubernetes.

This adds a common `MiqWorker#environment_variables` method that applies to all runtime platforms, as well as specific
systemd/container_environment_variables which are merged in depending on the runtime environment.

TODO:

Live test of standard workers, provider workers, opentofu-runner on:
- [x]  appliances
- [x] podified
- [x] dev-process

Dependent:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/74
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
