### PR TITLE
Include the GHSA number when sorting npm excludes

### DIFF
--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -166,7 +166,7 @@ class TestSecurityHelper
         end
 
         values
-        .sort_by { |v| YARN_AUDIT_SEVERITY_SORT.index(v[1]) || Float::MAX }
+        .sort_by { |v| [YARN_AUDIT_SEVERITY_SORT.index(v[1]) || Float::MAX, v[2]] } # Sort by severity, then by the GHSA number, for consistency
         .tableize(:header => false)
         .lines
         .map { |l| l.sub(/^ /, "# ") }


### PR DESCRIPTION
This allows for a more consistent sorting when running multiple times.

@jrafanie Please review. This is minor, but it allows for a more stable sort in the other repos.