### PR TITLE
Add appliance/container tests for ansible-runner

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,29 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "57a67fd8c12d36c64fa21e5e7a93eeb6eac1f6fd4e6a1666f98c503574c46360",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "lib/ansible/runner.rb",
+      "line": 451,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`#{(File.join(venv_bin_path, \"ansible\") or \"ansible\")} --version 2>/dev/null`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Ansible::Runner",
+        "method": "s(:self).ansible_version_raw"
+      },
+      "user_input": "File.join(venv_bin_path, \"ansible\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "This method is safe because it only uses hardcoded paths, which cannot be changed by user input."
+    },
+    {
       "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
@@ -22,18 +45,18 @@
     {
       "warning_type": "Command Injection",
       "warning_code": 14,
-      "fingerprint": "9a58ac820e59b1edb4530e27646edc1f328915a7a356d987397659b48c52239e",
+      "fingerprint": "c3234e1d86168cb0ac61761b99bdbbf493491fe9b1b5f808889c46e17a6aa781",
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "lib/ansible/runner.rb",
-      "line": 430,
+      "line": 445,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`python#{version} -c 'import site; print(\":\".join(site.getsitepackages()))'`",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Ansible::Runner",
-        "method": "s(:self).ansible_python_paths_raw"
+        "method": "s(:self).python_path_raw"
       },
       "user_input": "version",
       "confidence": "Medium",
@@ -43,6 +66,6 @@
       "note": "This method is safe because it verifies that the version is in the form #.#."
     }
   ],
-  "updated": "2025-03-31 10:21:49 -0400",
+  "updated": "2025-06-16 22:28:03 -0400",
   "brakeman_version": "6.2.2"
 }

--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -8,11 +8,11 @@ module Ansible
       @path = Pathname.new(path)
     end
 
-    def fetch_galaxy_roles
+    def fetch_galaxy_roles(env = {})
       return true unless requirements_file.exist?
 
       require "awesome_spawn"
-      AwesomeSpawn.run!("ansible-galaxy", :params => ["install", {:roles_path= => roles_dir, :role_file= => requirements_file}])
+      AwesomeSpawn.run!("ansible-galaxy", :env => env, :params => ["install", {:roles_path= => roles_dir, :role_file= => requirements_file}])
     end
 
     def self.fetch_plugin_galaxy_roles

--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -23,7 +23,7 @@ class TestSecurityHelper
     app_path = Rails.root.to_s
     engine_paths = Vmdb::Plugins.paths.except(ManageIQ::Schema::Engine).values
 
-    puts "** Running brakeman in #{app_path}"
+    puts "** Running brakeman in #{app_path}#{" (interactive ignore)" if interactive_ignore}"
     puts "**   engines:"
     puts "**   - #{engine_paths.join("\n**   - ")}"
 

--- a/spec/lib/ansible/content_spec.rb
+++ b/spec/lib/ansible/content_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Ansible::Content do
   after { FileUtils.rm_rf(content_dir) }
 
   describe "#fetch_galaxy_roles" do
+    let(:expected_params) do
+      [
+        "install",
+        {
+          :roles_path= => roles_dir,
+          :role_file=  => roles_requirements
+        }
+      ]
+    end
+
     it "doesn't run anything if there is no requirements file" do
       expect(AwesomeSpawn).not_to receive(:run!)
 
@@ -18,12 +28,7 @@ RSpec.describe Ansible::Content do
       FileUtils.mkdir(roles_dir)
       FileUtils.touch(roles_requirements)
 
-      expected_params = [
-        "install",
-        {:roles_path= => roles_dir,
-        :role_file=  => roles_requirements}
-      ]
-      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :env => {}, :params => expected_params)
 
       subject.fetch_galaxy_roles
     end
@@ -32,14 +37,19 @@ RSpec.describe Ansible::Content do
       FileUtils.mkdir(roles_dir)
       FileUtils.touch(roles_requirements)
 
-      expected_params = [
-        "install",
-        {:roles_path= => roles_dir,
-        :role_file=  => roles_requirements}
-      ]
-      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :env => {}, :params => expected_params)
 
       described_class.new(content_dir.to_s).fetch_galaxy_roles
+    end
+
+    it "accepts an env" do
+      FileUtils.mkdir(roles_dir)
+      FileUtils.touch(roles_requirements)
+      env = {"PYTHONPATH" => "/var/lib/manageiq/venv/python3.12/site-packages", "PATH" => "/var/lib/manageiq/venv/bin"}
+
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :env => env, :params => expected_params)
+
+      subject.fetch_galaxy_roles(env)
     end
   end
 end

--- a/spec/lib/ansible/runner/data/aws.yml
+++ b/spec/lib/ansible/runner/data/aws.yml
@@ -1,0 +1,8 @@
+- name: Test aws collection
+  hosts: localhost
+  tasks:
+  - name: Connect to aws
+    amazon.aws.ec2_instance_info:
+      access_key: 'access_key'
+      secret_key: 'secret_key'
+      region: us-east-1

--- a/spec/lib/ansible/runner/data/vmware.yml
+++ b/spec/lib/ansible/runner/data/vmware.yml
@@ -1,0 +1,9 @@
+- name: Test vmware collection
+  hosts: localhost
+  tasks:
+  - name: Connect to vcenter
+    community.vmware.vmware_vm_info:
+      hostname: 'vcenter_hostname'
+      username: 'vcenter_username'
+      password: 'vcenter_password'
+      validate_certs: false

--- a/spec/lib/ansible/runner_execution_spec.bats
+++ b/spec/lib/ansible/runner_execution_spec.bats
@@ -1,0 +1,202 @@
+#/usr/bin/env bats
+
+# This test file is for testing ansible-runner on a production appliance to verify
+# that the real installation is working as expected. It is a duplicate of the tests
+# in runner_execution_spec.rb but without the rspec and rspec-rails overhead.
+#
+# This test requires the Bats test framework to be installed
+#   macOS: brew install bats-core
+#   appliance: dnf install bats
+# as well as the bats-support and bats-assert plugins installed
+#   git clone https://github.com/bats-core/bats-support ~/.bats/libs/bats-support
+#   git clone https://github.com/bats-core/bats-assert ~/.bats/libs/bats-assert
+
+setup_file() {
+  export BATS_LIB_PATH="$HOME/.bats/libs:$BATS_LIB_PATH"
+
+  export PYTHON_VERSION="3.12"
+
+  export SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  export DATA_DIR="$SCRIPT_DIR/runner/data"
+  export TEST_DIR="/tmp/ansible-runner-test"
+  export ROLES_DIR="/tmp/ansible-runner-test-roles"
+  export VAULT_FILE="$TEST_DIR/vault_password"
+}
+
+setup() {
+  bats_load_library 'bats-support'
+  bats_load_library 'bats-assert'
+
+  rm -rf $TEST_DIR
+  rm -rf $ROLES_DIR
+
+  mkdir -p $TEST_DIR
+}
+
+teardown() {
+  rm -rf $DATA_DIR/hello_world_with_requirements_github/roles/manageiq.example
+}
+
+setup_roles_dir() {
+  # In prod builds, ansible-galaxy lives in the venv, so set up the PATH temporarily to install the roles
+  PATH="/var/lib/manageiq/venv/bin:$PATH"
+
+  roles_path="$1"
+  source_role_file="${2:-$1/requirements.yml}"
+  role_file="$roles_path/requirements.yml"
+  if [ "$source_role_file" != "$role_file" ]; then
+    mkdir -p $roles_path
+    cp $source_role_file $role_file
+  fi
+  ansible-galaxy install --roles-path=$roles_path --role-file=$role_file
+
+  PATH="${PATH#*:}"
+}
+
+################################################################################
+
+exec_ansible_runner_cli() {
+  PATH="/var/lib/manageiq/venv/bin:$PATH" \
+    PYTHONPATH="/var/lib/manageiq/venv/lib/python${PYTHON_VERSION}/site-packages:/usr/local/lib64/python${PYTHON_VERSION}/site-packages:/usr/local/lib/python${PYTHON_VERSION}/site-packages:/usr/lib64/python${PYTHON_VERSION}/site-packages:/usr/lib/python${PYTHON_VERSION}/site-packages" \
+    ansible-runner run $TEST_DIR --ident result --playbook $1 --project-dir $DATA_DIR
+}
+
+exec_ansible_runner_cli_role() {
+  PATH="/var/lib/manageiq/venv/bin:$PATH" \
+    PYTHONPATH="/var/lib/manageiq/venv/lib/python${PYTHON_VERSION}/site-packages:/usr/local/lib64/python${PYTHON_VERSION}/site-packages:/usr/local/lib/python${PYTHON_VERSION}/site-packages:/usr/lib64/python${PYTHON_VERSION}/site-packages:/usr/lib/python${PYTHON_VERSION}/site-packages" \
+    ansible-runner run $TEST_DIR --ident result --role $1 --roles-path $ROLES_DIR --role-skip-facts --hosts localhost
+}
+
+@test "[ansible-runner] runs a playbook" {
+  run exec_ansible_runner_cli hello_world.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World!"'
+}
+
+@test "[ansible-runner] runs a playbook with variables in a vars file" {
+  run exec_ansible_runner_cli hello_world_vars_file.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! vars_file_1=vars_file_1_value, vars_file_2=vars_file_2_value"'
+}
+
+@test "[ansible-runner] runs a playbook with vault encrypted variables" {
+  echo -n "vault" >> $VAULT_FILE
+  ANSIBLE_VAULT_PASSWORD_FILE=$VAULT_FILE run exec_ansible_runner_cli hello_world_vault_encrypted_vars.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! (NOTE: This message has been encrypted with ansible-vault)"'
+}
+
+@test "[ansible-runner] runs a playbook with variables in a vault encrypted vars file" {
+  echo -n "vault" >> $VAULT_FILE
+  ANSIBLE_VAULT_PASSWORD_FILE=$VAULT_FILE run exec_ansible_runner_cli hello_world_vault_encrypted_vars_file.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! vars_file_1=vars_file_1_value, vars_file_2=vars_file_2_value"'
+}
+
+@test "[ansible-runner] runs a playbook using roles from github" {
+  setup_roles_dir $DATA_DIR/hello_world_with_requirements_github/roles
+
+  run exec_ansible_runner_cli hello_world_with_requirements_github/hello_world_with_requirements_github.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! example_var='\''example var value'\''"'
+}
+
+@test "[ansible-runner] runs a role" {
+  setup_roles_dir $ROLES_DIR $DATA_DIR/hello_world_with_requirements_github/roles/requirements.yml
+
+  run exec_ansible_runner_cli_role manageiq.example
+  assert_success
+  assert_output --partial '"msg": "Hello from manageiq.example role! example_var='\''example var value'\''"'
+}
+
+@test "[ansible-runner] vmware collection" {
+  if [ ! -d /var/lib/manageiq/venv ]; then
+    skip "manageiq venv collections are not present"
+  fi
+
+  run exec_ansible_runner_cli vmware.yml
+  assert_failure # We expect to this to fail due to connecting to an unknown vcenter
+  assert_output --partial '"msg": "Unknown error while connecting to vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+}
+
+@test "[ansible-runner] aws collection" {
+  if [ ! -d /var/lib/manageiq/venv ]; then
+    skip "manageiq venv collections are not present"
+  fi
+
+  run exec_ansible_runner_cli aws.yml
+  assert_failure # We expect to this to fail due to connecting with bad creds
+  assert_output --partial '"msg": "Failed to describe instances: An error occurred (AuthFailure) when calling the DescribeInstances operation: AWS was not able to validate the provided access credentials"'
+}
+
+################################################################################
+
+exec_ansible_runner() {
+  rails runner "resp = Ansible::Runner.run({}, {}, '$DATA_DIR/$1'); puts resp.human_stdout; exit resp.return_code"
+}
+
+exec_ansible_runner_role() {
+  rails runner "resp = Ansible::Runner.run_role({}, {}, '$1', roles_path: '$ROLES_DIR'); puts resp.human_stdout; exit resp.return_code"
+}
+
+@test "[Ansible::Runner] runs a playbook" {
+  run exec_ansible_runner hello_world.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World!"'
+}
+
+@test "[Ansible::Runner] runs a playbook with variables in a vars file" {
+  run exec_ansible_runner hello_world_vars_file.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! vars_file_1=vars_file_1_value, vars_file_2=vars_file_2_value"'
+}
+
+@test "[Ansible::Runner] runs a playbook with vault encrypted variables" {
+  skip "requires database access"
+
+  run exec_ansible_runner hello_world_vault_encrypted_vars.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! (NOTE: This message has been encrypted with ansible-vault)"'
+}
+
+@test "[Ansible::Runner] runs a playbook with variables in a vault encrypted vars file" {
+  skip "requires database access"
+
+  run exec_ansible_runner hello_world_vault_encrypted_vars_file.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! vars_file_1=vars_file_1_value, vars_file_2=vars_file_2_value"'
+}
+
+@test "[Ansible::Runner] runs a playbook using roles from github" {
+  run exec_ansible_runner hello_world_with_requirements_github/hello_world_with_requirements_github.yml
+  assert_success
+  assert_output --partial '"msg": "Hello World! example_var='\''example var value'\''"'
+}
+
+@test "[Ansible::Runner] runs a role" {
+  setup_roles_dir $ROLES_DIR $DATA_DIR/hello_world_with_requirements_github/roles/requirements.yml
+
+  run exec_ansible_runner_role manageiq.example
+  assert_success
+  assert_output --partial '"msg": "Hello from manageiq.example role! example_var='\''example var value'\''"'
+}
+
+@test "[Ansible::Runner] vmware collection" {
+  if [ ! -d /var/lib/manageiq/venv ]; then
+    skip "manageiq venv collections are not present"
+  fi
+
+  run exec_ansible_runner vmware.yml
+  assert_failure # We expect to this to fail due to connecting to an unknown vcenter
+  assert_output --partial '"msg": "Unknown error while connecting to vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+}
+
+@test "[Ansible::Runner] aws collection" {
+  if [ ! -d /var/lib/manageiq/venv ]; then
+    skip "manageiq venv collections are not present"
+  fi
+
+  run exec_ansible_runner aws.yml
+  assert_failure # We expect to this to fail due to connecting with bad creds
+  assert_output --partial '"msg": "Failed to describe instances: An error occurred (AuthFailure) when calling the DescribeInstances operation: AWS was not able to validate the provided access credentials"'
+}


### PR DESCRIPTION
This commit introduces Bats tests for ansible-runner to allow testing the manageiq-ansible-venv installation. This tests cover ansible-runner CLI tests as well as tests running through the Ansible::Runner Ruby class, even without database access.

This commit also includes changes to Ansible::Runner itself to allow for better detection of ansible and the manageiq-ansible-venv, allowing the tests to run on the old appliances with python3.9 as well as the new appliances with python3.12.

As such, this can (and should) be merged ahead of https://github.com/ManageIQ/manageiq-rpm_build/pull/573.

I've executed these tests on containers and appliances before and after the RPM upgrade in https://github.com/ManageIQ/manageiq-rpm_build/pull/573 both with and without sourcing the manageiq-ansible-venv.

Testing in containers you do the following:
```bash
dnf install bats
git clone https://github.com/bats-core/bats-support ~/.bats/libs/bats-support
git clone https://github.com/bats-core/bats-assert ~/.bats/libs/bats-assert

vmdb
source ./container_env
mkdir -p spec/lib

# Then outside of the container in the manageiq repo you do
# docker cp spec/lib/ansible <container_id>:/var/www/miq/vmdb/spec/lib

$ bats spec/lib/ansible/runner_execution_spec.bats
runner_execution_spec.bats
 ✓ [ansible-runner] runs a playbook
 ✓ [ansible-runner] runs a playbook with variables in a vars file
 ✓ [ansible-runner] runs a playbook with vault encrypted variables
 ✓ [ansible-runner] runs a playbook with variables in a vault encrypted vars file
 ✓ [ansible-runner] runs a playbook using roles from github
 ✓ [ansible-runner] runs a role
 ✓ [ansible-runner] vmware collection
 ✓ [ansible-runner] aws collection
 ✓ [Ansible::Runner] runs a playbook
 ✓ [Ansible::Runner] runs a playbook with variables in a vars file
 - [Ansible::Runner] runs a playbook with vault encrypted variables (skipped: requires database access)
 - [Ansible::Runner] runs a playbook with variables in a vault encrypted vars file (skipped: requires database access)
 ✓ [Ansible::Runner] runs a playbook using roles from github
 ✓ [Ansible::Runner] runs a role
 ✓ [Ansible::Runner] vmware collection
 ✓ [Ansible::Runner] aws collection

16 tests, 0 failures, 2 skipped
```

Folow ups:
- Add the new aws and vmware tests to the rspec tests.
- Add tests for all of the other collections