### PR TITLE
Rails 7.1 friendly attribute changes

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -1,11 +1,17 @@
 class AutomationRequest < MiqRequest
-  alias_attribute :automation_tasks, :miq_request_tasks
-
   TASK_DESCRIPTION  = N_('Automation Request')
   DEFAULT_NAMESPACE = "SYSTEM"
   DEFAULT_CLASS     = "PROCESS"
   DEFAULT_INSTANCE  = "AUTOMATION_REQUEST"
   SOURCE_CLASS_NAME = nil
+
+  def automation_tasks
+    miq_request_tasks
+  end
+
+  def automation_tasks=(objects)
+    self.miq_request_tasks = objects
+  end
 
   ##############################################
   # uri_parts:  instance=IIII|message=MMMM or any subset thereof

--- a/app/models/automation_task.rb
+++ b/app/models/automation_task.rb
@@ -1,6 +1,13 @@
 class AutomationTask < MiqRequestTask
-  alias_attribute :automation_request, :miq_request
   AUTOMATE_DRIVES = false
+
+  def automation_request
+    miq_request
+  end
+
+  def automation_request=(object)
+    self.miq_request = object
+  end
 
   def self.get_description(_request_obj)
     "Automation Task"

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -305,7 +305,6 @@ class ExtManagementSystem < ApplicationRecord
   virtual_sum :total_cloud_memory, :vms,   :ram_size
 
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
-  alias_attribute :to_s, :name
 
   default_value_for :enabled, true
 
@@ -421,6 +420,10 @@ class ExtManagementSystem < ApplicationRecord
     else
       name
     end
+  end
+
+  def to_s
+    name
   end
 
   def self.base_manager

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -17,9 +17,6 @@ class Flavor < ApplicationRecord
   alias_attribute :cpus, :cpu_total_cores
   alias_attribute :cpu_cores, :cpu_cores_per_socket
 
-  virtual_column :cpus, :type => :integer
-  virtual_column :cpu_cores, :type => :integer
-
   def name_with_details
     details = if cpus == 1
                 if root_disk_size.nil?

--- a/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
@@ -4,8 +4,6 @@ class ManageIQ::Providers::EmbeddedAutomationManager::Authentication < ManageIQ:
   # other models
 
   alias_attribute :manager_id, :resource_id
-  alias_attribute :manager, :resource
-
   after_create :set_manager_ref
 
   supports :create
@@ -15,6 +13,14 @@ class ManageIQ::Providers::EmbeddedAutomationManager::Authentication < ManageIQ:
   COMMON_ATTRIBUTES = {}.freeze
   EXTRA_ATTRIBUTES = {}.freeze
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  def manager
+    resource
+  end
+
+  def manager=(object)
+    self.resource = object
+  end
 
   def self.display_name(number = 1)
     n_('Credential', 'Credentials', number)

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -16,23 +16,42 @@ class MiqProvision < MiqProvisionTask
   include StateMachine
   include Tagging
 
-  alias_attribute :miq_provision_request, :miq_request   # Legacy provisioning support
-  alias_attribute :provision_type,        :request_type  # Legacy provisioning support
-  alias_attribute :vm,                    :destination
-  alias_attribute :vm_template,           :source
-
+  alias_attribute :provision_type,        :request_type # Legacy provisioning support
   before_create :set_template_and_networking
 
   virtual_belongs_to :miq_provision_request  # Legacy provisioning support
   virtual_belongs_to :vm
   virtual_belongs_to :vm_template
   virtual_column     :placement_auto, :type => :boolean
-  virtual_column     :provision_type, :type => :string  # Legacy provisioning support
 
   scope :with_miq_request_id, ->(request_id) { where(:miq_request_id => request_id) }
 
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
+
+  def miq_provision_request
+    miq_request
+  end
+
+  def miq_provision_request=(object)
+    self.miq_request = object
+  end
+
+  def vm
+    destination
+  end
+
+  def vm=(object)
+    self.destination = object
+  end
+
+  def vm_template
+    source
+  end
+
+  def vm_template=(object)
+    self.source = object
+  end
 
   def self.base_model
     MiqProvision

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -1,7 +1,5 @@
 class MiqProvisionRequest < MiqRequest
-  alias_attribute :vm_template,    :source
   alias_attribute :provision_type, :request_type
-  alias_attribute :miq_provisions, :miq_request_tasks
   alias_attribute :src_vm_id,      :source_id
 
   delegate :my_zone, :to => :source
@@ -20,10 +18,24 @@ class MiqProvisionRequest < MiqRequest
   default_value_for(:source_id)    { |r| r.get_option(:src_vm_id) || r.get_option(:source_id) }
   default_value_for :source_type,  "VmOrTemplate"
 
-  virtual_column :provision_type, :type => :string
-
   include MiqProvisionMixin
   include MiqProvisionQuotaMixin
+
+  def vm_template
+    source
+  end
+
+  def vm_template=(object)
+    self.source = object
+  end
+
+  def miq_provisions
+    miq_request_tasks
+  end
+
+  def miq_provisions=(objects)
+    self.miq_request_tasks = objects
+  end
 
   def self.request_task_class_from(attribs)
     source_id = MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -51,7 +51,6 @@ class MiqRequest < ApplicationRecord
   virtual_column  :v_workflow_class,     :type => :string,   :uses => :workflow
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
-  virtual_column  :state,                :type => :string
 
   delegate :allowed_tags,                :to => :workflow,   :prefix => :v,  :allow_nil => true
   delegate :class,                       :to => :workflow,   :prefix => :v_workflow

--- a/app/models/mixins/deprecation_mixin.rb
+++ b/app/models/mixins/deprecation_mixin.rb
@@ -21,7 +21,9 @@ module DeprecationMixin
     end
 
     def deprecate_attribute_methods(old_attribute, new_attribute)
-      alias_attribute old_attribute, new_attribute
+      define_method(old_attribute) { self.send(new_attribute) }
+      define_method("#{old_attribute}=") { |object| self.send("#{new_attribute}=", object) }
+      define_method("#{old_attribute}?") { self.send("#{new_attribute}?") }
       ["", "=", "?"].each { |suffix| Vmdb::Deprecation.deprecate_methods(self, "#{old_attribute}#{suffix}" => "#{new_attribute}#{suffix}") }
     end
   end

--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -5,10 +5,17 @@ class PersistentVolume < ContainerVolume
   delegate :name, :to => :parent, :prefix => true, :allow_nil => true
   has_many :container_volumes, -> { where(:type => 'ContainerVolume') }, :through => :persistent_volume_claim
   has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'
-  alias_attribute :container_groups, :parents
 
   virtual_attribute :parent_name, :string
   virtual_attribute :storage_capacity, :string
+
+  def container_groups
+    parents
+  end
+
+  def container_groups=(objects)
+    self.parents = objects
+  end
 
   def storage_capacity
     capacity[:storage]

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -22,7 +22,13 @@ class PhysicalSwitch < Switch
            :through     => :connected_components,
            :source      => :managed_entity
 
-  alias_attribute :physical_servers, :connected_physical_servers
+  def physical_servers
+    connected_physical_servers
+  end
+
+  def physical_servers=(objects)
+    self.connected_physical_servers = objects
+  end
 
   def my_zone
     ems = ext_management_system

--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -1,6 +1,5 @@
 class ResourceGroup < ApplicationRecord
   acts_as_miq_taggable
-  alias_attribute :images, :templates
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
 
@@ -13,4 +12,12 @@ class ResourceGroup < ApplicationRecord
   has_many :cloud_networks, :dependent => :nullify
   has_many :network_ports, :dependent => :nullify
   has_many :security_groups, :dependent => :nullify
+
+  def images
+    templates
+  end
+
+  def images=(objects)
+    self.templates = objects
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -104,9 +104,17 @@ class Service < ApplicationRecord
   supports :retire
 
   alias parent_service parent
-  alias_attribute :service, :parent
+
   deprecate_attribute :display, :visible, :type => :boolean
   virtual_belongs_to :service
+
+  def service
+    parent
+  end
+
+  def service=(object)
+    self.parent = object
+  end
 
   def power_states
     vms.map(&:power_state)

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -9,8 +9,6 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   after_create :process_service_order
 
-  alias_attribute :service_template, :source
-
   virtual_has_one :picture
   virtual_has_one :service_template
   virtual_has_one :provision_dialog
@@ -24,6 +22,14 @@ class ServiceTemplateProvisionRequest < MiqRequest
 
   alias_method :user, :get_user
   include MiqProvisionQuotaMixin
+
+  def service_template
+    source
+  end
+
+  def service_template=(object)
+    self.source = object
+  end
 
   def process_service_order
     if cancel_requested?

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -52,7 +52,6 @@ class TenantQuota < ApplicationRecord
   scope :templates_allocated, -> { where(:name => :templates_allocated) }
 
   virtual_column :name, :type => :string
-  virtual_column :total, :type => :integer
   virtual_column :used, :type => :float
   virtual_column :allocated, :type => :float
   virtual_column :available, :type => :float

--- a/app/models/vm_cloud_reconfigure_task.rb
+++ b/app/models/vm_cloud_reconfigure_task.rb
@@ -1,6 +1,4 @@
 class VmCloudReconfigureTask < MiqRequestTask
-  alias_attribute :vm, :source
-
   validate :validate_request_type, :validate_state
 
   AUTOMATE_DRIVES = false
@@ -23,6 +21,14 @@ class VmCloudReconfigureTask < MiqRequestTask
       name = req_obj.source.name
     end
     "#{request_class::TASK_DESCRIPTION} for: #{name}"
+  end
+
+  def vm
+    source
+  end
+
+  def vm=(object)
+    self.source = object
   end
 
   def after_request_task_create

--- a/app/models/vm_migrate_task.rb
+++ b/app/models/vm_migrate_task.rb
@@ -1,10 +1,16 @@
 class VmMigrateTask < MiqRequestTask
-  alias_attribute :vm, :source
-
   validate :validate_request_type, :validate_state
   default_value_for :request_type, "vm_migrate"
 
   AUTOMATE_DRIVES = true
+
+  def vm
+    source
+  end
+
+  def vm=(object)
+    self.source = object
+  end
 
   def self.base_model
     VmMigrateTask

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -1,9 +1,15 @@
 class VmReconfigureTask < MiqRequestTask
-  alias_attribute :vm, :source
-
   validate :validate_request_type, :validate_state
 
   AUTOMATE_DRIVES = false
+
+  def vm
+    source
+  end
+
+  def vm=(object)
+    self.source = object
+  end
 
   def self.base_model
     VmReconfigureTask

--- a/app/models/vm_retire_task.rb
+++ b/app/models/vm_retire_task.rb
@@ -1,6 +1,13 @@
 class VmRetireTask < MiqRetireTask
-  alias_attribute :vm, :source
   default_value_for :request_type, "vm_retire"
+
+  def vm
+    source
+  end
+
+  def vm=(object)
+    self.source = object
+  end
 
   def self.base_model
     VmRetireTask

--- a/spec/models/mixins/deprecation_mixin_spec.rb
+++ b/spec/models/mixins/deprecation_mixin_spec.rb
@@ -1,17 +1,5 @@
 RSpec.describe DeprecationMixin do
   # Host.deprecate_attribute :address, :hostname
-  context ".arel_table" do
-    # this is defining an alias
-    # it is not typical for aliases to work through arel_table
-    # may need to get rid of this in the future
-    it "works for deprecate_attribute columns" do
-      expect(Host.attribute_supported_by_sql?(:address)).to eq(true)
-      expect(Host.arel_table[:address]).to_not be_nil
-      expect(Host.arel_table[:address].name).to eq("hostname") # typically this is a symbol. not perfect but it works
-    end
-  end
-
-  # Host.deprecate_attribute :address, :hostname
   context ".visible_attribute_names" do
     it "hides deprecate_attribute columns" do
       expect(Host.visible_attribute_names).not_to include("address")


### PR DESCRIPTION
* alias_attribute on non-attributes, such as associations, produce a lot of warnings, will break in 7.2
* alias_method doesn't work on all associations due to rails 7.1 lazy method definition so we do runtime delegation to the original method.  Note, this may work depending on where you are in the class hierarchy but it's dangerous to assume the methods coming from other classes in the hierarchy are defined.
* remove virtuals on attributes that are handled by alias_attribute - it's redundant
(made possible by https://github.com/ManageIQ/manageiq/pull/23324, https://github.com/ManageIQ/manageiq-automation_engine/pull/565, https://github.com/ManageIQ/manageiq-api/pull/1278, https://github.com/ManageIQ/manageiq/pull/23321)

Extracted from https://github.com/ManageIQ/manageiq/pull/23225 to make it easier to review both this and the rails 7.1 PR separately.

- [x] 💚 [Cross repo on rails 7.0](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/948)