### PR TITLE
Use foreign_key on the base model's name if ems_events association doesn't exist

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -204,6 +204,12 @@ class EmsCluster < ApplicationRecord
     cond_params
   end
 
+  # TODO: ems_events already exists as a method but it uses
+  # event_where_clause which tacks on additional possibly expensive queries
+  # such as all events for all hosts or vms in the cluster.
+  # Should we move to looking at ems events specifically for the ems cluster?
+  # like this:
+  #   has_many :ems_events, :foreign_key => :ems_cluster_id
   def ems_events
     ewc = event_where_clause
     return [] if ewc.blank?

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -2,6 +2,9 @@ class HostAggregate < ApplicationRecord
   include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include Metric::CiMixin
+
+  # TODO: this model doesn't have an event_where_clause, doesn't have a *_id in event_streams but includes
+  # event mixin.  Track down if we need timeline events for this as they look to not be completely supported yet.
   include EventMixin
   include ProviderObjectMixin
 

--- a/app/models/mixins/event_mixin.rb
+++ b/app/models/mixins/event_mixin.rb
@@ -63,7 +63,7 @@ module EventMixin
 
   module ClassMethods
     def ems_event_filter_column
-      @ems_event_filter_column ||= reflect_on_association(:ems_events).try(:foreign_key) || name.foreign_key
+      @ems_event_filter_column ||= reflect_on_association(:ems_events).try(:foreign_key) || base_model.name.foreign_key
     end
 
     def miq_event_filter_column

--- a/app/models/physical_server_profile.rb
+++ b/app/models/physical_server_profile.rb
@@ -4,6 +4,9 @@ class PhysicalServerProfile < ApplicationRecord
   include NewWithTypeStiMixin
   include TenantIdentityMixin
   include SupportsFeatureMixin
+
+  # TODO: this model doesn't have an event_where_clause, doesn't have a *_id in event_streams but includes
+  # event mixin.  Track down if we need timeline events for this as they look to not be completely supported yet.
   include EventMixin
   include ProviderObjectMixin
   include EmsRefreshMixin

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -9,7 +9,11 @@ class PhysicalSwitch < Switch
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => :resource
   has_one :hardware, :dependent => :destroy, :foreign_key => :switch_id, :inverse_of => :physical_switch
   has_many :physical_network_ports, :dependent => :destroy, :foreign_key => :switch_id
+
+  # TODO: Deprecate event_streams if it makes sense, find callers, and change to use ems_events.  Even though event_streams
+  # have only ever been ems_events in this model, we shouldn't rely on that, so callers should use ems_events.
   has_many :event_streams, :inverse_of => :physical_switch, :dependent => :nullify
+  has_many :ems_events, :inverse_of => :physical_switch, :dependent => :nullify
 
   has_many :connected_components, :through => :physical_network_ports, :source => :connected_computer_system
 


### PR DESCRIPTION
`EmsCluster#ems_event_filter_column` was correctly `ems_cluster_id`,
subclasses were wrong as it returned `cluster_id` as the column.

Fix `PhysicalSwitch` to correctly implement `ems_events` association. Previously,
it assumed `event_streams` association was the same as `ems_events` just because
all `event_streams` for that model have always been ems events.  Instead, we
implement `event_streams` association so we can correctly detect the foreign
key in `ems_event_filter_column`.

Fix tests to test descendant classes so we can recreate and verify the fix for `EmsCluster`
base class and subclasses.  Add `HostAggregate` and `PhysicalServerProfile` to pending list
as they include the mixin but don't implement the interface (`event_where_clause`, _id column, no `ems_events` association).

Fixes a UI timeline bug shown for Ems clusters as seen below:

![image](https://github.com/user-attachments/assets/416563d2-8e2f-4250-bc88-497818a3c323)

Background: https://github.com/ManageIQ/manageiq/pull/22361 (see the table of models and desired values for ems_event_filter_column and miq_event_filter_column.)
