### PR TITLE
Bump puma to 6.4.3 for CVE-2024-45614

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -279,7 +279,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
 end
 
 group :web_server, :manageiq_default do
-  gem "puma",                           "~>6.4", ">=6.4.2"
+  gem "puma",                           "~>6.4", ">=6.4.3"
   gem "ruby-dbus" # For external auth
   gem "secure_headers",                 "~>3.9"
 end


### PR DESCRIPTION
@jrafanie Please review.  master and radjabov security suite are broken because of this.