### PR TITLE
Fix issue where brakeman does not detect lockfile correctly from engines

### DIFF
--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -24,6 +24,14 @@ class TestSecurityHelper
     puts "**   engines:"
     puts "**   - #{engine_paths.join("\n**   - ")}"
 
+    # Brakeman's Gemfile detection does not work properly with engines
+    #   Brakeman detects the Gemfile.lock from the application root directory,
+    #   however when running from an engine the lockfile is in the engine
+    #   directory. So, we copy the Gemfile.lock into the application directory.
+    if defined?(ENGINE_ROOT)
+      FileUtils.cp(File.join(ENGINE_ROOT, "Gemfile.lock"), File.join(app_path, "Gemfile.lock"))
+    end
+
     # See all possible options here:
     #   https://brakemanscanner.org/docs/brakeman_as_a_library/#using-options
     options = {


### PR DESCRIPTION
@jrafanie Please review.  This should allow ui-classic to go green.

This is admittedly a hack, but the alternative is to patch brakeman's process_gems method, which feels riskier. Note that in an upcoming brakeman, there is a [patch to be able to pass the BUNDLE_GEMFILE](https://github.com/presidentbeef/brakeman/pull/1912), which might be a possible way to solve this better.