### PR TITLE
Use the rails 7.1+ serialize interface

### DIFF
--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -1,6 +1,6 @@
 class ChargebackRateDetailMeasure < ApplicationRecord
-  serialize :units, Array
-  serialize :units_display, Array
+  serialize :units, :type => Array
+  serialize :units_display, :type => Array
   validates :name, :presence => true, :length => {:maximum => 100}
   validates :step, :presence => true, :numericality => {:greater_than => 0}
   validates :units, :presence => true, :length => {:minimum => 2}

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -42,8 +42,8 @@ class ContainerImage < ApplicationRecord
   has_many :metrics, :as => :resource, :dependent => :nullify, :inverse_of => :resource
   has_many :vim_performance_states, :as => :resource, :dependent => :nullify, :inverse_of => :resource
 
-  serialize :exposed_ports, Hash
-  serialize :environment_variables, Hash
+  serialize :exposed_ports, :type => Hash
+  serialize :environment_variables, :type => Hash
 
   virtual_column :display_registry, :type => :string
   virtual_total :total_containers, :containers

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -15,8 +15,8 @@ class ContainerTemplate < ApplicationRecord
            :as         => :resource,
            :inverse_of => :resource
 
-  serialize :objects, Array
-  serialize :object_labels, Hash
+  serialize :objects, :type => Array
+  serialize :object_labels, :type => Hash
 
   acts_as_miq_taggable
 

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -6,7 +6,7 @@ class CustomButton < ApplicationRecord
     order(Arel.sql(order))
   }
 
-  serialize :options, Hash
+  serialize :options, :type => Hash
   serialize :visibility_expression
   serialize :enablement_expression
   serialize :visibility

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -35,10 +35,10 @@ class DialogField < ApplicationRecord
   default_value_for :load_values_on_init, true
 
   serialize :values
-  serialize :values_method_options,   Hash
-  serialize :display_method_options,  Hash
-  serialize :required_method_options, Hash
-  serialize :options,                 Hash
+  serialize :values_method_options,   :type => Hash
+  serialize :display_method_options,  :type => Hash
+  serialize :required_method_options, :type => Hash
+  serialize :options,                 :type => Hash
 
   after_initialize :default_resource_action
 

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -25,7 +25,7 @@ class GenericObjectDefinition < ApplicationRecord
   REG_METHOD_NAME    = /\A[a-z][a-zA-Z_0-9]*[!?]?\z/
   ALLOWED_ASSOCIATION_TYPES = (MiqReport.reportable_models + %w[GenericObject]).freeze
 
-  serialize :properties, Hash
+  serialize :properties, :type => Hash
 
   include CustomActionsMixin
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -96,7 +96,7 @@ class Host < ApplicationRecord
   # Physical server reference
   belongs_to :physical_server, :inverse_of => :host
 
-  serialize :settings, Hash
+  serialize :settings, :type => Hash
 
   deprecate_attribute :address,  :hostname, :type => :string
   alias_attribute     :state,    :power_state

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -35,7 +35,7 @@ class MiqAction < ApplicationRecord
 
   has_many :miq_policy_contents
 
-  serialize :options, Hash
+  serialize :options, :type => Hash
 
   # Add a instance method to store the sequence and synchronous values from the policy contents
   attr_accessor :sequence, :synchronous, :reserved

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -9,7 +9,7 @@ class MiqAeMethod < ApplicationRecord
   # switch back to validates :exclusion once rails 6.1 issue is fixed
   # https://github.com/rails/rails/issues/41051
   validate :embedded_methods_not_nil
-  serialize :options, Hash
+  serialize :options, :type => Hash
   before_validation :set_relative_path
 
   belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -103,8 +103,8 @@ class MiqQueue < ApplicationRecord
 
   TIMEOUT = 10.minutes
 
-  serialize :args, Array
-  serialize :miq_callback, Hash
+  serialize :args, :type => Array
+  serialize :miq_callback, :type => Hash
 
   validate :validate_zone_name
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -22,7 +22,7 @@ class MiqRequest < ApplicationRecord
 
   alias_attribute :state, :request_state
 
-  serialize   :options, Hash
+  serialize   :options, :type => Hash
 
   default_value_for(:message)       { |r| "#{r.class::TASK_DESCRIPTION} - Request Created" }
   default_value_for :options,       {}

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -10,8 +10,8 @@ class MiqRequestTask < ApplicationRecord
   belongs_to :miq_request_task
   belongs_to :tenant
 
-  serialize   :phase_context, Hash
-  serialize   :options,       Hash
+  serialize   :phase_context, :type => Hash
+  serialize   :options,       :type => Hash
 
   default_value_for :phase_context, {}
   default_value_for :options,       {}

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -6,7 +6,7 @@ module ServiceMixin
     has_many   :service_resources, -> { order("group_idx ASC") }, :dependent => :destroy
     has_many   :resource_actions, :as => :resource, :dependent => :destroy
 
-    serialize  :options, Hash
+    serialize  :options, :type => Hash
 
     include UuidMixin
     acts_as_miq_taggable

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -15,7 +15,7 @@ class Notification < ApplicationRecord
 
   before_save :backup_subject_name
 
-  serialize :options, Hash
+  serialize :options, :type => Hash
   default_value_for(:options) { {} }
 
   validate :complete_bindings

--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -1,7 +1,7 @@
 class PersistentVolume < ContainerVolume
   acts_as_miq_taggable
   include NewWithTypeStiMixin
-  serialize :capacity, Hash
+  serialize :capacity, :type => Hash
   delegate :name, :to => :parent, :prefix => true, :allow_nil => true
   has_many :container_volumes, -> { where(:type => 'ContainerVolume') }, :through => :persistent_volume_claim
   has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'

--- a/app/models/persistent_volume_claim.rb
+++ b/app/models/persistent_volume_claim.rb
@@ -2,9 +2,9 @@ class PersistentVolumeClaim < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
   has_many :container_volumes
-  serialize :capacity, Hash
-  serialize :requests, Hash
-  serialize :limits, Hash
+  serialize :capacity, :type => Hash
+  serialize :requests, :type => Hash
+  serialize :limits, :type => Hash
 
   virtual_column :storage_capacity, :type => :integer
 

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -4,7 +4,7 @@ class ResourceAction < ApplicationRecord
   belongs_to :configuration_script_payload, :foreign_key => :configuration_script_id
   belongs_to :dialog
 
-  serialize  :ae_attributes, Hash
+  serialize  :ae_attributes, :type => Hash
 
   validate :ensure_configuration_script_or_automate
 

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -5,7 +5,7 @@ class Snapshot < ApplicationRecord
 
   belongs_to :vm_or_template
 
-  serialize :disks, Array
+  serialize :disks, :type => Array
 
   after_create  :after_create_callback
 

--- a/app/models/system_service.rb
+++ b/app/models/system_service.rb
@@ -6,7 +6,7 @@ class SystemService < ApplicationRecord
   belongs_to :host_service_group
   has_one    :cloud_service, :dependent => :nullify
 
-  serialize :dependencies, Hash
+  serialize :dependencies, :type => Hash
 
   scope :running_systemd_services, -> { where(:systemd_active => 'active', :systemd_sub => 'running') }
   scope :failed_systemd_services, -> { where(:systemd_active => 'failed').or(where(:systemd_sub => 'failed')) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
   # with the class method of the same name (User.authenticate)
   alias_method :authenticate_bcrypt, :authenticate
 
-  serialize     :settings, Hash   # Implement settings column as a hash
+  serialize     :settings, :type => Hash   # Implement settings column as a hash
   default_value_for(:settings) { {} }
 
   default_value_for :failed_login_attempts, 0

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -2,7 +2,7 @@ class Zone < ApplicationRecord
   validates_presence_of   :name, :description
   validates :name, :unique_within_region => true
 
-  serialize :settings, Hash
+  serialize :settings, :type => Hash
 
   belongs_to :log_file_depot, :class_name => "FileDepot"
 


### PR DESCRIPTION
Type was changed from positional to a keyword argument 'type' in 7.1. The positional argument is removed in rails 7.2.

We have a helper bridge module prepending support for either kwargs or positional arguments passed to serialize which converts to positional for rails 7.0 and kwargs for 7.1+.  This was added and automatically loaded in the rails app via the engine in schema:
https://github.com/ManageIQ/manageiq-schema/pull/756

Extracted from #23225

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
