### PR TITLE
Remove url delegate from base AutomationManager

### DIFF
--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -10,8 +10,6 @@ class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
   has_many :configuration_script_sources, :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_script_payloads, :through => :configuration_script_sources
 
-  delegate :url, :to => :provider
-
   virtual_column  :total_configuration_profiles, :type => :integer
   virtual_column  :total_configured_systems, :type => :integer
   virtual_column  :url, :type => :string


### PR DESCRIPTION
The Ansible-type providers (`EmbeddedAnsible`, `AWX`, `AnsibleTower`) all have a parent `Provider` which holds the `Endpoint` and `Authentication` records, so they delegate the url to the provider object.

This isn't true of _all_ `AutomationManagers` however, and the others to date simply haven't used a `url` (aka embedded) but this prevents other `AutomationManagers` without a `Provider` from using `url`

There are only 3 subclasses of the base `AutomationManager` that have a `Provider`:
```
>> ManageIQ::Providers::AutomationManager.leaf_subclasses.map(&:module_parent).map { |v| "#{v}::Provider".safe_constantize&.name }.compact
=> ["ManageIQ::Providers::Awx::Provider", "ManageIQ::Providers::AnsibleTower::Provider", "ManageIQ::Providers::EmbeddedAnsible::Provider"]
```

The AWX/AnsibleTower `AutomationManagers` already have this delegate:
https://github.com/ManageIQ/manageiq-providers-awx/blob/master/app/models/manageiq/providers/awx/automation_manager.rb#L19
https://github.com/ManageIQ/manageiq-providers-ansible_tower/blob/master/app/models/manageiq/providers/ansible_tower/automation_manager.rb#L19

And `EmbeddedAnsible` doesn't have an `Endpoint` record since it is embedded
```
>> ManageIQ::Providers::EmbeddedAnsible::Provider.first.endpoints
=> []
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
