### PR TITLE
Add a spec verifying all providers have a matching vendor asset

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -804,4 +804,12 @@ RSpec.describe ExtManagementSystem do
       expect(ems.supports_create_security_group).to be(true)
     end
   end
+
+  describe "#image_name", :providers_common => true do
+    described_class.concrete_subclasses.each do |klass|
+      it "has a vendor asset for #{klass.ems_type}" do
+        expect(ActionController::Base.helpers.asset_path("svg/vendor-#{klass.new.image_name}.svg")).to_not be_blank
+      end
+    end
+  end
 end


### PR DESCRIPTION
@agrare Please review. I chose concrete_subclasses, and there are 3 that are missing images. Is that the right choice, or should I use supported_types_for_create.  I thought the former was better because even if we can't create it, it can still appear and might need an image.