### PR TITLE
Rails 7.1+ migration context simplifies our code

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -175,8 +175,7 @@ class EvmApplication
 
   def self.deployment_status
     migration_dir  = Rails.application.config.paths["db/migrate"]
-    migration_conn = ActiveRecord::Base.connection_pool.schema_migration
-    context        = ActiveRecord::MigrationContext.new(migration_dir, migration_conn)
+    context        = ActiveRecord::MigrationContext.new(migration_dir)
 
     return "new_deployment" if context.current_version.zero? || MiqServer.none?
     return "new_replica"    if MiqServer.my_server.nil?


### PR DESCRIPTION
See: https://www.github.com/rails/rails/commit/9ef79385d92876dd5944e9d5eabd2a25853eed7a

Basically, you only need to provide a schema_migration class if not using the default connection. Since we are using the default connection, we can exclude this entirely.

Similar to https://github.com/ManageIQ/manageiq-schema/pull/800

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
