### PR TITLE
Extract connectable! method

### DIFF
--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -35,8 +35,12 @@ module ActiveRecord
 
     CONNECTIVITY_ERRORS = [ActiveRecord::ConnectionNotEstablished, ActiveRecord::DatabaseConnectionError, ActiveRecord::NoDatabaseError, PG::ConnectionBad].freeze
 
-    def self.connectable?
+    def self.connectable!
       with_connection { |conn| conn.connect! && conn.connected? }
+    end
+
+    def self.connectable?
+      connectable!
     rescue *CONNECTIVITY_ERRORS
       false
     end


### PR DESCRIPTION
@jrafanie Please review.  This is a follow up to https://github.com/ManageIQ/manageiq-ui-classic/pull/9619. With this separate method, I can let the PingController actually blow up to get a more detailed reason (as opposed to being just swallowed up into a boolean).

I'm not 100% sold on the name, but it aligns with the `connectable?` method.  If you have better ideas, let me know.