### PR TITLE
Add purge orphan tool

### DIFF
--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -116,10 +116,10 @@ module PurgingMixin
       total
     end
 
-    def purge_by_orphaned(fk_name, window = purge_window_size)
+    def purge_by_orphaned(fk_name, window = purge_window_size, purge_mode = :purge)
       _log.info("Purging orphans in #{table_name}...")
-      total = purge_orphans(fk_name, window)
-      _log.info("Purging orphans in #{table_name}...Complete - Deleted #{total} records")
+      total = purge_orphans(fk_name, window, purge_mode)
+      _log.info("Purging orphans in #{table_name}...Complete - #{purge_mode.to_sym == :count ? 'Would delete' : 'Deleted'} #{total} records")
       total
     end
 
@@ -133,40 +133,38 @@ module PurgingMixin
 
     private
 
-    def purge_orphans(fk_name, window)
+    def purge_orphans(fk_name, window, purge_mode = :purge)
       reflection = reflect_on_association(fk_name)
-      if reflection.polymorphic?
-        purge_polymorphic_orphans(fk_name, window)
+      scopes = reflection.polymorphic? ? polymorphic_orphan_scopes(fk_name) : non_polymorphic_orphan_scopes(fk_name, reflection.klass)
+
+      if purge_mode.to_sym == :count
+        scopes.sum(&:count)
       else
-        purge_non_polymorphic_orphans(fk_name, window, reflection.klass)
+        scopes.sum { |s| purge_in_batches(s, window) }
       end
     end
 
-    def purge_polymorphic_orphans(fk_name, window)
+    def polymorphic_orphan_scopes(fk_name)
       polymorphic_type_column = "#{fk_name}_type"
       polymorphic_id_column   = connection.quote_column_name("#{fk_name}_id")
-      total = 0
 
-      polymorphic_classes(polymorphic_type_column).each do |klass|
+      polymorphic_classes(polymorphic_type_column).collect do |klass|
         resource_table = connection.quote_table_name(klass.table_name)
         q_table_name = connection.quote_table_name(table_name)
 
-        scope = joins("LEFT OUTER JOIN #{resource_table} ON #{q_table_name}.#{polymorphic_id_column} = #{resource_table}.id")
-                .where(resource_table => {:id => nil})
-                .where("#{q_table_name}.#{connection.quote_column_name(polymorphic_type_column)} = #{connection.quote(klass.name)}")
-        total += purge_in_batches(scope, window)
+        joins("LEFT OUTER JOIN #{resource_table} ON #{q_table_name}.#{polymorphic_id_column} = #{resource_table}.id")
+          .where(resource_table => {:id => nil})
+          .where("#{q_table_name}.#{connection.quote_column_name(polymorphic_type_column)} = #{connection.quote(klass.name)}")
       end
-      total
     end
 
-    def purge_non_polymorphic_orphans(fk_name, window, reflection_klass)
+    def non_polymorphic_orphan_scopes(fk_name, reflection_klass)
       resource_table = connection.quote_table_name(reflection_klass.table_name)
       assoc_id = connection.quote_column_name("#{fk_name}_id")
       q_table_name = connection.quote_table_name(table_name)
 
-      scope = joins("LEFT OUTER JOIN #{resource_table} ON #{q_table_name}.#{assoc_id} = #{resource_table}.id")
-              .where(resource_table => {:id => nil})
-      purge_in_batches(scope, window)
+      [joins("LEFT OUTER JOIN #{resource_table} ON #{q_table_name}.#{assoc_id} = #{resource_table}.id")
+        .where(resource_table => {:id => nil})]
     end
 
     def polymorphic_classes(polymorphic_type_column)

--- a/spec/models/vim_performance_state/purging_spec.rb
+++ b/spec/models/vim_performance_state/purging_spec.rb
@@ -1,26 +1,34 @@
 RSpec.describe VimPerformanceState do
   context "::Purging" do
     describe ".purge_by_orphaned" do
-      it "purges all the orphaned rows for all referenced classes" do
+      before do
         # Create an orphaned row referencing VmOrTemplate
         vm1      = FactoryBot.create(:vm_or_template)
-        vm_perf1 = FactoryBot.create(:vim_performance_state, :resource => vm1)
+        @vm_perf1 = FactoryBot.create(:vim_performance_state, :resource => vm1)
         vm1.delete
 
         # Create a non-orphaned row referencing VmOrTemplate
-        vm_perf2 = FactoryBot.create(:vim_performance_state, :resource => FactoryBot.create(:vm_or_template))
+        @vm_perf2 = FactoryBot.create(:vim_performance_state, :resource => FactoryBot.create(:vm_or_template))
 
         # Create an orphaned row referencing ExtManagementSystem
         ems1      = FactoryBot.create(:ext_management_system)
-        ems_perf1 = FactoryBot.create(:vim_performance_state, :resource => ems1)
+        @ems_perf1 = FactoryBot.create(:vim_performance_state, :resource => ems1)
         ems1.delete
 
         # Create a non-orphaned row referencing ExtManagementSystem
-        ems_perf2 = FactoryBot.create(:vim_performance_state, :resource => FactoryBot.create(:ext_management_system))
+        @ems_perf2 = FactoryBot.create(:vim_performance_state, :resource => FactoryBot.create(:ext_management_system))
+        expect(described_class.all).to match_array([@vm_perf1, @vm_perf2, @ems_perf1, @ems_perf2])
+      end
 
-        expect(described_class.all).to match_array([vm_perf1, vm_perf2, ems_perf1, ems_perf2])
+      it "purges all the orphaned rows for all referenced classes" do
         count = described_class.purge_by_orphaned("resource")
-        expect(described_class.all).to match_array([vm_perf2, ems_perf2])
+        expect(described_class.all).to match_array([@vm_perf2, @ems_perf2])
+        expect(count).to eq(2)
+      end
+
+      it "count purge_mode returns count of the orphaned rows for all referenced classes without actually purging" do
+        count = described_class.purge_by_orphaned("resource", 1000, :count)
+        expect(described_class.all).to match_array([@vm_perf1, @vm_perf2, @ems_perf1, @ems_perf2])
         expect(count).to eq(2)
       end
     end

--- a/tools/purge_orphans.rb
+++ b/tools/purge_orphans.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
+def purge_by_orphaned(klass, fk, window)
+  klass.include PurgingMixin
+  klass.define_method(:purge_method) { :destroy }
+  klass.purge_by_orphaned(fk, window).tap { |total| puts "Purged: #{klass}: #{total}" }
+end
+
+CLASSES_TO_PURGE = [
+  BinaryBlob,            :resource,           100,
+  ContainerCondition,    :container_entity,  1000,
+  ContainerEnvVar,       :container,         1000,
+  ContainerPortConfig,   :container,         1000,
+  ContainerVolume,       :parent,            1000,
+  CustomAttribute,       :resource,          1000,
+  MiqReportResultDetail, :miq_report_result, 1000,
+  RequestLog,            :resource,           500,
+  SecurityContext,       :resource,          1000
+]
+
+_result, bm = Benchmark.realtime_block("TotalTime") do
+  CLASSES_TO_PURGE.each_slice(3) do |klass, fk, window|
+    Benchmark.realtime_block(klass.name) do
+      purge_by_orphaned(klass, fk, window)
+    end
+  end
+  nil
+end
+puts "Timing by model:"
+pp bm


### PR DESCRIPTION
* Add purge for non-polymorphic orphans
* Add start of a script to purge orphaned rows in known problem models
* Add purge mode support: counts or purge (defaults to counts)

## Example CLI usage:


### Help menu

```
% be ruby tools/purge_orphans.rb -h
** override_gem("byebug", :require=>"byebug") at /Users/joerafaniello/.bundler.d/byebug.rb:1
Usage: purge_orphans [options]
Purge orphaned rows from several tables.

Options:
  -m, --mode=<s>    Mode (default: count) (permitted: count, purge)
  -h, --help        Show this message
```


### Script will default to count if no mode specified

```
% be ruby tools/purge_orphans.rb
** override_gem("byebug", :require=>"byebug") at /Users/joerafaniello/.bundler.d/byebug.rb:1
** ManageIQ master, codename: Tal

Note: Count mode was provided.  No changes are being made.  Use --mode purge to purge the rows.

Purging BinaryBlob...Done!
Purging ContainerCondition...Done!
Purging ContainerEnvVar...Done!
Purging ContainerPortConfig...Done!
Purging ContainerVolume...Done!
Purging CustomAttribute...Done!
Purging MiqReportResultDetail...Done!
Purging RequestLog...Done!
Purging SecurityContext...Done!

Results:

 Class                 | Orphan Count
-----------------------|--------------
 BinaryBlob            |           22
 ContainerCondition    |         2584
 ContainerEnvVar       |          520
 ContainerPortConfig   |          546
 ContainerVolume       |         1876
 CustomAttribute       |         3674
 MiqReportResultDetail |          252
 RequestLog            |         3556
 SecurityContext       |          646

Timing by class:

 Model                 | Time (s)
-----------------------|----------
 BinaryBlob            | 0.089011
 ContainerCondition    | 0.043033
 ContainerEnvVar       | 0.014842
 ContainerPortConfig   | 0.001715
 ContainerVolume       | 0.039398
 CustomAttribute       | 0.144239
 MiqReportResultDetail | 0.046786
 RequestLog            | 0.013888
 SecurityContext       | 0.002554
 TotalTime             | 0.395581
```


### Invalid mode handling

```
% be ruby tools/purge_orphans.rb -m purged
** override_gem("byebug", :require=>"byebug") at /Users/joerafaniello/.bundler.d/byebug.rb:1
Error: option '-m' only accepts one of: count, purge.
Try --help for help.
```

### Purge mode must be specified

```
% be ruby tools/purge_orphans.rb -m purge
** override_gem("byebug", :require=>"byebug") at /Users/joerafaniello/.bundler.d/byebug.rb:1
** ManageIQ master, codename: Tal

Purging BinaryBlob...Done!
Purging ContainerCondition...Done!
Purging ContainerEnvVar...Done!
Purging ContainerPortConfig...Done!
Purging ContainerVolume...Done!
Purging CustomAttribute...Done!
Purging MiqReportResultDetail...Done!
Purging RequestLog...Done!
Purging SecurityContext...Done!

Results:

 Class                 | Purged Rows
-----------------------|-------------
 BinaryBlob            |          22
 ContainerCondition    |        2584
 ContainerEnvVar       |         520
 ContainerPortConfig   |         546
 ContainerVolume       |        1876
 CustomAttribute       |        3674
 MiqReportResultDetail |         252
 RequestLog            |        3556
 SecurityContext       |         646

Timing by class:

 Model                 | Time (s)
-----------------------|----------
 BinaryBlob            | 0.116072
 ContainerCondition    | 0.050117
 ContainerEnvVar       | 0.015245
 ContainerPortConfig   | 0.006876
 ContainerVolume       | 0.053625
 CustomAttribute       | 0.174056
 MiqReportResultDetail | 0.066558
 RequestLog            | 0.029409
 SecurityContext       | 0.007552
 TotalTime             | 0.519666
```


Note, I tested this locally using a neat transaction trick from rails so I could do count or purge mode and not have to restore my database afterwards.

```diff
diff --git a/tools/purge_orphans.rb b/tools/purge_orphans.rb
index 071ec3e513..4798b4b6cf 100755
--- a/tools/purge_orphans.rb
+++ b/tools/purge_orphans.rb
@@ -11,6 +11,7 @@ purge_mode = opts[:mode].to_sym

 # now load rails
 require File.expand_path('../config/environment', __dir__)
+require "active_record/railties/console_sandbox"

 def purge_by_orphaned(klass, fk, window, purge_mode = false)
   klass.include PurgingMixin
```
