### PR TITLE
fix_auth: gracefully handle bad password encryption

### DIFF
--- a/tools/fix_auth/auth_model.rb
+++ b/tools/fix_auth/auth_model.rb
@@ -116,7 +116,8 @@ module FixAuth
             records_changed += 1 if r.changed?
             r.save! if !options[:dry_run] && r.changed?
             processed += 1
-          rescue ArgumentError # undefined class/module
+          rescue ArgumentError, # undefined class/module
+                 ManageIQ::Password::PasswordError
             errors += 1
             unless options[:allow_failures]
               STDERR.puts "unable to fix #{r.class.table_name}:#{r.id}" unless options[:silent]


### PR DESCRIPTION
The `--allow-failures` option goes through re-encryption, doing what it can. The `PasswordError` was added to `MiqPassword`, but is not currently handled.

This allows `fix_auth` to keep working despite that failure

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
