### PR TITLE
Add a rack session dalli debug logger

### DIFF
--- a/lib/manageiq/session.rb
+++ b/lib/manageiq/session.rb
@@ -46,6 +46,7 @@ module ManageIQ
     def self.configure_session_store(adapter)
       Vmdb::Application.config.session_store(adapter.type, **adapter.session_options)
       msg = "Using session_store: #{Vmdb::Application.config.session_store}"
+      adapter.enable_rack_session_debug_logger
       _log.info(msg)
       puts "** #{msg}" if !Rails.env.production? && adapter.type != :mem_cache_store
     end

--- a/lib/manageiq/session/abstract_store_adapter.rb
+++ b/lib/manageiq/session/abstract_store_adapter.rb
@@ -12,6 +12,38 @@ module ManageIQ
 
         session_options
       end
+
+      # Enables debug logging for Rack session operations.
+      #
+      # This method should be overridden by subclasses to implement session debugging.
+      # When implemented, it should add logging capabilities to the Rack session class
+      # used by the specific adapter.
+      #
+      # ## Implementation Guidelines
+      #
+      # 1. Create a module that adds logging to the Rack session methods:
+      #    - `find_session`
+      #    - `write_session`
+      #    - `delete_session`
+      #
+      # 2. In your subclass implementation:
+      #    - Skip logging in production environments
+      #    - Require and specify the appropriate Rack session class for your adapter
+      #    - Prepend your logging module to the Rack session class
+      #
+      # @example Implementation in a subclass
+      #   def enable_rack_session_debug_logger
+      #     return if Rails.env.production?
+      #
+      #     puts "** Enabling rack session debug logger"
+      #     rack_session_class_to_prepend.prepend(MyLoggingModule)
+      #   end
+      #
+      # @see ManageIQ::Session::RackSessionDalliLogger For a reference logging module
+      # @see ManageIQ::Session::MemCacheStoreAdapter#enable_rack_session_debug_logger For a concrete implementation
+      def enable_rack_session_debug_logger
+        return if Rails.env.production?
+      end
     end
   end
 end

--- a/lib/manageiq/session/mem_cache_store_adapter.rb
+++ b/lib/manageiq/session/mem_cache_store_adapter.rb
@@ -16,6 +16,18 @@ module ManageIQ
           :value_max_bytes => 10.megabytes
         )
       end
+
+      def enable_rack_session_debug_logger
+        return if Rails.env.production?
+
+        puts "** Enabling rack session debug logger"
+        rack_session_class_to_prepend.prepend(ManageIQ::Session::RackSessionDalliLogger)
+      end
+
+      def rack_session_class_to_prepend
+        require 'rack/session/dalli'
+        ::Rack::Session::Dalli
+      end
     end
   end
 end

--- a/lib/manageiq/session/rack_session_dalli_logger.rb
+++ b/lib/manageiq/session/rack_session_dalli_logger.rb
@@ -1,0 +1,26 @@
+module ManageIQ
+  module Session
+    module RackSessionDalliLogger
+      def log_rack_session_access(*args, **_kwargs)
+        request = args.first
+        Rails.logger.debug("RackSessionDalliLogger##{caller_locations.first.label.ljust(14, ' ')} id: #{request.request_id} method: #{request.request_method} fullpath: #{request.fullpath}")
+      end
+
+      def find_session(...)
+        log_rack_session_access(...)
+        super
+      end
+
+      def write_session(...)
+        log_rack_session_access(...)
+        super
+      end
+
+      def delete_session(...)
+        log_rack_session_access(...)
+        super
+      end
+    end
+  end
+end
+

--- a/spec/lib/manageiq/session/active_record_store_adapter_spec.rb
+++ b/spec/lib/manageiq/session/active_record_store_adapter_spec.rb
@@ -1,0 +1,15 @@
+describe ManageIQ::Session::ActiveRecordStoreAdapter do
+  describe "#enable_rack_session_debug_logger" do
+    let(:adapter) { described_class.new }
+
+    it "returns nil in production environment" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      expect(adapter.enable_rack_session_debug_logger).to be_nil
+    end
+
+    it "returns nil (inherited behavior from AbstractStoreAdapter) in non-production environment" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      expect(adapter.enable_rack_session_debug_logger).to be_nil
+    end
+  end
+end

--- a/spec/lib/manageiq/session/mem_cache_store_adapter_spec.rb
+++ b/spec/lib/manageiq/session/mem_cache_store_adapter_spec.rb
@@ -1,0 +1,24 @@
+describe ManageIQ::Session::MemCacheStoreAdapter do
+  describe "#enable_rack_session_debug_logger" do
+    let(:adapter) { described_class.new }
+
+    it "returns nil in production environment" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      expect(adapter).to receive(:rack_session_class_to_prepend).never
+      expect(adapter.enable_rack_session_debug_logger).to be_nil
+    end
+
+    context "in non-production environment" do
+      let(:mock_class) { Class.new }
+
+      it "enables debug logging and returns a truthy value" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+        allow(adapter).to receive(:rack_session_class_to_prepend).and_return(mock_class)
+
+        expect(mock_class).to receive(:prepend).and_call_original
+        expect(adapter).to receive(:puts).with(/enabling/i)
+        expect(adapter.enable_rack_session_debug_logger).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/lib/manageiq/session/memory_store_adapter_spec.rb
+++ b/spec/lib/manageiq/session/memory_store_adapter_spec.rb
@@ -1,0 +1,15 @@
+describe ManageIQ::Session::MemoryStoreAdapter do
+  describe "#enable_rack_session_debug_logger" do
+    let(:adapter) { described_class.new }
+
+    it "returns nil in production environment" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      expect(adapter.enable_rack_session_debug_logger).to be_nil
+    end
+
+    it "returns nil (inherited behavior from AbstractStoreAdapter) in non-production environment" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      expect(adapter.enable_rack_session_debug_logger).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Provides a better glimpse of the contention on the memcached session store.

It shows:
* find/write/delete session operations
* the request id to associate the find with the write
* the http verb / method (GET/POST/etc.)
* the requested path (to help us track down which request is doing the session operation)

It demonstrates how many requests are writing to session when they do not need to.  This may cause UI session changes to be lost if slow requests such as /ws/notification or /api/notifications end up writing session using stale session data.

This can help determine how issues like this can occur: https://github.com/ManageIQ/manageiq-ui-classic/issues/9515

```
...40.887267#92021:ec9a0] DEBUG -- development: RackSessionDalliLogger#find_session   id: e363af03-c5ac-4923-9496-748cc5b41f6c method: GET fullpath: /dashboard/show
...41.180823#92021:ec9a0] DEBUG -- development: RackSessionDalliLogger#write_session  id: e363af03-c5ac-4923-9496-748cc5b41f6c method: GET fullpath: /dashboard/show
...41.526539#92021:ec9a0] DEBUG -- development: RackSessionDalliLogger#find_session   id: 4b57c731-8728-4041-be36-08601195656f method: GET fullpath: /api/notifications?expand=resources&attributes=details&sort_by=id&sort_order=desc&limit=100
...41.672085#92021:f4a60] DEBUG -- development: RackSessionDalliLogger#find_session   id: 6bba7e69-2d31-4f06-a353-7578e1f5bc73 method: GET fullpath: /ws/notifications
...41.682299#92021:f4a60] DEBUG -- development: RackSessionDalliLogger#write_session  id: 6bba7e69-2d31-4f06-a353-7578e1f5bc73 method: GET fullpath: /ws/notifications
...41.687380#92021:f4a74] DEBUG -- development: RackSessionDalliLogger#find_session   id: 28773dae-858d-4af1-8458-eb45676f26e4 method: GET fullpath: /api/notifications
...41.690606#92021:f4aec] DEBUG -- development: RackSessionDalliLogger#find_session   id: d5a25aa0-1b78-40c6-9c11-a07674599d12 method: GET fullpath: /dashboard/widget_report_data/24
...41.693611#92021:bc98] DEBUG -- development: RackSessionDalliLogger#find_session   id: ba0d3944-9fa2-432d-93ed-f224986a18cb method: GET fullpath: /dashboard/widget_chart_data/9
...41.713985#92021:f4a60] DEBUG -- development: RackSessionDalliLogger#find_session   id: 274972a4-07ab-4c08-b61f-719c586e86e5 method: GET fullpath: /dashboard/widget_report_data/22
...42.104101#92021:f4aec] DEBUG -- development: RackSessionDalliLogger#write_session  id: d5a25aa0-1b78-40c6-9c11-a07674599d12 method: GET fullpath: /dashboard/widget_report_data/24
...42.133387#92021:f4a60] DEBUG -- development: RackSessionDalliLogger#write_session  id: 274972a4-07ab-4c08-b61f-719c586e86e5 method: GET fullpath: /dashboard/widget_report_data/22
...42.142790#92021:bc98] DEBUG -- development: RackSessionDalliLogger#write_session  id: ba0d3944-9fa2-432d-93ed-f224986a18cb method: GET fullpath: /dashboard/widget_chart_data/9
...42.249762#92021:f4aec] DEBUG -- development: RackSessionDalliLogger#find_session   id: 832f117b-4ae8-49a0-b88b-4357aa455edc method: GET fullpath: /dashboard/widget_chart_data/10
...42.390277#92021:f4aec] DEBUG -- development: RackSessionDalliLogger#write_session  id: 832f117b-4ae8-49a0-b88b-4357aa455edc method: GET fullpath: /dashboard/widget_chart_data/10
...42.483746#92021:f4a60] DEBUG -- development: RackSessionDalliLogger#find_session   id: 3e9dd675-de5d-46ec-b55a-d6554d853d8b method: GET fullpath: /api/auth?requester_type=ws
...42.756503#92021:bc98] DEBUG -- development: RackSessionDalliLogger#find_session   id: 9b7f072f-d1f7-4e57-afa4-5a36eba5b5ea method: GET fullpath: /dashboard/widget_report_data/21
...42.771013#92021:bc98] DEBUG -- development: RackSessionDalliLogger#write_session  id: 9b7f072f-d1f7-4e57-afa4-5a36eba5b5ea method: GET fullpath: /dashboard/widget_report_data/21
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
