### PR TITLE
Set secret_key_base early enough for rails processes

### DIFF
--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -12,7 +12,6 @@ module MiqWebServerRunnerMixin
     # The heartbeating will be done in a separate thread
     worker_thread = Thread.new { super }
 
-    worker.class.configure_secret_token
     start_rails_server(worker.rails_server_options)
 
     # when puma exits allow the heartbeat thread to exit cleanly using #do_exit

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -18,25 +18,8 @@ module MiqWebServerWorkerMixin
       BINDING_ADDRESS
     end
 
-    def preload_for_console
-      configure_secret_token(SecureRandom.hex(64))
-    end
-
     def preload_for_worker_role
       raise "Expected database to be seeded via `rake db:seed`." unless EvmDatabase.seeded_primordially?
-
-      configure_secret_token
-    end
-
-    def configure_secret_token(token = MiqDatabase.first.session_secret_token)
-      return if Rails.application.config.secret_key_base
-
-      Rails.application.config.secret_key_base = token
-
-      # To set a secret token after the Rails.application is initialized,
-      # we need to reset the secrets since they are cached:
-      # https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/application.rb#L392-L404
-      Rails.application.secrets = nil if Rails.version < "7.1"
     end
 
     def rails_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -209,6 +209,11 @@ module Vmdb
       end
     end
 
+    # Run after code is eager loaded so we can autoload MiqDatabase and ApplicationRecord
+    initializer :init_secret_token, :after => :eager_load! do
+      Vmdb::Initializer.init_secret_token
+    end
+
     config.after_initialize do
       Vmdb::Initializer.init
       ActiveRecord::Base.connection_pool.release_connection

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -12,11 +12,18 @@ module Vmdb
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update(:status => "started")
       end
+    end
 
-      # Rails console needs session store configured
-      if defined?(Rails::Console)
-        MiqUiWorker.preload_for_console
+    def self.init_secret_token
+      return if Rails.application.config.secret_key_base
+
+      token = if ActiveRecord::Base.connectable? && MiqDatabase.table_exists? && MiqDatabase.any?
+        MiqDatabase.first.session_secret_token
+      else
+        SecureRandom.hex(64)
       end
+
+      Rails.application.config.secret_key_base = token
     end
 
     private_class_method def self.log_db_connectable

--- a/spec/lib/vmdb/initializer_spec.rb
+++ b/spec/lib/vmdb/initializer_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Vmdb::Initializer do
+  describe ".init_secret_token" do
+    before do
+      @token = Rails.application.secret_key_base
+    end
+
+    after do
+      Rails.application.config.secret_key_base = @token
+      Rails.application.secrets = nil
+    end
+
+    it "defaults to MiqDatabase session_secret_token" do
+      MiqDatabase.seed
+      Rails.application.config.secret_key_base = nil
+      Rails.application.secrets = nil
+
+      described_class.init_secret_token
+      expect(Rails.application.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
+      expect(Rails.application.config.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
+    end
+
+    it "uses random hex when MiqDatabase isn't seeded" do
+      Rails.application.config.secret_key_base = nil
+      Rails.application.secrets = nil
+
+      described_class.init_secret_token
+      expect(Rails.application.secret_key_base).to match(/^\h{128}$/)
+      expect(Rails.application.config.secret_key_base).to match(/^\h{128}$/)
+    end
+
+    it "does not reset secrets when token already configured" do
+      existing_value = SecureRandom.hex(64)
+      Rails.application.config.secret_key_base = existing_value
+      Rails.application.secrets = nil
+
+      described_class.init_secret_token
+      expect(Rails.application.secret_key_base).to eq(existing_value)
+      expect(Rails.application.config.secret_key_base).to eq(existing_value)
+    end
+  end
+end

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe MiqUiWorker do
 
   it "#preload_for_worker_role autoloads api collection classes and descendants" do
     allow(EvmDatabase).to receive(:seeded_primordially?).and_return(true)
-    expect(MiqUiWorker).to receive(:configure_secret_token)
     MiqUiWorker.preload_for_worker_role
     expect(defined?(ServiceAnsibleTower)).to be_truthy
   end

--- a/spec/models/miq_web_service_worker_spec.rb
+++ b/spec/models/miq_web_service_worker_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe MiqWebServiceWorker do
 
   it "preload_for_worker_role autoloads api collection classes and descendants" do
     allow(EvmDatabase).to receive(:seeded_primordially?).and_return(true)
-    expect(MiqWebServiceWorker).to receive(:configure_secret_token)
     MiqWebServiceWorker.preload_for_worker_role
     expect(defined?(ServiceAnsibleTower)).to be_truthy
   end

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -14,43 +14,6 @@ RSpec.describe MiqWebServerWorkerMixin do
     end
   end
 
-  before do
-    @token = Rails.application.secret_key_base
-    MiqDatabase.seed
-  end
-
-  after do
-    Rails.application.config.secret_key_base = @token
-    Rails.application.secrets = nil if Rails.version < "7.1"
-  end
-
-  it ".configure_secret_token defaults to MiqDatabase session_secret_token" do
-    Rails.application.config.secret_key_base = nil
-
-    test_class.configure_secret_token
-    expect(Rails.application.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
-    expect(Rails.application.config.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
-  end
-
-  it ".configure_secret_token accepts an input token" do
-    Rails.application.config.secret_key_base = nil
-
-    token = SecureRandom.hex(64)
-    test_class.configure_secret_token(token)
-    expect(Rails.application.secret_key_base).to eq(token)
-    expect(Rails.application.config.secret_key_base).to eq(token)
-  end
-
-  it ".configure_secret_token does not reset secrets when token already configured" do
-    existing_value = SecureRandom.hex(64)
-    Rails.application.config.secret_key_base = existing_value
-    Rails.application.secrets = nil if Rails.version < "7.1"
-
-    test_class.configure_secret_token
-    expect(Rails.application.secret_key_base).to eq(existing_value)
-    expect(Rails.application.config.secret_key_base).to eq(existing_value)
-  end
-
   it "#rails_server_options" do
     w = FactoryBot.create(:miq_ui_worker, :uri => "http://127.0.0.1:3000")
     expect(w.rails_server_options).to include(


### PR DESCRIPTION
We don't use secret_key_base like vanilla rails. We implemented secrets through MiqPassword before any of this existed in rails.  Our only things currently going through rails secrets perhaps is the provider vcr cassette information.

Rails 7.1 asserts secret_key_base is now set and set during rails boot fairly early.

So, now, we can't only set this for puma based workers, but all rails processes. We also, must move this logic to be done earlier during boot.  It was found that after eager load allows us to leverage autoload and access the database, both are required in order to fetch the secrets from the database.

Move over the logic for rails console so it can use a dummy secret key base.

Move the tests to a vmdb/initializer test.

Co-Authored-By: Jason Frey <fryguy9@gmail.com>

- [ ] [cross repo tests](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/950)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
