### PR TITLE
Remove declared system gems that are actual dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -295,9 +295,7 @@ group :web_socket, :manageiq_default do
 end
 
 group :appliance, :optional => true do
-  gem "irb",                            "=1.4.1",             :require => false # Locked to same version as the installed RPM rubygem-irb-1.4.1-142.module_el9+787+b20bfeee.noarch so that we don't bundle our own
   gem "manageiq-appliance_console",     "~>10.0", ">=10.0.2", :require => false
-  gem "rdoc",                                                 :require => false # Needed for rails console
 end
 
 ### Development and test gems are excluded from appliance and container builds to reduce size and license issues


### PR DESCRIPTION
These were added to the Gemfile in https://github.com/ManageIQ/manageiq/pull/22899 when we were still on Rails 6.1 
and Rails didn't specify a dependency on irb. Now that we are on Rails 7, railties specifies irb as a dependency, and also irb specifies a dependency on rdoc, so these lines are no longer needed.

This is effectively a revert of #22899

@bdunne Please review.

