### PR TITLE
Fail locale:update_all if subprocess fails

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -147,7 +147,7 @@ namespace :locale do
 
   desc "Run store_model_attributes task in i18n environment"
   task "run_store_model_attributes" do
-    system({"RAILS_ENV" => "i18n"}, "bundle exec rake locale:store_model_attributes")
+    abort unless system({"RAILS_ENV" => "i18n"}, "bundle exec rake locale:store_model_attributes")
   end
 
   task "delete_pot_file", :root do |_, args|


### PR DESCRIPTION
When we shell out for one of the rake tasks, a failure would continue on. This commit now aborts when the subprocess fails.

For example if you don't have the vmdb_i18n database, it will fail, but before this PR it would blow up and then continue on.

@jrafanie Please review.