### PR TITLE
Fix test issues from rspec-mocks 3.13.3

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -93,7 +93,7 @@ class MiqSchedule < ApplicationRecord
 
       _log.info("Queueing start of schedule id: [#{id}] [#{sched.name}] [#{sched.resource_type}] [#{method}]...complete")
       msg
-    elsif sched.resource.respond_to?(method)
+    elsif sched.resource.respond_to?(method, true)
       sched.resource.send(method, *sched.sched_action[:args])
       sched.update(:last_run_on => Time.now.utc)
     else

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -741,15 +741,18 @@ RSpec.describe MiqSchedule do
         end
 
         it "and responds to the method with arguments" do
+          cluster = FactoryBot.create(:ems_cluster)
+          resource.update!(:ems_cluster => cluster)
+
           schedule = FactoryBot.create(
             :miq_schedule,
             :resource     => resource,
-            :sched_action => {:method => "raise_cluster_event", :args => ["abc", 123]}
+            :sched_action => {:method => "raise_cluster_event", :args => [cluster.id, "abc"]}
           )
 
-          expect_any_instance_of(Host).to receive("raise_cluster_event").once.with("abc", 123)
+          expect_any_instance_of(Host).to receive("raise_cluster_event").with(cluster.id, "abc").once
 
-          MiqSchedule.queue_scheduled_work(schedule.id, nil, "abc", nil)
+          MiqSchedule.queue_scheduled_work(schedule.id, nil, nil, nil)
         end
       end
     end

--- a/spec/models/service/dialog_properties/retirement_spec.rb
+++ b/spec/models/service/dialog_properties/retirement_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Service::DialogProperties::Retirement do
   context 'when setting retirement warn date' do
     it 'with retirement_warn_on' do
       user = FactoryBot.create(:user)
-      expect(user).to receive(:with_my_timezone).exactly(3).times.and_yield
+      allow(user).to receive(:with_my_timezone).and_yield
 
       Timecop.freeze(time) do
         options = {'dialog_service_retires_in_days'    => 5,


### PR DESCRIPTION
See the individual commits and commit messages for the details.
See https://github.com/rspec/rspec/blob/rspec-support-v3.13.3/rspec-mocks/Changelog.md for the details of rspec-mocks 3.13.3

These changes are backwards compatible with rspec-mocks 3.13.2, so no need to enforce a new minimum.

@kbrock Please review - (@jrafanie helped me with this one, so he's recused)