### PR TITLE
remove unnecessary instance variables in specs

### DIFF
--- a/spec/lib/manageiq/reporting/formatter/timeline_message_spec.rb
+++ b/spec/lib/manageiq/reporting/formatter/timeline_message_spec.rb
@@ -1,16 +1,20 @@
 describe ManageIQ::Reporting::Formatter::TimelineMessage do
   context "#message_html" do
     context "for unknown column names" do
-      subject { described_class.new({'column' => @value}, nil, {:time_zone => 'Mexico City'}, nil).message_html('column') }
+      subject { described_class.new({'column' => value}, nil, {:time_zone => 'Mexico City'}, nil).message_html('column') }
 
-      it 'returns a string for text columns' do
-        @value = '123""45/\\'
-        expect(subject).to eq '123""45/\\'
+      context "with text column" do
+        let(:value) { '123""45/\\' }
+        it 'returns a string' do
+          expect(subject).to eq '123""45/\\'
+        end
       end
 
-      it 'returns formatted time for time columns' do
-        @value = Time.new(2002, 10, 31, 2, 2, 2, '+02:00')
-        expect(subject).to eq '2002-10-30 18:02:02 CST'
+      context "with a time column" do
+        let(:value) { Time.new(2002, 10, 31, 2, 2, 2, '+02:00') }
+        it 'returns formatted time for time columns' do
+          expect(subject).to eq '2002-10-30 18:02:02 CST'
+        end
       end
     end
   end

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe MiqEnvironment do
   context "with linux platform" do
-    before do
-      @old_impl = Sys::Platform::IMPL
+    around do |example|
+      old_impl = Sys::Platform::IMPL
       silence_warnings { Sys::Platform::IMPL = :linux }
-    end
-
-    after do
-      silence_warnings { Sys::Platform::IMPL = @old_impl } if @old_impl
+      begin
+        example.run
+      ensure
+        silence_warnings { Sys::Platform::IMPL = old_impl }
+      end
     end
 
     context "Host Info" do

--- a/spec/lib/vmdb/initializer_spec.rb
+++ b/spec/lib/vmdb/initializer_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe Vmdb::Initializer do
   describe ".init_secret_token" do
-    before do
-      @token = Rails.application.config.secret_key_base
-    end
-
-    after do
-      Rails.application.config.secret_key_base = @token
+    around do |example|
+      token = Rails.application.config.secret_key_base
+      example.run
+    ensure
+      Rails.application.config.secret_key_base = token
     end
 
     it "defaults to MiqDatabase session_secret_token" do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -645,18 +645,18 @@ RSpec.describe Authenticator::Httpd do
       end
 
       describe ".user_attrs_from_external_directory_via_dbus" do
+        let(:ifp_interface) { double('ifp_interface') }
         before do
           require "dbus"
           sysbus = double('sysbus')
           ifp_service = double('ifp_service')
           ifp_object  = double('ifp_object')
-          @ifp_interface = double('ifp_interface')
 
           allow(DBus).to receive(:system_bus).and_return(sysbus)
           allow(sysbus).to receive(:[]).with("org.freedesktop.sssd.infopipe").and_return(ifp_service)
           allow(ifp_service).to receive(:object).with("/org/freedesktop/sssd/infopipe").and_return(ifp_object)
           allow(ifp_object).to receive(:introspect)
-          allow(ifp_object).to receive(:[]).with("org.freedesktop.sssd.infopipe").and_return(@ifp_interface)
+          allow(ifp_object).to receive(:[]).with("org.freedesktop.sssd.infopipe").and_return(ifp_interface)
         end
 
         it "should return nil for unspecified user" do
@@ -678,7 +678,7 @@ RSpec.describe Authenticator::Httpd do
                                  "displayname" => "John Doe",
                                  "domainname"  => "example.com"}
 
-          allow(@ifp_interface).to receive(:GetUserAttr).with('jdoe', requested_attrs).and_return(jdoe_attrs)
+          allow(ifp_interface).to receive(:GetUserAttr).with('jdoe', requested_attrs).and_return(jdoe_attrs)
 
           expect(subject.send(:user_attrs_from_external_directory_via_dbus, 'jdoe')).to eq(expected_jdoe_attrs)
         end

--- a/spec/models/container_project/purging_spec.rb
+++ b/spec/models/container_project/purging_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe ContainerProject do
     context ".purge" do
       let(:deleted_date) { 6.months.ago }
       let(:new_container_project) { FactoryBot.create(:container_project, :deleted_on => deleted_date + 1.day) }
-
+      let(:old_container_project) { FactoryBot.create(:container_project, :deleted_on => deleted_date - 1.day) }
       before do
-        @old_container_project = FactoryBot.create(:container_project, :deleted_on => deleted_date - 1.day)
+        old_container_project
         FactoryBot.create(:container_project, :deleted_on => deleted_date)
         new_container_project
       end
@@ -45,9 +45,9 @@ RSpec.describe ContainerProject do
       end
 
       it "purges associated rows" do
-        @old_container_project.miq_alert_statuses << FactoryBot.create(:miq_alert_status)
+        old_container_project.miq_alert_statuses << FactoryBot.create(:miq_alert_status)
         described_class.purge(deleted_date)
-        expect(@old_container_project.miq_alert_statuses.count).to eq(0)
+        expect(old_container_project.miq_alert_statuses.count).to eq(0)
       end
     end
   end

--- a/spec/models/manageiq/providers/inventory/persister/finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/finders_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister do
   ######################################################################################################################
   #
   before do
-    @ems = FactoryBot.create(:ems_cloud)
+    @ems = FactoryBot.create(:ems_cloud) # this is used to populate parent
   end
 
   let(:persister) { create_persister }

--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe ManageIQ::Providers::PhysicalInfraManager do
-  before :all do
-    @auth = {:user => 'admin', :pass => 'smartvm', :host => 'localhost', :port => '3000'}
-  end
-
   it 'will count physical servers' do
     ps = FactoryBot.create(:physical_server)
     pim = FactoryBot.create(:ems_physical_infra,

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -69,15 +69,15 @@ RSpec.describe MeteringVm do
     end
 
     context 'for any virtual machine' do
+      let(:tag) { Tag.find_by(:name => "/managed/environment/prod") }
       before do
         cat = FactoryBot.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
         FactoryBot.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
-        @tag = Tag.find_by(:name => "/managed/environment/prod")
       end
 
       let!(:vm1) do
         FactoryBot.create(:vm_infra, :hardware => hardware, :created_on => report_run_time - 1.day).tap do |vm|
-          vm.tag_with(@tag.name, :ns => '*')
+          vm.tag_with(tag.name, :ns => '*')
           stub_supports(vm, :capture)
         end
       end

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe Metric::Capture do
 
   before do
     Zone.seed
-    @zone = EvmSpecHelper.local_miq_server.zone
   end
 
   describe ".perf_capture_timer" do

--- a/spec/models/miq_provision_configured_system_request_spec.rb
+++ b/spec/models/miq_provision_configured_system_request_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe MiqProvisionConfiguredSystemRequest do
   let(:request)           { FactoryBot.create(:miq_provision_configured_system_request, :requester => admin, :options => {:src_configured_system_ids => [configured_system.id]}) }
   let(:vm_amazon)         { FactoryBot.create(:vm_amazon) }
 
-  before { @zone1 = EvmSpecHelper.local_miq_server.zone }
-
   it("#my_role should be 'ems_operations'") { expect(request.my_role).to eq('ems_operations') }
   it("#originating_controller should be 'configured_system'") { expect(request.originating_controller).to eq('configured_system') }
   it("#src_configured_systems from options hash src_ids") { expect(request.src_configured_systems.first).to eq(configured_system) }
@@ -43,9 +41,10 @@ RSpec.describe MiqProvisionConfiguredSystemRequest do
   end
 
   context '#my_zone' do
+    let!(:zone1)            { EvmSpecHelper.local_miq_server.zone }
     it "with valid source should have the VM's zone, not the requests zone" do
       expect(request.my_zone).to     eq(configured_system.my_zone)
-      expect(request.my_zone).not_to eq(@zone1.name)
+      expect(request.my_zone).not_to eq(zone1.name)
     end
   end
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -453,7 +453,11 @@ RSpec.describe MiqRequest do
     let(:ems)      { FactoryBot.create(:ems_vmware_with_authentication) }
     let(:template) { FactoryBot.create(:template_vmware, :ext_management_system => ems) }
     let(:request)  do
-      FactoryBot.create(:miq_provision_request, :requester => fred, :options => @options, :source => template)
+      options = {
+        :src_vm_id     => template.id,
+        :number_of_vms => 3,
+      }
+      FactoryBot.create(:miq_provision_request, :requester => fred, :options => options, :source => template)
     end
 
     before do
@@ -461,11 +465,6 @@ RSpec.describe MiqRequest do
       ae_workspace = double("ae_workspace")
       allow(ae_workspace).to receive(:root).and_return("test_vm")
       allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(ae_workspace)
-
-      @options = {
-        :src_vm_id     => template.id,
-        :number_of_vms => 3,
-      }
     end
 
     it '1 task' do

--- a/spec/models/miq_widget/import_export_spec.rb
+++ b/spec/models/miq_widget/import_export_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe MiqWidget::ImportExport do
   context "legacy tests" do
-    before do
-      MiqReport.seed_report("Vendor and Guest OS")
-      @widget_report_vendor_and_guest_os = MiqWidget.sync_from_hash(YAML.load('
+    before { MiqReport.seed_report("Vendor and Guest OS") }
+    let(:widget_report_vendor_and_guest_os) do
+      MiqWidget.sync_from_hash(YAML.load('
       description: report_vendor_and_guest_os
       title: Vendor and Guest OS
       content_type: report
@@ -22,7 +22,7 @@ RSpec.describe MiqWidget::ImportExport do
     end
 
     context "#export_to_array" do
-      subject { @widget_report_vendor_and_guest_os.export_to_array.first }
+      subject { widget_report_vendor_and_guest_os.export_to_array.first }
 
       it "MiqWidget" do
         expect(subject["MiqWidget"]).not_to be_empty

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe TenantQuota do
   context "formatted tenant quota values" do
     include Spec::Support::QuotaHelper
 
+    # TODO: who set @tenant?
     let(:child_tenant) { FactoryBot.create(:tenant, :parent => @tenant) }
 
     let(:child_tenant_quota_cpu)       { FactoryBot.create(:tenant_quota_cpu, :tenant => child_tenant) }

--- a/spec/models/vm_scan/dispatcher_embedded_scan_spec.rb
+++ b/spec/models/vm_scan/dispatcher_embedded_scan_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "VmScanDispatcherEmbeddedScanSpec" do
         allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
         allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => true)
 
-        @hosts, @proxies, @storages, @vms, @repo_vms = build_entities(
+        _hosts, _proxies, _storages, @vms, _repo_vms = build_entities(
           :hosts    => host_count,
           :storages => storage_count,
           :vms      => vm_count,
@@ -58,7 +58,7 @@ RSpec.describe "VmScanDispatcherEmbeddedScanSpec" do
 
       context "and a scan job for each vm" do
         before do
-          @jobs = @vms.collect(&:raw_scan)
+          _jobs = @vms.collect(&:raw_scan)
         end
 
         context "and embedded scans on ems" do


### PR DESCRIPTION
These specs don't need instance variables

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
