### PR TITLE
Fix k8s deployment marshal error with EMS workers

### DIFF
--- a/app/models/miq_worker/deployment_per_worker.rb
+++ b/app/models/miq_worker/deployment_per_worker.rb
@@ -5,7 +5,7 @@ class MiqWorker
     def create_container_objects
       ContainerOrchestrator.new.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition, 1)
-        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_ID", :value => self.class.ems_id_from_queue_name(queue_name)}
+        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_ID", :value => self.class.ems_id_from_queue_name(queue_name).to_s}
       end
     end
 


### PR DESCRIPTION
The `.ems_id_from_queue_name` method returns an integer and all env var values have to be strings.

Broken by: https://github.com/ManageIQ/manageiq/pull/23195/files#diff-56487075e313126652963fef186a0e79517048b9f872a77695b35ea3ddbe4a17L8
Fixes https://github.com/ManageIQ/manageiq/issues/23207
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
