### PR TITLE
Resurrect dashboard widgets not actually using rss feeds

### DIFF
--- a/product/dashboard/dashboards/default.yaml
+++ b/product/dashboard/dashboards/default.yaml
@@ -5,10 +5,12 @@ description: Default Dashboard
 set_data_by_description:
   :col1:
   - chart_vendor_and_guest_os
+  - rss_newest_hosts
   - report_top_memory_consumers_weekly
   :col2:
   - report_top_cpu_consumers_weekly
   - chart_virtual_infrastructure_platforms
   :col3:
   - chart_guest_os_information_any_os
+  - rss_newest_vms
   - report_top_storage_consumers

--- a/product/dashboard/dashboards/physical_infrastructure_default.yaml
+++ b/product/dashboard/dashboards/physical_infrastructure_default.yaml
@@ -9,3 +9,5 @@ set_data_by_description:
   - chart_server_health
   :col2:
   - chart_server_availability
+  :col3:
+  - rss_newest_servers

--- a/product/dashboard/widgets/rss_newest_hosts.yaml
+++ b/product/dashboard/widgets/rss_newest_hosts.yaml
@@ -1,0 +1,18 @@
+description: rss_newest_hosts
+title: "EVM: Recently Discovered Hosts"
+content_type: report
+options:
+  :row_count: 5
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: Recently Added Hosts
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval:
+      :value: "1"
+      :unit: hourly
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/rss_newest_servers.yaml
+++ b/product/dashboard/widgets/rss_newest_servers.yaml
@@ -1,0 +1,18 @@
+description: rss_newest_servers
+title: "Recently Discovered Physical Servers"
+content_type: report
+options:
+  :row_count: 5
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: Recently Discovered Physical Servers
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval:
+      :value: "1"
+      :unit: hourly
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/rss_newest_vms.yaml
+++ b/product/dashboard/widgets/rss_newest_vms.yaml
@@ -1,0 +1,18 @@
+description: rss_newest_vms
+title: "EVM: Recently Discovered VMs"
+content_type: report
+options:
+  :row_count: 5
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: Recently Discovered VMs
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval:
+      :value: "1"
+      :unit: hourly
+enabled: true
+read_only: true


### PR DESCRIPTION
This is a partial revert of 7764eceea5.

These are based on MiqReport and not actually utilizing RSS feed endpoints.

After:

![image](https://github.com/user-attachments/assets/a99b039f-594c-4b3d-b1cb-9152fc17a362)

![image](https://github.com/user-attachments/assets/6cb22456-c88d-42f5-88c7-48dc5a423e2e)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
