### PR TITLE
Remove newlines from error message

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -772,11 +772,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     values[:vm_tags] = p.ws_tags(tags, :parse_ws_string_v1)
     values[:ws_values] = p.ws_values(additional_values, :parse_ws_string_v1)
 
-    if p.validate(values) == false
-      errors = []
-      p.fields { |_fn, f, _dn, _d| errors << f[:error] unless f[:error].nil? }
-      raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
-    end
+    p.raise_validate_errors if p.validate(values) == false
 
     p.make_request(nil, values, nil, auto_approve)
   end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1507,9 +1507,9 @@ class MiqRequestWorkflow
   def raise_validate_errors
     errors = []
     fields { |_fn, f, _dn, _d| errors << f[:error] unless f[:error].nil? }
-    err_text = "Provision failed for the following reasons:\n#{errors.join("\n")}"
-    _log.error("<#{err_text}>")
-    raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
+    err_text = errors.join("\n").insert(0, "\n")
+    _log.error("<Provision failed for the following reasons:#{err_text}>")
+    raise _("Provision failed for the following reasons:%{errors}") % {:errors => err_text}
   end
 
   private


### PR DESCRIPTION
Newlines can cause trouble with translations as well as presentation in the UI. This particular string doesn't actually need the newline as part of the translation string, so this commit changes it to just not have it.

Alternative to ManageIQ/manageiq#23213

@jrafanie Please review.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
