### PR TITLE
spec: Support ruby 3.1 and 3.3 error message formats

### DIFF
--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -257,12 +257,12 @@ RSpec.describe ProcessTasksMixin do
           expect(api_collection).to receive(:find).with(0).and_return(Struct.new(:id).new(0))
           expect(api_collection).to receive(:find).with(1).and_return(double("Something that responds", :id => 0, :the_task => nil))
 
-          expect($log).to receive(:error).with(a_string_including("undefined method `the_task' for #<struct id=0>")).and_call_original
+          expect($log).to receive(:error).with(a_string_including("undefined method `the_task' for")).and_call_original
           expect(test_class.invoke_api_tasks(api_connection, :ids => [0, 1], :task => "the_task")).to eq([0, 1])
         end
 
         it "collection" do
-          expect($log).to receive(:error).with(a_string_including("undefined method `the_task' for []:Array")).and_call_original
+          expect($log).to receive(:error).with(a_string_including("undefined method `the_task' for")).and_call_original
           expect { test_class.invoke_api_tasks(api_connection, :task => "the_task") }.not_to raise_error
         end
       end


### PR DESCRIPTION
This message is different for ruby 3.3 and 3.1

Change phrase to be the common factor for both ruby versions

This is currently the only failure for 3.1/3.3 on master
(besides the gem changes)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
