### PR TITLE
Remove sporadic fix_auth spec pt2

### DIFF
--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -74,10 +74,6 @@ RSpec.describe FixAuth::AuthModel do
         expect(plain).to_not be_password_changed
       end
 
-      it "should raise exception for bad encryption" do
-        expect { subject.fix_passwords(bad, options) }.to raise_error(ManageIQ::Password::PasswordError)
-      end
-
       context "with the rare case where recryption succeeds but returns garbage" do
         # NOTE: This legacy key only returns garbage specifically with the
         #   built-in v2_key.dev and the plaintext string "password", which is


### PR DESCRIPTION
When some encryption keys decode a secret, it looks like they succeed but the end result is garbage.

In specs, when we pick (1) 2 random keys, we area getting these garbage decrypts and it causes a sporadic spec failure

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
