### PR TITLE
Upgrade rack gem CVE-2025-27111

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "prism",                            ">=0.25.0",          :require => false # Used by DescendantLoader
 gem "psych",                            ">=3.1",             :require => false # 3.1 safe_load changed positional to kwargs like aliases: true: https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd
 gem "query_relation",                   "~>0.1.0",           :require => false
-gem "rack",                             ">=2.2.6.4",         :require => false
+gem "rack",                             ">=2.2.12",          :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
 gem "rails",                            "~>7.1.5", ">=7.1.5.1"
 gem "rails-i18n",                       "~>7.x"


### PR DESCRIPTION
We're currently in the 2.2.x world
Radjabov `Gemfile.lock.release` points to 2.2.10 (vulnerable)

https://github.com/advisories/GHSA-8cgq-6mh2-7j6v

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
