### PR TITLE
It now takes no args as it uses the connection_specification_name

### DIFF
--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -145,8 +145,7 @@ class EvmServer
 
   def validate_database
     # Remove the connection and establish a new one since reconnect! doesn't always play nice with SSL postgresql connections
-    spec_name = ActiveRecord::Base.connection_specification_name
-    ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection(spec_name))
+    ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection)
 
     # Log the Versions
     _log.info("Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], version: [#{ActiveRecord::Base.connection.database_version_details}]") if ActiveRecord::Base.connection.respond_to?(:database_version_details)


### PR DESCRIPTION
Fixes a breakage with rails 7.2 running rake evm:start (server process)

Deprecated in https://www.github.com/rails/rails/pull/48681 (7.1)
Removed in https://www.github.com/rails/rails/commit/7a08a86d21508d62c77d0cacc3f466c62460d782 (7.2)

CP4AIOPS-16762

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
