### PR TITLE
Fix 7.1 deprecated and 7.2 removed name arg to remove_connection

### DIFF
--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -101,9 +101,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
         begin
           _log.info("#{log_prefix} Reconnecting to DB after timeout error during queue deliver")
 
-          # Remove the connection and establish a new one since reconnect! doesn't always play nice with SSL postgresql connections
-          spec_name = ActiveRecord::Base.connection_specification_name
-          ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection(spec_name))
+          ActiveRecord::Base.postgresql_ssl_friendly_base_reconnect
           @worker.update_spid!
         rescue => err
           do_exit("Exiting worker due to timeout error that could not be recovered from...error: #{err.class.name}: #{err.message}", 1)

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -220,9 +220,7 @@ class MiqServer < ApplicationRecord
 
     begin
       _log.info("Reconnecting to database after error...")
-      # Remove the connection and establish a new one since reconnect! doesn't always play nice with SSL postgresql connections
-      spec_name = ActiveRecord::Base.connection_specification_name
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection(spec_name))
+      ActiveRecord::Base.postgresql_ssl_friendly_base_reconnect
     rescue Exception => err
       _log.error("#{err.message}, during reconnect!")
     else

--- a/app/models/miq_server/queue_management.rb
+++ b/app/models/miq_server/queue_management.rb
@@ -30,9 +30,7 @@ module MiqServer::QueueManagement
       if status == "timeout"
         begin
           _log.info("Reconnecting to DB after timeout error during queue deliver")
-          # Remove the connection and establish a new one since reconnect! doesn't always play nice with SSL postgresql connections
-          spec_name = ActiveRecord::Base.connection_specification_name
-          ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection(spec_name))
+          ActiveRecord::Base.postgresql_ssl_friendly_base_reconnect
         rescue => err
           _log.error("Error encountered reconnecting to the database, error:#{err.class.name}: #{err.message}")
         end

--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -27,6 +27,12 @@ module ActiveRecord
       _log.info("Completed Vacuuming of table #{table_name} with result #{result.result_status}")
     end
 
+    def self.postgresql_ssl_friendly_base_reconnect
+      # Remove the connection and establish a new one since reconnect! doesn't always play nice with SSL postgresql connections
+      # See: https://github.com/ManageIQ/manageiq/pull/18010
+      ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection)
+    end
+
     CONNECTIVITY_ERRORS = [ActiveRecord::ConnectionNotEstablished, ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError, PG::ConnectionBad].freeze
 
     def self.connectable?

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -144,8 +144,7 @@ class EvmServer
   end
 
   def validate_database
-    # Remove the connection and establish a new one since reconnect! doesn't always play nice with SSL postgresql connections
-    ActiveRecord::Base.establish_connection(ActiveRecord::Base.remove_connection)
+    ActiveRecord::Base.ssl_postgresql_friendly_reconnect
 
     # Log the Versions
     _log.info("Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], version: [#{ActiveRecord::Base.connection.database_version_details}]") if ActiveRecord::Base.connection.respond_to?(:database_version_details)

--- a/spec/lib/extensions/ar_base_spec.rb
+++ b/spec/lib/extensions/ar_base_spec.rb
@@ -10,5 +10,19 @@ RSpec.describe "ar_base extension" do
       expect(test_class.connection).to receive(:vacuum_analyze_table).and_return(double(:result_status => 1))
       test_class.vacuum
     end
+
+    it "#postgresql_ssl_friendly_base_reconnect creates new pool/connection objects across models" do
+      old_ar_connection, old_ar_pool = ActiveRecord::Base.connection.object_id, ActiveRecord::Base.connection_pool.object_id
+      expect(old_ar_connection).to eq(test_class.connection.object_id)
+      expect(old_ar_pool).to eq(test_class.connection_pool.object_id)
+
+      test_class.send(:postgresql_ssl_friendly_base_reconnect)
+
+      new_ar_connection, new_ar_pool = ActiveRecord::Base.connection.object_id, ActiveRecord::Base.connection_pool.object_id
+      expect(old_ar_connection).not_to eq(new_ar_connection)
+      expect(old_ar_pool).not_to eq(new_ar_pool)
+      expect(new_ar_connection).to eq(test_class.connection.object_id)
+      expect(new_ar_pool).to eq(test_class.connection_pool.object_id)
+    end
   end
 end


### PR DESCRIPTION
Create an AR Base method for this common pattern and write a test for it.

Followup to: https://github.com/ManageIQ/manageiq/pull/23503
The original logic was added in https://github.com/ManageIQ/manageiq/pull/18010

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
