### PR TITLE
deprecate attribute no longer uses virtual attribute

### DIFF
--- a/app/models/mixins/deprecation_mixin.rb
+++ b/app/models/mixins/deprecation_mixin.rb
@@ -17,7 +17,6 @@ module DeprecationMixin
 
     def deprecate_attribute(old_attribute, new_attribute, type:)
       deprecate_attribute_methods(old_attribute, new_attribute)
-      virtual_attribute(old_attribute, type)
       hide_attribute(old_attribute)
     end
 


### PR DESCRIPTION
virtual_attribute marked the attribute for discovery we have modified discovery to include aliases so it is no longer necessary

Depends upon:
- [x] https://github.com/ManageIQ/manageiq/pull/23324
- [x] https://github.com/ManageIQ/manageiq-api/pull/1278
- [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/565

Can be merged without those, but need them to ensure the attributes are still exposed in automate and the api