### PR TITLE
Update entitlement filters when a tag is renamed

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -79,10 +79,7 @@ class Entitlement < ApplicationRecord
 
   def remove_tag_from_managed_filter(filter_to_remove)
     if get_managed_filters.present?
-      *category, _tag = filter_to_remove.split("/")
-      category = category.join("/")
       self.filters["managed"].each do |filter|
-        next unless filter.first.starts_with?(category)
         next unless filter.include?(filter_to_remove)
 
         filter.delete(filter_to_remove)

--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -25,7 +25,7 @@ class Entitlement < ApplicationRecord
   end
 
   def self.remove_tag_from_all_managed_filters(tag)
-    find_each do |entitlement|
+    where.not(:filters => nil).find_each do |entitlement|
       entitlement.remove_tag_from_managed_filter(tag)
       entitlement.save if entitlement.filters_changed?
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -6,6 +6,7 @@ class Tag < ApplicationRecord
 
   has_many :provider_tag_mappings
 
+  after_update :update_managed_filters_on_name_change, if: :saved_change_to_name?
   before_destroy :remove_from_managed_filters
 
   # Note those scopes exclude Tags that don't have a Classification.
@@ -159,6 +160,9 @@ class Tag < ApplicationRecord
   end
 
   private
+  def update_managed_filters_on_name_change
+    Entitlement.with_region(self.class.id_to_region(id)) { Entitlement.update_managed_filters_on_name_change(name_previously_was, name) }
+  end
 
   def remove_from_managed_filters
     Entitlement.with_region(self.class.id_to_region(id)) { Entitlement.remove_tag_from_all_managed_filters(name) }


### PR DESCRIPTION
Previously, the managed filter is orphaned and no warning is displayed. We probably want to implement some UI / API validation / warning like we do for belongsto filters as described in https://github.com/ManageIQ/manageiq/issues/23392

But, this change fixes the problem in the future to handle tag renames:
1) Assign filter to group:

![image](https://github.com/user-attachments/assets/7f782d91-4255-4d60-92e1-f7e1eddac34d)

2) View existing tag

![image](https://github.com/user-attachments/assets/07796330-2478-4417-b57c-773bebe0cf53)


3) Rename 001 to 111
![image](https://github.com/user-attachments/assets/e8929ccc-565c-47d7-a221-b81e91d8d129)

4) The group's filter is automatically updated to 111:

![image](https://github.com/user-attachments/assets/f8b93ec5-23ac-450f-8cce-8cc8fa13baf4)



<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
