### PR TITLE
Fix sporadic ansible-runner macOS bug and remove extra listener thread

### DIFF
--- a/spec/lib/ansible/runner_execution_spec.rb
+++ b/spec/lib/ansible/runner_execution_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe Ansible::Runner do
         expect(response.human_stdout).to include('"msg": "Hello World! example_var=\'example var value\'"')
       end
     end
+
+    it "with a payload that fails before running even starts" do
+      playbook = data_directory.join("hello_world.yml")
+
+      expect(AwesomeSpawn).to receive(:run).and_raise(RuntimeError.new("Some failure"))
+
+      expect { Ansible::Runner.public_send(method_under_test, env_vars, extra_vars, playbook) }.to raise_error(RuntimeError, "Some failure")
+    end
   end
 
   describe ".run" do


### PR DESCRIPTION
It was found that on macOS a sporadic failure would occur where the internal listener, while started, wouldn't actually start listening right away, causing the listener to miss the file we were waiting for.

The listen gem [creates an internal thread, `@run_thread`][1], which on most target systems is where the actually listening is done. However, [on macOS, `@run_thread` creates a second thread, `@worker_thread`][2], which does the actual listening. It's possible that although the listener is started, the `@worker_thread` hasn't actually started yet. This leaves a window where the target_path we are waiting on can actually be created before the `@worker_thread` is started and we "miss" the creation of the target_path. This commit ensures that we won't move on until that thread is ready, further ensuring we can't miss the creation of the target_path.

Ansible::Runner#wait_for was also creating an extra thread when starting the listener, but this thread is unnecessary as the listen gem creates its own internal thread under the covers.

[1]: https://github.com/guard/listen/blob/f186b2fa159a2458f3ff7e8680c3a4fcbdc636d1/lib/listen/adapter/base.rb#L75
[2]: https://github.com/guard/listen/blob/f186b2fa159a2458f3ff7e8680c3a4fcbdc636d1/lib/listen/adapter/darwin.rb#L49

---

@agrare Please review.  I'd also like it if you could verify this on linux, since the removal of that extra thread could affect that path. I'm concerned that while macOS has this special case, there might be a different, but similar, special case on Linux we need to account for after calling `listener.start`.

I've also considering opening a bug in the upstream listen gem but would like your thoughts. IMO, `listener.start` shouldn't return until the underlying watching has _actually_ started.