### PR TITLE
CVE-2024-43380 rufus-scheduler version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -260,7 +260,7 @@ group :rest_api, :manageiq_default do
 end
 
 group :scheduler, :manageiq_default do
-  gem "rufus-scheduler"
+  gem "rufus-scheduler", ">=3.9.2" # CVE-2024-43380
 end
 # rufus has et-orbi dependency, v1.2.2 has patch for ConvertTimeToEoTime that we need
 gem "et-orbi",                          ">= 1.2.2"


### PR DESCRIPTION
We need the latest version of fudit
Fudit is a dependency of rufus-scheduler.
This upgrade to rufus-scheduler sets a minimum version for fudit and this resolves the CVE

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
