### PR TITLE
Remove MiqAlert eval in favor of predefined methods

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -422,7 +422,7 @@ class MiqAlert < ApplicationRecord
           {:name => :ems_id, :description => N_("Management System")},
           {:name => :ems_alarm_mor, :description => N_("Alarm")}
         ]},
-      {:name => "event_threshold", :description => N_("Event Threshold"), :db => ["Vm"], :responds_to_events => '#{hash_expression[:options][:event_types]}',
+      {:name => "event_threshold", :description => N_("Event Threshold"), :db => ["Vm"], :responds_to_events => '#{hash_expression[:options][:event_types].join(",")}',
         :options => [
           {:name => :event_types, :description => N_("Event to Check"), :values => ["CloneVM_Task", "CloneVM_Task_Complete", "DrsVmPoweredOnEvent", "MarkAsTemplate_Complete", "MigrateVM_Task", "PowerOnVM_Task_Complete", "ReconfigVM_Task_Complete", "ResetVM_Task_Complete", "ShutdownGuest_Complete", "SuspendVM_Task_Complete", "UnregisterVM_Complete", "VmPoweredOffEvent", "RelocateVM_Task_Complete"]},
           {:name => :time_threshold, :description => N_("How Far Back to Check"), :required => true},

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -798,18 +798,24 @@ class MiqAlert < ApplicationRecord
 
       alist.each do |alert_hash|
         guid = alert_hash["guid"] || alert_hash[:guid]
-        rec = find_by(:guid => guid)
-        if rec.nil?
-          alert_hash[:read_only] = true
-          alert = create(alert_hash)
-          _log.info("Added sample Alert: #{alert.description}")
-          if action
-            alert.options ||= {}
-            alert.options[:notifications] ||= {}
-            alert.options[:notifications][action.action_type.to_sym] = action.options
-            alert.save
-          end
+        alert_hash[:read_only] = true
+
+        alert = find_by(:guid => guid)
+        if alert.nil?
+          alert = new(alert_hash)
+          _log.info("Adding sample Alert: #{alert.description}")
+        else
+          alert.attributes = alert_hash
+          _log.info("Updating sample Alert: #{alert.description}")
         end
+
+        if action
+          alert.options ||= {}
+          alert.options[:notifications] ||= {}
+          alert.options[:notifications][action.action_type.to_sym] = action.options
+        end
+
+        alert.save!
       end
     end
   end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -417,12 +417,12 @@ class MiqAlert < ApplicationRecord
   def self.automate_expressions
     @automate_expressions ||= [
       {:name => "nothing", :description => N_(" Nothing"), :db => BASE_TABLES, :options => []},
-      {:name => "ems_alarm", :description => N_("VMware Alarm"), :db => ["Vm", "Host", "EmsCluster"], :responds_to_events => 'AlarmStatusChangedEvent_#{hash_expression[:options][:ems_id]}_#{hash_expression[:options][:ems_alarm_mor]}',
+      {:name => "ems_alarm", :description => N_("VMware Alarm"), :db => ["Vm", "Host", "EmsCluster"], :responds_to_events => :ems_alarm,
         :options => [
           {:name => :ems_id, :description => N_("Management System")},
           {:name => :ems_alarm_mor, :description => N_("Alarm")}
         ]},
-      {:name => "event_threshold", :description => N_("Event Threshold"), :db => ["Vm"], :responds_to_events => '#{hash_expression[:options][:event_types].join(",")}',
+      {:name => "event_threshold", :description => N_("Event Threshold"), :db => ["Vm"], :responds_to_events => :event_threshold,
         :options => [
           {:name => :event_types, :description => N_("Event to Check"), :values => ["CloneVM_Task", "CloneVM_Task_Complete", "DrsVmPoweredOnEvent", "MarkAsTemplate_Complete", "MigrateVM_Task", "PowerOnVM_Task_Complete", "ReconfigVM_Task_Complete", "ResetVM_Task_Complete", "ShutdownGuest_Complete", "SuspendVM_Task_Complete", "UnregisterVM_Complete", "VmPoweredOffEvent", "RelocateVM_Task_Complete"]},
           {:name => :time_threshold, :description => N_("How Far Back to Check"), :required => true},
@@ -448,7 +448,7 @@ class MiqAlert < ApplicationRecord
           {:name => :time_threshold, :description => N_("How Far Back to Check"), :required => true},
           {:name => :freq_threshold, :description => N_("Event Count Threshold"), :required => true, :numeric => true}
         ]},
-      {:name => "realtime_performance", :description => N_("Real Time Performance"), :db => (dbs = ["Vm", "Host", "EmsCluster"]), :responds_to_events => '#{db.underscore}_perf_complete',
+      {:name => "realtime_performance", :description => N_("Real Time Performance"), :db => (dbs = ["Vm", "Host", "EmsCluster"]), :responds_to_events => :realtime_performance,
         :options => [
           {:name => :perf_column, :description => N_("Performance Field"), :values => rt_perf_model_details(dbs)},
           {:name => :operator, :description => N_("Operator"), :values => [">", ">=", "<", "<=", "="]},
@@ -560,11 +560,20 @@ class MiqAlert < ApplicationRecord
     return nil if miq_expression || hash_expression.nil? || hash_expression[:eval_method] == "nothing"
 
     options = self.class.expression_by_name(hash_expression[:eval_method])
-    options && substitute(options[:responds_to_events])
+    options && evaluate_responds_to_events(options[:responds_to_events])
   end
 
-  def substitute(str)
-    eval("result = \"#{str}\"")
+  private def evaluate_responds_to_events(responds_to_events_value)
+    case responds_to_events_value
+    when :ems_alarm
+      "AlarmStatusChangedEvent_#{hash_expression[:options][:ems_id]}_#{hash_expression[:options][:ems_alarm_mor]}"
+    when :event_threshold
+      hash_expression[:options][:event_types].join(",")
+    when :realtime_performance
+      "#{db.underscore}_perf_complete"
+    else
+      responds_to_events_value
+    end
   end
 
   def evaluate_in_automate(target, inputs = {})

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -1,4 +1,16 @@
 RSpec.describe MiqAlert do
+  describe ".seed" do
+    it "sets responds_to_events for automate_expressions with dynamic values" do
+      MiqAlert.seed
+
+      alert = MiqAlert.find_by(:description => "VM Power On > 2 in last 15 min")
+      expect(alert.responds_to_events).to eq("PowerOnVM_Task_Complete")
+
+      alert = MiqAlert.find_by(:description => "VM Memory Balloon > 250 in last 10 min")
+      expect(alert.responds_to_events).to eq("vm_perf_complete")
+    end
+  end
+
   context "With single server with a single generic worker with the notifier role," do
     before do
       ServerRole.seed

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -372,12 +372,12 @@ RSpec.describe MiqAlert do
     end
 
     let(:vm_alert_set) do
-      alert = FactoryBot.create(:miq_alert_vm, :responds_to_events => "xxx|vm_perf_complete|zzz")
+      alert = FactoryBot.create(:miq_alert_vm, :responds_to_events => "xxx,vm_perf_complete,zzz")
       FactoryBot.create(:miq_alert_set_vm, :alerts => [alert])
     end
 
     let(:host_alert_set) do
-      alert = FactoryBot.create(:miq_alert_host, :responds_to_events => "xxx|host_perf_complete|zzz")
+      alert = FactoryBot.create(:miq_alert_host, :responds_to_events => "xxx,host_perf_complete,zzz")
       FactoryBot.create(:miq_alert_set_host, :alerts => [alert])
     end
 


### PR DESCRIPTION
@jrafanie Please review.

This is not a security issue, because, MiqAlert have a `hash_expression[:eval_method]`, which leads you to one of the predefined `automate_expressions` that are hardcoded.  One of the fields, `responds_to_events` could have dynamic content and is why the eval was needed.  As I was fixing this I noticed multiple weird issues, which fixes are included in this PR for.

1. Before the eval fix, when there are multiple responds_to_events, the previous code was basically doing an Array#to_s and putting that in the column (e.g. `"\["PowerOnVM_Task_Complete\"]"`).  One of the tests showed that a `|` character was used as the delimiter, but another test actually _parses_ the output using `,`, so it's clear to me that it was always a comma, and the `|` test happens to work because that test works with any delimiter.  I've fixed the delimiter, and ensured that when there are multiple events, they are comma-separated.
2. Since I've changed the default values for built-in events, seeding wasn't updating those records. This is wrong in general - if we make any changes to out of the box alerts, we want it to update the records, so there is a commit to add update support during seeding. I didn't add delete support, but I can, however maybe that should be a separate PR.
3. Finally, we can get rid of the eval, but using symbols to represent the method to evaluate.  Alternatively, I could use procs+instance_exec, but that felt unnecessary and might just trigger more security issues, whereas this is very straightforward.