### PR TITLE
pool#connection is deprecated in 7.2, use with_connection here

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -79,7 +79,7 @@ class MiqRegionRemote < ApplicationRecord
     return host, port, username, password, database, adapter
   end
 
-  def self.with_remote_connection(host, port, username, password, database, adapter, connect_timeout = 0)
+  def self.with_remote_connection(host, port, username, password, database, adapter, connect_timeout = 0, &block)
     # Don't allow accidental connections to localhost.  A blank host will
     # connect to localhost, so don't allow that at all.
     host = host.to_s.strip
@@ -103,8 +103,7 @@ class MiqRegionRemote < ApplicationRecord
         :database        => database,
         :connect_timeout => connect_timeout
       }.delete_blanks)
-      conn = pool.connection
-      yield conn
+      pool.with_connection { |conn| block.call(conn) }
     ensure
       remove_connection
     end


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: ActiveRecord::ConnectionAdapters::ConnectionPool#connection is deprecated
  and will be removed in Rails 8.0. Use #lease_connection instead.
   (called from with_remote_connection at .../app/models/miq_region_remote.rb:106)
```

Related to https://www.github.com/rails/rails/pull/51353, we don't need a permanent connection here so with_connection is more appropriate.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
