### PR TITLE
converge MiqExpression#lenient evaluate and evaluate

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -206,14 +206,14 @@ class CustomButton < ApplicationRecord
     return true unless enablement_expression
     return false if enablement_expression && !object # list
 
-    enablement_expression.lenient_evaluate(object)
+    enablement_expression.evaluate(object)
   end
 
   def evaluate_visibility_expression_for(object)
     return true unless visibility_expression
     return false if visibility_expression && !object # object == nil, method is called for list of objects
 
-    visibility_expression.lenient_evaluate(object)
+    visibility_expression.evaluate(object)
   end
 
   # End - Helper methods to support moving automate columns to resource_actions table

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -52,7 +52,7 @@ module MiqReport::Generator::Trend
 
     if conditions
       tz = User.lookup_by_userid(options[:userid]).get_timezone if options[:userid]
-      results = results.reject { |obj| conditions.lenient_evaluate(obj, tz) }
+      results = results.reject { |obj| conditions.evaluate(obj, tz) }
     end
     results = results[0...options[:limit]] if options[:limit]
     [results]

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -575,14 +575,9 @@ class MiqExpression
     }
   end
 
-  def lenient_evaluate(obj, timezone = nil, prune_sql: false)
+  def evaluate(obj, timezone = nil, prune_sql: false)
     ruby_exp = to_ruby(timezone, :prune_sql => prune_sql)
     ruby_exp.nil? || Condition.subst_matches?(ruby_exp, obj)
-  end
-
-  def evaluate(obj, tz = nil)
-    ruby_exp = to_ruby(tz)
-    Condition.subst_matches?(ruby_exp, obj)
   end
 
   def self.evaluate_atoms(exp, obj)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -919,7 +919,7 @@ module Rbac
     end
 
     def matches_search_filters?(obj, filter, timezone, prune_sql: true)
-      filter.nil? || filter.lenient_evaluate(obj, timezone, :prune_sql => prune_sql)
+      filter.nil? || filter.evaluate(obj, timezone, :prune_sql => prune_sql)
     end
   end
 end


### PR DESCRIPTION
(Extracted from a number of local branches)

Goal: converge miq_expression so we can remove `eval`
----


`evaluate` is only called with an miq expression value (throws an error otherwise).

```ruby
def evaluate
  return anything if !expression # this can not happen, so we don't care
  return run_the_expression
end

def lenient_evaluate
  return true if !expression
  return run_the_expression
end
```

Returning true when no expression (Lenient case) seems to work for both evaluates. Since we are not throwing an error for the non-lenient case, then we know that case is not called with a blankfds expression.

Having a single evaluate pattern then simplifies filtering. By filtering, I mean running a single expression across an array of objects, returning the objects when they match.

```ruby
# filtering example
[1, 2, 3].select { |x| evaluate(x) }
```
