### PR TITLE
Be lenient with schedule expressions

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -126,7 +126,10 @@ class MiqSchedule < ApplicationRecord
   def target_ids
     # Let RBAC evaluate the filter's MiqExpression, and return the first value (the target ids)
     my_filter = get_filter
-    return [] if my_filter.nil?
+    if my_filter.nil? || !my_filter.valid?
+      _log.warn("[#{name}] Filter is #{my_filter.nil? ? "empty" : "invalid"}")
+      return []
+    end
 
     Rbac.filtered(resource_type, :filter => my_filter).pluck(:id)
   end
@@ -136,8 +139,8 @@ class MiqSchedule < ApplicationRecord
     return [Object.const_get(resource_type)] if sched_action.kind_of?(Hash) && ALLOWED_CLASS_METHOD_ACTIONS.include?(sched_action[:method])
 
     my_filter = get_filter
-    if my_filter.nil?
-      _log.warn("[#{name}] Filter is empty")
+    if my_filter.nil? || !my_filter.valid?
+      _log.warn("[#{name}] Filter is #{my_filter.nil? ? "empty" : "invalid"}")
       return []
     end
 

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.parse(tag)).to be_nil
     end
 
+    it "doesn't parse bad text" do
+      expect(MiqExpression::Field.parse("Vm.name")).to be_nil
+    end
+
     it 'parses field with numbers in association' do
       field = 'Vm.win32_services-dependencies'
       expect(described_class.parse(field)).to have_attributes(:model        => Vm,

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe MiqExpression do
       expect(expression).to be_valid
     end
 
+    # in the future, we may decide to allow this. A few people had these in the database
+    it "returns false for an invalid flat expression (dot attribute)" do
+      expression = described_class.new("=" => {"field" => "MiqWidget.id", "value" => 5})
+      expect(expression).not_to be_valid
+    end
+
     it "returns false for an invalid flat expression" do
       expression = described_class.new("=" => {"field" => "Vm-destroy", "value" => true})
       expect(expression).not_to be_valid

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -757,4 +757,34 @@ RSpec.describe MiqSchedule do
       end
     end
   end
+
+  describe "#target_ids" do
+    let(:resource) { FactoryBot.create(:host) }
+
+    it "fetches targets" do
+      miqe = MiqExpression.new("=" => {"field" => "Host-id", "value" => resource.id})
+      sch = FactoryBot.create(:miq_schedule, :resource => resource, :filter => miqe)
+
+      expect(sch._log).not_to receive(:warn)
+      expect(sch.get_filter.exp).to eq(miqe.exp)
+      expect(sch.target_ids).to eq([resource.id])
+    end
+
+    it "handles invalid targets" do
+      miqe = MiqExpression.new("=" => {"field" => "Host.id", "value" => resource.id})
+      sch = FactoryBot.create(:miq_schedule, :resource => resource, :filter => miqe)
+
+      expect(sch._log).to receive(:warn).with(/invalid/)
+      expect(sch.get_filter.exp).to eq(miqe.exp)
+      expect(sch.target_ids).to eq([])
+    end
+
+    it "fetches nil targets" do
+      sch = FactoryBot.create(:miq_schedule, :resource => resource, :filter => nil)
+
+      expect(sch._log).to receive(:warn).with(/empty/)
+      expect(sch.get_filter).to eq(nil)
+      expect(sch.target_ids).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Pre morphy, there are some schedules with invalid miq_exp field values.

This causes MiqSchedule.get_targets to fail.
When deleting reports it wants to delete the associated schedule. This depends upon MiqSchedule.target_ids working.
Since it blows up, seeding does not work. (see adds, removes and changes records)

Example of bad values in MiqSchedule:

```
  MiqSchedule.all.each {|ms|
    puts "#{ms.id} #{ms.get_filter&.exp}";
    puts "==> #{ms.target_ids rescue "BAD"}"
  }.count

1000000000017 {"="=>{"field"=>"MiqWidget.id", "value"=>1000000000014}}
==> BAD
1000000000096 {"="=>{"field"=>"MiqWidget-id", "value"=>1000000000059}}
==> GOOD
```

Related to: https://github.com/ManageIQ/manageiq/issues/23081

Summary
=======

It validated an expression, but if there were invalid field entries, it would not catch it.
Adding field validations blew up.

Caught an edge case where `<find><checkcount>` can use use a field of `<count>`; which wouldn't parse ok but is valid in this context.
From what I could tell, there are no other special cases like that.

There is a case for `count=$field` (vs the typical `field=$field`), but that is a relation. So while I had wanted to add validation to this, it was outside this primary case and there was the potential for issues here. I held off