### PR TITLE
Fix metric/ci_mixin_spec using kubevirt vm

### DIFF
--- a/spec/models/metric/ci_mixin_spec.rb
+++ b/spec/models/metric/ci_mixin_spec.rb
@@ -63,26 +63,4 @@ RSpec.describe Metric::CiMixin do
       end
     end
   end
-
-  context "#supports?(:capture)" do
-    context "with a VM" do
-      let(:unsupported_vm) { FactoryBot.create(:vm_kubevirt) }
-      let(:supported_vm)   { FactoryBot.create(:vm_vmware) }
-
-      it "correctly checks capture support" do
-        expect(unsupported_vm.supports?(:capture)).to be_falsy
-        expect(supported_vm.supports?(:capture)).to be_truthy
-      end
-    end
-
-    context "with a Host" do
-      let(:unsupported_host) { FactoryBot.create(:ibm_power_hmc_host) }
-      let(:supported_host)   { FactoryBot.create(:host_vmware) }
-
-      it "correctly checks capture support" do
-        expect(unsupported_host.supports?(:capture)).to be_falsy
-        expect(supported_host.supports?(:capture)).to be_truthy
-      end
-    end
-  end
 end


### PR DESCRIPTION
The metric/ci_mixin_spec was using a kubeivrt vm as an example of a class which doesn't support capture.

This is no longer accurate as we have added C&U support for kubevirt, plus we shouldn't be using provider plugin classes in core specs so use stub_supports instead.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
