### PR TITLE
Fix to skip runner_execution_spec when Ansible Runner is not installed locally

### DIFF
--- a/spec/lib/ansible/runner_execution_spec.rb
+++ b/spec/lib/ansible/runner_execution_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Ansible::Runner do
   before do
-    pending("ansible-runner executable not available") unless described_class.available?
+    skip("ansible-runner executable not available") unless described_class.available?
   end
 
   let(:data_directory) { Pathname.new(__dir__).join("runner/data") }


### PR DESCRIPTION
Previously, runner_execution_spec would fail if Ansible Runner wasn't installed locally. This fix ensures the spec only runs when the package is available.

Please review @Fryguy 