### PR TITLE
[WIP] Fix widget sets with orphaned group

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -24,7 +24,7 @@ class MiqGroup < ApplicationRecord
 
   validates :description, :presence => true, :unique_within_region => {:match_case => false}
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
-  before_destroy :ensure_can_be_destroyed
+  before_destroy :ensure_can_be_destroyed, :destroy_subscribed_widget_sets
   after_destroy :reset_current_group_for_users
 
   # For REST API compatibility only; Don't use otherwise!
@@ -340,6 +340,10 @@ class MiqGroup < ApplicationRecord
 
   def current_user_group?
     id == current_user_group.try(:id)
+  end
+
+  def destroy_subscribed_widget_sets
+    MiqWidgetSet.where(:group_id => id).destroy_all
   end
 
   def ensure_can_be_destroyed

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -407,6 +407,8 @@ class MiqWidget < ApplicationRecord
     groups_by_id    = MiqGroup.in_my_region.where(:id => grouped_users.keys).index_by(&:id)
     users_by_userid = User.in_my_region.where(:userid => grouped_users.values.flatten.uniq).index_by(&:userid)
     grouped_users.each_with_object({}) do |(k, v), h|
+      next unless groups_by_id.key?(k) # Make sure the group associated with a widget set / dashboard hasn't been removed
+
       user_objs = users_by_userid.values_at(*v).reject(&:blank?)
       h[groups_by_id[k]] = user_objs if user_objs.present?
     end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe MiqWidgetSet do
     end
   end
 
+  it "group and owner associated to a deleted group" do
+    @ws_group.update(:group => group)
+    user.destroy
+    group.destroy!
+    expect(MiqWidgetSet.count).to eq(0)
+  end
+
+  it "group associated to a deleted group, nil owner" do
+    @ws_group.update!(:group => group, :owner => nil)
+    user.destroy
+    group.destroy!
+    expect(MiqWidgetSet.count).to eq(0)
+  end
+
   it "when a group dashboard is deleted" do
     expect(MiqWidgetSet.count).to eq(1)
     @ws_group.destroy


### PR DESCRIPTION
TODO: I have no idea why we have ownership AND group association for a widget set and why the owner can be nil and the group pointing to an orphaned group id.  This is fixing the symptoms but not really solving the problem yet.  We need to understand why these things were happening and how to properly fix it going forward.

see also:
- https://github.com/ManageIQ/manageiq/pull/23491