### PR TITLE
Add a RequestLogger that creates RequestLog records

### DIFF
--- a/lib/vmdb/loggers/request_logger.rb
+++ b/lib/vmdb/loggers/request_logger.rb
@@ -1,0 +1,32 @@
+module Vmdb::Loggers
+  class RequestLogger < ManageIQ::Loggers::Base
+    attr_reader :resource_id
+
+    def initialize(*args, resource_id:, **kwargs)
+      @resource_id = resource_id
+      super(nil, *args, **kwargs)
+    end
+
+    def add(severity, message = nil, progname = nil)
+      severity ||= Logger::UNKNOWN
+      if resource_id.nil? or severity < level
+        return true
+      end
+      if progname.nil?
+        progname = @progname
+      end
+      if message.nil?
+        if block_given?
+          message = yield
+        else
+          message = progname
+          progname = @progname
+        end
+      end
+
+      RequestLog.create(:message => message, :severity => format_severity(severity), :resource_id => resource_id)
+
+      true
+    end
+  end
+end

--- a/lib/vmdb/loggers/request_logger.rb
+++ b/lib/vmdb/loggers/request_logger.rb
@@ -3,30 +3,17 @@ module Vmdb::Loggers
     attr_reader :resource_id
 
     def initialize(*args, resource_id:, **kwargs)
-      @resource_id = resource_id
       super(nil, *args, **kwargs)
+
+      @resource_id = resource_id
+      @logdev      = Logdev.new(resource_id) if resource_id
+      @formatter   = Formatter.new
     end
 
-    def add(severity, message = nil, progname = nil)
-      severity ||= Logger::UNKNOWN
-      if resource_id.nil? or severity < level
-        return true
+    class Formatter
+      def call(severity, _time, _progname, msg)
+        "#{severity}:#{msg}"
       end
-      if progname.nil?
-        progname = @progname
-      end
-      if message.nil?
-        if block_given?
-          message = yield
-        else
-          message = progname
-          progname = @progname
-        end
-      end
-
-      RequestLog.create(:message => message, :severity => format_severity(severity), :resource_id => resource_id)
-
-      true
     end
   end
 end

--- a/lib/vmdb/loggers/request_logger/logdev.rb
+++ b/lib/vmdb/loggers/request_logger/logdev.rb
@@ -1,0 +1,17 @@
+module Vmdb::Loggers
+  class RequestLogger
+    class Logdev
+      attr_reader :resource_id
+
+      def initialize(resource_id)
+        @resource_id = resource_id
+      end
+
+      def write(message)
+        severity, message = message.split(":", 2)
+
+        RequestLog.create(:message => message, :severity => severity, :resource_id => resource_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows us to use `ManageIQ::Loggers::Base#wrap` to broadcast logs over to the RequestLogger from anywhere,
```
>> logger = Vmdb::Loggers.create_logger("automation.log").wrap(Vmdb::Loggers::RequestLogger.new(:resource_id => 2))
=> 
#<ActiveSupport::BroadcastLogger:0x00007ff698812658
...
>> logger.info("hi")
The version of PostgreSQL being connected to (170004) is incompatible with ManageIQ (130000 / 13 required)
The version of PostgreSQL being connected to (170004) is incompatible with ManageIQ (130000 / 13 required)
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 1, waiting_in_queue: 0
  TRANSACTION (0.7ms)  BEGIN
  RequestLog Create (9.3ms)  INSERT INTO "request_logs" ("message", "severity", "resource_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"  [["message", "hi"], ["severity", "INFO"], ["resource_id", 2], ["created_at", "2025-04-25 14:13:55.088777"], ["updated_at", "2025-04-25 14:13:55.088777"]]
  TRANSACTION (2.1ms)  COMMIT
=> true
>> RequestLog.last
  RequestLog Load (3.8ms)  SELECT "request_logs".* FROM "request_logs" ORDER BY "request_logs"."id" DESC LIMIT $1  [["LIMIT", 1]]
  RequestLog Inst Including Associations (0.1ms - 1rows)
=> 
#<RequestLog:0x00007ff68b5ef3d8
 id: 1094,
 message: "hi",
 severity: "INFO",
 resource_id: 2,
 created_at: Fri, 25 Apr 2025 14:13:55.088777000 UTC +00:00,
 updated_at: Fri, 25 Apr 2025 14:13:55.088777000 UTC +00:00>
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
