### PR TITLE
Rails 7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,9 @@ jobs:
       timeout-minutes: 30
     - name: Prepare tests
       run: bin/setup
-    - name: Check DB access on initialization
-      run: bundle exec rake test:verify_no_db_access_loading_rails_environment
+    - name: Run database connectivity tests
+      if: ${{ matrix.test-suite == 'vmdb' }}
+      run: bin/test_database_connectivity
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem "psych",                            ">=3.1",             :require => false #
 gem "query_relation",                   "~>0.1.0",           :require => false
 gem "rack",                             ">=2.2.14",          :require => false
 gem "rack-attack",                      "~>6.5.0",           :require => false
-gem "rails",                            "~>7.1.5", ">=7.1.5.1"
+gem "rails",                            "~>7.2.0", ">= 7.2.2.1"
 gem "rails-i18n",                       "~>7.x"
 gem "rake",                             ">=12.3.3",          :require => false
 gem "rest-client",                      "~>2.1.0",           :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-session_store",       "~>2.0"
-gem "activerecord-virtual_attributes",  "~>7.1.2"
+gem "activerecord-virtual_attributes",  "~>7.2.0"
 gem "acts_as_tree",                     "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                         "~>4.1.0",           :require => false
 gem "awesome_spawn",                    "~>1.6",             :require => false

--- a/bin/test_database_connectivity
+++ b/bin/test_database_connectivity
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd
+
+set -x
+bundle exec rake test:verify_no_db_access_loading_rails_environment
+bundle exec rake test:verify_connectable_with_valid_database
+bundle exec rake test:verify_not_connectable_with_invalid_database

--- a/config/application.rb
+++ b/config/application.rb
@@ -112,7 +112,7 @@ module Vmdb
 
     # FYI, this is where load_defaults is defined as of 7.2:
     # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
-    config.load_defaults 7.1
+    config.load_defaults 7.2
     # ensure MiqReport#extras will marshal/dump back out. 7.1 is default (and has better performance)
     # See for probable culprit https://www.github.com/rails/rails/pull/47747
     config.active_record.marshalling_format_version = 6.1

--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -1,5 +1,5 @@
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(Module.new do
-  def initialize(*args)
+  def configure_connection(*args)
     super
     check_version if respond_to?(:check_version)
   end

--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -27,9 +27,11 @@ module ActiveRecord
       _log.info("Completed Vacuuming of table #{table_name} with result #{result.result_status}")
     end
 
+    CONNECTIVITY_ERRORS = [ActiveRecord::ConnectionNotEstablished, ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError, PG::ConnectionBad].freeze
+
     def self.connectable?
       with_connection { |conn| conn.connect! && conn.connected? }
-    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError, PG::ConnectionBad
+    rescue *CONNECTIVITY_ERRORS
       false
     end
   end

--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -28,8 +28,8 @@ module ActiveRecord
     end
 
     def self.connectable?
-      connection && connected?
-    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError, PG::ConnectionBad
+      with_connection { |conn| conn.connect! && conn.connected? }
+    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError, PG::ConnectionBad
       false
     end
   end

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -25,7 +25,7 @@ module ArPglogicalMigrationHelper
 
     if direction == :up
       if version == SCHEMA_MIGRATIONS_RAN_MIGRATION
-        to_add = ActiveRecord::Base.connection.schema_migration.normalized_versions << version
+        to_add = ActiveRecord::Base.connection_pool.schema_migration.normalized_versions << version
       else
         to_add = [version]
       end

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -175,7 +175,7 @@ class EvmApplication
 
   def self.deployment_status
     migration_dir  = Rails.application.config.paths["db/migrate"]
-    migration_conn = ::ActiveRecord::Base.connection.schema_migration
+    migration_conn = ActiveRecord::Base.connection_pool.schema_migration
     context        = ActiveRecord::MigrationContext.new(migration_dir, migration_conn)
 
     return "new_deployment" if context.current_version.zero? || MiqServer.none?

--- a/lib/tasks/evm_rake_helper.rb
+++ b/lib/tasks/evm_rake_helper.rb
@@ -3,7 +3,7 @@ module EvmRakeHelper
   # For some rake tasks, the database.yml may not yet be setup and is not required anyway.
   # Note: Rails will not actually use the configuration and connect until you issue a query.
   def self.with_dummy_database_url_configuration
-    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql:///not_existing_db?host=/var/lib/postgresql"
+    before, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgresql:///not_existing_db"
     before_db_check, ENV["PERFORM_DB_CONNECTABLE_CHECK"] = ENV["PERFORM_DB_CONNECTABLE_CHECK"], "false"
     yield
   ensure

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -22,7 +22,7 @@ if defined?(RSpec)
         begin
           puts "** Confirming rails environment does not connect to the database"
           Rake::Task['environment'].invoke
-        rescue ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError
+        rescue *ActiveRecord::Base::CONNECTIVITY_ERRORS
           STDERR.write "\e[31;1mDetected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n\e[0m"
           raise
         end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -13,7 +13,7 @@ if defined?(RSpec)
     end
 
     desc "Verifies that the rails environment does not require DB access"
-    task :verify_no_db_access_loading_rails_environment do
+    task :verify_no_db_access_loading_rails_environment => :initialize do
       if Rake::Task['environment'].already_invoked
         raise "Failed to verify database access when loading rails because the 'environment' rake task has already been invoked!"
       end
@@ -23,9 +23,29 @@ if defined?(RSpec)
           puts "** Confirming rails environment does not connect to the database"
           Rake::Task['environment'].invoke
         rescue ActiveRecord::NoDatabaseError
-          STDERR.write "Detected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n"
+          STDERR.write "\e[31;1mDetected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n\e[0m"
           raise
         end
+      end
+    end
+
+    desc "Verifies that a valid database is connectable"
+    task :verify_connectable_with_valid_database => :initialize do
+      puts "** Confirming valid database is connectable"
+      Rake::Task['environment'].invoke
+      raise "\e[31;1mExpected valid database to be connectable!\e[0m" unless ActiveRecord::Base.connectable?
+    end
+
+    desc "Verifies that an invalid database is not connectable"
+    task :verify_not_connectable_with_invalid_database => :initialize do
+      if Rake::Task['environment'].already_invoked
+        raise "\e[31;1mFailed to verify database access when loading rails because the 'environment' rake task has already been invoked!\e[0m"
+      end
+
+      EvmRakeHelper.with_dummy_database_url_configuration do
+        puts "** Confirming invalid database is not connectable"
+        Rake::Task['environment'].invoke
+        raise "\e[31;1mExpected invalid database to not be connectable!\e[0m" if ActiveRecord::Base.connectable?
       end
     end
 

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -22,7 +22,7 @@ if defined?(RSpec)
         begin
           puts "** Confirming rails environment does not connect to the database"
           Rake::Task['environment'].invoke
-        rescue ActiveRecord::NoDatabaseError
+        rescue ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError
           STDERR.write "\e[31;1mDetected Rails environment trying to connect to the database!  Check the backtrace for an initializer trying to access the database.\n\n\e[0m"
           raise
         end

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -15,11 +15,8 @@ module Vmdb
     end
 
     def self.init_secret_token
-      return if Rails.application.config.secret_key_base
-
-      token = session_secret_token || SecureRandom.hex(64)
-
-      Rails.application.config.secret_key_base = token
+      # secret_key_base getter changed in 7.2 to provide a local default if not provided but we ignore it
+      Rails.application.config.secret_key_base = session_secret_token || SecureRandom.hex(64)
     end
 
     private_class_method def self.session_secret_token

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ArPglogicalMigrationHelper do
     let(:version) { "1234567890" }
 
     # sanity check - if this is somehow a version we have, these tests will make no sense
-    before { expect(ActiveRecord::Base.connection.schema_migration.normalized_versions).not_to include(version) }
+    before { expect(ActiveRecord::Base.connection_pool.schema_migration.normalized_versions).not_to include(version) }
   end
 
   context "with a region seeded" do
@@ -23,7 +23,7 @@ RSpec.describe ArPglogicalMigrationHelper do
         include_context "without the schema_migrations_ran table"
 
         it "does nothing" do
-          expect(ActiveRecord::Base.connection.schema_migration).not_to receive(:normalized_versions)
+          expect(ActiveRecord::Base.connection_pool.schema_migration).not_to receive(:normalized_versions)
           described_class.update_local_migrations_ran("12345", :up)
         end
       end

--- a/spec/lib/vmdb/initializer_spec.rb
+++ b/spec/lib/vmdb/initializer_spec.rb
@@ -1,18 +1,24 @@
 RSpec.describe Vmdb::Initializer do
   describe ".init_secret_token" do
     before do
-      @token = Rails.application.secret_key_base
+      @token = Rails.application.config.secret_key_base
     end
 
     after do
       Rails.application.config.secret_key_base = @token
-      Rails.application.secrets = nil
     end
 
     it "defaults to MiqDatabase session_secret_token" do
       MiqDatabase.seed
-      Rails.application.config.secret_key_base = nil
-      Rails.application.secrets = nil
+
+      described_class.init_secret_token
+      expect(Rails.application.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
+      expect(Rails.application.config.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
+    end
+
+    it "running init_secret_token a second time will not change the token" do
+      MiqDatabase.seed
+      Rails.application.config.secret_key_base = MiqDatabase.first.session_secret_token
 
       described_class.init_secret_token
       expect(Rails.application.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
@@ -20,22 +26,9 @@ RSpec.describe Vmdb::Initializer do
     end
 
     it "uses random hex when MiqDatabase isn't seeded" do
-      Rails.application.config.secret_key_base = nil
-      Rails.application.secrets = nil
-
       described_class.init_secret_token
       expect(Rails.application.secret_key_base).to match(/^\h{128}$/)
       expect(Rails.application.config.secret_key_base).to match(/^\h{128}$/)
-    end
-
-    it "does not reset secrets when token already configured" do
-      existing_value = SecureRandom.hex(64)
-      Rails.application.config.secret_key_base = existing_value
-      Rails.application.secrets = nil
-
-      described_class.init_secret_token
-      expect(Rails.application.secret_key_base).to eq(existing_value)
-      expect(Rails.application.config.secret_key_base).to eq(existing_value)
     end
 
     it "uses random hex when MiqDatabase is seeded with invalid session_secret_token" do
@@ -43,8 +36,6 @@ RSpec.describe Vmdb::Initializer do
         d.session_secret_token_encrypted = "xxx"
         d.save!(validate: false)
       end
-      Rails.application.config.secret_key_base = nil
-      Rails.application.secrets = nil
       expect(described_class).to receive(:log_error_and_tty_aware_warn).at_least(:once)
 
       described_class.init_secret_token


### PR DESCRIPTION
Fixes #23201 

TODO:

- [x] Release virtual attributes and use it, 🙇 Keenan: https://github.com/ManageIQ/activerecord-virtual_attributes/pull/187
- [x] Fix credentials in provider repos, 🙇 Fryguy: https://github.com/ManageIQ/manageiq/pull/23496
- [x] 💚 on [cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/971)
- [x] Test with rails 7.2 defaults
- [x] Set rails 7.2 minimum to latest before merge


Details:

Here's the load_defaults for 7.2: https://github.com/rails/rails/blob/v7.2.2.1/railties/lib/rails/application/configuration.rb#L321-L337


```ruby
        when "7.2"
          load_defaults "7.1"

          self.yjit = true

          if respond_to?(:active_job)
            active_job.enqueue_after_transaction_commit = :default
          end

          if respond_to?(:active_storage)
            active_storage.web_image_content_types = %w( image/png image/jpeg image/gif image/webp )
          end

          if respond_to?(:active_record)
            active_record.postgresql_adapter_decode_dates = true
            active_record.validate_migration_timestamps = true
          end
```


* postgresql_adapter_decode_dates: https://www.github.com/rails/rails/pull/51483 https://www.github.com/rails/rails/pull/51763
* validate_migration_timestamps: https://www.github.com/rails/rails/pull/50400
* yjit: https://www.github.com/rails/rails/pull/51894
