### PR TITLE
Add interactive-ignore support through test:security:brakeman

### DIFF
--- a/lib/extensions/brakeman_fingerprint_patch.rb
+++ b/lib/extensions/brakeman_fingerprint_patch.rb
@@ -77,8 +77,6 @@ module BrakemanFingerprintPatch
   def to_hash(absolute_paths: true)
     super.tap do |h|
       h[:file] = (absolute_paths ? self.file.absolute : file_string)
-      h[:file_rel] = self.file.relative
-      h[:file_abs] = self.file.absolute
     end
   end
 end


### PR DESCRIPTION
Building the brakeman.ignore file requires us to have our patches in place so that the values are built correctly to have the right fingerprint. Thus, we can't just run brakeman -I directly. This change allows us to pass `-I` or `--interactive-ignore` to the rake task, which aids in updating the brakeman.ignore file.

@jrafanie Please review.