### PR TITLE
Avoid calling MiqQueue.messaging_client and stub it as missing

### DIFF
--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe EmsEvent do
             :args        => [event_hash],
           }
 
+          expect(MiqQueue).to receive(:messaging_client).with('event_handler').and_return(nil)
           expect(MiqQueue).to receive(:submit_job).with(expected_queue_payload)
 
           described_class.add_queue('add', ems.id, event_hash)


### PR DESCRIPTION
This is a rails 7.1 related change.  The code path changes in rails 7.1 so we need to make sure we're not actually trying to call the real queue messaging client in this test.

extracted from https://github.com/ManageIQ/manageiq/pull/23225