### PR TITLE
Bump manageiq-loggers to v1.2.1 for journald fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "kubeclient",                       "~>4.0",             :require => false #
 gem "linux_admin",                      ">=3.0", "<5",       :require => false
 gem "listen",                           "~>3.2",             :require => false
 gem "manageiq-api-client",              "~>0.6.0",           :require => false
-gem "manageiq-loggers",                 "~>1.2",             :require => false
+gem "manageiq-loggers",                 "~>1.2", ">= 1.2.1", :require => false
 gem "manageiq-messaging",               "~>1.5",             :require => false
 gem "manageiq-password",                "~>1.0",             :require => false
 gem "manageiq-postgres_ha_admin",       "~>3.4",             :require => false


### PR DESCRIPTION
Fix an issue where the caller_locations returns `nil` causing an exception.

https://github.com/ManageIQ/manageiq-loggers/releases/tag/v1.2.1
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
