### PR TITLE
Fallback to existing project if new project name is empty or whitespace

### DIFF
--- a/app/models/service_container_template.rb
+++ b/app/models/service_container_template.rb
@@ -100,8 +100,8 @@ class ServiceContainerTemplate < ServiceGeneric
     existing_name = overrides.delete(:existing_project_name) || dialog_options['dialog_existing_project_name']
     new_project_name = overrides.delete(:new_project_name) || dialog_options['dialog_new_project_name']
 
-    create_project(new_project_name) if new_project_name
-    project_name = new_project_name || existing_name
+    create_project(new_project_name) if new_project_name.present?
+    project_name = new_project_name.presence || existing_name
 
     raise _("A project is required for the container template provisioning") unless project_name
 


### PR DESCRIPTION
While using service dialogs for container template provisioning, the original method attempted to create a project even when the `new_project_name` was empty or contained only whitespace. This caused errors.

The fix adds `.present?` checks to ensure `new_project_name` is only used to create a project if it contains a valid, non-blank value. It also uses `.presence` to fall back to the existing project name when appropriate, preventing invalid project creation attempts and ensuring reliable provisioning.