### PR TITLE
Fix positional argument deprecations with ERB.new

### DIFF
--- a/tools/miq_config_sssd_ldap/sssd_conf.rb
+++ b/tools/miq_config_sssd_ldap/sssd_conf.rb
@@ -42,7 +42,7 @@ module MiqConfigSssdLdap
       LOGGER.debug("Invoked #{self.class}##{__method__}")
 
       begin
-        File.write(dest_path, ERB.new(File.read(src_path), nil, '-').result(binding))
+        File.write(dest_path, ERB.new(File.read(src_path), :trim_mode => '-').result(binding))
         FileUtils.chmod(0o600, dest_path)
       rescue Errno::ENOENT, IndexError => e
         LOGGER.fatal(e.message)


### PR DESCRIPTION
Extracted from #23225

Drop second argument as safe_level was removed.
Change third argument for trim_mode to keyword argument.

Oops, this PR doesn't need cross repo.  😅 