### PR TITLE
Add a shared vcr spec helper for access to secrets

### DIFF
--- a/spec/shared/cassette_secrets_helper.rb
+++ b/spec/shared/cassette_secrets_helper.rb
@@ -1,0 +1,32 @@
+module Spec
+  module Shared
+    module CassetteSecretsHelper
+      DEFAULT_VCR_SECRETS_PATH = Pathname.new(Dir.pwd).join("config/secrets.defaults.yml")
+      VCR_SECRETS_PATH         = Pathname.new(Dir.pwd).join("config/secrets.yml")
+
+      def load_vcr_secrets(pathname)
+        if pathname.exist?
+          YAML.load_file(pathname)
+        else
+          {}
+        end
+      end
+
+      def default_vcr_secrets
+        @default_vcr_secrets ||= load_vcr_secrets(DEFAULT_VCR_SECRETS_PATH)
+      end
+
+      def vcr_secrets
+        @vcr_secrets ||= load_vcr_secrets(VCR_SECRETS_PATH)
+      end
+
+      def default_vcr_secret_by_key_path(*args)
+        default_vcr_secrets.dig(*args)
+      end
+
+      def vcr_secret_by_key_path(*args)
+        vcr_secrets.dig(*args) || default_vcr_secret_by_key_path(*args)
+      end
+    end
+  end
+end

--- a/spec/shared/cassette_secrets_helper.rb
+++ b/spec/shared/cassette_secrets_helper.rb
@@ -1,8 +1,15 @@
 module Spec
   module Shared
     module CassetteSecretsHelper
-      DEFAULT_VCR_SECRETS_PATH = Pathname.new(Dir.pwd).join("config/secrets.defaults.yml")
-      VCR_SECRETS_PATH         = Pathname.new(Dir.pwd).join("config/secrets.yml")
+      def default_vcr_secrets_path
+        Pathname.new(Dir.pwd).join("config/secrets.defaults.yml").tap do |path|
+          raise "Default vcr cassette secrets not found: #{path}! Create this file with placeholder secrets to be used in cassettes to avoid leaking actual secrets." unless path.exist?
+        end
+      end
+
+      def vcr_secrets_path
+        Pathname.new(Dir.pwd).join("config/secrets.yml")
+      end
 
       def load_vcr_secrets(pathname)
         if pathname.exist?
@@ -13,11 +20,11 @@ module Spec
       end
 
       def default_vcr_secrets
-        @default_vcr_secrets ||= load_vcr_secrets(DEFAULT_VCR_SECRETS_PATH)
+        @@default_vcr_secrets ||= load_vcr_secrets(default_vcr_secrets_path)
       end
 
       def vcr_secrets
-        @vcr_secrets ||= load_vcr_secrets(VCR_SECRETS_PATH)
+        @@vcr_secrets ||= load_vcr_secrets(vcr_secrets_path)
       end
 
       def default_vcr_secret_by_key_path(*args)


### PR DESCRIPTION
Note: rails secrets are deprecated and some features are actually removed in rails 7.1.  This PR allows us to use plain text files for use for dev environments with an easy mechanism for sanitizing the real credentials with fake values to be used as placeholders in the vcr cassettes.

Here's one provider using this feature: https://github.com/ManageIQ/manageiq-providers-vmware/pull/928

We need a way to sanitize actual secrets with fake and consistent values so tests are reliable.  This mechanism must allow us to provide overide values with real secrets when we're actually recording new or updated cassettes.

For now, we're reusing the existing mechanism of specifying the secrets:

* relative to the current directory - we run specs for plugins from the plugin's directory
* config/secrets.yml - actual secrets
* config/secrets.defaults.yml - defaults for sanitizing real values with consistent repeatable replacements

Plugins can use this mechanism by adding:

Object.include Spec::Shared::CassetteSecretsHelper to their spec_helper.rb.

You can then access these values via helper methods with interfaces like below:

default_vcr_secret_by_key_path(:vmware_infra, :hostname) vcr_secret_by_key_path(:vmware_tanzu, :hostname)

Each plugin should define their own:
config/secrets.default.yml, which can look something like this:

```
---
:vmware_cloud:
  :host: vmwarecloudhost
  :userid: VMWARE_CLOUD_USERID
  :password: VMWARE_CLOUD_PASSWORD
:vmware_infra:
  :hostname: HOSTNAME
:vmware_tanzu:
  :hostname: vmware-tanzu-hostname
  :userid: VMWARE_TANZU_USERID
  :password: VMWARE_TANZU_PASSWORD

```

Developers can then copy this file to config/secrets.yml and provide actual values for each of the keys.

When recording, the cassettes will use the real values for connecting to environments, but store the resulting placeholder using the fake value for that key from the defaults.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
