### PR TITLE
Update fix_auth verbiage

### DIFF
--- a/tools/fix_auth/auth_model.rb
+++ b/tools/fix_auth/auth_model.rb
@@ -102,8 +102,8 @@ module FixAuth
 
         puts "fixing #{table_name}.#{available_columns.join(", ")}" unless options[:silent]
         processed = 0
+        records_changed = 0
         errors = 0
-        would_make_changes = false
         contenders.each do |r|
           begin
             fix_passwords(r, options)
@@ -113,7 +113,7 @@ module FixAuth
                 display_column(r, column, options)
               end
             end
-            would_make_changes ||= r.changed?
+            records_changed += 1 if r.changed?
             r.save! if !options[:dry_run] && r.changed?
             processed += 1
           rescue ArgumentError # undefined class/module
@@ -127,9 +127,8 @@ module FixAuth
             puts "processed #{processed} with #{errors} errors"
           end
         end
-        puts "#{options[:dry_run] ? "viewed" : "processed"} #{processed} records" unless options[:silent]
+        puts "#{records_changed} of #{processed} records #{options[:dry_run] ? 'would change (dry run enabled)' : 'changed'}" unless options[:silent]
         puts "found #{errors} errors" if errors > 0 && !options[:silent]
-        puts "** This was executed in dry-run, and no actual changes will be made to #{table_name} **" if would_make_changes && options[:dry_run]
       end
 
       def clean_up

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -7,8 +7,9 @@ module FixAuth
     def parse(args, env = {})
       args.shift if args.first == "--" # Handle when called through script/runner
       self.options = Optimist.options(args) do
-        banner "Usage: ruby #{$PROGRAM_NAME} [options] database [...]\n" \
-               "       ruby #{$PROGRAM_NAME} [options] -P new_password database [...] to replace all passwords"
+        banner "Usage: #{File.basename($PROGRAM_NAME)} [options] database            # to migrate from a different or lost key\n" \
+               "       #{File.basename($PROGRAM_NAME)} -P new_password --databaseyml # to fix database.yml\n" \
+               "       #{File.basename($PROGRAM_NAME)} --key                         # to generate a new certs/v2_key "
 
         opt :verbose,  "Verbose",           :short => "v"
         opt :dry_run,  "Dry Run",           :short => "d"
@@ -16,15 +17,15 @@ module FixAuth
         opt :port,     "Database Port",     :type => :integer, :default => 5432
         opt :username, "Database Username", :type => :string,  :short => "U", :default => (env['PGUSER'] || "root")
         opt :password, "Database Password", :type => :string,  :short => "p", :default => env['PGPASSWORD']
-        opt :hardcode, "Password to use for all passwords",     :type => :string, :short => "P"
-        opt :invalid,  "Password to use for invalid passwords", :type => :string, :short => "i"
-        opt :key,      "Generate key",      :type => :boolean, :short => "k"
+        opt :hardcode, "Password used to replace all passwords", :type => :string, :short => "P"
+        opt :invalid,  "Password used to replace non-decryptable passwords", :type => :string, :short => "i"
+        opt :key,      "Generate encryption key", :type => :boolean, :short => "k"
         opt :v2,       "ignored, available for backwards compatibility", :type => :boolean, :short => "f"
         opt :root,     "Rails Root",        :type => :string,  :short => "r",
             :default => (env['RAILS_ROOT'] || File.expand_path(File.join(File.dirname(__FILE__), %w[.. ..])))
-        opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false
+        opt :databaseyml, "Fix database.yml", :type => :boolean, :short => "y", :default => false
         opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
-        opt :legacy_key, "Legacy Key",      :type => :string, :short => "K"
+        opt :legacy_key, "Key used to decrypt old passwords when migrating to new key", :type => :string, :short => "K"
         opt :allow_failures, "Run through all records, even with errors", :type => :boolean, :short => nil, :default => false
       end
 

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -29,9 +29,15 @@ module FixAuth
         opt :allow_failures, "Run through all records, even with errors", :type => :boolean, :short => nil, :default => false
       end
 
-      options[:database] = args.first || "vmdb_production"
       # default to updating the db
       options[:db] = true if !options[:key] && !options[:databaseyml]
+
+      # When converting the database, require database name
+      # When RAILS_ENV specified (aka on the appliance) default to production db
+      Optimist::die "please specify a database as an argument" if args.empty? && ENV["RAILS_ENV"].nil? && options[:db]
+
+      # default to updating 
+      options[:database] = args.first || "vmdb_production"
       self.options = options.delete_if { |_n, v| v.blank? }
       self
     end

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -67,6 +67,9 @@ module FixAuth
         ActiveRecord::Base.logger = Logger.new("#{options[:root]}/log/fix_auth.log")
         ActiveRecord::Base.establish_connection(db_attributes(database))
       end
+
+      puts "processing database: #{options[:database]}"
+
       models.each do |model|
         model.run(run_options)
       end


### PR DESCRIPTION
# Display the Database

I think most users expect it to change the one specified in database.yml We will have to change this one day. Until then, it is now displaying it

# Message around the number of records actually changed.

We see processed, but it is not clear if anything actually happened. This is fixed

# Update usage

Usage has removed `[...]` since we no longer handle multiple databases and it was distracting. Removed `ruby` since it is no longer required.

# New Output

```
# ./tools/fix_auth.rb --help
Usage: fix_auth.rb [options] database            # to migrate from a different or lost key
       fix_auth.rb -P new_password --databaseyml # to fix database.yml
       fix_auth.rb --key                         # to generate a new certs/v2_key
  -v, --verbose           Verbose
  -d, --dry-run           Dry Run
  -h, --hostname=<s>      Database Hostname (default: localhost)
  -o, --port=<i>          Database Port (default: 5432)
  -U, --username=<s>      Database Username (default: postgres)
  -p, --password=<s>      Database Password (default: postgres)
  -P, --hardcode=<s>      Password used to replace all passwords
  -i, --invalid=<s>       Password used to replace non-decryptable passwords
  -k, --key               Generate key
  -f, --v2                ignored, available for backwards compatibility
  -r, --root=<s>          Rails Root (default: /Users/kbrock/src/manageiq)
  -y, --databaseyml       Fix database.yml
  -x, --db                Upgrade database
  -K, --legacy-key=<s>    Key used to decrypt old passwords when migrating to new key
  -a, --allow-failures    Run through all records, even with errors
  -e, --help              Show this message
```

```
# ./tools/fix_auth.rb
Error: please specify a database as an argument.
Try --help for help.
```
(couldn't figure out how to auto print the usage

```

** fix_database_passwords is executing in dry-run mode, and no actual changes will be made **
processing database: vmdb_development_fail_v2
fixing authentications.password, auth_key
0 of 8 records would change (dry run enabled)
fixing configuration_scripts.credentials
0 of 0 records would change (dry run enabled)
fixing miq_databases.session_secret_token, csrf_secret_token
0 of 1 records would change (dry run enabled)
fixing miq_ae_values.value
0 of 0 records would change (dry run enabled)
fixing miq_ae_fields.default_value
0 of 0 records would change (dry run enabled)
fixing settings_changes.value
0 of 1 records would change (dry run enabled)
fixing miq_requests.options
0 of 0 records would change (dry run enabled)
fixing miq_request_tasks.options
0 of 0 records would change (dry run enabled)
```