### PR TITLE
Revert "Update dependency gettext_i18n_rails_js to "~>1.4.0""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "elif",                             "=0.1.0",            :require => false
 gem "fast_gettext",                     "~>3.1"
 gem "ffi",                              "< 1.17.0",          :require => false # Locked down due to build issue assertion failure on 1.17.3
 gem "gettext_i18n_rails",               "~>1.11"
-gem "gettext_i18n_rails_js",            "~>1.4.0"
+gem "gettext_i18n_rails_js",            "~>1.3.0"
 gem "hamlit",                           "~>2.11.0"
 gem "inifile",                          "~>3.0",             :require => false
 gem "inventory_refresh",                "~>2.2",             :require => false


### PR DESCRIPTION
This reverts commit 4aeed7ab0aae967b26cd48e0c5c70936a978e40a, #23566 

https://github.com/ManageIQ/manageiq/pull/23583 is showing some changes we didn't expect.  We will need to verify the patches as we upgrade as we have patches in our locale.rake, gettext_task_overide.rb, and po_to_json_override.rb, and possibly elsewhere so we'll need to remove/changes things when we do the upgrade in https://github.com/ManageIQ/manageiq/pull/23580

For now, let's just revert.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
