### PR TITLE
Remove references.includes from non Rbac usage

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -31,6 +31,7 @@ class Classification < ApplicationRecord
   scope :is_category, -> { where(:parent_id => nil) }
   scope :is_entry,    -> { where.not(:parent_id => nil) }
 
+  # TODO: move over to joins(:parent) or preload(:parent) - need something that works well with load()
   scope :with_writable_parents, -> { includes(:parent).where(:parents_classifications => {:read_only => false}) }
 
   DEFAULT_NAMESPACE = "/managed".freeze
@@ -211,13 +212,13 @@ class Classification < ApplicationRecord
   end
 
   def self.categories(region_id = my_region_number, ns = DEFAULT_NAMESPACE)
-    cats = is_category.in_region(region_id).includes(:tag, :children)
+    cats = is_category.in_region(region_id).preload(:tag, :children)
     cats.select { |c| c.ns == ns }
   end
 
   def self.category_names_for_perf_by_tag(region_id = my_region_number, ns = DEFAULT_NAMESPACE)
     in_region(region_id).is_category.where(:perf_by_tag => true)
-      .includes(:tag)
+      .preload(:tag)
       .collect { |c| c.name if c.tag2ns(c.tag.name) == ns }
       .compact
   end
@@ -513,7 +514,7 @@ class Classification < ApplicationRecord
   def validate_uniqueness_on_tag_name
     tag_name = Classification.name2tag(name, parent, ns)
     exist_scope = Classification.default_scoped
-                                .includes(:tag)
+                                .left_joins(:tag)
                                 .where(:tags => {:name => tag_name})
                                 .merge(Tag.in_region(region_id))
     exist_scope = exist_scope.where.not(:id => id) unless new_record?

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -187,7 +187,6 @@ class CloudTenant < ApplicationRecord
   end
 
   def self.tenant_joins_clause(scope)
-    scope.includes(:source_tenant, :ext_management_system)
-         .references(:source_tenant, :ext_management_system)
+    scope.left_outer_joins(:source_tenant, :ext_management_system)
   end
 end

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -173,8 +173,8 @@ module AssignmentMixin
       records = kind_of?(Class) ? all : self
       assignment_map = records.index_by { |a| a.id }
       Tag
-        .includes(:taggings).references(:taggings)
-        .where("taggings.taggable_type = ? and tags.name like ?", name, "#{namespace}/%")
+        .eager_load(:taggings).where(:taggings => {:taggable_type => name})
+        .where("tags.name like ?", "#{namespace}/%")
         .each_with_object(Hash.new { |h, k| h[k] = [] }) do |tag, ret|
           tag.taggings.each do |tagging|
             tag_name = Tag.filter_ns([tag], namespace).first

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -221,8 +221,7 @@ module AssignmentMixin
       # look for alert_set running off of tags (not individual tags)
       # TODO: we may need to change taggings-related code to use base_model too
       tlist = Tagging.where("tags.name like '/managed/%'")
-                     .where(:taggable => parents)
-                     .references(:tag).includes(:tag).map do |t|
+                     .where(:taggable => parents).eager_load(:tag).map do |t|
         "#{tag_class(t.taggable_type)}/tag#{t.tag.name}"
       end
 

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -45,35 +45,20 @@ class Vm < VmOrTemplate
   end
 
   def self.find_all_by_mac_address_and_hostname_and_ipaddress(mac_address, hostname, ipaddress)
-    return [] if mac_address.blank? && hostname.blank? && ipaddress.blank?
+    return Vm.none if mac_address.blank? && hostname.blank? && ipaddress.blank?
 
-    include = [:vm_or_template]
-    references = []
-    conds = [["hardwares.vm_or_template_id IS NOT NULL"]]
+    scope = Hardware.preload(:vm_or_template).where.not(:vm_or_template_id => nil)
     if mac_address
-      conds[0] << "guest_devices.address = ?"
-      conds << mac_address
-      include << :nics
-      references << :guest_devices
+      scope = scope.where(:guest_devices => {:address => mac_address}).preload(:nics).joins(:guest_devices)
     end
     if hostname
-      conds[0] << "networks.hostname = ?"
-      conds << hostname
-      include << :networks
-      references << :networks
+      scope = scope.where(:networks => {:hostname => hostname}).preload(:networks).joins(:networks)
     end
     if ipaddress
-      conds[0] << "networks.ipaddress = ?"
-      conds << ipaddress
-      include << :networks
-      references << :networks
+      scope = scope.where(:networks => {:ipaddress => ipaddress}).preload(:networks).joins(:networks)
     end
-    conds[0] = "(#{conds[0].join(" AND ")})"
 
-    Hardware.includes(include.uniq)
-            .references(references.uniq)
-            .where(conds)
-            .map(&:vm_or_template).select { |vm| vm.kind_of?(Vm) }
+    scope.map(&:vm_or_template).select { |vm| vm.kind_of?(Vm) }
   end
 
   def running_processes

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -166,10 +166,7 @@ module ActsAsTaggable
   end
 
   def tagged_with(options = {})
-    tagging = Tagging.arel_table
-    query = Tag.includes(:taggings).references(:taggings)
-    query = query.where(tagging[:taggable_type].eq(self.class.base_class.name))
-    query = query.where(tagging[:taggable_id].eq(id))
+    query = Tag.eager_load(:taggings).where(:taggings => {:taggable_type => self.class.base_class.name, :taggable_id => id})
     ns    = Tag.get_namespace(options)
     query = query.where(Tag.arel_table[:name].matches("#{ns}%")) if ns
     query

--- a/spec/lib/extensions/ar_order_spec.rb
+++ b/spec/lib/extensions/ar_order_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe "ar_order extension" do
   # the string munging gives us issues.
   it "supports order when distinct is present for has_many virtual column" do
     expect do
-      VmOrTemplate.includes(:disks).references(:disks).order(:last_compliance_status).first
+      VmOrTemplate.eager_load(:disks).order(:last_compliance_status).first
     end.not_to raise_error
   end
 
   it "supports order when distinct is present for basic column" do
     expect do
-      VmOrTemplate.includes(:disks).references(:disks).order(:id).first
+      VmOrTemplate.eager_load(:disks).order(:id).first
     end.not_to raise_error
   end
 end

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ContainerGroup do
     it "preloads the conditions" do
       condition_other
       cr = condition_ready
-      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status).find_by(:id => container_group.id)
+      cg = ContainerGroup.preload(:ready_condition_status).find_by(:id => container_group.id)
 
       expect { expect(cg.ready_condition).to eq(cr) }.to_not make_database_queries
     end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -49,39 +49,40 @@ RSpec.describe Vm do
   end
 
   context ".find_all_by_mac_address_and_hostname_and_ipaddress" do
-    before do
-      @hardware1 = FactoryBot.create(:hardware)
-      @vm1 = FactoryBot.create(:vm_vmware, :hardware => @hardware1)
-
-      @hardware2 = FactoryBot.create(:hardware)
-      @vm2 = FactoryBot.create(:vm_vmware, :hardware => @hardware2)
-    end
+    let(:vm1) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware)) }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware)) }
 
     it "mac_address" do
       address = "ABCDEFG"
-      guest_device = FactoryBot.create(:guest_device, :address => address, :device_type => "ethernet")
-      @hardware1.guest_devices << guest_device
+      vm1.hardware.guest_devices << FactoryBot.create(:guest_device, :address => address, :device_type => "ethernet")
+      vm2
 
-      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(address, nil, nil))
-        .to eql([@vm1])
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(address, nil, nil)).to eql([vm1])
     end
 
     it "hostname" do
       hostname = "ABCDEFG"
-      network = FactoryBot.create(:network, :hostname => hostname)
-      @hardware1.networks << network
+      vm1.hardware.networks << FactoryBot.create(:network, :hostname => hostname)
+      vm2
 
-      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, hostname, nil))
-        .to eql([@vm1])
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, hostname, nil)).to eql([vm1])
     end
 
     it "ipaddress" do
       ipaddress = "127.0.0.1"
-      network = FactoryBot.create(:network, :ipaddress => ipaddress)
-      @hardware1.networks << network
+      vm1.hardware.networks << FactoryBot.create(:network, :ipaddress => ipaddress)
+      vm2
 
-      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, nil, ipaddress))
-        .to eql([@vm1])
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, nil, ipaddress)).to eql([vm1])
+    end
+
+    it "hostname and ipaddress" do
+      hostname = "ABCDEFG"
+      ipaddress = "127.0.0.1"
+      vm1.hardware.networks << FactoryBot.create(:network, :hostname => hostname, :ipaddress => ipaddress)
+      vm2
+
+      expect(described_class.find_all_by_mac_address_and_hostname_and_ipaddress(nil, hostname, nil)).to eql([vm1])
     end
 
     it "returns an empty list when all are blank" do

--- a/tools/convert_mapped_tags.rb
+++ b/tools/convert_mapped_tags.rb
@@ -28,9 +28,10 @@ ActiveRecord::Base.transaction do
   condition_for_mapped_tags = ProviderTagMapping::TAG_PREFIXES.map { "tags.name LIKE ?" }.join(' OR ')
   tag_values = ProviderTagMapping::TAG_PREFIXES.map { |x| "#{x}%:%" }
 
+  # TODO: do we want eager_load, or left join these
   Classification.where.not(:id => Classification.region_to_range) # only other regions(not current, we expected that current region is global)
                 .is_category
-                .includes(:tag, :children).references(:tag, :children)
+                .eager_load(:tag, :children)
                 .where(condition_for_mapped_tags, *tag_values) # only mapped categories
                 .find_each do |category|
     new_parent_category = Classification.in_my_region.find_by(:description => category.description)


### PR DESCRIPTION
extracted from #23601

We have documented issues with `references().includes()` since at least 2015, but probably further.
So I went through and removed them where possible.

Since these do not call into `Rbac`, there is no dependency between this and #23601 
And thb/ these work fine. Just removing these because they are bad implementations and it is best to keep our distance.

