### PR TITLE
Avoid scope query when preloading

### DIFF
--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -22,9 +22,7 @@ module MiqPreloader
   #        Currently an array does not work
   # @return [Array<ActiveRecord::Base>] records
   def self.preload(records, associations, preload_scope = nil)
-    # Rails 7 changed the interface.  See rails commit: e3b9779cb701c63012bc1af007c71dc5a888d35a
-    # Note, added Array(records) as it could be a single element
-    ActiveRecord::Associations::Preloader.new(:records => Array(records), :associations => associations, :available_records => Array(preload_scope)).call
+    ActiveRecord::Associations::Preloader.new(:records => Array(records), :associations => associations, :scope => preload_scope).call
   end
 
   # for a record, cache results. Also cache the children's links back

--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ToModelHash do
 
     def assert_preloaded(associations)
       allow(ActiveRecord::Associations::Preloader).to receive(:new)
-        .with(:records => kind_of(Array), :associations => array_including(associations), :available_records => kind_of(Array))
+        .with(:records => kind_of(Array), :associations => array_including(associations), :scope => nil)
         .and_return(mocked_preloader)
       expect(mocked_preloader).to receive(:call)
 

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -46,28 +46,21 @@ RSpec.describe MiqPreloader do
       emses = ExtManagementSystem.all.load
       vms   = Vm.where(:ems_id => emses.select(:id))
 
-      # TODO: With rails 7, the query count below increased by 1.
-      # This PR says only the singular associations are preloaded in rails 7:
-      # https://github.com/rails/rails/pull/42654
-      expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 2)
+      expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 1)
       expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
     end
 
     # original behavior - not calling our code
     it "preloads with an unloaded simple relation" do
       vms = Vm.where(:ems_id => ems.id)
-      vms2 = vms.order(:id).to_a # preloaded vms to be used in tests
+      vms2 = vms.order(:id).load # preloaded vms to be used in tests
 
-      # TODO: With rails 7, the query count below increased by 1.
-      # This PR says only the singular associations are preloaded in rails 7:
-      # https://github.com/rails/rails/pull/42654
-      expect { preload(ems, :vms, vms) }.to make_database_queries(:count => 2)
+      expect { preload(ems, :vms, vms) }.to make_database_queries(:count => 1)
 
       expect { preload(ems, :vms, vms) }.not_to make_database_queries
       expect { expect(ems.vms).to match_array(vms2) }.not_to make_database_queries
 
-      # TODO: With rails 7, the query count below decreased by 1.
-      expect { expect(vms.first.ext_management_system).to eq(ems) }.to make_database_queries(:count => 1)
+      expect { expect(vms.first.ext_management_system).to eq(ems) }.to make_database_queries(:count => 2)
     end
 
     it "preloads with a loaded relation (records is a relation)" do
@@ -75,9 +68,6 @@ RSpec.describe MiqPreloader do
       emses = ExtManagementSystem.all.load
       vms   = Vm.where(:ems_id => emses.select(:id)).load
 
-      # TODO: With rails 7, the query count below increased by 1.
-      # This PR says only the singular associations are preloaded in rails 7:
-      # https://github.com/rails/rails/pull/42654
       expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 1)
 
       expect { preload(emses, :vms, vms) }.not_to make_database_queries
@@ -95,36 +85,6 @@ RSpec.describe MiqPreloader do
       expect { preload(vms, :ext_management_system, emses) }.not_to make_database_queries
       expect { expect(vms.size).to eq(2) }.not_to make_database_queries
       expect { expect(vms.first.ext_management_system).to eq(emses.first) }.not_to make_database_queries
-    end
-
-    it "preloads with an array (records is a relation)" do
-      ems
-      emses = ExtManagementSystem.all.load
-      vms = Vm.where(:ems_id => emses.select(:id)).to_a
-      expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 1)
-
-      expect { preload(emses, :vms, vms) }.not_to make_database_queries
-      expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
-
-      # TODO: With rails 7, the query count below increased by 1.
-      # This PR says only the singular associations are preloaded in rails 7:
-      # https://github.com/rails/rails/pull/42654
-      expect { expect(vms.first.ext_management_system).to eq(ems) }.to make_database_queries(:count => 1)
-    end
-
-    it "preloads with an array (records is an array)" do
-      ems
-      emses = ExtManagementSystem.all.load.to_a
-      vms   = Vm.where(:ems_id => emses.map(&:id)).to_a
-      expect { preload(emses, :vms, vms) }.to make_database_queries(:count => 1)
-
-      expect { preload(emses, :vms, vms) }.not_to make_database_queries
-      expect { expect(emses.first.vms.size).to eq(2) }.not_to make_database_queries
-
-      # TODO: With rails 7, the query count below increased by 1.
-      # This PR says only the singular associations are preloaded in rails 7:
-      # https://github.com/rails/rails/pull/42654
-      expect { expect(vms.first.ext_management_system).to eq(ems) }.to make_database_queries(:count => 1)
     end
 
     it "preloads a through with a loaded scope" do


### PR DESCRIPTION
MiqPreloader.preload(...,...,scope) correctly identifies the scope coming in and passes off to the preloader

This prevents an extra (big) query from being performed

---

When we upgraded from rails 6.1 to 7.0, the preloader interface changed. We spent most of our efforts on how that affected virtual attributes, but there was one change here.

We only use preload with a scope in one spot - for preloading `VimPerformanceState`.
Joe had documented all the places in the preloader test where the number of records loaded were different.
The very name of the variable `scope` suggests that this code change is correct and should not point to `records`

This change gets those test values back to where they need to be for all but one (?) of the cases.
But of interest, we have a lot of tests talking about arrays instead of scopes.
Now in use, we only ever pass scopes.
But the tests were (probably) introduced when I was trying to treat that scope as a preloaded records implementation. Never got it working correctly and ended up reverting to `preload_with_array` instead.

I'm thinking we should remove these preload with an array tests since this method was only ever written for passing a scope that was later applied to the records