### PR TITLE
[MORPHY] Resolve Rack CVE through 2024

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "pg",                                                    :require => false
 gem "pg-dsn_parser",                    "~>0.1.0",           :require => false
 gem "psych",                            "~>3.1",             :require => false # This can be dropped once we drop ruby 2.5
 gem "query_relation",                   "~>0.1.0",           :require => false
+gem "rack",                             "~>2.2", ">=2.2.10", :require => false # indirect dependency for CVE-2024-26146 (among others)
 gem "rack-attack",                      "~>6.5.0",           :require => false
 gem "rails",                            "~>6.0.4", ">=6.0.5.1"
 gem "rails-i18n",                       "~>6.x"

--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -924,7 +924,7 @@ GEM
       more_core_extensions
     raabro (1.4.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.10)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
     rack-test (1.1.0)
@@ -1244,6 +1244,7 @@ DEPENDENCIES
   puma (~> 4.2)
   qpid_proton (~> 0.30.0)
   query_relation (~> 0.1.0)
+  rack (~> 2.2, >= 2.2.10)
   rack-attack (~> 6.5.0)
   rails (~> 6.0.4, >= 6.0.5.1)
   rails-i18n (~> 6.x)


### PR DESCRIPTION
cve             | severity | resolved
---|---|---
CVE-2022-30123  | critical | rack 2.2.3.1
CVE-2022-30122  | high     | rack 2.2.3.1
CVE-2022-44570  | high     | rack 2.2.6.1
CVE-2022-44571  | high     | rack 2.2.6.1
CVE-2022-44572  | high     | rack 2.2.4.1
CVE-2023-27530  | high     | rack 2.2.6.3
CVE-2023-27539  | low      | rack 2.2.6.5 (only 2.2.6.4, 3.0.6.1)
CVE-2024-25126  | low      | not in 2.x
CVE-2024-26141  | low      | not in 2.x
CVE-2024-26146  | low      | rack 2.2.8.1

We could not upgraded to `rack 3.x` since necessary `activerecord-session_store` change requires `rails 6.1`

