### PR TITLE
Call sync_from_system before_sync_workers at startup

### DIFF
--- a/app/models/miq_server/worker_management.rb
+++ b/app/models/miq_server/worker_management.rb
@@ -41,6 +41,7 @@ class MiqServer::WorkerManagement
     clean_heartbeat_files # Appliance specific
     sync_config
     start_drb_server
+    sync_from_system
     sync_workers
     wait_for_started_workers
   end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/23112 allowed non-rails workers to be marked as started even if they didn't go through run_single_worker with database access, specifically the opentofu-worker.

The issue here is that the threads which keep the list of current deployments and pods up to date are not started by `MiqServer#start_workers`, rather only the initial startup has completed and MiqServer has moved to the `MiqServer#monitor_workers` loop.  The result of this was everything worked if the server was started with the embedded_terraform role disabled and the role was enabled later, but if the role was enabled at startup the `wait_for_started_workers` would never complete and timeout.

Fixes https://github.com/ManageIQ/manageiq-providers-embedded_terraform/issues/81

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
