### PR TITLE
Remove noisy test output logging we've never cared about

### DIFF
--- a/spec/shared/i18n/newlines.rb
+++ b/spec/shared/i18n/newlines.rb
@@ -24,11 +24,6 @@ shared_examples :newlines do |dir|
         if (translation[0] == "\n" && original[0] != "\n") || (translation[0] != "\n" && original[0] == "\n")
           boundary_errors.store_path(po_file.to_s, add_string_chevrons(original), add_string_chevrons(translation))
         end
-
-        # Check that overall amount of newlines in original and translation matches
-        if original.scan("\n").length != translation.scan("\n").length
-          overall_errors.store_path(po_file.to_s, add_string_chevrons(original), add_string_chevrons(translation))
-        end
       end
     end
 


### PR DESCRIPTION
Technically, we could try to fix this and get the translators to update their data to have this fixed, but it's possible there are situations where this happens again and it's not an actual problem for gettext.

Even the original PR that added this said this overall number of newlines check could flag intentionally changed values.  Since we've never reacted to this output, we can remove it.

From that PR (we care about the 3rd check below):

```
1. if original string starts with a newline, translation needs to start with a newline too
2. if original string ends with a newline, translated string also needs to end with a newline
3. overal amount of newlines in original and translated string needs to match

In this PR, I am introducing a new test, which tests the above rules. The exception is the 3rd rule, since it seems that in some places the newline might have been added (or omitted) intentionaly. So we're just logging these.
```

Reference:: https://github.com/ManageIQ/manageiq/pull/20815

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
