### PR TITLE
Fix Marshal.load ArgumentError on ruby3.3

### DIFF
--- a/config/initializers/marshal_autoloader.rb
+++ b/config/initializers/marshal_autoloader.rb
@@ -3,7 +3,7 @@
 # processes or load just the classes that are marshaled, which may be far less classes and locations than when
 # we originally wrote this initializer.
 module MarshalAutoloader
-  def load(data)
+  def load(data, _proc = nil)
     super
   rescue ArgumentError => error
     if error.to_s.include?('undefined class')


### PR DESCRIPTION
I ran into this using tab-complete in a rails console on ruby 3.3.  It appears that rdoc is passing a proc to Marshal.load and that is causing our initializer monkeypatch to fail.
```
config/initializers/marshal_autoloader.rb:6:in `load': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /usr/lib/ruby/3.3.0/rdoc/store.rb:974:in `block in marshal_load'
	from /usr/lib/ruby/3.3.0/rdoc/store.rb:974:in `open'
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
