### PR TITLE
Numerics shouldn't be tested for ".bytes" like suffix

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -804,9 +804,10 @@ class MiqExpression
   def self.quote_human(val, typ)
     case typ&.to_sym
     when :integer, :decimal, :fixnum, :float
+      return val if val.kind_of?(Numeric)
       return val.to_i unless val.to_s.number_with_method? || typ == :float
 
-      if val =~ /^([0-9.,]+)\.([a-z]+)$/
+      if val.to_s =~ /^([0-9.,]+)\.([a-z]+)$/
         val, sfx = $1, $2
         if sfx.ends_with?("bytes") && FORMAT_BYTE_SUFFIXES.key?(sfx.to_sym)
           "#{val} #{FORMAT_BYTE_SUFFIXES[sfx.to_sym]}"

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -805,17 +805,13 @@ class MiqExpression
     case typ&.to_sym
     when :integer, :decimal, :fixnum, :float
       return val if val.kind_of?(Numeric)
-      return val.to_i unless val.to_s.number_with_method? || typ == :float
+      return val.to_i unless val.to_s.number_with_method?
 
-      if val.to_s =~ /^([0-9.,]+)\.([a-z]+)$/
-        val, sfx = $1, $2
-        if sfx.ends_with?("bytes") && FORMAT_BYTE_SUFFIXES.key?(sfx.to_sym)
-          "#{val} #{FORMAT_BYTE_SUFFIXES[sfx.to_sym]}"
-        else
-          "#{val} #{sfx.titleize}"
-        end
+      val, sfx = String::NUMBER_WITH_METHOD_REGEX.match(val.to_s).captures
+      if sfx.ends_with?("bytes") && FORMAT_BYTE_SUFFIXES.key?(sfx.to_sym)
+        "#{val} #{FORMAT_BYTE_SUFFIXES[sfx.to_sym]}"
       else
-        val
+        "#{val} #{sfx.titleize}"
       end
     when :string, :date, :datetime, nil
       "\"#{val}\""

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2428,6 +2428,11 @@ RSpec.describe MiqExpression do
       expect(exp.to_human).to eq("VM and Instance.Hardware.Volumes : Free Space Percent > 75")
     end
 
+    it "generates a human readable string for a float FIELD value expression" do
+      exp = MiqExpression.new(">" => {"field" => "Vm.hardware.volumes-free_space_percent", "value" => 75.0})
+      expect(exp.to_human).to eq("VM and Instance.Hardware.Volumes : Free Space Percent > 75.0")
+    end
+
     it "generates a human readable string for a symbol FIELD value expression" do
       exp = MiqExpression.new(">" => {"field" => "Vm-allocated_disk_storage", "value" => :"5.megabytes"})
       expect(exp.to_human).to eq("VM and Instance : Allocated Disk Storage > 5 MB")

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2423,6 +2423,16 @@ RSpec.describe MiqExpression do
       expect(exp.to_human).to eq("COUNT OF Snaps > 1")
     end
 
+    it "generates a human readable string for a numeric FIELD value expression" do
+      exp = MiqExpression.new(">" => {"field" => "Vm.hardware.volumes-free_space_percent", "value" => 75})
+      expect(exp.to_human).to eq("VM and Instance.Hardware.Volumes : Free Space Percent > 75")
+    end
+
+    it "generates a human readable string for a symbol FIELD value expression" do
+      exp = MiqExpression.new(">" => {"field" => "Vm-allocated_disk_storage", "value" => :"5.megabytes"})
+      expect(exp.to_human).to eq("VM and Instance : Allocated Disk Storage > 5 MB")
+    end
+
     context "TAG type expression" do
       before do
         # tags contain the root tenant's name


### PR DESCRIPTION
Symbols or other non-strings should be converted to strings before testing the regex.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/9357

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
