### PR TITLE
Allow OOtB ansible content to also come from galaxy

### DIFF
--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -1,6 +1,6 @@
 module Ansible
   class Content
-    PLUGIN_CONTENT_DIR = Rails.root.join("content/ansible_consolidated").to_s.freeze
+    PLUGIN_CONTENT_DIR = Rails.root.join("content/ansible_consolidated").freeze
 
     attr_accessor :path
 
@@ -33,11 +33,13 @@ module Ansible
     def self.consolidate_plugin_content(dir = PLUGIN_CONTENT_DIR)
       require "vmdb/plugins"
 
+      roles_dir = dir.join("roles")
       FileUtils.rm_rf(dir)
-      FileUtils.mkdir_p(dir)
+      FileUtils.mkdir_p(roles_dir)
 
       Vmdb::Plugins.ansible_content.each do |content|
-        FileUtils.cp_r(Dir.glob("#{content.path}/*"), dir)
+        new(content.path).fetch_galaxy_roles
+        FileUtils.cp_r(Dir.glob(content.path.join("roles/*/")), roles_dir)
       end
     end
 


### PR DESCRIPTION
Required for:
- [ ] https://github.com/ManageIQ/manageiq-content/pull/761

In the end this keeps the same structure, without forcing us to keep a copy of any roles in the content dir (but if we choose to that also still works)