### PR TITLE
Remove unnecessary test failing on rails 7.1.

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -757,14 +757,6 @@ RSpec.describe MiqExpression do
         sql, * = exp.to_sql
         expect(sql).to eq("\"vms\".\"last_scan_on\" BETWEEN '2011-01-10 08:00:00' AND '2011-01-10 17:00:00'")
       end
-
-      it "generates the SQL for a FROM expression with two identical datetimes" do
-        exp = MiqExpression.new(
-          "FROM" => {"field" => "Vm-last_scan_on", "value" => ["2011-01-10 00:00", "2011-01-10 00:00"]}
-        )
-        sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"last_scan_on\" BETWEEN '2011-01-10 00:00:00' AND '2011-01-10 00:00:00'")
-      end
     end
 
     context "relative date/time support" do


### PR DESCRIPTION
Rails 7.1 detects this as a useless between clause, changing it to a simple = operator with the timestamp value.

It was originally added in 6a94a1d93b801f88 #7075 and it seems it was only to capture the current behavior at the time.  I think it's testing internals of rails and not really important for testing behavior of MiqExpression.

In rails 7.1, it was failing with:

       expected: "\"vms\".\"last_scan_on\" BETWEEN '2011-01-10 00:00:00' AND '2011-01-10 00:00:00'"
            got: "\"vms\".\"last_scan_on\" = '2011-01-10 00:00:00'"

Extracted from #23225

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
