### PR TITLE
Add VcrSecrets spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ require 'rspec/mocks'
 require 'vcr'
 require 'cgi'
 
+# Set up ENGINE_ROOT if running tests from within a plugin.
+require_relative 'support/prepare_engine_root'
+Spec::Support::PrepareEngineRoot.setup
+
 # Fail tests that try to include stuff in `main`
 require_relative 'support/test_contamination'
 Spec::Support::TestContamination.setup

--- a/spec/support/prepare_engine_root.rb
+++ b/spec/support/prepare_engine_root.rb
@@ -1,0 +1,32 @@
+# Helper that sets up ENGINE_ROOT if running from within a plugin. This is normally
+# setup by bin/rails or in the plugin Rakefile via rails/tasks/engine.rake,
+# however it's possible to bypass those, such as when running `rspec`.
+#
+# `find_engine_path` and parts of `define_engine_root` are copied from Rails'
+# rails/tasks/engine.rake which detects the ENGINE_ROOT for use in Rake tasks.
+module Spec
+  module Support
+    module PrepareEngineRoot
+      def self.setup
+        define_engine_root
+      end
+
+      def self.find_engine_path(path)
+        return File.expand_path(Dir.pwd) if path.root?
+
+        if Rails::Engine.find(path)
+          path.to_s
+        else
+          find_engine_path(path.join(".."))
+        end
+      end
+
+      def self.define_engine_root
+        if !defined?(::ENGINE_ROOT) || !::ENGINE_ROOT
+          engine_path = find_engine_path(Pathname.new(Dir.pwd))
+          Object.const_set("ENGINE_ROOT", engine_path) if Rails.root.to_s != engine_path
+        end
+      end
+    end
+  end
+end

--- a/spec/support/vcr_secrets.rb
+++ b/spec/support/vcr_secrets.rb
@@ -1,0 +1,38 @@
+require "config"
+
+class VcrSecrets
+  DEFAULTS_FILE = "spec/config/secrets.defaults.yml".freeze
+  SECRETS_FILE  = "spec/config/secrets.yml".freeze
+
+  def self.secrets
+    @secrets ||= Config.load_files(_root.join(DEFAULTS_FILE), _root.join(SECRETS_FILE))
+  end
+
+  def self.defaults
+    @defaults ||= Config.load_files(_root.join(DEFAULTS_FILE))
+  end
+
+  def self.method_missing(m)
+    secrets[m]
+  end
+
+  def self.respond_to_missing?(_m)
+    true
+  end
+
+  def self.define_cassette_placeholder(vcr_config, toplevel_key, secret_key)
+    vcr_config.define_cassette_placeholder(defaults[toplevel_key][secret_key]) do
+      secrets[toplevel_key][secret_key]
+    end
+  end
+
+  def self.define_all_cassette_placeholders(vcr_config, toplevel_key)
+    secrets[toplevel_key].keys.each do |secret_key| # rubocop:disable Style/HashEachMethods
+      define_cassette_placeholder(vcr_config, toplevel_key, secret_key)
+    end
+  end
+
+  private_class_method def self._root
+    @root ||= defined?(ENGINE_ROOT) ? Pathname.new(ENGINE_ROOT) : Rails.root
+  end
+end


### PR DESCRIPTION
This spec helper is meant to be used by provider plugins as a way to handle secrets for providers in VCR cassettes. This replaces the usage of Rails.application.secrets for this purpose.

This PR also includes a helper that sets up the ENGINE_ROOT constant when tests are run from a plugin. When tests are run from core, ENGINE_ROOT is not set.

Example of typical provider plugin changes: https://github.com/ManageIQ/manageiq-providers-terraform_enterprise/pull/15
Example of changes to the vmware provider that are a little more complex: https://github.com/ManageIQ/manageiq-providers-vmware/pull/946


Replaces #23292

@agrare @jrafanie Please review.