### PR TITLE
Bump rugged to 1.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "rest-client",                      "~>2.1.0",           :require => false
 gem "ruby_parser",                                           :require => false # Required for i18n string extraction, and DescentdantLoader (via prism)
 gem "ruby-progressbar",                 "~>1.7.0",           :require => false
 gem "rubyzip",                          "~>2.0.0",           :require => false
-gem "rugged",                           "~>1.5.0",           :require => false
+gem "rugged",                           "~>1.9",             :require => false
 gem "ruport",                           "~>1.8.0"
 gem "snmp",                             "~>1.2.0",           :require => false
 gem "sprockets",                        "~>3.7.2",           :require => false


### PR DESCRIPTION
Rugged 1.6.2 fixes a Ruby 3.2+ issue where warnings were emitted of the form

```
warning: undefining the allocator of T_DATA class Rugged::Repository
```

See https://github.com/libgit2/rugged/pull/935
Spassky run with the warnings: https://github.com/ManageIQ/manageiq/actions/runs/13552984631/job/37880823140#step:8:24

This was seen in the specs that used spec/support/fake_git_repo.rb and lib/git_worktree.rb.

@jrafanie Please review.
