### PR TITLE
Prevent orphans by purging associated records before the parent table

### DIFF
--- a/app/models/miq_report_result/purging.rb
+++ b/app/models/miq_report_result/purging.rb
@@ -24,7 +24,9 @@ module MiqReportResult::Purging
 
     def purge_associated_records(ids)
       MiqReportResultDetail.where(:miq_report_result_id => ids).delete_all
-      BinaryBlob.where(:resource_type => name, :resource_id => ids).destroy_all
+      binary_ids = BinaryBlob.where(:resource_type => name, :resource_id => ids).pluck(:id)
+      BinaryBlobPart.where(:binary_blob_id => binary_ids).delete_all
+      BinaryBlob.where(:id => binary_ids).delete_all
     end
 
     private

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -200,23 +200,24 @@ module PurgingMixin
           query = query.limit(current_window)
         end
 
+        _log.info("Purging #{current_window} #{table_name.humanize}.")
         if respond_to?(:purge_associated_records)
           # pull back ids - will slow performance
           batch_ids = query.pluck(:id)
           break if batch_ids.empty?
 
           current_window = batch_ids.size
+
+          # Purge the associated records before we purge the parent records to avoid leaving them orphaned
+          purge_associated_records(batch_ids)
         else
           batch_ids = query
         end
 
-        _log.info("Purging #{current_window} #{table_name.humanize}.")
         count = unscoped.where(:id => batch_ids).delete_all
         break if count == 0
 
         total += count
-
-        purge_associated_records(batch_ids) if respond_to?(:purge_associated_records)
 
         yield(count, total) if block_given?
         break if count < window || (total_limit && (total_limit <= total))

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -28,6 +28,37 @@ RSpec.describe MiqReportResult do
       ]
     end
 
+    context "#purge_by_date" do
+      before do
+        MiqReportResult.all.each do |r|
+          r.binary_blob = FactoryBot.create(:binary_blob)
+          r.miq_report_result_details << FactoryBot.create(:MiqReportResultDetail)
+          r.save!
+        end
+      end
+
+      it "deletes rows and associated table rows" do
+        MiqReportResult.purge_by_date(Time.now + 1.day)
+
+        expect(MiqReportResult.count).to eq 0
+        expect(MiqReportResultDetail.count).to eq 0
+        expect(BinaryBlob.count).to eq 0
+      end
+
+      it "deletes associated records first, leaving parent rows in case of error" do
+        initial_count = MiqReportResult.count
+        allow(MiqReportResult).to receive(:purge_associated_records).and_raise
+
+        begin
+          MiqReportResult.purge_by_date(Time.now + 1.day)
+        rescue
+          # Ignore the error, we only care that it failed
+        end
+
+        expect(MiqReportResult.count).to eq initial_count # parent is kept due to a failure
+      end
+    end
+
     context "#purge_mode_and_value" do
       it "with date" do
         settings.store_path(:reporting, :history, :keep_reports, "1.day")


### PR DESCRIPTION
Alternative to #23381, where each purge batch was done in a transaction. Actually,
we only care about eventual consistency, so we can purge the associated records
first, and if that completes, we purge the parent table's rows for that batch.
This allows us to deal with timeouts or other errors by continuing a prior run
by cleaning up associated rows and only removing the parent when there are no more
associated rows in other tables that remain.

Note, there is no recourse for delete_all that has a failure as it's a vanilla DELETE
FROM where ... so it's very unlikely to fail for anything we care to handle.