### PR TITLE
Fix deprecations using activesupport deprecation

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -667,7 +667,7 @@ class MiqQueue < ApplicationRecord
     )
 
     if result[:class_name].kind_of?(Class)
-      ActiveSupport::Deprecation.warn("Rails 5.1 dropped support for Class query values, use a String for class_name.", caller[1..-1])
+      Vmdb::Deprecation.warn("Rails 5.1 dropped support for Class query values, use a String for class_name.", caller[1..-1])
       result[:class_name] = result[:class_name].name
     end
     result

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -51,7 +51,7 @@ module CustomAttributeMixin
     def self.add_custom_attribute(custom_attribute)
       return if respond_to?(custom_attribute)
 
-      ActiveSupport::Deprecation.warn(invalid_custom_attribute_message(custom_attribute)) unless CUSTOM_ATTRIBUTE_VALID_NAME_REGEXP.match?(custom_attribute.to_s)
+      Vmdb::Deprecation.warn(invalid_custom_attribute_message(custom_attribute)) unless CUSTOM_ATTRIBUTE_VALID_NAME_REGEXP.match?(custom_attribute.to_s)
 
       ca_sym                 = custom_attribute.to_sym
       without_prefix         = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
@@ -115,7 +115,7 @@ module CustomAttributeMixin
   def miq_custom_set(key, value)
     return miq_custom_delete(key) if value.blank?
 
-    ActiveSupport::Deprecation.warn(self.class.invalid_custom_attribute_message(key)) unless self.class::CUSTOM_ATTRIBUTE_VALID_NAME_REGEXP.match?(key.to_s)
+    Vmdb::Deprecation.warn(self.class.invalid_custom_attribute_message(key)) unless self.class::CUSTOM_ATTRIBUTE_VALID_NAME_REGEXP.match?(key.to_s)
 
     record = miq_custom_attributes.find_by(:name => key.to_s)
     if record.nil?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -65,7 +65,7 @@ class Notification < ApplicationRecord
     # 1. Deprecate now
     # 2. Fail validation going forward via errors.add(error_args)
     error_args = [:options, "text bindings for notification_type: '#{notification_type.name}' failed with error: '#{e.message}' with options: '#{options.inspect}' and message #{notification_type.message.inspect}. Next release will not allow a notification without complete bindings."]
-    ActiveSupport::Deprecation.warn(error_args.join(' '), caller_locations[1..-1].reject { |location| location.label.include?("emit_for_event") })
+    Vmdb::Deprecation.warn(error_args.join(' '), caller_locations[1..-1].reject { |location| location.label.include?("emit_for_event") })
   end
 
   def emit_message

--- a/lib/manageiq/reporting/formatter.rb
+++ b/lib/manageiq/reporting/formatter.rb
@@ -21,19 +21,19 @@ end
 # Deprecate the constants within ReportFormatter with a helpful replacement.
 module ReportFormatter
   include ActiveSupport::Deprecation::DeprecatedConstantAccessor
-  deprecate_constant :BLANK_VALUE,       'ManageIQ::Reporting::Formatter::BLANK_VALUE'
-  deprecate_constant :CRLF,              'ManageIQ::Reporting::Formatter::CRLF'
-  deprecate_constant :LABEL_LENGTH,      'ManageIQ::Reporting::Formatter::LABEL_LENGTH'
-  deprecate_constant :LEGEND_LENGTH,     'ManageIQ::Reporting::Formatter::LEGEND_LENGTH'
+  deprecate_constant :BLANK_VALUE,       'ManageIQ::Reporting::Formatter::BLANK_VALUE',     :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :CRLF,              'ManageIQ::Reporting::Formatter::CRLF',            :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :LABEL_LENGTH,      'ManageIQ::Reporting::Formatter::LABEL_LENGTH',    :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :LEGEND_LENGTH,     'ManageIQ::Reporting::Formatter::LEGEND_LENGTH',   :deprecator => Vmdb::Deprecation.deprecator
 
-  deprecate_constant :C3Formatter,       'ManageIQ::Reporting::Formatter::C3'
-  deprecate_constant :C3Series,          'ManageIQ::Reporting::Formatter::C3Series'
-  deprecate_constant :C3Charting,        'ManageIQ::Reporting::Formatter::C3Charting'
-  deprecate_constant :ChartCommon,       'ManageIQ::Reporting::Formatter::ChartCommon'
-  deprecate_constant :Converter,         'ManageIQ::Reporting::Formatter::Converter'
-  deprecate_constant :ReportHTML,        'ManageIQ::Reporting::Formatter::Html'
-  deprecate_constant :ReportRenderer,    'ManageIQ::Reporting::Formatter::ReportRenderer'
-  deprecate_constant :ReportText,        'ManageIQ::Reporting::Formatter::Text'
-  deprecate_constant :ReportTimeline,    'ManageIQ::Reporting::Formatter::Timeline'
-  deprecate_constant :TimelineMessage,   'ManageIQ::Reporting::Formatter::TimelineMessage'
+  deprecate_constant :C3Formatter,       'ManageIQ::Reporting::Formatter::C3',              :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :C3Series,          'ManageIQ::Reporting::Formatter::C3Series',        :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :C3Charting,        'ManageIQ::Reporting::Formatter::C3Charting',      :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :ChartCommon,       'ManageIQ::Reporting::Formatter::ChartCommon',     :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :Converter,         'ManageIQ::Reporting::Formatter::Converter',       :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :ReportHTML,        'ManageIQ::Reporting::Formatter::Html',            :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :ReportRenderer,    'ManageIQ::Reporting::Formatter::ReportRenderer',  :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :ReportText,        'ManageIQ::Reporting::Formatter::Text',            :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :ReportTimeline,    'ManageIQ::Reporting::Formatter::Timeline',        :deprecator => Vmdb::Deprecation.deprecator
+  deprecate_constant :TimelineMessage,   'ManageIQ::Reporting::Formatter::TimelineMessage', :deprecator => Vmdb::Deprecation.deprecator
 end

--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -13,6 +13,7 @@ module Vmdb
     end
 
     class << self
+      alias_method :deprecator, :instance
       delegate :silence, :warn, :to => :instance
     end
 

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -758,7 +758,7 @@ RSpec.describe MiqQueue do
     end
 
     it "supports a Class object for the class name(deprecated)" do
-      expect(ActiveSupport::Deprecation).to receive(:warn).with(/use a String for class_name/, anything)
+      expect(Vmdb::Deprecation).to receive(:warn).with(/use a String for class_name/, anything)
       msg = MiqQueue.put_or_update(:class_name => MiqServer, :instance_id => miq_server.id, :method_name => "my_zone")
 
       status, message, result = msg.deliver

--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe CustomAttributeMixin do
     end
 
     it "key with a space(deprecated)" do
-      ActiveSupport::Deprecation.silence { test_class.add_custom_attribute("exit message") }
+      Vmdb::Deprecation.silence { test_class.add_custom_attribute("exit message") }
       expect(test_class.new).to respond_to(:"exit message")
       expect(test_class.new).to respond_to(:"exit message=")
     end
 
     it "key with leading number(deprecated)" do
-      ActiveSupport::Deprecation.silence { test_class.add_custom_attribute("4fun") }
+      Vmdb::Deprecation.silence { test_class.add_custom_attribute("4fun") }
       expect(test_class.new).to respond_to(:"4fun")
       expect(test_class.new).to respond_to(:"4fun=")
     end
@@ -121,7 +121,7 @@ RSpec.describe CustomAttributeMixin do
 
   it "#miq_custom_set with a space(deprecated)" do
     object = test_class.create!
-    ActiveSupport::Deprecation.silence { object.miq_custom_set("hello world", "baz") }
+    Vmdb::Deprecation.silence { object.miq_custom_set("hello world", "baz") }
     ca = CustomAttribute.find_by(:resource_type => test_class.name, :resource_id => object.id)
     expect(ca.name).to  eq("hello world")
     expect(ca.value).to eq("baz")


### PR DESCRIPTION
Extracted from #23225

Don't use singleton, use a deprecator.  We already had instance, which is a deprecator so make that obvious.

As an aside, I think some of these deprecations should be reviewed for deletion before the next release.

- [x] 💚 [Cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/926)