### PR TITLE
remove unused tota11y.js reference

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,9 +43,6 @@ Vmdb::Application.configure do
   # Include miq_debug in the list of assets here because it is only used in development
   config.assets.precompile << 'miq_debug.js'
   config.assets.precompile << 'miq_debug.css'
-  # Include totally (https://khan.github.io/tota11y/) here for dev-mode only to help working
-  # on accessibility issues.
-  config.assets.precompile << 'tota11y.js'
 
   # Customize any additional options below...
 

--- a/config/environments/i18n.rb
+++ b/config/environments/i18n.rb
@@ -37,9 +37,6 @@ Vmdb::Application.configure do
   # Include miq_debug in the list of assets here because it is only used in development
   config.assets.precompile << 'miq_debug.js'
   config.assets.precompile << 'miq_debug.css'
-  # Include totally (https://khan.github.io/tota11y/) here for dev-mode only to help working
-  # on accessibility issues.
-  config.assets.precompile << 'tota11y.js'
 
   # Customize any additional options below...
 


### PR DESCRIPTION
followup to https://github.com/ManageIQ/manageiq-ui-classic/pull/3406

remove tota11y assets from core

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
