### PR TITLE
Remove destroy_all from MiqReportResult#purge

### DIFF
--- a/app/models/miq_report_result/purging.rb
+++ b/app/models/miq_report_result/purging.rb
@@ -24,7 +24,10 @@ module MiqReportResult::Purging
 
     def purge_associated_records(ids)
       MiqReportResultDetail.where(:miq_report_result_id => ids).delete_all
-      BinaryBlob.where(:resource_type => name, :resource_id => ids).destroy_all
+      # BinaryBlob.where(:resource_type => name, :resource_id => ids).destroy_all
+      binary_ids = BinaryBlob.where(:resource_type => name, :resource_id => ids).pluck(:id)
+      BinaryBlobParts.where(:binary_blob_id => binary_ids).delete_all
+      BinaryBlob.where(:id => binary_ids).delete_all
     end
 
     private


### PR DESCRIPTION
The BinaryBlob#destroy_all was failing, but nothing was thrown. So the MiqReportResult would still be deleted and then the blobs will be orphaned

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
