### PR TITLE
Pin concurrent-ruby to < 1.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>5.1",             :require => false
 gem "connection_pool",                                       :require => false # For Dalli
+gem "concurrent-ruby",                  "< 1.3.5",           :require => false # Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 7.0, and rails-core doesn't
+                                                                               # plan to ship a new 7.0 to fix it. See https://github.com/rails/rails/pull/54264
 gem "dalli",                            "~>3.2.3",           :require => false
 gem "default_value_for",                "~>4.0"
 gem "docker-api",                       "~>1.33.6",          :require => false


### PR DESCRIPTION
Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 7.0, and rails-core doesn't plan to ship a new 7.0 to fix it. See https://github.com/rails/rails/pull/54264

@jrafanie Please review.