### PR TITLE
Add purge_by_date_and_orphaned

### DIFF
--- a/app/models/vim_performance_state/purging.rb
+++ b/app/models/vim_performance_state/purging.rb
@@ -11,8 +11,7 @@ class VimPerformanceState < ApplicationRecord
       # remove anything where the resource no longer exists AND
       # remove anything older than a certain date
       def purge_timer
-        purge_queue(:orphaned, "resource")
-        purge_queue(:date, purge_date)
+        purge_queue(:date_and_orphaned, purge_date, "resource")
       end
 
       def purge_window_size

--- a/spec/models/vim_performance_state/purging_spec.rb
+++ b/spec/models/vim_performance_state/purging_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe VimPerformanceState do
         stub_settings_merge(:vim_performance_states => {:history => {:keep_states => "6.months"}})
         described_class.purge_timer
 
-        expect(MiqQueue.count).to eq(2)
-        q1, q2 = MiqQueue.order(:id).to_a
-        expect(q1).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_orphaned", :args => ["resource"])
-        expect(q2).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date")
-        expect(q2.args.first).to be_within(2.days).of 6.months.ago.utc
+        expect(MiqQueue.count).to eq(1)
+        q = MiqQueue.first
+        expect(q).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date_and_orphaned")
+        expect(q.args.first).to be_within(2.days).of 6.months.ago.utc
+        expect(q.args.last).to eq("resource")
       end
     end
   end


### PR DESCRIPTION
Introduce purging first by date and then by orphanes.

It is not optimal to take 2 arguments, since most purging has stuck to one But both of these need to be passed in.

We could have leveraged these 2 methods separately, but we wanted them to be serialized, and avoid adding a dependency in the queue.

Alternative to #23383 and #23381