### PR TITLE
Fix EvmServer.validate_database calling wrong method

### DIFF
--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -144,7 +144,7 @@ class EvmServer
   end
 
   def validate_database
-    ActiveRecord::Base.ssl_postgresql_friendly_reconnect
+    ActiveRecord::Base.postgresql_ssl_friendly_base_reconnect
 
     # Log the Versions
     _log.info("Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], version: [#{ActiveRecord::Base.connection.database_version_details}]") if ActiveRecord::Base.connection.respond_to?(:database_version_details)


### PR DESCRIPTION
The `validate_database` method should be calling `postgresql_ssl_friendly_base_reconnect` not `ssl_postgresql_friendly_reconnect`
Looks like just a typo, https://github.com/ManageIQ/manageiq/pull/23512/files#diff-80846863187bee450399df49df4646545e3f11bdd31d88b98ccf422309db365aR147
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
