### PR TITLE
DRb has been extracted from stdlib to a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "connection_pool",                                       :require => false #
 gem "dalli",                            "~>3.2.3",           :require => false
 gem "default_value_for",                "~>4.0"
 gem "docker-api",                       "~>1.33.6",          :require => false
+gem "drb",                              "~>2.2",             :require => false
 gem "elif",                             "=0.1.0",            :require => false
 gem "fast_gettext",                     "~>3.1"
 gem "ffi",                              "< 1.17.0",          :require => false


### PR DESCRIPTION
Add DRb to the Gemfile as a gem as it has been extracted from stdlib to a standalone gem.

```
lib/miq_automation_engine/miq_ae_exception.rb:1: warning: lib/ruby/3.3.0/drb.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add drb to your Gemfile or gemspec to silence this warning.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
