### PR TITLE
Host#verify_credentials_task payload string keys

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1447,9 +1447,7 @@ class Host < ApplicationRecord
   # Ensure that any passwords are encrypted before putting them onto the queue for any
   # DDF fields which are a password type
   def encrypt_verify_credential_params!(options)
-    # NOTE the API always symbolizes the username/password keys so it is safe
-    # to assume the keys will be symbols until we move to passing the DDF payload in
-    encrypted_columns = Authentication.encrypted_columns.map(&:to_sym)
+    encrypted_columns = Authentication.encrypted_columns
 
     traverse_hash(options) do |value, key_path|
       value.slice(*encrypted_columns).each do |key, val|


### PR DESCRIPTION
Now that we've dropped the legacy host verify credentials path from the data hash has string keys like a typical JSON API payload.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
