### PR TITLE
Fix issue where a different git init.defaultbranch can break the tests

### DIFF
--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Vmdb::Plugins do
 
         Dir.chdir(dir) do
           `
-          git init &&
+          git init --initial-branch master &&
           touch foo  && git add -A && git commit -m "Added foo" --no-gpg-sign &&
           touch foo2 && git add -A && git commit -m "Added foo2" --no-gpg-sign
           `


### PR DESCRIPTION
A local git setup with init.defaultbranch=main will break these tests. We enforce the name as master to ensure the tests pass regardless of the system setting.

@jrafanie @elsamaryv Please review