### PR TITLE
Fix brakeman warnings

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -2,63 +2,22 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.0.8.7 ends on 2025-04-01",
-      "file": "Gemfile.lock",
-      "line": 1048,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": "Work is in progress to upgrade to Rails 7.1"
-    },
-    {
-      "warning_type": "Unmaintained Dependency",
       "warning_code": 123,
-      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "fingerprint": "870fa4a5cfd770898e1b7a159368b4210fe366634512563f9fb1c1cbbfef1d78",
       "check_name": "EOLRuby",
       "message": "Support for Ruby 3.1.6 ends on 2025-03-31",
       "file": "Gemfile.lock",
-      "line": 1471,
+      "line": 1518,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
       "code": null,
       "render_path": null,
       "location": null,
       "user_input": null,
-      "confidence": "Weak",
+      "confidence": "Medium",
       "cwe_id": [
         1104
       ],
       "note": "Ruby 3.1 is only in place as a backup. Ruby 3.3 is the shipped version."
-    },
-    {
-      "warning_type": "Cross-Site Request Forgery",
-      "warning_code": 86,
-      "fingerprint": "6301c055d2b1a4bc467bcd405b0ba295893f71df183eae355cd1a8b6c0ed0588",
-      "check_name": "ForgerySetting",
-      "message": "`protect_from_forgery` should be configured with `with: :exception`",
-      "file": "(engine:manageiq-ui-classic) app/controllers/application_controller.rb",
-      "line": 13,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/",
-      "code": "protect_from_forgery(:secret => SecureRandom.hex(64), :except => ([:authenticate, :external_authenticate, :kerberos_authenticate, :saml_login, :initiate_saml_login, :oidc_login, :initiate_oidc_login, :csp_report]), :with => :reset_session)",
-      "render_path": null,
-      "location": {
-        "type": "controller",
-        "controller": "ApplicationController"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        352
-      ],
-      "note": "This was intentionally changed from :exception to :reset_session in ManageIQ/manageiq-ui-classic#4901"
     },
     {
       "warning_type": "Command Injection",
@@ -84,6 +43,6 @@
       "note": "This method is safe because it verifies that the version is in the form #.#."
     }
   ],
-  "updated": "2025-02-03 15:35:46 -0500",
+  "updated": "2025-03-03 17:36:11 -0500",
   "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
Remove the Rails 7.0 and CSRF warnings now that we are on Rails 7.1.
Update the Ruby 3.1 warning with the new fingerprint.