### PR TITLE
Fix evm_application_spec parallel spec failure

### DIFF
--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -320,6 +320,7 @@ RSpec.describe EvmApplication do
 
     it "returns redeployment otherwise" do
       EvmSpecHelper.local_miq_server
+      expect(ActiveRecord::MigrationContext).to receive(:new).and_return(double(:current_version => 20190712135032, :needs_migration? => false))
       expect(described_class.deployment_status).to eq("redeployment")
     end
   end


### PR DESCRIPTION
Fix the `.deployment_status` failure when running in parallel.  When running `rake parallel:spec` this test would reliably fail.

```
Failures:

  1) EvmApplication.deployment_status with a seeded server returns redeployment otherwise
     Failure/Error: expect(described_class.deployment_status).to eq("redeployment")
     
       expected: "redeployment"
            got: "upgrade"
     
       (compared using ==)
     # ./spec/lib/tasks/evm_application_spec.rb:334:in `block (4 levels) in <main>'
     # /home/grare/adam/.gem/ruby/3.1.0/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

Finished in 12.11 seconds (files took 6.64 seconds to load)
164 examples, 1 failure

Failed examples:

rspec ./spec/lib/tasks/evm_application_spec.rb:333 # EvmApplication.deployment_status with a seeded server returns redeployment otherwise
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
