### PR TITLE
Enqueue the purge of orphans through the date purge callback

### DIFF
--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -63,11 +63,12 @@ module PurgingMixin
       purge_queue(*purge_mode_and_value)
     end
 
-    def purge_queue(mode, value = nil)
+    def purge_queue(mode, value = nil, callback = nil)
       MiqQueue.submit_job(
-        :class_name  => name,
-        :method_name => "purge_by_#{mode}",
-        :args        => [value]
+        :class_name   => name,
+        :method_name  => "purge_by_#{mode}",
+        :args         => [value],
+        :miq_callback => callback
       )
     end
 

--- a/app/models/vim_performance_state/purging.rb
+++ b/app/models/vim_performance_state/purging.rb
@@ -8,11 +8,16 @@ class VimPerformanceState < ApplicationRecord
         %w[orphaned resource]
       end
 
-      # remove anything where the resource no longer exists AND
-      # remove anything older than a certain date
+      # remove anything older than a certain date AND
+      # remove anything where the resource no longer exists
+      # Use a callback to ensure :date is run first, before
+      # :orphaned and not concurrently.
       def purge_timer
+        purge_queue(:date, purge_date, {class_name => name, :method_name => :purge_callback})
+      end
+
+      def purge_callback(*_unused)
         purge_queue(:orphaned, "resource")
-        purge_queue(:date, purge_date)
       end
 
       def purge_window_size


### PR DESCRIPTION
The objective is to ensure purge by date is run first and purge by orphans
is run after, not concurrently.

Example logging:

```
[----] I, [2025-03-20T14:10:23.319433#16662:88cc]  INFO -- evm: MIQ(MiqQueue.put) Message id: [25981200], Zone: [default], Role: [], Server: [], MiqTask id: [], Handler id: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [VimPerformanceState.purge_by_date], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: [2025-03-19 18:10:23.202642 UTC]
...
[----] I, [2025-03-20T14:10:27.212822#16662:88cc]  INFO -- evm: MIQ(MiqQueue#deliver) Message id: [25981200], Delivering...
[----] I, [2025-03-20T14:10:27.213027#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_by_date) Purging vim_performance_states older than [2025-03-19 18:10:23 UTC]...
[----] I, [2025-03-20T14:10:27.214291#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_in_batches) Purging 1000 vim_performance_states.
[----] I, [2025-03-20T14:10:27.226195#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_in_batches) Purging 1000 vim_performance_states.
...
[----] I, [2025-03-20T14:10:39.800924#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_in_batches) Purging 1000 vim_performance_states.
[----] I, [2025-03-20T14:10:39.806890#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_in_batches) Purging 1000 vim_performance_states.
[----] I, [2025-03-20T14:10:39.887594#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_by_date) Purging vim_performance_states older than [2025-03-19 18:10:23 UTC]...Complete - Deleted 844406 records
[----] I, [2025-03-20T14:10:39.887705#16662:88cc]  INFO -- evm: MIQ(MiqQueue#delivered) Message id: [25981200], State: [ok], Delivered in [12.674864] seconds
[----] I, [2025-03-20T14:10:39.888159#16662:88cc]  INFO -- evm: MIQ(MiqQueue#m_callback) Message id: [25981200], Invoking Callback with args: ["ok", "Message delivered successfully", "844406"]
[----] I, [2025-03-20T14:10:39.897129#16662:88cc]  INFO -- evm: MIQ(MiqQueue.put) Message id: [25981202], Zone: [default], Role: [], Server: [], MiqTask id: [], Handler id: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [VimPerformanceState.purge_by_orphaned], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: ["resource"]
[----] I, [2025-03-20T14:10:39.902338#16662:88cc]  INFO -- evm: MIQ(MiqQueue#deliver) Message id: [25981202], Delivering...
[----] I, [2025-03-20T14:10:39.902388#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_by_orphaned) Purging orphans in vim_performance_states...
[----] I, [2025-03-20T14:10:39.979684#16662:88cc]  INFO -- evm: MIQ(VimPerformanceState.purge_by_orphaned) Purging orphans in vim_performance_states...Complete - Deleted 0 records
[----] I, [2025-03-20T14:10:39.979807#16662:88cc]  INFO -- evm: MIQ(MiqQueue#delivered) Message id: [25981202], State: [ok], Delivered in [0.077451] seconds
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
