### PR TITLE
Use `hostname -f` for `MiqEnvironment.fully_qualified_domain_name`

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -9,10 +9,7 @@ module MiqEnvironment
   # Return the fully qualified hostname for the local host.
   #
   def self.fully_qualified_domain_name
-    hostname    = Socket.gethostname
-    addrinfo    = Addrinfo.getaddrinfo(hostname, nil, nil, :STREAM).first
-    fqdn, _port = addrinfo.getnameinfo
-    fqdn
+    @fully_qualified_domain_name ||= `hostname -f`.chomp
   end
 
   # Return the local IP v4 address of the local host

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -3,14 +3,12 @@ require 'socket'
 RSpec.describe "Server Environment Management" do
   context ".get_network_information" do
     let(:mac_address) { 'a:1:b:2:c:3:d:4' }
-    let(:hostname)    { "localhost" }
+    let(:hostname)    { `hostname -f`.chomp }
     let(:ip_address)  { "10.1.2.3" }
 
     before do
       require "uuidtools"
       allow(UUIDTools::UUID).to receive(:mac_address).and_return(mac_address)
-      allow(Socket).to receive(:gethostname).and_return("localhost")
-      allow(Addrinfo).to receive(:getaddrinfo).with("localhost", nil, nil, :STREAM).and_return([Addrinfo.tcp("localhost", nil)])
       allow(Socket).to receive(:ip_address_list).and_return([Addrinfo.ip(ip_address)])
     end
 


### PR DESCRIPTION
Part of me wants to say screw it and just shell out to `hostname -f` instead of trying to chase the complexity of multiple interfaces each with different hostnames / different resolver configurations causing the dns portion to be different.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
