### PR TITLE
Drop cgi from the Gemfile as the default in ruby 3.1.3 and 3.3 has the CVE fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby ">= 3.1.1", "< 3.5.0"
+ruby ">= 3.1.3", "< 3.5.0"
 warn "Ruby versions >= 3.4.0 are untested!" if RUBY_VERSION >= "3.4.0"
 source 'https://rubygems.org'
 
@@ -88,8 +88,6 @@ gem "terminal",                                              :require => false
 gem "wim_parser",                       "~>1.0",             :require => false
 
 # gems to resolve security issues
-# CVE-2021-33621 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-vc47-6rqg-c7f5
-gem "cgi",  "~> 0.3.5"
 # CVE-2023-28756 fixed: ruby 3.1.4 - https://github.com/advisories/GHSA-fg7x-g82r-94qc
 gem "time", "~> 0.2.2"
 # CVE-2023-36617 https://github.com/advisories/GHSA-hww2-5g85-429m


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
