### PR TITLE
Don't blow up on missing assets in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,7 @@ Vmdb::Application.configure do
   config.action_controller.allow_forgery_protection = true
 
   config.assets.css_compressor = :sass
+
+  # Don't raise exceptions on missing assets
+  config.assets.unknown_asset_fallback = true
 end


### PR DESCRIPTION
In production, it's preferable for a missing asset to just gracefully show a broken image than to blow out the call stack and potentially break a page. This commit sets unknown_asset_fallback to true in production mode to avoid blowing up.

In development and test, we leave it as the default, which will continue to blow up, allowing us to find the missing assets.

@jrafanie Please review.  Related to https://github.com/ManageIQ/manageiq-ui-classic/issues/9355