### PR TITLE
Fix ServiceTemplate#available_managers

### DIFF
--- a/app/models/mixins/service_template_automation_mixin.rb
+++ b/app/models/mixins/service_template_automation_mixin.rb
@@ -10,4 +10,6 @@ module ServiceTemplateAutomationMixin
       @automation_manager_klass ||= "ManageIQ::Providers::#{name.sub("ServiceTemplate", "")}::AutomationManager".constantize
     end
   end
+
+  delegate :available_managers, :to => :class
 end


### PR DESCRIPTION
The CatalogController creates a new in-memory instance of a ServiceTemplate so this has to be accessible via the instance as well.

Follow-up to: https://github.com/ManageIQ/manageiq/pull/23447

Test coverage added in https://github.com/ManageIQ/manageiq-ui-classic/pull/9445
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
