### PR TITLE
Humanizing the table name makes debugging harder

### DIFF
--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -84,9 +84,9 @@ module PurgingMixin
     end
 
     def purge_by_date(older_than, window = nil, &block)
-      _log.info("Purging #{table_name.humanize} older than [#{older_than}]...")
+      _log.info("Purging #{table_name} older than [#{older_than}]...")
       total = purge_in_batches(purge_scope(older_than), window || purge_window_size, &block)
-      _log.info("Purging #{table_name.humanize} older than [#{older_than}]...Complete - Deleted #{total} records")
+      _log.info("Purging #{table_name} older than [#{older_than}]...Complete - Deleted #{total} records")
       total
     end
 
@@ -98,23 +98,23 @@ module PurgingMixin
     # @param [Integer] window number of records to delete in a batch
     # @return [Integer] number of records deleted
     def purge_by_remaining(remaining, window = nil, &block)
-      _log.info("Purging #{table_name.humanize} older than last #{remaining} results...")
+      _log.info("Purging #{table_name} older than last #{remaining} results...")
       total = purge_in_batches(purge_ids_for_remaining(remaining), window || purge_window_size, &block)
-      _log.info("Purging #{table_name.humanize} older than last #{remaining} results...Complete - Deleted #{total} records")
+      _log.info("Purging #{table_name} older than last #{remaining} results...Complete - Deleted #{total} records")
       total
     end
 
     def purge_by_scope(older_than = nil, window = nil, &block)
-      _log.info("Purging #{table_name.humanize}...")
+      _log.info("Purging #{table_name}...")
       total = purge_in_batches(purge_scope(older_than), window || purge_window_size, &block)
-      _log.info("Purging #{table_name.humanize}...Complete - Deleted #{total} records")
+      _log.info("Purging #{table_name}...Complete - Deleted #{total} records")
       total
     end
 
     def purge_by_orphaned(fk_name, window = purge_window_size)
-      _log.info("Purging orphans in #{table_name.humanize}...")
+      _log.info("Purging orphans in #{table_name}...")
       total = purge_orphans(fk_name, window)
-      _log.info("Purging orphans in #{table_name.humanize}...Complete - Deleted #{total} records")
+      _log.info("Purging orphans in #{table_name}...Complete - Deleted #{total} records")
       total
     end
 
@@ -200,7 +200,7 @@ module PurgingMixin
           query = query.limit(current_window)
         end
 
-        _log.info("Purging #{current_window} #{table_name.humanize}.")
+        _log.info("Purging #{current_window} #{table_name}.")
         if respond_to?(:purge_associated_records)
           # pull back ids - will slow performance
           batch_ids = query.pluck(:id)


### PR DESCRIPTION
It unnecessarily complicates what's happening here and doesn't really help at all.

Followup to https://github.com/ManageIQ/manageiq/pull/23384

It looks like this now:

```
[----] I, [2025-03-20T12:26:41.222617#12271:88cc]  INFO -- evm: MIQ(MiqQueue#deliver) Message id: [25981194], Delivering...
[----] I, [2025-03-20T12:26:41.222828#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_by_date) Purging miq_report_results older than [2025-03-19 16:26:38 UTC]...
[----] I, [2025-03-20T12:26:41.224023#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.308750#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.446023#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.595626#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.670404#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.784560#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.857384#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:41.923067#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
[----] I, [2025-03-20T12:26:42.034501#12271:88cc]  INFO -- evm: MIQ(MiqReportResult.purge_in_batches) Purging 100 miq_report_results.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
