### PR TITLE
[WIP] Upgrade gettext_i18n_rails_js for escape fix and lazy loaded parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "elif",                             "=0.1.0",            :require => false
 gem "fast_gettext",                     "~>3.1"
 gem "ffi",                              "< 1.17.0",          :require => false # Locked down due to build issue assertion failure on 1.17.3
 gem "gettext_i18n_rails",               "~>1.11"
-gem "gettext_i18n_rails_js",            "~>1.4.0"
+gem "gettext_i18n_rails_js",            "~>2.1.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.2",             :require => false


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq/pull/23566

2.0.0 includes a bug fix we reported in:
https://www.github.com/webhippie/gettext_i18n_rails_js/issues/42
Compare: https://github.com/webhippie/gettext_i18n_rails_js/compare/v1.4.0...v2.0.0

Note, this also pulls in a new po_to_json gem.

2.1.0 includes a lazy load parser fix from me, so I think that's safe to move to.
Compare: https://github.com/webhippie/gettext_i18n_rails_js/compare/v2.0.0...v2.1.0

I ran it locally with 1.4.0 and and 2.1.0 and the json files are identical.

NOTE:  bundle exec rake locale:update_all produces much different results with 1.4.0, 2.0.0, 2.1.0, and 2.2.0 versions so we'll need to handle both upgrades together.  

See revert in https://github.com/ManageIQ/manageiq/pull/23584 and some issues found in https://github.com/ManageIQ/manageiq/pull/23583

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
