### PR TITLE
Remove task_id from AE deliver_queue

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -90,8 +90,7 @@ class ResourceAction < ApplicationRecord
     else
       MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
                                 :zone     => target.try(:my_zone),
-                                :priority => MiqQueue::HIGH_PRIORITY,
-                                :task_id  => "#{self.class.name.underscore}_#{id}")
+                                :priority => MiqQueue::HIGH_PRIORITY)
     end
   end
 

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe ResourceAction do
         :role        => 'automate',
         :zone        => zone_name,
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :task_id     => "#{ra.class.name.underscore}_#{ra.id}",
         :msg_timeout => 3600
       }
     end


### PR DESCRIPTION
`task_id` may not be necessary with AE. This can cause issues in the event that there are multiple items in the queue with the same `task_id`

@miq-bot assign @Fryguy 
@miq-bot add_reviewers @agrare, @Fryguy 
@miq-bot assign_labels bug, radjabov/yes?