### PR TITLE
[WIP] Fix warnings raised by URI 1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem "cgi",  "~> 0.3.5"
 # CVE-2023-28756 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-fg7x-g82r-94qc
 gem "time", "~> 0.2.2"
 # CVE-2023-36617 https://github.com/advisories/GHSA-hww2-5g85-429m
-gem "uri",  "~> 0.13.1" # Avoid URI 1.0.0 for now due to: https://github.com/ruby/uri/issues/125
+gem "uri", "~>1.0", ">=1.0.1" # Avoid URI 1.0.0 due to: https://github.com/ruby/uri/issues/125
 
 # Custom gem that replaces mime-types in order to redirect mime-types calls to mini_mime
 #   Source is located at https://github.com/ManageIQ/mime-types-redirector

--- a/app/models/external_url.rb
+++ b/app/models/external_url.rb
@@ -2,5 +2,5 @@ class ExternalUrl < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :user
 
-  validates :url, :format => URI::DEFAULT_PARSER.make_regexp, :allow_nil => false
+  validates :url, :format => URI::RFC2396_PARSER.make_regexp, :allow_nil => false
 end

--- a/app/models/file_depot_ftp.rb
+++ b/app/models/file_depot_ftp.rb
@@ -127,7 +127,7 @@ class FileDepotFtp < FileDepot
 
   def base_path
     # uri: "ftp://ftp.example.com/incoming" => #<Pathname:incoming>
-    path = URI(URI::DEFAULT_PARSER.escape(uri)).path
+    path = URI(URI::RFC2396_PARSER.escape(uri)).path
     Pathname.new(path)
   end
 

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -9,7 +9,7 @@ class GitRepository < ApplicationRecord
 
   attr_reader :git_lock
 
-  validates :url, :format => Regexp.union(URI::DEFAULT_PARSER.make_regexp(%w[http https file ssh]), /\A[-\w:.]+@.*:/), :allow_nil => false
+  validates :url, :format => Regexp.union(URI::RFC2396_PARSER.make_regexp(%w[http https file ssh]), /\A[-\w:.]+@.*:/), :allow_nil => false
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -27,7 +27,7 @@ class LogFile < ApplicationRecord
   # Base is the URI defined by the user
   # loc_file is the name of the original file
   def build_log_uri(base_uri, loc_file)
-    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(base_uri))
+    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI::RFC2396_PARSER.escape(base_uri))
 
     # Convert encoded spaces back to spaces
     path.gsub!('%20', ' ')
@@ -211,7 +211,7 @@ class LogFile < ApplicationRecord
     # Strip any leading and trailing whitespace
     uri.strip!
 
-    URI.split(URI::DEFAULT_PARSER.escape(uri))[0]
+    URI.split(URI::RFC2396_PARSER.escape(uri))[0]
   end
 
   def legacy_depot_hash

--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -57,7 +57,7 @@ module FileDepotMixin
       # Strip any leading and trailing whitespace
       uri_str.strip!
 
-      scheme, _userinfo, _host, _port, _registry, _path, _opaque, _query, _fragment = URI.split(URI::DEFAULT_PARSER.escape(uri_str))
+      scheme, _userinfo, _host, _port, _registry, _path, _opaque, _query, _fragment = URI.split(URI::RFC2396_PARSER.escape(uri_str))
       scheme
     end
   end


### PR DESCRIPTION
WIP:  

- [ ] [cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/928)
- [ ] This PR and the related PRs require bumping URI to 1.0.1+.  Determine when it's a good time to do this.
- [ ] When ready, merge related PRs after this one:
  - [ ] https://github.com/ManageIQ/vmware_web_service/pull/141
  - [ ] https://github.com/ManageIQ/manageiq-automation_engine/pull/562
  - [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/9307
  - [ ] https://github.com/ManageIQ/manageiq-gems-pending/pull/596
  - [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/926
  - [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/680

Related to:
https://www.github.com/ruby/uri/issues/125
https://github.com/ManageIQ/manageiq/pull/23260

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
