### PR TITLE
Rails 7.1 deprecated pool_size in AS::Cache::Store/removed in 7.2

### DIFF
--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -53,7 +53,7 @@ class TokenStore
       {
         :namespace  => "MIQ:TOKENS:#{namespace.upcase}",
         :expires_in => token_ttl,
-        :pool_size  => 10,
+        :pool       => {:size => 10} # runs through ActiveSupport::Cache::MemCacheStore, it expects pool key with size/timeout key/values in 7.2
       }
     )
   end


### PR DESCRIPTION
Note, ManageIQ::Session goes through ActionDispatch::Session::SessionObject.
TokenManager#token_store goes through ActiveSupport::Cache::MemCacheStore.

This commit resolves the deprecated and removed support for pool_size in AS::Cache::Store in 7.2.

Followup to #23424

Before:

```
vmdb(dev)> TokenManager.new.send(:token_store).instance_variable_get(:@data).size
=> 5
vmdb(dev)> ManageIQ::Session.store.instance_variable_get(:@data).size
=> 10
```

After:

```
vmdb(dev)> TokenManager.new.send(:token_store).instance_variable_get(:@data).size
=> 10
vmdb(dev)> ManageIQ::Session.store.instance_variable_get(:@data).size
=> 10
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
