### PR TITLE
set automation attrs to get service object in ae root for service reconfiguration

### DIFF
--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -36,6 +36,8 @@ class ServiceReconfigureTask < MiqRequestTask
         :tenant_id        => get_user.current_tenant.id
       }
 
+      MiqAeEngine.set_automation_attributes_from_objects(source, args[:attrs])
+
       MiqQueue.put(
         :class_name     => 'MiqAeEngine',
         :method_name    => 'deliver',
@@ -44,7 +46,7 @@ class ServiceReconfigureTask < MiqRequestTask
         :zone           => zone,
         :tracking_label => tracking_label_id
       )
-      update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
+      update_and_notify_parent(:state => "pending", :status => "Ok", :message => "Automation Starting")
     else
       update_and_notify_parent(:state   => "finished",
                                :status  => "Ok",

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe ServiceReconfigureTask do
           :class_name       => 'class',
           :instance_name    => 'instance',
           :automate_message => 'create',
-          :attrs            => task.options[:dialog].merge("request" => task.request_type),
+          :attrs            => task.options[:dialog].merge("request" => task.request_type, "Service::service" => service.id),
           :user_id          => user.id,
           :miq_group_id     => user.current_group_id,
           :tenant_id        => user.current_tenant.id,


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

This change adds 'service' attribute/object in the ae root, for using during the Service Reconfiguration steps

https://jsw.ibm.com/browse/CP4AIOPS-5515

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
