### PR TITLE
Set bcrypt cost low for faster dev and test environment

### DIFF
--- a/config/initializers/bcrypt_engine.rb
+++ b/config/initializers/bcrypt_engine.rb
@@ -1,0 +1,9 @@
+# Reduce dev/test computational cost to authenticate users by using
+# 4 (minimum) cost instead of 12 (default).
+# See https://github.com/bcrypt-ruby/bcrypt-ruby/issues/180
+unless Rails.env.production?
+  ActiveSupport.on_load(:active_record) do
+    require 'bcrypt'
+    BCrypt::Engine.cost = 4
+  end
+end


### PR DESCRIPTION
Reduce dev/test computational cost to authenticate users by using the minium cost, 4, instead of the default of 12.

See https://www.github.com/bcrypt-ruby/bcrypt-ruby/issues/180

For cypress tests especially, but anywhere we do logins such as test or dev will be faster by using a low cost when creating the bcrypt password.

In my testing, it was 7x faster.  For cypress tests that login hundreds of times, it can add up.

```
Benchmark.realtime_block(:authenticate) { User.authenticate("user", "password") }
```

```
before:
{:authenticate=>0.28246092796325684}

after:
{:authenticate=>0.04195690155029297}]
```

Note, you'll need to create new passwords with this cost set.  For me, it was easiest to recreate the admin user in dev with this in rails console:

```ruby
User.first.destroy
User.seed
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
