### PR TITLE
Prevent bundler 2.5.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "awesome_spawn",                    "~>1.6",             :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load
-gem "bundler",                          "~> 2.2", ">= 2.2.15", *("!= 2.5.0".."!= 2.5.9"), :require => false
+gem "bundler",                          "~> 2.2", ">= 2.2.15", *("!= 2.5.0".."!= 2.5.9"), "!= 2.5.19", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>2.2", ">=2.2.3",  :require => false


### PR DESCRIPTION
bundler 2.5.19 introduced an issue where bundler/inline would accidentally overwrite lockfiles. This impacts the release builds because it tries to write to a location it does not have access to. This was fixed in bundler 2.5.20

@agrare Please review.