### PR TITLE
Catch Kubeclient::HttpError in start_kube_monitor

### DIFF
--- a/app/models/miq_server/worker_management/kubernetes.rb
+++ b/app/models/miq_server/worker_management/kubernetes.rb
@@ -172,7 +172,7 @@ class MiqServer::WorkerManagement::Kubernetes < MiqServer::WorkerManagement
       _log.info("Starting new #{resource} monitor thread of #{Thread.list.length} total")
       begin
         send(:"monitor_#{resource}", monitor_started)
-      rescue HTTP::ConnectionError => e
+      rescue HTTP::ConnectionError, Kubeclient::HttpError => e
         _log.error("Exiting #{resource} monitor thread due to [#{e.class.name}]: #{e}")
       rescue => e
         _log.error("Exiting #{resource} monitor thread after uncaught error")


### PR DESCRIPTION
If an HTTP error is reached in a `Kubeclient::WatchStream#each` it is wrapped in a `Kubeclient::HttpError`.  This wasn't being caught by the existing rescue so it reached the `after uncaught error` case and dumped a stack trace that didn't include the http error code.

Before:
```
MIQ(MiqServer::WorkerManagement::Kubernetes#start_kube_monitor) Exiting pods monitor thread after uncaught error[Kubeclient::HttpError]:   Method:[block in method_missing]
/opt/IBM/infrastructure-management-gemset/gems/kubeclient-4.12.0/lib/kubeclient/watch_stream.rb:21:in `each'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:251:in `watch_for_events'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:240:in       `block in monitor_pods'
<internal:kernel>:187:in `loop'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:233:in `monitor_pods'
/var/www/miq/vmdb/app/models/miq_server/worker_management/kubernetes.rb:174:in `block in start_kube_monitor
```

After:
```
MIQ(MiqServer::WorkerManagement::Kubernetes#start_kube_monitor) Exiting pods monitor thread due to [Kubeclient::HttpError]: HTTP status code 522, 
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
