### PR TITLE
introduce all_attribute_names

### DIFF
--- a/lib/extensions/ar_visible_attribute.rb
+++ b/lib/extensions/ar_visible_attribute.rb
@@ -15,10 +15,16 @@ module ArVisibleAttribute
       self.hidden_attribute_names += [attribute.to_s]
     end
 
+    # @return Array[String] name of hidden and attributes visible in the api
+    # This includes both attribute names and column aliases
+    def all_attribute_names
+      attribute_names | (try(:attribute_aliases)&.keys || [])
+    end
+
     # @return Array[String] attribute names that can be advertised in the api and reporting
     # Other attributes are accessible, they are just no longer in our public api (or never were)
     def visible_attribute_names
-      attribute_names - hidden_attribute_names
+      all_attribute_names - hidden_attribute_names
     end
   end
 end

--- a/spec/lib/extensions/ar_visible_attribute_spec.rb
+++ b/spec/lib/extensions/ar_visible_attribute_spec.rb
@@ -94,4 +94,15 @@ RSpec.describe ArVisibleAttribute do
       end
     end
   end
+
+  context ".all_attribute_names" do
+    it "returns columns" do
+      expect(klass.all_attribute_names).to include("name")
+    end
+
+    it "returns aliases" do
+      klass.alias_attribute :name2, :name
+      expect(klass.all_attribute_names).to include("name2")
+    end
+  end
 end


### PR DESCRIPTION
## Before

`attribute_alias` values do not show up in `attribute_names`, so they are not discoverable.

## After

`all_attribute_names` show attributes and aliases and can be used for api and automate methods.

## See Also

- https://github.com/ManageIQ/manageiq/pull/23321
- https://github.com/ManageIQ/manageiq-automation_engine/pull/565
- https://github.com/ManageIQ/manageiq-api/pull/1278