### PR TITLE
Reset cached secrets on Rails 7.0

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -32,6 +32,11 @@ module MiqWebServerWorkerMixin
       return if Rails.application.config.secret_key_base
 
       Rails.application.config.secret_key_base = token
+
+      # To set a secret token after the Rails.application is initialized,
+      # we need to reset the secrets since they are cached:
+      # https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/application.rb#L392-L404
+      Rails.application.secrets = nil if Rails.version < "7.1"
     end
 
     def rails_server


### PR DESCRIPTION
Partial Revert of https://github.com/ManageIQ/manageiq/pull/23254

Enhanced the test to check both the app config secret_key_base and app secret_key_base as there's caches in both.  These test changes make the test fail if we do not clear the cached secrets on Rails 7.0.

This seems to fix an issue with caching in both secrets and the config on rails 7.0:

```
Missing `secret_key_base` for 'production' environment, set this string with `bin/rails credentials:edit` (ArgumentError)
```