### PR TITLE
clean_up was last called in 2014 :wink:

### DIFF
--- a/tools/fix_auth/auth_model.rb
+++ b/tools/fix_auth/auth_model.rb
@@ -131,10 +131,6 @@ module FixAuth
         puts "#{records_changed} of #{processed} records #{options[:dry_run] ? 'would change (dry run enabled)' : 'changed'}" unless options[:silent]
         puts "found #{errors} errors" if errors > 0 && !options[:silent]
       end
-
-      def clean_up
-        clear_active_connections!
-      end
     end
   end
 end


### PR DESCRIPTION
Rails 7.2 removed usage of this method directly on AR::Base. You can still do AR::Base.connection_handler.clear_active_connections!  It's removed on AR::Base.

The last caller of clean_up was here:

```
commit 11d0b91c62f7ed1b11c581c38b184481080acb64
Date:   Mon Jun 2 12:07:06 2014 -0400

resolve fix_auth database connectivity oddities
```

See also, no callers to it: https://github.com/search?q=org%3AManageIQ%20clean_up&type=code

We removed the other place we were doing clear_active_connections! on AR::Base in: https://github.com/ManageIQ/manageiq/pull/15697

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
