### PR TITLE
Specify the FQ class name for the provisioning manager

### DIFF
--- a/app/models/operating_system_flavor.rb
+++ b/app/models/operating_system_flavor.rb
@@ -1,6 +1,6 @@
 class OperatingSystemFlavor < ApplicationRecord
   acts_as_miq_taggable
-  belongs_to :provisioning_manager
+  belongs_to :provisioning_manager, :class_name => "ManageIQ::Providers::ProvisioningManager"
 
   has_and_belongs_to_many :customization_scripts
   has_and_belongs_to_many :customization_script_ptables,


### PR DESCRIPTION
Rails 7.1 added validations here that raise in the foreman provider specs. This commit resolves it for those specs:

```
    3) ManageIQ::Providers::Foreman::Provider#destroy will remove all child objects
       Failure/Error: provider.provisioning_manager.operating_system_flavors =

       NameError:
         Missing model class ProvisioningManager for the OperatingSystemFlavor#provisioning_manager association. You can specify a different model class with the :class_name option.
       # ./spec/models/manageiq/providers/foreman/provider_spec.rb:50:in `block (3 levels) in <top (required)>'
       # ------------------
       # --- Caused by: ---
       # NameError:
       #   uninitialized constant OperatingSystemFlavor::ProvisioningManager
       #   ./spec/models/manageiq/providers/foreman/provider_spec.rb:50:in `block (3 levels) in <top (required)>'
```
 Extracted from https://github.com/ManageIQ/manageiq/pull/23225

- [ ] [Cross repo test](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/946)