### PR TITLE
Upgrade config to latest 5.x version for rails 7.1 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "bootsnap",                         ">= 1.8.1",          :require => false #
 gem "bundler",                          "~> 2.2", ">= 2.2.15", *("!= 2.5.0".."!= 2.5.9"), "!= 2.5.19", :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
-gem "config",                           "~>2.2", ">=2.2.3",  :require => false
+gem "config",                           "~>5.1",             :require => false
 gem "connection_pool",                                       :require => false # For Dalli
 gem "dalli",                            "~>3.2.3",           :require => false
 gem "default_value_for",                "~>4.0"


### PR DESCRIPTION
Update: no longer WIP.

- [x] https://github.com/ManageIQ/manageiq-api/pull/1275
- [x] [cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/931) is green except nuage and openstack where before_install hook isn't run in cross repo so qpid_proton gem fails to install

I noticed deep_merge was behaving differently in tests and failing on 7.1.

Digging in, rails 7.0 was using the gem, 7.1 was using the activesupport module:

rails 7.1:

```
(byebug) {}.method(:deep_merge)
  #<Method: Hash(DeepMerge::DeepMergeHash)#deep_merge(source, options=...) /Users/joerafaniello/.gem/ruby/3.3.6/gems/deep_merge-1.2.2/lib/deep_merge/deep_merge_hash.rb:18>
```

rails 7.0:

```
(byebug) {}.method(:deep_merge)
  #<Method: Hash#deep_merge(other_hash, &block) /Users/joerafaniello/.gem/ruby/3.3.6/gems/activesupport-7.0.8.6/lib/active_support/core_ext/hash/deep_merge.rb:18>
```

Rails 7.1 changed the way their deep_merge is defined via a refactored module: https://www.github.com/rails/rails/commit/43b980368a7628fac95cc4f673e0dfbcee77c10b

This was raised in:
https://www.github.com/rails/rails/issues/49457

Config gem fixed this in 5.0 and subsequently fixed another compatibility issue in 5.1 https://www.github.com/rubyconfig/config/commit/759c0fe271b4b90d534217a5b6e0653d0c94ee85

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
