### PR TITLE
Add RequestLogger from AutomationEngine

### DIFF
--- a/lib/vmdb/loggers/request_logger.rb
+++ b/lib/vmdb/loggers/request_logger.rb
@@ -1,17 +1,10 @@
 module Vmdb::Loggers
   class RequestLogger < ManageIQ::Loggers::Base
-    attr_reader :automation_log_wrapper
+    attr_reader :log_wrapper
 
-    def initialize(*args, automation_log_wrapper:, **kwargs)
-      @automation_log_wrapper = automation_log_wrapper
+    def initialize(*args, log_wrapper:, **kwargs)
+      @log_wrapper = log_wrapper
       super(*args, **kwargs)
-    end
-
-    def self.create_log_wrapper(io = File::NULL)
-      # We modify the interface of logger methods such as info/warn/etc. to allow the keyword argument
-      # resource_id. Therefore, we need to wrap all client logger calls to these methods to process the resource_id,
-      # cut the request_log entry and forward the remaining arguments to the logger.
-      new(io, :progname => "automation", :automation_log_wrapper => Vmdb::Loggers.create_logger("automation.log"))
     end
 
     private def add_to_db(severity, message = nil, progname = nil, resource_id: nil)
@@ -41,37 +34,37 @@ module Vmdb::Loggers
 
     def info(progname = nil, resource_id: nil, &block)
       severity, message, progname = add_to_db(INFO, nil, progname, resource_id: resource_id, &block)
-      automation_log_wrapper.add(severity, message, progname, &block)
+      log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def debug(progname = nil, resource_id: nil, &block)
       severity, message, progname = add_to_db(DEBUG, nil, progname, resource_id: resource_id, &block)
-      automation_log_wrapper.add(severity, message, progname, &block)
+      log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def warn(progname = nil, resource_id: nil, &block)
       severity, message, progname = add_to_db(WARN, nil, progname, resource_id: resource_id, &block)
-      automation_log_wrapper.add(severity, message, progname, &block)
+      log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def error(progname = nil, resource_id: nil, &block)
       severity, message, progname = add_to_db(ERROR, nil, progname, resource_id: resource_id, &block)
-      automation_log_wrapper.add(severity, message, progname, &block)
+      log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def fatal(progname = nil, resource_id: nil, &block)
       severity, message, progname = add_to_db(FATAL, nil, progname, resource_id: resource_id, &block)
-      automation_log_wrapper.add(severity, message, progname, &block)
+      log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def unknown(progname = nil, resource_id: nil, &block)
       severity, message, progname = add_to_db(UNKNOWN, nil, progname, resource_id: resource_id, &block)
-      automation_log_wrapper.add(severity, message, progname, &block)
+      log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
   end

--- a/lib/vmdb/loggers/request_logger.rb
+++ b/lib/vmdb/loggers/request_logger.rb
@@ -11,10 +11,11 @@ module Vmdb::Loggers
       return [severity, message, progname] unless resource_id
 
       # Adapted from Logger#add
-      severity ||= UNKNOWN
+      severity ||= Logger::UNKNOWN
       if severity < level
         return [severity, message, progname]
       end
+
       if progname.nil?
         progname = @progname
       end
@@ -33,37 +34,37 @@ module Vmdb::Loggers
     end
 
     def info(progname = nil, resource_id: nil, &block)
-      severity, message, progname = add_to_db(INFO, nil, progname, resource_id: resource_id, &block)
+      severity, message, progname = add_to_db(INFO, nil, progname, :resource_id => resource_id, &block)
       log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def debug(progname = nil, resource_id: nil, &block)
-      severity, message, progname = add_to_db(DEBUG, nil, progname, resource_id: resource_id, &block)
+      severity, message, progname = add_to_db(DEBUG, nil, progname, :resource_id => resource_id, &block)
       log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def warn(progname = nil, resource_id: nil, &block)
-      severity, message, progname = add_to_db(WARN, nil, progname, resource_id: resource_id, &block)
+      severity, message, progname = add_to_db(WARN, nil, progname, :resource_id => resource_id, &block)
       log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def error(progname = nil, resource_id: nil, &block)
-      severity, message, progname = add_to_db(ERROR, nil, progname, resource_id: resource_id, &block)
+      severity, message, progname = add_to_db(ERROR, nil, progname, :resource_id => resource_id, &block)
       log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def fatal(progname = nil, resource_id: nil, &block)
-      severity, message, progname = add_to_db(FATAL, nil, progname, resource_id: resource_id, &block)
+      severity, message, progname = add_to_db(FATAL, nil, progname, :resource_id => resource_id, &block)
       log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end
 
     def unknown(progname = nil, resource_id: nil, &block)
-      severity, message, progname = add_to_db(UNKNOWN, nil, progname, resource_id: resource_id, &block)
+      severity, message, progname = add_to_db(UNKNOWN, nil, progname, :resource_id => resource_id, &block)
       log_wrapper.add(severity, message, progname, &block)
       add(severity, message, progname, &block)
     end

--- a/lib/vmdb/loggers/request_logger.rb
+++ b/lib/vmdb/loggers/request_logger.rb
@@ -1,0 +1,78 @@
+module Vmdb::Loggers
+  class RequestLogger < ManageIQ::Loggers::Base
+    attr_reader :automation_log_wrapper
+
+    def initialize(*args, automation_log_wrapper:, **kwargs)
+      @automation_log_wrapper = automation_log_wrapper
+      super(*args, **kwargs)
+    end
+
+    def self.create_log_wrapper(io = File::NULL)
+      # We modify the interface of logger methods such as info/warn/etc. to allow the keyword argument
+      # resource_id. Therefore, we need to wrap all client logger calls to these methods to process the resource_id,
+      # cut the request_log entry and forward the remaining arguments to the logger.
+      new(io, :progname => "automation", :automation_log_wrapper => Vmdb::Loggers.create_logger("automation.log"))
+    end
+
+    private def add_to_db(severity, message = nil, progname = nil, resource_id: nil)
+      return [severity, message, progname] unless resource_id
+
+      # Adapted from Logger#add
+      severity ||= UNKNOWN
+      if severity < level
+        return [severity, message, progname]
+      end
+      if progname.nil?
+        progname = @progname
+      end
+      if message.nil?
+        if block_given?
+          message = yield
+        else
+          message = progname
+          progname = @progname
+        end
+      end
+
+      RequestLog.create(:message => message, :severity => format_severity(severity), :resource_id => resource_id) if resource_id
+
+      [severity, message, progname]
+    end
+
+    def info(progname = nil, resource_id: nil, &block)
+      severity, message, progname = add_to_db(INFO, nil, progname, resource_id: resource_id, &block)
+      automation_log_wrapper.add(severity, message, progname, &block)
+      add(severity, message, progname, &block)
+    end
+
+    def debug(progname = nil, resource_id: nil, &block)
+      severity, message, progname = add_to_db(DEBUG, nil, progname, resource_id: resource_id, &block)
+      automation_log_wrapper.add(severity, message, progname, &block)
+      add(severity, message, progname, &block)
+    end
+
+    def warn(progname = nil, resource_id: nil, &block)
+      severity, message, progname = add_to_db(WARN, nil, progname, resource_id: resource_id, &block)
+      automation_log_wrapper.add(severity, message, progname, &block)
+      add(severity, message, progname, &block)
+    end
+
+    def error(progname = nil, resource_id: nil, &block)
+      severity, message, progname = add_to_db(ERROR, nil, progname, resource_id: resource_id, &block)
+      automation_log_wrapper.add(severity, message, progname, &block)
+      add(severity, message, progname, &block)
+    end
+
+    def fatal(progname = nil, resource_id: nil, &block)
+      severity, message, progname = add_to_db(FATAL, nil, progname, resource_id: resource_id, &block)
+      automation_log_wrapper.add(severity, message, progname, &block)
+      add(severity, message, progname, &block)
+    end
+
+    def unknown(progname = nil, resource_id: nil, &block)
+      severity, message, progname = add_to_db(UNKNOWN, nil, progname, resource_id: resource_id, &block)
+      automation_log_wrapper.add(severity, message, progname, &block)
+      add(severity, message, progname, &block)
+    end
+  end
+end


### PR DESCRIPTION
Add a `Vmdb::Loggers::RequestLogger` based on the `AutomationEngine::Logger`

* Commit 1: straight copy from automation_engine/logger just copying it into `Vmdb::Loggers::RequestLogger`
* Commit 2:  rename `automation_log_wrapper` to just `log_wrapper`, drop the `.create_log_wrapper` class method since that was hard-coded to use the automation logger and it makes sense to just do this in a subclass
* Commit 3: rubocop -A on `request_logger.rb`

Follow-ups:
* Can we set resource_id in the initializer or do we need to log to different resources on each call?
* Can we use ManageIQ::Loggers.wrap

Related:
* https://github.com/ManageIQ/manageiq-providers-workflows/pull/128
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
