### PR TITLE
Add logger that creates request_log entries

### DIFF
--- a/lib/vmdb/loggers/request_logger.rb
+++ b/lib/vmdb/loggers/request_logger.rb
@@ -1,0 +1,42 @@
+module Vmdb::Loggers
+  class RequestLogger
+
+    attr_accessor :logger
+
+    def initialize(resource_id, logger: $log)
+      @resource_id = resource_id
+      @logger = logger
+    end
+
+    LEVELS = [:debug, :info, :warn, :error]
+
+    # def debug?
+    # def info?
+    # def warn?
+    # def error?
+    # def add
+    # def level
+    # def log_backtrace
+    (LEVELS.map { |l| :"#{l}?" } + %i[add level log_backtrace]).each do |method|
+      define_method(method) { |*args| logger.send(method, *args) }
+    end
+
+    LEVELS.each do |level|
+      define_method(level) do |msg = nil, &blk|
+        request_log(level, msg, &blk)
+      end
+    end
+
+    private
+
+    def request_log(severity, message = nil)
+      # Partially copied from Logger#add
+      return true unless logger.send("#{severity}?".to_sym)
+
+      message = yield if message.nil? && block_given?
+
+      RequestLog.create(:message => message, :severity => severity.to_s.upcase, :resource_id => @resource_id)
+      logger.public_send(severity, message)
+    end
+  end
+end

--- a/spec/lib/vmdb/loggers/request_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/request_logger_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Vmdb::Loggers::RequestLogger do
+  let(:object_id) { 10 }
+  let(:log_stream) { double }
+  let(:log) { described_class.new(object_id, logger: log_stream) }
+
+  let(:message) { "stuff happened" }
+
+  it "logs to output" do
+    expect(log_stream).to receive(:info?).and_return(true)
+    expect(log_stream).to receive(:info).with(message)
+    log.info(message)
+  end
+
+  it "creates a record" do
+    expect(log_stream).to receive(:info?).and_return(true)
+    expect(log_stream).to receive(:info).with(message)
+
+    log.info(message)
+    request_log = RequestLog.last
+    expect(request_log.severity).to eq("INFO")
+    expect(request_log.message).to eq(message)
+  end
+
+  it "doesn't log when the level is too low" do
+    expect(log_stream).to receive(:debug?).and_return(false)
+    expect(log_stream).not_to receive(:debug)
+
+    log.debug(message)
+
+    expect(RequestLog.exists?).to be(false)
+  end
+end


### PR DESCRIPTION
This will be used by workflows, but possibly others

Extracted from:
- https://github.com/ManageIQ/manageiq-providers-workflows/pull/128


<img width="908" alt="SCR-20250401-qjhv" src="https://github.com/user-attachments/assets/f0b98b7f-9481-45f8-b80d-ad8f25fedd64" />


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
