### PR TITLE
Rails 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,6 @@ gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>5.1",             :require => false
 gem "connection_pool",                                       :require => false # For Dalli
-gem "concurrent-ruby",                  "< 1.3.5",           :require => false # Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 7.0, and rails-core doesn't
-                                                                               # plan to ship a new 7.0 to fix it. See https://github.com/rails/rails/pull/54264
 gem "dalli",                            "~>3.2.3",           :require => false
 gem "default_value_for",                "~>4.0"
 gem "docker-api",                       "~>1.33.6",          :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-session_store",       "~>2.0"
-gem "activerecord-virtual_attributes",  "~>7.0.0"
+gem "activerecord-virtual_attributes",  "~>7.1.0"
 gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                         "~>4.1.0",           :require => false
 gem "awesome_spawn",                    "~>1.6",             :require => false
@@ -46,15 +46,15 @@ gem "gettext_i18n_rails",               "~>1.11"
 gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
-gem "inventory_refresh",                "~>2.1",             :require => false
+gem "inventory_refresh",                "~>2.2",             :require => false
 gem "kubeclient",                       "~>4.0",             :require => false # For scaling pods at runtime
 gem "linux_admin",                      ">=3.0", "<5",       :require => false
 gem "listen",                           "~>3.2",             :require => false
-gem "manageiq-api-client",              "~>0.5.0",           :require => false
-gem "manageiq-loggers",                 "~>1.0", ">=1.1.1",  :require => false
-gem "manageiq-messaging",               "~>1.0", ">=1.4.3",  :require => false
+gem "manageiq-api-client",              "~>0.6.0",           :require => false
+gem "manageiq-loggers",                 "~>1.2",             :require => false
+gem "manageiq-messaging",               "~>1.5",             :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
-gem "manageiq-postgres_ha_admin",       "~>3.3",             :require => false
+gem "manageiq-postgres_ha_admin",       "~>3.4",             :require => false
 gem "manageiq-ssh-util",                "~>0.2.0",           :require => false
 gem "memoist",                          "~>0.16.0",          :require => false
 gem "money",                            "~>6.13.5",          :require => false
@@ -71,7 +71,7 @@ gem "psych",                            ">=3.1",             :require => false #
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.6.4",         :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>7.0.8", ">=7.0.8.7"
+gem "rails",                            "~>7.1.5", ">=7.1.5.1"
 gem "rails-i18n",                       "~>7.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false
@@ -278,7 +278,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   manageiq_plugin "manageiq-decorators"
   manageiq_plugin "manageiq-ui-classic"
   # Modified gems (forked on Github)
-  gem "jquery-rjs",                     "=0.1.1.3",          :source => "https://rubygems.manageiq.org"
+  gem "jquery-rjs",                     "=0.1.1.4",          :source => "https://rubygems.manageiq.org"
 end
 
 group :web_server, :manageiq_default do
@@ -310,7 +310,7 @@ group :test do
   gem "brakeman",                       "~>6.2",             :require => false
   gem "bundler-audit",                                       :require => false
   gem "capybara",                       "~>2.5.0",           :require => false
-  gem "db-query-matchers",              "~>0.11.0"
+  gem "db-query-matchers",              "~>0.13.0"
   gem "factory_bot",                    "~>6.5",             :require => false
   gem "simplecov",                      ">=0.21.2",          :require => false
   gem "timecop",                        "~>0.9", "!= 0.9.7", :require => false

--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -112,9 +112,7 @@ module Service::Aggregation
     #   the aggregate column, which returns an Arel statement when called
     def aggregate_hardware_arel(virtual_column_name, aggregation_sql, options = {})
       lambda do |t|
-        subtree_services             = Arel::Table.new(:services)
-        subtree_services.table_alias = "#{virtual_column_name}_services"
-
+        subtree_services = Arel::Table.new(:services, :as => "#{virtual_column_name}_services")
         subselect = subtree_services.project(aggregation_sql)
         subselect = base_service_aggregation_join(subselect, subtree_services, options)
         join_on_disks(subselect) if options[:include_disks]

--- a/config/application.rb
+++ b/config/application.rb
@@ -131,6 +131,8 @@ module Vmdb
 
     config.autoload_once_paths << Rails.root.join("lib/vmdb/console_methods.rb").to_s
 
+    config.active_record.default_column_serializer = YAML if Rails.version >= "7.1"
+
     require_relative '../lib/request_started_on_middleware'
     config.middleware.use RequestStartedOnMiddleware
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,10 +91,6 @@ module Vmdb
     config.action_cable.allow_same_origin_as_host = true
     config.action_cable.mount_path = '/ws/notifications'
 
-    # In Rails 6.1+, Active Record provides a new internal API for connection management
-    # and the legacy connection handling is deprecated.
-    config.active_record.legacy_connection_handling = false
-
     # Rails 6.1.7+ has a protection to not lookup values by a large number.
     # A lookup/comparison with a large number (bigger than bigint)
     # needs to cast the db column to a double/numeric.

--- a/config/application.rb
+++ b/config/application.rb
@@ -112,7 +112,7 @@ module Vmdb
 
     # FYI, this is where load_defaults is defined as of 7.2:
     # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # TODO: this is the only change we had from defaults in 7.0.  See secure_headers.rb.  It's 0 in defaults.
     config.action_dispatch.default_headers["X-XSS-Protection"] = "1; mode=block"
@@ -128,6 +128,10 @@ module Vmdb
     # TODO: We should fix this so we don't need to carry this override.
     config.active_record.belongs_to_required_by_default = false
 
+    # TODO: Rails 7.1 default overridden to fix loading scanning_operations_mixin, dialog_import_service
+    # manageiq/providers/infra_manager/template, dialog_field_importer, workers/event_catcher
+    config.add_autoload_paths_to_load_path = true
+
     # NOTE:  If you are going to make changes to autoload_paths, please make
     # sure they are all strings.  Rails will push these paths into the
     # $LOAD_PATH.
@@ -136,12 +140,6 @@ module Vmdb
     #
     #   https://bugs.ruby-lang.org/issues/14372
     #
-
-    # TODO: Remove this once we move to config.load_defaults 7.0 as this is the default.
-    # Note, rails 7 can read cache format from 6 or 7 so there is no risk if you're running rails 7.
-    # See: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
-    warn "Warning: Remove redundant config.active_support.cache_format_version = 7.0 from #{__FILE__}:#{__LINE__ + 1} if using config.load_defaults 7.0" if config.active_support.cache_format_version == 7.0
-    config.active_support.cache_format_version = 7.0
 
     config.autoload_paths << Rails.root.join("app/models/aliases").to_s
     config.autoload_paths << Rails.root.join("app/models/mixins").to_s

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,6 +86,10 @@ module Vmdb
 
     # Disable ActionCable's request forgery protection
     # This is basically matching a set of allowed origins which is not good for us
+    # Note, similarly named forgery protections in action controller are set to true
+    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L115C12-L115C69
+    # 5.0 sets: action_controller.forgery_protection_origin_check = true
+    # 5.2 sets: action_controller.default_protect_from_forgery = true
     config.action_cable.disable_request_forgery_protection = false
     # Matching the origin against the HOST header is much more convenient
     config.action_cable.allow_same_origin_as_host = true
@@ -106,8 +110,23 @@ module Vmdb
 
     config.autoload_paths += config.eager_load_paths
 
-    # config.load_defaults 6.1
-    # Disable defaults as ActiveRecord::Base.belongs_to_required_by_default = true causes MiqRegion.seed to fail validation on belongs_to maintenance zone
+    # FYI, this is where load_defaults is defined as of 7.2:
+    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
+    config.load_defaults 7.0
+
+    # TODO: this is the only change we had from defaults in 7.0.  See secure_headers.rb.  It's 0 in defaults.
+    config.action_dispatch.default_headers["X-XSS-Protection"] = "1; mode=block"
+
+    # TODO: Find and fix any deprecated behavior.  Opt in later.
+    config.active_support.remove_deprecated_time_with_zone_name = false
+    config.active_support.disable_to_s_conversion = false
+
+    # TODO: If disabled, causes cross repo test failures in content, ui-classic and amazon provider
+    config.active_record.partial_inserts = true
+
+    # Disable this setting as it causes MiqRegion.seed to fail validation on belongs_to maintenance zone.
+    # TODO: We should fix this so we don't need to carry this override.
+    config.active_record.belongs_to_required_by_default = false
 
     # NOTE:  If you are going to make changes to autoload_paths, please make
     # sure they are all strings.  Rails will push these paths into the

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,6 +10,15 @@ if defined?(SecureHeaders)
     config.x_content_type_options = "nosniff"
     # X-XSS-Protection
     # X-Permitted-Cross-Domain-Policies
+
+    # TODO: This was deprecated and disabled in rails 7.  Using content security policy is the desired behavior going forward:
+    # https://github.com/rails/rails/commit/1f4714c3f798df227222f531141880b8e1b4170a
+    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L227
+    # Once we remove unsafe-inline, then we can set this to the default, 0. Since we still use unsafe-inline, we still use X-XSS-Protection.
+    # From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+    # "The HTTP X-XSS-Protection response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when
+    # they detected reflected cross-site scripting (XSS) attacks. These protections are largely unnecessary in modern browsers when sites
+    # implement a strong Content-Security-Policy that disables the use of inline JavaScript ('unsafe-inline')."
     config.x_xss_protection = "1; mode=block"
     config.referrer_policy = "no-referrer-when-downgrade"
     # Content-Security-Policy

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -25,7 +25,7 @@ module ArPglogicalMigrationHelper
 
     if direction == :up
       if version == SCHEMA_MIGRATIONS_RAN_MIGRATION
-        to_add = ActiveRecord::SchemaMigration.normalized_versions << version
+        to_add = ActiveRecord::Base.connection.schema_migration.normalized_versions << version
       else
         to_add = [version]
       end

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ArPglogicalMigrationHelper do
     let(:version) { "1234567890" }
 
     # sanity check - if this is somehow a version we have, these tests will make no sense
-    before { expect(ActiveRecord::SchemaMigration.normalized_versions).not_to include(version) }
+    before { expect(ActiveRecord::Base.connection.schema_migration.normalized_versions).not_to include(version) }
   end
 
   context "with a region seeded" do
@@ -23,7 +23,7 @@ RSpec.describe ArPglogicalMigrationHelper do
         include_context "without the schema_migrations_ran table"
 
         it "does nothing" do
-          expect(ActiveRecord::SchemaMigration).not_to receive(:normalized_versions)
+          expect(ActiveRecord::Base.connection.schema_migration).not_to receive(:normalized_versions)
           described_class.update_local_migrations_ran("12345", :up)
         end
       end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -234,7 +234,6 @@ RSpec.describe MiqExpression::Field do
 
     it "returns the table of the target association with an alias if needed" do
       field = described_class.new(Vm, ["miq_provision_template"], "name")
-      expect(field.arel_table.table_name).to eq(Vm.arel_table.table_name)
       expect(field.arel_table.name).not_to eq(Vm.arel_table.name)
     end
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -204,15 +204,25 @@ RSpec.describe Service do
     end
 
     describe "#v_total_vms" do
+      # @service -> [@vm]
+      #   \
+      #    @service_c1 -> [@vm1]
+      #      \
+      #       @service_c2 -> [@vm1, @vm2]
       it "sql" do
-        service = Service.select(:id, :v_total_vms).find_by(:id => @service.id)
-        expect(service.v_total_vms).to eq 4
-        expect(service.attribute_present?(:v_total_vms)).to eq true
+        # TODO: This is how rails 7.0 worked... not sure why v_total_vms is 1 for @service_c1!
+        [@service, 4, @service_c1, 1, @service_c2, 2].each_slice(2) do |expected, count|
+          actual = Service.select(:id, :v_total_vms).find_by(:id => expected.id)
+          expect(actual.v_total_vms).to eq count
+          expect(actual.attribute_present?(:v_total_vms)).to eq true
+        end
       end
 
       it "ruby" do
-        expect(@service.v_total_vms).to eq 4
-        expect(@service.attribute_present?(:v_total_vms)).to eq false
+        [@service, 4, @service_c1, 3, @service_c2, 2].each_slice(2) do |expected, count|
+          expect(expected.v_total_vms).to eq count
+          expect(expected.attribute_present?(:v_total_vms)).to eq false
+        end
       end
     end
 


### PR DESCRIPTION
* Update gem dependencies for rails 7.1
* Drop legacy connection handler option previously disabled
* Use new schema migration interface
* Explicitly set YAML default column serializer to avoid having to set coder everywhere
* Update Arel::Table usage
* Allow concurrent-ruby 1.3.5+ (wasn't fixed in rails 7.0)
* Use new broadcast logging API
* Load Rails 7.1 defaults with exceptions for tests that fail
  * Here's the list of the changes for defaults in 7.0 and 7.1: https://github.com/rails/rails/blob/v7.1.5.1/railties/lib/rails/application/configuration.rb#L219-L331

- [x] Waiting on 💚 [cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/937) after pulling in virtual attributes release.