### PR TITLE
drop unneeded et-orbi versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -262,8 +262,6 @@ end
 group :scheduler, :manageiq_default do
   gem "rufus-scheduler", ">=3.9.2" # CVE-2024-43380
 end
-# rufus has et-orbi dependency, v1.2.2 has patch for ConvertTimeToEoTime that we need
-gem "et-orbi",                          ">= 1.2.2"
 
 group :seed, :manageiq_default do
   manageiq_plugin "manageiq-content"

--- a/config/initializers/add_active_support_duration_to_eo_time.rb
+++ b/config/initializers/add_active_support_duration_to_eo_time.rb
@@ -7,3 +7,6 @@ end
 
 require 'et-orbi'
 EtOrbi::EoTime.prepend(AddActiveSupportDurationToEoTime)
+if EtOrbi::VERSION > "1.2.2"
+  warn "EtOrbi monkey patch may no longer be necessary"
+end

--- a/spec/lib/et_orbi_spec.rb
+++ b/spec/lib/et_orbi_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe EtOrbi do
+  it '#can add times' do
+    eot = EtOrbi::EoTime.new(0, 'Europe/Moscow')
+    eot + 1.hour
+  end
+end


### PR DESCRIPTION
We upgraded rufus-scheduler to 3.9.2
which means, we upgraded fugit to 1.11.1
which means we upgraded et-orbi to 1.2.11

No longer need to declare this indirect dependency >= 1.2.2 This gem is not directly used by our code.

Also, we're waiting a release of et-orbi 1.3, which contains: https://github.com/floraison/et-orbi/commit/b758c913188c5b21d6c1512884cbe9a7791e2a34

This was added in https://github.com/ManageIQ/manageiq/pull/19188 and we can hopefully drop that patch with the et-orbi upgrade

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
