### PR TITLE
Lock URI to 0.13.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem "cgi",  "~> 0.3.5"
 # CVE-2023-28756 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-fg7x-g82r-94qc
 gem "time", "~> 0.2.2"
 # CVE-2023-36617 https://github.com/advisories/GHSA-hww2-5g85-429m
-gem "uri",  ">= 0.12.2"
+gem "uri",  "~> 0.13.1" # Avoid URI 1.0.0 for now due to: https://github.com/ruby/uri/issues/125
 
 # Custom gem that replaces mime-types in order to redirect mime-types calls to mini_mime
 #   Source is located at https://github.com/ManageIQ/mime-types-redirector


### PR DESCRIPTION
In 1.0.0, URI::PATTERN constant was removed without a depecation warning: https://github.com/ruby/uri/compare/v0.13.1...v1.0.0#diff-936b286152b1184cde04f027289d65e633d0f3ee52fdc42cf4eb072c24312e15R48-R54

For now, let's stick with 0.13.1 until we can know the proper solution.

Related: https://www.github.com/ruby/uri/issues/125

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
