### PR TITLE
Quiet connections from the log

### DIFF
--- a/lib/extensions/ar_adapter/ar_checkin_checkout_callbacks.rb
+++ b/lib/extensions/ar_adapter/ar_checkin_checkout_callbacks.rb
@@ -1,22 +1,24 @@
-ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-  set_callback(:checkout, :after, :log_after_checkout)
-  set_callback(:checkin,  :after, :log_after_checkin)
+unless ENV['MIQ_QUIET']
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
+    set_callback(:checkout, :after, :log_after_checkout)
+    set_callback(:checkin,  :after, :log_after_checkin)
 
-  def connection_info_for_logging
-    pool             = ActiveRecord::Base.connection_pool
-    pool_size        = pool.size
-    count            = pool.connections.count
-    in_use           = pool.connections.count(&:in_use?)
-    waiting_in_queue = pool.num_waiting_in_queue
+    def connection_info_for_logging
+      pool             = ActiveRecord::Base.connection_pool
+      pool_size        = pool.size
+      count            = pool.connections.count
+      in_use           = pool.connections.count(&:in_use?)
+      waiting_in_queue = pool.num_waiting_in_queue
 
-    "connection_pool: size: #{pool_size}, connections: #{count}, in use: #{in_use}, waiting_in_queue: #{waiting_in_queue}"
-  end
+      "connection_pool: size: #{pool_size}, connections: #{count}, in use: #{in_use}, waiting_in_queue: #{waiting_in_queue}"
+    end
 
-  def log_after_checkin
-    logger.debug { "#{self.class.name.demodulize}##{__method__}, #{connection_info_for_logging}" } if logger && ActiveRecord::Base.connected?
-  end
+    def log_after_checkin
+      logger.debug { "#{self.class.name.demodulize}##{__method__}, #{connection_info_for_logging}" } if logger && ActiveRecord::Base.connected?
+    end
 
-  def log_after_checkout
-    logger.debug { "#{self.class.name.demodulize}##{__method__}, #{connection_info_for_logging}" } if logger && ActiveRecord::Base.connected?
+    def log_after_checkout
+      logger.debug { "#{self.class.name.demodulize}##{__method__}, #{connection_info_for_logging}" } if logger && ActiveRecord::Base.connected?
+    end
   end
 end


### PR DESCRIPTION
The connections checkout often output 5 lines for every connection. this puts a bunch into the logs. When MIQ_QUIET is enabled, this will no longer be output to the logs

This is coded to work at class load time. It would need to be implemented differently if you wanted to have this option in settings.

--

Just like with removing instantiations in the log, this cuts down on verbiage. see #21462

excerpt from my logs:

```
  TRANSACTION (0.8ms)  COMMIT
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
  TRANSACTION (0.4ms)  BEGIN
  RequestLog Create (1.1ms)  INSERT INTO "request_logs" ("message", "severity", "resource_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"  [["message", "<AEMethod [/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template/update_serviceprovision_status]> Starting "], ["severity", "INFO"], ["resource_id", 53], ["created_at", "2025-03-27 23:08:20.407727"], ["updated_at", "2025-03-27 23:08:20.407727"]]
  TRANSACTION (0.5ms)  COMMIT
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
  Service Load (0.3ms)  SELECT "services".* FROM "services" WHERE "services"."id" = $1 LIMIT $2  [["id", 31], ["LIMIT", 1]]
  Service Inst Including Associations (0.1ms - 1rows)
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
  MiqRequest Load (0.3ms)  SELECT "miq_requests".* FROM "miq_requests" WHERE "miq_requests"."id" = $1 LIMIT $2  [["id", 53], ["LIMIT", 1]]
  MiqRequest Inst Including Associations (0.1ms - 1rows)
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkin, connection_pool: size: 5, connections: 3, in use: 2, waiting_in_queue: 0
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 3, in use: 3, waiting_in_queue: 0
  TRANSACTION (0.2ms)  BEGIN
  ServiceTemplateProvisionRequest Update (0.7ms)  UPDATE "miq_requests" SET "updated_on" = $1, "options" = $2 WHERE "miq_requests"."id" = $3  [["updated_on", "2025-03-27 23:08:20.795032"], ["options", "---\n:dialog:\n  dialog_vm_name: kbrock-demo\n  dialog_size: small\n  password::dialog_vm_pass: v2:{}\n:workflow_settings:\n  :resource_action_id: 3\n  :dialog_id: 2\n:initiator:\n:src_id: 1\n:request_options:\n  :submit_workflow: true\n  :init_defaults: false\n:cart_state: ordered\n:requester_group: EvmGroup-super_administrator\n:executed_on_servers:\n- 1\n:delivered_on: 2025-03-27 23:01:56.096503000 Z\n:user_message: Server [EVM] Service [Vm with Size-20250327-190204] Step [checkprovisioned]\n  Status [Creating Service] Message [In Process] Current Retry Number [7]\n"], ["id", 53]]
  TRANSACTION (0.4ms)  COMMIT
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
