### PR TITLE
Opt into purging by destroy for container entities, use delete elsewhere

### DIFF
--- a/app/models/container/purging.rb
+++ b/app/models/container/purging.rb
@@ -15,6 +15,10 @@ class Container < ApplicationRecord
       def purge_scope(older_than)
         where(arel_table[:deleted_on].lteq(older_than))
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_build.rb
+++ b/app/models/container_build.rb
@@ -9,7 +9,7 @@ class ContainerBuild < ApplicationRecord
            :as         => :resource,
            :inverse_of => :resource
 
-  has_many :container_build_pods
+  has_many :container_build_pods # delete to be handled by refresh
 
   acts_as_miq_taggable
 end

--- a/app/models/container_group/purging.rb
+++ b/app/models/container_group/purging.rb
@@ -15,6 +15,10 @@ class ContainerGroup < ApplicationRecord
       def purge_scope(older_than)
         where(arel_table[:deleted_on].lteq(older_than))
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -38,9 +38,9 @@ class ContainerImage < ApplicationRecord
            :inverse_of => :resource
   has_one :last_scan_result, :class_name => "ScanResult", :as => :resource, :dependent => :destroy, :autosave => true
 
-  has_many :metric_rollups, :as => :resource, :dependent => :nullify, :inverse_of => :resource
-  has_many :metrics, :as => :resource, :dependent => :nullify, :inverse_of => :resource
-  has_many :vim_performance_states, :as => :resource, :dependent => :nullify, :inverse_of => :resource
+  has_many :metric_rollups, :as => :resource, :inverse_of => :resource         # Destroy will be handled by purger
+  has_many :metrics, :as => :resource, :inverse_of => :resource                # Destroy will be handled by purger
+  has_many :vim_performance_states, :as => :resource, :inverse_of => :resource # Destroy will be handled by purger
 
   serialize :exposed_ports, :type => Hash
   serialize :environment_variables, :type => Hash

--- a/app/models/container_image/purging.rb
+++ b/app/models/container_image/purging.rb
@@ -15,6 +15,10 @@ class ContainerImage < ApplicationRecord
       def purge_scope(older_than)
         where(arel_table[:deleted_on].lteq(older_than))
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -2,13 +2,13 @@ class ContainerImageRegistry < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
   # Associated with images in the registry.
-  has_many :container_images, :dependent => :nullify
+  has_many :container_images, :dependent => :nullify # images has a purger and are associated to containers so we can only disassociate them here
   has_many :containers, :through => :container_images
   has_many :container_groups, :through => :container_images
 
   # Associated with serving the registry itself - for openshift's internal
   # image registry. These will be empty for external registries.
-  has_many :container_services
+  has_many :container_services # delete to be handled by refresh
   has_many :service_container_groups, :through => :container_services, :as => :container_groups
 
   acts_as_miq_taggable

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -44,7 +44,7 @@ class ContainerNode < ApplicationRecord
   has_many :metrics, :as => :resource
   has_many :metric_rollups, :as => :resource
   has_many :vim_performance_states, :as => :resource
-  has_many :miq_alert_statuses, :as => :resource
+  has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
   delegate :my_zone, :to => :ext_management_system, :allow_nil => true
 
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions

--- a/app/models/container_node/purging.rb
+++ b/app/models/container_node/purging.rb
@@ -15,6 +15,10 @@ class ContainerNode < ApplicationRecord
       def purge_scope(older_than)
         where(arel_table[:deleted_on].lteq(older_than))
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -10,22 +10,22 @@ class ContainerProject < ApplicationRecord
   include Purging
   belongs_to :ext_management_system, :class_name => "ManageIQ::Providers::ContainerManager", :foreign_key => "ems_id", :inverse_of => :container_projects
   has_many :container_groups, -> { active }, :inverse_of => :container_project
-  has_many :container_routes
-  has_many :container_replicators
-  has_many :container_services
+  has_many :container_routes      # delete to be handled by refresh
+  has_many :container_replicators # delete to be handled by refresh
+  has_many :container_services    # delete to be handled by refresh
   has_many :containers, :through => :container_groups
   has_many :container_images, -> { distinct }, :through => :container_groups
   has_many :container_nodes, -> { distinct }, :through => :container_groups
   has_many :container_quotas, -> { active }, :inverse_of => :container_project
   has_many :container_quota_scopes, :through => :container_quotas
   has_many :container_quota_items, :through => :container_quotas
-  has_many :container_limits
+  has_many :container_limits      # delete to be handled by refresh
   has_many :container_limit_items, :through => :container_limits
-  has_many :container_builds
-  has_many :container_templates
+  has_many :container_builds      # delete to be handled by refresh
+  has_many :container_templates   # delete to be handled by refresh
   has_many :all_container_groups, :class_name => "ContainerGroup", :inverse_of => :container_project
   has_many :archived_container_groups, -> { archived }, :class_name => "ContainerGroup"
-  has_many :persistent_volume_claims
+  has_many :persistent_volume_claims # claims are removed by the container_volume when it's removed
   has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
   has_many :computer_systems, :through => :container_nodes
 

--- a/app/models/container_project/purging.rb
+++ b/app/models/container_project/purging.rb
@@ -15,6 +15,10 @@ class ContainerProject < ApplicationRecord
       def purge_scope(older_than)
         where(arel_table[:deleted_on].lteq(older_than))
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_quota/purging.rb
+++ b/app/models/container_quota/purging.rb
@@ -20,6 +20,10 @@ class ContainerQuota < ApplicationRecord
         ContainerQuotaScope.where(:container_quota_id => ids).delete_all
         ContainerQuotaItem.where(:container_quota_id => ids).delete_all
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_quota_item/purging.rb
+++ b/app/models/container_quota_item/purging.rb
@@ -3,6 +3,9 @@ class ContainerQuotaItem < ApplicationRecord
     extend ActiveSupport::Concern
     include PurgingMixin
 
+    # According to 022e15256fd07fa7bf5b3ade7ce16b13daa87b84
+    # This is necessary because ContainerQuotaItem may be archived due to edits
+    # to parent ContainerQuota that is still alive.
     module ClassMethods
       def purge_date
         ::Settings.container_entities.history.keep_archived_quotas.to_i_with_method.seconds.ago.utc

--- a/app/models/container_quota_item/purging.rb
+++ b/app/models/container_quota_item/purging.rb
@@ -15,6 +15,10 @@ class ContainerQuotaItem < ApplicationRecord
       def purge_scope(older_than)
         where(arel_table[:deleted_on].lteq(older_than))
       end
+
+      def purge_method
+        :destroy
+      end
     end
   end
 end

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -6,7 +6,7 @@ class ContainerService < ApplicationRecord
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_and_belongs_to_many :container_groups, :join_table => :container_groups_container_services
-  has_many :container_routes
+  has_many :container_routes # delete to be handled by refresh
   has_many :container_service_port_configs, :dependent => :destroy
   belongs_to :container_project
   has_many :annotations, -> { where(:section => "annotations") }, # rubocop:disable Rails/HasManyOrHasOneDependent

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -228,17 +228,7 @@ module PurgingMixin
         end
 
         batch_records = unscoped.where(:id => batch_ids)
-        count =
-          if purge_method == :destroy
-            destroyed = batch_records.destroy_all
-            destroyed.detect { |d| !d.destroyed? }.tap do |failed|
-              raise "failed removing record: #{failed.class.name} with id: #{failed.id} with error: #{failed.errors.full_messages}" if failed
-            end
-
-            destroyed.count
-          else
-            batch_records.delete_all
-          end
+        count = purge_one_batch(batch_records)
         break if count == 0
 
         total += count
@@ -247,6 +237,19 @@ module PurgingMixin
         break if count < window || (total_limit && (total_limit <= total))
       end
       total
+    end
+
+    def purge_one_batch(scope)
+      if purge_method == :destroy
+        destroyed = scope.destroy_all
+        destroyed.detect { |d| !d.destroyed? }.tap do |failed|
+          raise "failed removing record: #{failed.class.name} with id: #{failed.id} with error: #{failed.errors.full_messages}" if failed
+        end
+
+        destroyed.count
+      else
+        scope.delete_all
+      end
     end
   end
 end

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -55,6 +55,10 @@ module PurgingMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def purge_method
+      :delete
+    end
+
     def purge_mode_and_value
       [:date, purge_date]
     end
@@ -223,7 +227,8 @@ module PurgingMixin
           batch_ids = query
         end
 
-        count = unscoped.where(:id => batch_ids).delete_all
+        batch_records = unscoped.where(:id => batch_ids)
+        count = purge_method == :destroy ? batch_records.destroy_all.count : batch_records.delete_all
         break if count == 0
 
         total += count

--- a/app/models/persistent_volume_claim.rb
+++ b/app/models/persistent_volume_claim.rb
@@ -1,7 +1,7 @@
 class PersistentVolumeClaim < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
-  has_many :container_volumes
+  has_many :container_volumes # volumes can be reused by a different claim - no dependent destroy
   serialize :capacity, :type => Hash
   serialize :requests, :type => Hash
   serialize :limits, :type => Hash

--- a/lib/extensions/ar_base_model.rb
+++ b/lib/extensions/ar_base_model.rb
@@ -1,7 +1,8 @@
 module ActiveRecord
   class Base
     class << self
-      alias_method :base_model, :base_class
+      alias_method :base_model,  :base_class
+      alias_method :base_model?, :base_class?
 
       def model_suffix
         name[base_model.name.length..-1]

--- a/spec/models/container/purging_spec.rb
+++ b/spec/models/container/purging_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Container do
         described_class.purge(deleted_date, 1)
         assert_unpurged_ids(@new_container.id)
       end
+
+      it "purges associated rows" do
+        @old_container.container_env_vars << FactoryBot.create(:container_env_var)
+        @old_container.container_port_configs << FactoryBot.create(:container_port_config)
+        described_class.purge(deleted_date)
+        expect(@old_container.container_env_vars.count).to eq(0)
+        expect(@old_container.container_port_configs.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/container_group/purging_spec.rb
+++ b/spec/models/container_group/purging_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe ContainerGroup do
         described_class.purge(deleted_date, 1)
         assert_unpurged_ids(@new_container_group.id)
       end
+
+      it "purges associated rows" do
+        @old_container_group.container_conditions << FactoryBot.create(:container_condition)
+        @old_container_group.custom_attributes << FactoryBot.create(:custom_attribute)
+        described_class.purge(deleted_date)
+        expect(@old_container_group.container_conditions.count).to eq(0)
+        expect(@old_container_group.custom_attributes.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/container_image/purging_spec.rb
+++ b/spec/models/container_image/purging_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe ContainerImage do
         described_class.purge(deleted_date, 1)
         assert_unpurged_ids(@new_container_image.id)
       end
+
+      it "purges associated rows" do
+        @old_container_image.guest_applications << FactoryBot.create(:guest_application)
+        @old_container_image.custom_attributes << FactoryBot.create(:custom_attribute)
+        described_class.purge(deleted_date)
+        expect(@old_container_image.guest_applications.count).to eq(0)
+        expect(@old_container_image.custom_attributes.count).to eq(0)
+      end
+
     end
   end
 end

--- a/spec/models/container_node/purging_spec.rb
+++ b/spec/models/container_node/purging_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe ContainerNode do
         described_class.purge(deleted_date, 1)
         assert_unpurged_ids(@new_container_node.id)
       end
+
+      it "purges associated rows" do
+        @old_container_node.container_conditions << FactoryBot.create(:container_condition)
+        @old_container_node.custom_attributes << FactoryBot.create(:custom_attribute)
+        described_class.purge(deleted_date)
+        expect(@old_container_node.container_conditions.count).to eq(0)
+        expect(@old_container_node.custom_attributes.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/container_project/purging_spec.rb
+++ b/spec/models/container_project/purging_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ContainerProject do
       let(:new_container_project) { FactoryBot.create(:container_project, :deleted_on => deleted_date + 1.day) }
 
       before do
-        FactoryBot.create(:container_project, :deleted_on => deleted_date - 1.day)
+        @old_container_project = FactoryBot.create(:container_project, :deleted_on => deleted_date - 1.day)
         FactoryBot.create(:container_project, :deleted_on => deleted_date)
         new_container_project
       end
@@ -42,6 +42,12 @@ RSpec.describe ContainerProject do
       it "with a window" do
         described_class.purge(deleted_date, 1)
         assert_unpurged_ids([new_container_project.id])
+      end
+
+      it "purges associated rows" do
+        @old_container_project.miq_alert_statuses << FactoryBot.create(:miq_alert_status)
+        described_class.purge(deleted_date)
+        expect(@old_container_project.miq_alert_statuses.count).to eq(0)
       end
     end
   end

--- a/spec/models/container_quota/purging_spec.rb
+++ b/spec/models/container_quota/purging_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe ContainerQuota do
         # This quota item is itself due for purging, but not as part of ContainerQuota::Purging.
         assert_unpurged_ids(ContainerQuotaItem, @new_quota_old_item.id)
       end
+
+      it "purges associated rows" do
+        described_class.purge(deleted_date)
+        expect(@old_quota.container_quota_scopes.count).to eq(0)
+        expect(@old_quota.all_container_quota_items.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PurgingMixin do
   let(:example_class) { PolicyEvent }
   let(:purge_date) { 2.weeks.ago }
-  purge_by_delete_classes, purge_by_destroy_classes = ActiveRecord::Base.descendants.select { |m| m.ancestors.include?(PurgingMixin) && m.base_model == m }.partition { |m| m.purge_method == :delete }
+  purge_by_delete_classes, purge_by_destroy_classes = ActiveRecord::Base.descendants.select { |m| m.ancestors.include?(PurgingMixin) && m.base_model? }.partition { |m| m.purge_method == :delete }
 
   purge_by_delete_classes.each do |klass|
     it "#{klass}.purge_method is delete" do

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -1,6 +1,19 @@
 RSpec.describe PurgingMixin do
   let(:example_class) { PolicyEvent }
   let(:purge_date) { 2.weeks.ago }
+  purge_by_delete_classes, purge_by_destroy_classes = ActiveRecord::Base.descendants.select { |m| m.ancestors.include?(PurgingMixin) && m.base_model == m }.partition { |m| m.purge_method == :delete }
+
+  purge_by_delete_classes.each do |klass|
+    it "#{klass}.purge_method is delete" do
+      expect(klass.purge_method).to eq(:delete)
+    end
+  end
+
+  purge_by_destroy_classes.each do |klass|
+    it "#{klass}.purge_method is destroy" do
+      expect(klass.purge_method).to eq(:destroy)
+    end
+  end
 
   describe ".purge_date" do
     it "purge_date should not raise exception" do


### PR DESCRIPTION
Fixes most of the issues in #23307

We were leaving around lots of orphaned container* rows when we removed the container entities.  This change allows us to opt-into use destroy on the primary table in situations where know the associated records are NOT going to be many tens of thousands of rows.  If they are, those associations should NOT be using dependent :destroy, and have their own purger.

TODO:

Note: I've moved additional tasks for more non-container purging to https://github.com/ManageIQ/manageiq/issues/23394

- [x] Verify and test dependent => destroy on associations from (except metrics, metric_rollups, vim_performance_states handled by separate purger):
  - [x] models
    - [x] container
    - [x] container_group
    - [x] container_image
    - [x] container_node
    - [x] container_project
    - [x] container_quota
    - [x] container_quota_item
  - [x] associations (known to be previously orphaned)
    - [x] container_condition (many millions)
      - [x] container_group
      - [x] container_node
    - [x] container_env_var (millions)
      - [x] container
    - [x] container_volume (millions)
      - [x] container_group
      - [x] persistent_volume_claim (NO change, claims can be used by other volumes)
    - [x] security_context (millions)
      - [x] container
    - [x] container_port_config (million)
      - [x] container
    - [x] custom_attribute (many millions)
      - [x] via CustomAttributeMixin
    - [x] guest_applications (million)
      - [x] container_image
- [x] Other associations
  - [x] containers
    - [x] container_image (NO change, handled by purger)
  - [x] container_builds
    - [x] container_project (NO change, handled by refresh)
  - [x] container_build_pods
    - [x] container_build (NO change, handled by refresh)
  - [x] container_group
    - [x] container_build_pod (NO change, handled by purger)
    - [x] container_replicator (NO change, handled by purger)
  - [x] container_groups -> {active} ?
    - [x] container_node (NO change, handled by purger)
    - [x] container_project (NO change, handled by purger)
  - [x] container_images (nullify)
    - [x] container_image_registry
  - [x] container_limits
    - [x] container_project (NO change, handled by refresh)
  - [x] container_quotas
    - [x] container_project (NO change, handled by purger)
  - [x] container_replicators
    - [x] container_project (NO change, handled by refresh)
  - [x] container_routes
    - [x] container_project (NO change, handled by refresh)
    - [x] container_service (NO change, handled by refresh)
  - [x] container_services
    - [x] container_project (NO change, handled by refresh)
    - [x] container_image_registry (NO change, handled by refresh)
  - [x] container_templates
    - [x] container_project (NO change, handled by refresh)
  - [x] container_volumes
    - [x] persistent_volume_claim (NO change, this is fine, container volume will remove pvc when it's removed)
  - [x] custom_attributes (no purger for model)
    - [x] container_build (destroyed from project purger now via destroy)
    - [x] container_build_pod (destroyed from project -> container_build project purger now via destroy)
    - [x] container_replicator (destroyed from project purger now via destroy)
    - [x] container_route (destroyed from project purger now via destroy)
    - [x] container_service (destroyed from project purger now via destroy)
    - [x] container_template (destroyed from project purger now via destroy) 
  - [x] metric_rollups, metrics, vim_performance_states (nullify)
    - [x] container_image
  - [x] miq_alert_statuses
    - [x] container_node
  - [x] persistent_volume_claims
    - [x] container_project (NO change, this is fine, handled by container volume when it's removed)
 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
