### PR TITLE
Marshal/dump session objects

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -113,6 +113,8 @@ module Vmdb
     # FYI, this is where load_defaults is defined as of 7.2:
     # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
     config.load_defaults 7.1
+    # ensure MiqReport#extras will marshal/dump back out. 7.1 is default (and has better performance)
+    config.active_record.marshalling_format_version = 6.1
 
     # TODO: this is the only change we had from defaults in 7.0.  See secure_headers.rb.  It's 0 in defaults.
     config.action_dispatch.default_headers["X-XSS-Protection"] = "1; mode=block"

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -336,6 +336,13 @@ RSpec.describe MiqReport do
     expect(after.table).to eq(fake_ruport_data_table)
   end
 
+  it "serializes (marshall/dump) special columns" do
+    before = MiqReport.new.tap { |r| r.extras = {:working => true} }
+    # reports are put into session[:view]. ensure when it comes out of the session, we don't loose values
+    after = Marshal.load(Marshal.dump(before))
+    expect(after.extras).to eq(before.extras)
+  end
+
   it '.get_expressions_by_model' do
     FactoryBot.create(:miq_report, :conditions => nil)
     rep_nil = FactoryBot.create(:miq_report)


### PR DESCRIPTION
The MiqReport has a non AR value: extras.
Extras stores auth count, filename, and others.

7.1 serialization looses the extras variable.
rolling back to 6.1 allows us to keep these values

#Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/9369
