### PR TITLE
Fix issue where test leaves a dirty git tree

### DIFF
--- a/spec/models/manageiq/providers/embedded_ansible_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible do
     let(:manager)  { provider.automation_manager }
 
     let(:consolidated_repo_path) { Ansible::Content::PLUGIN_CONTENT_DIR }
-    let(:manager_repo_path)      { GitRepository::GIT_REPO_DIRECTORY }
 
     before do
       EvmSpecHelper.local_miq_server
@@ -12,7 +11,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible do
     end
 
     after do
-      FileUtils.rm_rf(Dir.glob(File.join(manager_repo_path, "*")))
       FileUtils.rm_rf(Dir.glob(File.join(consolidated_repo_path, "*")))
     end
 


### PR DESCRIPTION
In 195a04f0, a test was removed that had created a local repo in the git_repos dir, but the cleanup from the after block was not removed. This cleanup removes the .gitkeep file, which causes a dirty tree.

@kbrock Please review.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
