### PR TITLE
Add gitignores for rails credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 BUILD
 ca/root
 certs/v2_key
-config/secrets.yml*
 coverage/
 Gemfile.lock*
 !Gemfile.lock.release
@@ -46,6 +45,23 @@ config/database.yml*
 config/messaging.yml
 config/vmdb.yml.db
 
+# See: EDITOR=vi be rails credentials:edit --help for more information
+# Rails credentials follow the following pattern:
+# If ENV['RAILS_MASTER_KEY'] isn't specified:
+# Global is used:
+#   * config/master.key (plain text encryption key)
+#   * config/credentials.yml.enc (encrypted credentials file)
+# If --environment test, the overrides for that environment is used:
+#   * config/credentials/test.key
+#   * test.yml.enc
+# If we want to commit and share encrypted credentials, we can change the two lines below to:
+#   config/*.key
+#   config/credentials/*.key
+config/credentials*
+config/master.key
+
+# For legacy rails secrets
+config/secrets.yml*
 config/initializers/*.local.rb
 
 config/settings.local.yml


### PR DESCRIPTION
We're switching to rails credentials to keep current with rails 7.1 and the future. Note, we're assuming we won't want to commit and share encrypted credentials. If we want to share them, such as for recording cassettes, the comments describe how to switch to only ignoring the plain text encryption key files.

Followup to:  https://github.com/ManageIQ/manageiq/pull/23254
Required for: https://github.com/ManageIQ/manageiq-providers-autosde/pull/253

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
