### PR TITLE
Improve allowed_storages filter spec

### DIFF
--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -350,19 +350,39 @@ RSpec.describe MiqRequestWorkflow do
         end
 
         context "with a user with a belongs_to_filter" do
+          let(:root_folder) { FactoryBot.create(:ems_folder, :ems_id => ems.id).tap        { |f| f.add_parent(ems) } }
+          let(:datacenter)  { FactoryBot.create(:vmware_datacenter, :ems_id => ems.id).tap { |d| d.add_parent(root_folder) } }
+          let(:storage)     { FactoryBot.create(:storage, :ems_id => ems.id).tap           { |s| s.add_parent(datacenter) } }
+
           before do
             group = workflow.requester.miq_groups.first
             group.entitlement = Entitlement.new
             group.entitlement.set_managed_filters([])
-            group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|#{ems.name}/EmsFolder|Datacenters"])
+            group.entitlement.set_belongsto_filters(belongsto_filter)
             group.save!
           end
 
-          it "filters out storages" do
-            allow(workflow).to receive(:get_source_and_targets).and_return(:ems => workflow.ci_to_hash_struct(ems))
-            allow(workflow).to receive(:allowed_hosts_obj).and_return([host])
+          context "with a filter that doesn't include the storage" do
+            let(:datacenter2) { FactoryBot.create(:vmware_datacenter, :ems_id => ems.id).tap { |f| f.add_parent(root_folder) } }
+            let(:belongsto_filter) { ["/belongsto/ExtManagementSystem|#{ems.name}/EmsFolder|#{root_folder.name}/EmsFolder|#{datacenter2.name}"] }
 
-            expect(workflow.allowed_storages.map(&:id)).to be_empty
+            it "filters out storages" do
+              allow(workflow).to receive(:get_source_and_targets).and_return(:ems => workflow.ci_to_hash_struct(ems))
+              allow(workflow).to receive(:allowed_hosts_obj).and_return([host])
+
+              expect(workflow.allowed_storages.map(&:id)).to be_empty
+            end
+          end
+
+          context "with a filter that includes the storage" do
+            let(:belongsto_filter) { ["/belongsto/ExtManagementSystem|#{ems.name}/EmsFolder|#{root_folder.name}/EmsFolder|#{datacenter.name}/Storage|#{storage.name}"] }
+
+            it "returns the storage" do
+              allow(workflow).to receive(:get_source_and_targets).and_return(:ems => workflow.ci_to_hash_struct(ems))
+              allow(workflow).to receive(:allowed_hosts_obj).and_return([host])
+
+              expect(workflow.allowed_storages.map(&:id)).to eq([storage.id])
+            end
           end
         end
       end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -354,11 +354,12 @@ RSpec.describe MiqRequestWorkflow do
           let(:datacenter)  { FactoryBot.create(:vmware_datacenter, :ems_id => ems.id).tap { |d| d.add_parent(root_folder) } }
           let(:storage)     { FactoryBot.create(:storage, :ems_id => ems.id).tap           { |s| s.add_parent(datacenter) } }
 
+          let(:entitlement_filters) { {"managed" => [], "belongsto" => belongsto_filter} }
+          let(:entitlement)         { FactoryBot.create(:entitlement, :filters => entitlement_filters) }
+
           before do
             group = workflow.requester.miq_groups.first
-            group.entitlement = Entitlement.new
-            group.entitlement.set_managed_filters([])
-            group.entitlement.set_belongsto_filters(belongsto_filter)
+            group.entitlement = entitlement
             group.save!
           end
 


### PR DESCRIPTION
The previous spec did not excercise the fix because the created objects' ems_metadata tree did not match the `belongsto_filter` so the `MiqFilter.belongsto2object_list` returned an empty array which bypassed the `MiqPreloader.preload_and_map(sources, :storages)` call which caused the exception.

Now without the fix in EmsFolder to add the `virtual_has_many` this spec will raise the same exception we observed during provisioning which is what I wanted.

I also added a test where it returns the storages in addition to the test where they are filtered out.

Undo the fix:
```
$ git diff
diff --git a/app/models/ems_folder.rb b/app/models/ems_folder.rb
index e89905e626..1db8684df4 100644
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -18,7 +18,7 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :vms,               :uses => :all_relationships
   virtual_has_many :miq_templates,     :uses => :all_relationships
   virtual_has_many :hosts,             :uses => :all_relationships
-  virtual_has_many :storages,          :uses => :all_relationships
+  #virtual_has_many :storages,          :uses => :all_relationships
 
   virtual_attribute :folder_path, :string, :uses => :all_relationships
```

Run the updated specs:
```
$ bundle exec rspec spec/models/miq_request_workflow_spec.rb:352
Randomized with seed 56749
FF

Failures:

  1) MiqRequestWorkflow 'allowed_*' methods #allowed_storages with writable accessible storages with a user with a belongs_to_filter with a filter that doesn't include the storage filters out storages
     Failure/Error: ActiveRecord::Associations::Preloader.new(:records => Array(records), :associations => associations, :available_records => Array(preload_scope)).call
     
     ActiveRecord::AssociationNotFoundError:
       Association named 'storages' was not found on ManageIQ::Providers::Vmware::InfraManager::Datacenter; perhaps you misspelled it?

  2) MiqRequestWorkflow 'allowed_*' methods #allowed_storages with writable accessible storages with a user with a belongs_to_filter with a filter that includes the storage returns the storage
     Failure/Error: ActiveRecord::Associations::Preloader.new(:records => Array(records), :associations => associations, :available_records => Array(preload_scope)).call
     
     ActiveRecord::AssociationNotFoundError:
       Association named 'storages' was not found on ManageIQ::Providers::Vmware::InfraManager::Datacenter; perhaps you misspelled it?
```

Follow-up to: https://github.com/ManageIQ/manageiq/pull/23252
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
