### PR TITLE
upgrade Factorybot to ruby3.3 friendly version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -309,7 +309,7 @@ group :test do
   gem "bundler-audit",                                       :require => false
   gem "capybara",                       "~>2.5.0",           :require => false
   gem "db-query-matchers",              "~>0.11.0"
-  gem "factory_bot",                    "~>5.1",             :require => false
+  gem "factory_bot",                    "~>6.5",             :require => false
   gem "simplecov",                      ">=0.21.2",          :require => false
   gem "timecop",                        "~>0.9", "!= 0.9.7", :require => false
   gem "vcr",                            "~>6.1",             :require => false

--- a/spec/factories/workflow.rb
+++ b/spec/factories/workflow.rb
@@ -1,3 +1,0 @@
-FactoryBot.define do
-  factory :workflow
-end

--- a/spec/factories/workflow_instance.rb
+++ b/spec/factories/workflow_instance.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :workflow_instance do
-    status { "pending" }
-  end
-end


### PR DESCRIPTION
Depends upon:
- https://github.com/ManageIQ/manageiq-providers-workflows/pull/118

(reference to bad factory was failing a cross repo)