### PR TITLE
Use Rails.application.credentials instead of deprecated secrets

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -32,11 +32,6 @@ module MiqWebServerWorkerMixin
       return if Rails.application.config.secret_key_base
 
       Rails.application.config.secret_key_base = token
-
-      # To set a secret token after the Rails.application is initialized,
-      # we need to reset the secrets since they are cached:
-      # https://github.com/rails/rails/blob/4-2-stable/railties/lib/rails/application.rb#L386-L401
-      Rails.application.secrets = nil
     end
 
     def rails_server

--- a/spec/models/firmware_registry/rest_api_depot_spec.rb
+++ b/spec/models/firmware_registry/rest_api_depot_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe FirmwareRegistry::RestApiDepot do
     VCR.turn_on!
   end
 
-  let(:host) { Rails.application.secrets.fwreg_rest_api_depot.try(:[], 'host') || 'host' }
-  let(:user) { Rails.application.secrets.fwreg_rest_api_depot.try(:[], 'userid') || 'username' }
-  let(:pass) { Rails.application.secrets.fwreg_rest_api_depot.try(:[], 'password') || 'password' }
+  let(:host) { Rails.application.credentials.fwreg_rest_api_depot.try(:[], 'host') || 'host' }
+  let(:user) { Rails.application.credentials.fwreg_rest_api_depot.try(:[], 'userid') || 'username' }
+  let(:pass) { Rails.application.credentials.fwreg_rest_api_depot.try(:[], 'password') || 'password' }
   let(:url) { "http://#{host}/images/" }
 
   describe '.fetch_from_remote' do

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe MiqWebServerWorkerMixin do
   end
 
   before do
-    @token   = Rails.application.config.secret_key_base
-    @secrets = Rails.application.secrets
+    @token = Rails.application.config.secret_key_base
+    @credentials = Rails.application.credentials
     MiqDatabase.seed
   end
 
   after do
     Rails.application.config.secret_key_base = @token
-    Rails.application.secrets = @secrets
+    Rails.application.credentials = @credentials
   end
 
   it ".configure_secret_token defaults to MiqDatabase session_secret_token" do
@@ -43,8 +43,8 @@ RSpec.describe MiqWebServerWorkerMixin do
   it ".configure_secret_token does not reset secrets when token already configured" do
     existing_value = SecureRandom.hex(64)
     Rails.application.config.secret_key_base = existing_value
-    Rails.application.secrets = nil
-    Rails.application.secrets
+    Rails.application.credentials = nil
+    Rails.application.credentials
 
     test_class.configure_secret_token
     expect(Rails.application.config.secret_key_base).to eq(existing_value)


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2.

Extracted from https://github.com/ManageIQ/manageiq/pull/23225
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
