### PR TITLE
[Spassky] Rack 2.2.8 upgrade for CVE-2025-59830

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "prism",                            ">=0.25.0",          :require => false # Used by DescendantLoader
 gem "psych",                            ">=3.1",             :require => false # 3.1 safe_load changed positional to kwargs like aliases: true: https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd
 gem "query_relation",                   "~>0.1.0",           :require => false
-gem "rack",                             ">=2.2.14",          :require => false
+gem "rack",                             ">=2.2.18",          :require => false # CVE-2025-59830 https://github.com/advisories/GHSA-625h-95r8-8xpm
 gem "rack-attack",                      "~>6.5.0",           :require => false
 gem "rails",                            "~>7.2.0", ">= 7.2.2.1"
 gem "rails-i18n",                       "~>7.x"

--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -1091,7 +1091,7 @@ GEM
       more_core_extensions
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.17)
+    rack (2.2.18)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
     rack-session (1.0.2)
@@ -1519,7 +1519,7 @@ DEPENDENCIES
   puma (~> 6.4, >= 6.4.3)
   qpid_proton (~> 0.37.0)
   query_relation (~> 0.1.0)
-  rack (>= 2.2.14)
+  rack (>= 2.2.18)
   rack-attack (~> 6.5.0)
   rails (~> 7.2.0, >= 7.2.2.1)
   rails-i18n (~> 7.x)


### PR DESCRIPTION
CVE-2025-59830 https://github.com/advisories/GHSA-625h-95r8-8xpm

alt to #23605 - has Gemfile.lock
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
