### PR TITLE
Drop Tenant#use_config_for_attributes

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1045,7 +1045,6 @@ en:
       uri_or_queue_name: Uri Or Queue Name
       uri: Uri
       url: URL
-      use_config_for_attributes: Use Config For Attributes
       used: Used
       used_storage: Used Storage
       user_assigned_os: User Assigned Os

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -460,16 +460,6 @@ RSpec.describe ChargebackVm do
       it "report a chargeback of a subtenant" do
         expect(subject.vm_name).to eq(vm.name)
       end
-
-      context "with settings derived tenant name" do
-        let(:tenant) { FactoryBot.create(:tenant, :use_config_for_attributes => true) }
-
-        before { stub_settings_merge(:server => {:company => "Special Name"}) }
-
-        it "report a chargeback of a subtenant" do
-          expect(subject&.vm_name).to eq(vm.name)
-        end
-      end
     end
 
     context "Monthly" do

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -121,7 +121,7 @@ module EvmSpecHelper
   end
 
   def self.remote_miq_server(attrs = {})
-    Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => false)
+    Tenant.root_tenant || Tenant.seed
 
     FactoryBot.create(:miq_server, attrs)
   end


### PR DESCRIPTION
Before
======

`use_config_for_attributes` allowed an admin to denote the top tenant to load the company name from settings instead of from the root Tenant record.

This is useful when multiple ui appliances are in the same region but they are configured quite differently (e.g.: different LDAP server) and they want to have different login pages to help the user login to the correct ui server

After
=====

The Tenant record is king and the company name value is read from the database record without special override logic.

`use_config_for_attributes` defaulted to true, meaning that settings was the default behavior. Since this is not our desired behavior, it was confusing for customers.

Settings
========

```yaml
settings:
  server:
    company:
    use_custom_login_text:
    custom_login_text:
```

See Also:
- [ ] Migrations
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/9455
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1285