### PR TITLE
Add `ServiceTemplate{Awx,AnsibleTower}.available_managers` to retrieve available automation managers generically

### DIFF
--- a/app/models/mixins/service_template_automation_mixin.rb
+++ b/app/models/mixins/service_template_automation_mixin.rb
@@ -1,0 +1,13 @@
+module ServiceTemplateAutomationMixin
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def available_managers
+      automation_manager_klass.all
+    end
+
+    def automation_manager_klass
+      @automation_manager_klass ||= "ManageIQ::Providers::#{name.sub("ServiceTemplate", "")}::AutomationManager".constantize
+    end
+  end
+end

--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -1,5 +1,6 @@
 class ServiceTemplateAnsibleTower < ServiceTemplate
   include ServiceConfigurationMixin
+  include ServiceTemplateAutomationMixin
 
   before_update :remove_invalid_resource
 

--- a/app/models/service_template_awx.rb
+++ b/app/models/service_template_awx.rb
@@ -1,5 +1,6 @@
 class ServiceTemplateAwx < ServiceTemplate
   include ServiceConfigurationMixin
+  include ServiceTemplateAutomationMixin
 
   before_update :remove_invalid_resource
 


### PR DESCRIPTION
Currently the CatalogController presents all automation managers as available selections for ServiceTemplates, e.g. you could select an EmbeddedTerraform provider for a ServiceTemplateAnsibleTower type catalog item.

Rather than hard code the class names in the CatalogController we can expose a method to generically get a list of managers that would work for each service catalog type.

Ref: https://github.com/ManageIQ/manageiq-ui-classic/issues/9430

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
