### PR TITLE
Add missing directory for postgresql pidfile

### DIFF
--- a/container-assets/entrypoint
+++ b/container-assets/entrypoint
@@ -23,6 +23,9 @@ KEY
 
 echo "== Checking MIQ database status =="
 
+mkdir -p /var/run/postgresql
+chown postgres:postgres /var/run/postgresql
+
 [[ -d /var/lib/pgsql/data/base ]]
 if [ $? -eq 0 ]; then
   echo "** DB already initialized"


### PR DESCRIPTION
Fixes monolithic container boot failure:
```
** Starting postgresql
waiting for server to start....2025-04-03 20:05:09.931 UTC [33] LOG:  redirecting log output to logging collector process 2025-04-03 20:05:09.931 UTC [33] HINT:  Future log output will appear in directory "log".
 stopped waiting
pg_ctl: could not start server
Examine the log output.
!! Failed to start postgresql service
```
