### PR TITLE
Ensure authenticator respects local_login_disabled

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -1,6 +1,6 @@
 module Authenticator
   def self.for(config, username = nil)
-    if username == 'admin'
+    if username == 'admin' && !::Settings.authentication.local_login_disabled
       Database.new(config)
     else
       authenticator_class(config[:mode])&.new(config)

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Authenticator do
       expect(Authenticator.for({:mode => 'ldap'}, 'admin')).to be_a(Authenticator::Database)
       expect(Authenticator.for({:mode => 'httpd'}, 'admin')).to be_a(Authenticator::Database)
     end
+
+    it "instantiates matching class for admin when local_login_disabled is enabled" do
+      stub_settings_merge(:authentication => {:local_login_disabled => true})
+      expect(Authenticator.for({:mode => 'httpd'}, 'admin')).to be_a(Authenticator::Httpd)
+    end
   end
 
   describe '#authorize' do


### PR DESCRIPTION
    

In the appliance console, the user can disable the local admin user.

In this case, the ldap server (or which ever the configuration) is
used to determine the admin's username/password

This is in response to https://github.com/orgs/ManageIQ/discussions/23468

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
