### PR TITLE
Use rails 7 cache format as 7 can read either 6 or 7

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -121,6 +121,13 @@ module Vmdb
     #
     #   https://bugs.ruby-lang.org/issues/14372
     #
+
+    # TODO: Remove this once we move to config.load_defaults 7.0 as this is the default.
+    # Note, rails 7 can read cache format from 6 or 7 so there is no risk if you're running rails 7.
+    # See: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+    warn "Warning: Remove redundant config.active_support.cache_format_version = 7.0 from #{__FILE__}:#{__LINE__ + 1} if using config.load_defaults 7.0" if config.active_support.cache_format_version == 7.0
+    config.active_support.cache_format_version = 7.0
+
     config.autoload_paths << Rails.root.join("app/models/aliases").to_s
     config.autoload_paths << Rails.root.join("app/models/mixins").to_s
     config.autoload_paths << Rails.root.join("lib").to_s


### PR DESCRIPTION
See: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format

Extracted from https://github.com/ManageIQ/manageiq/pull/23176

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
