### PR TITLE
Normalize ol_x64 as oracle OS

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -28,7 +28,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_debian",    %w[debian]],
     ["linux_esx",       %w[vmnixx86 vmwareesxserver esxserver vmwareesxi]],
     ["linux_solaris",   %w[solaris]],
-    ["linux_oracle",    %w[oracle]],
+    ["linux_oracle",    ["oracle", /^ol/]],
     ["linux_photon",    %w[photon]],
     ["linux_generic",   %w[linux]],
     ["unix_aix",        %w[aix vios]],
@@ -79,7 +79,10 @@ class OperatingSystem < ApplicationRecord
     clean_os_name = os_name.downcase.gsub(/[^a-z0-9]/, "")
     OS_MAP.each do |normalized_name, candidate_names|
       candidate_names.each do |candidate|
-        return normalized_name if clean_os_name.include?(candidate)
+        if (candidate.kind_of?(String) && clean_os_name.include?(candidate)) ||
+           (candidate.kind_of?(Regexp) && clean_os_name.match?(candidate))
+          return normalized_name
+        end
       end
     end
     "unknown"

--- a/spec/models/operating_system_spec.rb
+++ b/spec/models/operating_system_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe OperatingSystem do
       "linux debian"               => "linux_debian",
       "redhat coreos"              => "linux_coreos",
       "rhcos-4.11.2"               => "linux_coreos",
+      "ol_8x64"                    => "linux_oracle",
+      "oracle"                     => "linux_oracle"
     }.each do |image, expected|
       it "normalizes #{image}" do
         expect(described_class.normalize_os_name(image)).to eq(expected)


### PR DESCRIPTION
oVirt is returning `ol_8x64` and `ol_9x64` which is not being recognized as Oracle

For this issue: https://github.com/ManageIQ/manageiq-providers-ovirt/issues/683

```
3.1.3 :002 > OperatingSystem.normalize_os_name("ol_8x64")
 => "linux_oracle" 
```

@miq-bot add_label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @agrare, @Fryguy 