### PR TITLE
Fix spec on Rails 7.2.2.2

### DIFF
--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe MiqWidgetSet do
     end
 
     it "raises error if group with passed id does not exist" do
-      expect { MiqWidgetSet.copy_dashboard(@ws_group, name, tab, "9999") }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find MiqGroup with 'id'=9999")
+      expect { MiqWidgetSet.copy_dashboard(@ws_group, name, tab, "9999") }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find MiqGroup with 'id'="?9999"?/)
     end
 
     it "copy dashboard and set its owner to the group with passed group_id" do


### PR DESCRIPTION
Rails 7.2.2.2 fixes CVE-2025-55193, which is a bug where the .find method when taking in a String could have ANSI escape sequences, and thus when printed could cause issues. Rails changed the output that this test relies on, so this commit adjusts it to work on all 7.2.x versions.

@jrafanie Please review.