### PR TITLE
Move _queue methods into NetworkManager base class

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -83,6 +83,23 @@ module ManageIQ::Providers
       includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
     end
 
+    def create_cloud_network_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Cloud Network for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_cloud_network',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
     def create_cloud_subnet_queue(userid, options = {})
       task_opts = {
         :action => "creating Cloud Subnet for user #{userid}",
@@ -93,6 +110,92 @@ module ManageIQ::Providers
         :method_name => 'create_cloud_subnet',
         :instance_id => id,
         :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def create_network_router_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Network Router for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_network_router',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def create_floating_ip_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Floating IP for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_floating_ip',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def create_security_group_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Security Group for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_security_group',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def create_security_policy_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Security Policy for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_security_policy',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
+        :zone        => my_zone,
+        :args        => [options]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def create_security_policy_rule_queue(userid, options = {})
+      task_opts = {
+        :action => "creating Security Policy Rule for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'create_security_policy_rule',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :queue_name  => queue_name_for_ems_operations,
         :zone        => my_zone,
         :args        => [options]
       }


### PR DESCRIPTION
These methods were duplicated in provider NetworkManager subclasses

Follow-ups:
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/696
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/920

https://github.com/ManageIQ/manageiq-api/pull/1299
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
