### PR TITLE
Clean up: remove methods no longer in use

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -348,15 +348,6 @@ class MiqReportResult < ApplicationRecord
     result_type.to_sym == :html ? html_rows : report_results
   end
 
-  def self.counts_by_userid
-    where("userid NOT LIKE 'widget%'").select("userid, COUNT(id) as count").group("userid")
-      .collect { |rr| {:userid => rr.userid, :count => rr.count.to_i} }
-  end
-
-  def self.orphaned_counts_by_userid
-    counts_by_userid.reject { |h| User.exists?(:userid => h[:userid]) }
-  end
-
   def self.delete_by_userid(userids)
     userids = Array.wrap(userids.presence)
     _log.info("Queuing deletion of report results for the following user ids: #{userids.inspect}")

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -247,21 +247,6 @@ RSpec.describe MiqReportResult do
     end
   end
 
-  describe ".counts_by_userid" do
-    it "fetches counts" do
-      u1 = FactoryBot.create(:user)
-      u2 = FactoryBot.create(:user)
-      FactoryBot.create(:miq_report_result, :userid => u1.userid)
-      FactoryBot.create(:miq_report_result, :userid => u1.userid)
-      FactoryBot.create(:miq_report_result, :userid => u2.userid)
-
-      expect(MiqReportResult.counts_by_userid).to match_array([
-        {:userid => u1.userid, :count => 2},
-        {:userid => u2.userid, :count => 1}
-      ])
-    end
-  end
-
   describe "#to_pdf" do
     let(:user)   { FactoryBot.create(:user) }
     let(:report) { FactoryBot.create(:miq_report, :title => report_title) }


### PR DESCRIPTION
Removed methods related to orphaned data tab that is no longer used.