### PR TITLE
[DRAFT] Drafts only run with ruby 3.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version:
-        - '3.1'
-        - '3.3'
+        ruby-version: ${{ github.event.pull_request.draft && ['3.3'] || ['3.1', '3.3'] }}
         test-suite:
         - vmdb
         - security


### PR DESCRIPTION
When I make small changes, I want to pass as quickly as possible.

May also leverage `"$github.event.pull_request.title =~ ^[[]WIP`