### PR TITLE
Fix typo Memeory->Memory

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -700,9 +700,9 @@ en:
       mem_swapped_absolute_average: Memory - Swapped Average
       mem_swaptarget_absolute_average: Memory - Swap Target Average
       mem_usage_absolute_average: Memory - Usage of Total Allocated (%)
-      mem_usage_absolute_average_avg_over_time_period: Memeory Usage Absolute Average Avg Over Time Period
-      mem_usage_absolute_average_high_over_time_period: Memeory Usage Absolute Average High Over Time Period
-      mem_usage_absolute_average_low_over_time_period: Memeory Usage Absolute Average Low Over Time Period
+      mem_usage_absolute_average_avg_over_time_period: Memory Usage Absolute Average Avg Over Time Period
+      mem_usage_absolute_average_high_over_time_period: Memory Usage Absolute Average High Over Time Period
+      mem_usage_absolute_average_low_over_time_period: Memory Usage Absolute Average Low Over Time Period
       mem_vmmemctl_absolute_average: Memory - Balloon Average
       mem_vmmemctltarget_absolute_average: Memory - Balloon Target Average
       memory: Memory


### PR DESCRIPTION
I noticed this typo when scrolling this enormous list of fields:

![image](https://github.com/user-attachments/assets/4b67e4e7-c475-46e9-b1bd-95fc2311e532)
