### PR TITLE
Poll more frequently in Ansible::Runner::ResponseAsync#wait

### DIFF
--- a/lib/ansible/runner/response_async.rb
+++ b/lib/ansible/runner/response_async.rb
@@ -60,10 +60,10 @@ module Ansible
       # @return [Ansible::Runner::Response] Response object with all details about the Ansible run
       def wait(timeout)
         result = nil
-        # Poll once per second until complete
-        1.upto(timeout) do |t|
+        # Poll every 0.1s until complete
+        (0.1..timeout).step(0.1) do
           result = response
-          result ? break : sleep(1)
+          result ? break : sleep(0.1)
         end
         # If the process is still running, then stop it
         if result.nil?


### PR DESCRIPTION
This method is primarily used by tests, and it was noticed that most of the test cases complete in roughly 0.4s-0.9s in the normal case. Thus, polling more frequently every 0.1s seems to strike a nice balance. With this change, the tests seems to take on average 5s less time.

@agrare Please review.