### PR TITLE
simplify fix_auth tests

### DIFF
--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -78,11 +78,6 @@ RSpec.describe FixAuth::AuthModel do
         expect { subject.fix_passwords(bad, options) }.to raise_error(ManageIQ::Password::PasswordError)
       end
 
-      it "should replace for bad encryption" do
-        subject.fix_passwords(bad, options.merge(:invalid => "other"))
-        expect(bad.password).to be_encrypted("other")
-      end
-
       context "with the rare case where recryption succeeds but returns garbage" do
         # NOTE: This legacy key only returns garbage specifically with the
         #   built-in v2_key.dev and the plaintext string "password", which is


### PR DESCRIPTION
There is an issue in the way that encryption keys work. You can sometimes decrypt a string that has been encoded with a different passkey. You will get the wrong value out, but the system thinks that it succeeded.

Even though the odds of this are very low, since we run managiq so many times, we run across it as a sporadic test failure.

This is an issue and we're removing the offending tests. This functionality is tested in the `manageiq-password` gem.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
