### PR TITLE
Refactor spec to be run by all providers

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -38,11 +38,16 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
-  it ".model_name_from_emstype" do
+  describe ".model_name_from_emstype" do
     described_class.concrete_subclasses.each do |klass|
-      expect(described_class.model_name_from_emstype(klass.ems_type)).to eq(klass.name)
+      it "has a model name for #{klass.ems_type}", :providers_common => true do
+        expect(described_class.model_name_from_emstype(klass.ems_type)).to eq(klass.name)
+      end
     end
-    expect(described_class.model_name_from_emstype('foo')).to be_nil
+
+    it "handles unknown model names" do
+      expect(described_class.model_name_from_emstype('foo')).to be_nil
+    end
   end
 
   describe ".types" do


### PR DESCRIPTION
@agrare Please review.  I noticed this spec loops over all concrete_subclasses, and so by extension, it should be a providers_common.  That way if a new plugin is created, we run those tests as well at creation time.  (This follows the pattern I did with the `image_name` test)