### PR TITLE
[spassky] update lockfile

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -621,6 +621,7 @@ GEM
     drb (2.2.3)
     ed25519 (1.4.0)
     elif (0.1.0)
+    erb (5.0.2)
     erubi (1.13.1)
     escape_utils (1.3.0)
     et-orbi (1.2.11)
@@ -830,10 +831,12 @@ GEM
       activerecord (>= 7.0.8, < 8.0)
       more_core_extensions (>= 3.5, < 5)
       pg (> 0)
-    io-console (0.8.0)
+    io-console (0.8.1)
     io-wait (0.3.1)
-    irb (1.4.1)
-      reline (>= 0.3.0)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -1058,11 +1061,14 @@ GEM
       pg
     po_to_json (2.0.0)
       json (>= 1.6.0)
+    pp (0.6.2)
+      prettyprint
     prawn (2.4.0)
       pdf-core (~> 0.9.0)
       ttfunk (~> 1.7)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
+    prettyprint (0.2.0)
     prime (0.1.3)
       forwardable
       singleton
@@ -1138,6 +1144,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
+    rdoc (6.14.2)
+      erb
+      psych (>= 4.0.0)
     recursive-open-struct (1.3.1)
       ostruct
     redfish_client (0.5.4)


### PR DESCRIPTION
Fixes missing rdoc due to old irb
```
/usr/share/ruby/bundled_gems.rb:69:in `require': cannot load such file -- rdoc (LoadError)
	from /usr/share/ruby/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require'
	from /opt/IBM/infrastructure-management-gemset/gems/zeitwerk-2.7.3/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
	from /opt/IBM/infrastructure-management-gemset/gems/irb-1.4.1/lib/irb/input-method.rb:17:in `<main>'
	from /opt/IBM/infrastructure-management-gemset/gems/irb-1.4.1/lib/irb/context.rb:14:in `require_relative'
	from /opt/IBM/infrastructure-management-gemset/gems/irb-1.4.1/lib/irb/context.rb:14:in `<main>'
	from /opt/IBM/infrastructure-management-gemset/gems/irb-1.4.1/lib/irb.rb:16:in `require_relative'
	from /opt/IBM/infrastructure-management-gemset/gems/irb-1.4.1/lib/irb.rb:16:in `<main>'
	from /usr/share/ruby/bundled_gems.rb:69:in `require'
	from /usr/share/ruby/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /opt/IBM/infrastructure-management-gemset/gems/zeitwerk-2.7.3/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/commands/console/console_command.rb:35:in `initialize'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/commands/console/console_command.rb:16:in `new'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/commands/console/console_command.rb:16:in `start'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/commands/console/console_command.rb:106:in `perform'
	from /opt/IBM/infrastructure-management-gemset/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /opt/IBM/infrastructure-management-gemset/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/command/base.rb:178:in `invoke_command'
	from /opt/IBM/infrastructure-management-gemset/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/command/base.rb:73:in `perform'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/command.rb:71:in `block in invoke'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/command.rb:149:in `with_argv'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/command.rb:69:in `invoke'
	from /opt/IBM/infrastructure-management-gemset/gems/railties-7.1.5.1/lib/rails/commands.rb:18:in `<main>'
	from /usr/share/ruby/bundled_gems.rb:69:in `require'
	from /usr/share/ruby/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /opt/IBM/infrastructure-management-gemset/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
```