### PR TITLE
Add a block option to checkout_git_repository

### DIFF
--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -85,11 +85,22 @@ class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource 
     raise NotImplementedError, N_("sync must be implemented in a subclass")
   end
 
-  def checkout_git_repository(target_directory)
+  def checkout_git_repository(target_directory = nil)
     return if git_repository.nil?
+
+    target_directory_given = !!target_directory
+    target_directory     ||= Pathname.new(Dir.mktmpdir)
 
     git_repository.update_repo
     git_repository.checkout(scm_branch, target_directory)
+
+    return target_directory unless block_given?
+
+    begin
+      yield target_directory
+    ensure
+      FileUtils.rm_rf(target_directory.to_s) unless target_directory_given
+    end
   end
 
   private

--- a/spec/factories/configuration_script_source.rb
+++ b/spec/factories/configuration_script_source.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     sequence(:name) { |n| "configuration_script_source#{seq_padded_for_sorting(n)}" }
   end
 
+  factory :embedded_automation_configuration_script_source,
+          :parent => :configuration_script_source,
+          :class  => "ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource"
+
   factory :ansible_configuration_script_source,
           :parent => :configuration_script_source,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource"
@@ -12,13 +16,13 @@ FactoryBot.define do
           :class  => "ManageIQ::Providers::Awx::AutomationManager::ConfigurationScriptSource"
 
   factory :embedded_ansible_configuration_script_source,
-          :parent => :configuration_script_source,
+          :parent => :embedded_automation_configuration_script_source,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource" do
     scm_url { "https://example.com/foo.git" }
   end
 
   factory :embedded_workflow_configuration_script_source,
-          :parent => :configuration_script_source,
+          :parent => :embedded_automation_configuration_script_source,
           :class  => "ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSource" do
     scm_url { "https://example.com/foo.git" }
   end

--- a/spec/models/manageiq/providers/embedded_automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_automation_manager/configuration_script_source_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource do
+  let(:subject) { FactoryBot.create(:embedded_automation_configuration_script_source, :scm_url => "https://example.com/foo.git") }
+  let(:git_repository) { FactoryBot.create(:git_repository) }
+
+  describe "#checkout_git_repository" do
+    before do
+      expect(subject.git_repository).to receive(:update_repo)
+      expect(subject.git_repository).to receive(:checkout)
+    end
+
+    context "without a block" do
+      it "creates a temporary directory" do
+        expect(Dir).to receive(:mktmpdir).and_return("/tmp/mydir")
+
+        subject.checkout_git_repository
+      end
+
+      it "doesn't delete the temporary directory" do
+        expect(Dir).to           receive(:mktmpdir).and_return("/tmp/mydir")
+        expect(FileUtils).not_to receive(:rm_rf)
+
+        subject.checkout_git_repository
+      end
+
+      it "doesn't create a new temp dir when passing in a target directory" do
+        expect(Dir).not_to receive(:mktmpdir)
+
+        subject.checkout_git_repository("/tmp/mydir")
+      end
+    end
+
+    context "with a block" do
+      it "creates a temporary directory and deletes it" do
+        expect(Dir).to       receive(:mktmpdir).and_return("/tmp/mydir")
+        expect(FileUtils).to receive(:rm_rf).with("/tmp/mydir")
+
+        subject.checkout_git_repository { |target_directory| target_directory }
+      end
+
+      it "deletes the temporary directory if the block raises an exception" do
+        expect(Dir).to       receive(:mktmpdir).and_return("/tmp/mydir")
+        expect(FileUtils).to receive(:rm_rf).with("/tmp/mydir")
+
+        expect { subject.checkout_git_repository { |_| raise "Exception" } }.to raise_error(RuntimeError, "Exception")
+      end
+
+      it "doesn't create a new temp dir when passing in a target directory" do
+        expect(Dir).not_to       receive(:mktmpdir)
+        expect(FileUtils).not_to receive(:rm_rf).with("/tmp/mydir")
+
+        subject.checkout_git_repository("/tmp/mydir") { |target_directory| target_directory }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently it is up to the caller to create the temporary directory, pass that to checkout_git_repository, and clean that directory up.

If a caller doesn't need to keep the directory around across method invocations they could pass a block in and let the checkout_git_repository method clean up the temp directory.

Ref: https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/75#discussion_r1777076972

Follow-ups:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/79
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
