### PR TITLE
[WIP] Factory change removing abstract Vm

### DIFF
--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :vm_or_template do
+  factory :vm_or_template, :class => "ManageIQ::Providers::Vmware::InfraManager::Vm" do
     sequence(:name) { |n| "vm_#{seq_padded_for_sorting(n)}" }
     location        { "unknown" }
     uid_ems         { SecureRandom.uuid }
@@ -12,13 +12,13 @@ FactoryBot.define do
     end
   end
 
-  factory :template, :class => "MiqTemplate", :parent => :vm_or_template do
+  factory :template, :class => "ManageIQ::Providers::Vmware::InfraManager::Template", :parent => :vm_or_template do
     sequence(:name) { |n| "template_#{seq_padded_for_sorting(n)}" }
     template        { true }
     raw_power_state { "never" }
   end
 
-  factory(:vm,             :class => "Vm",            :parent => :vm_or_template)
+  factory(:vm,             :class => "ManageIQ::Providers::Vmware::InfraManager::Vm",       :parent => :vm_or_template)
   factory(:vm_cloud,       :class => "VmCloud",       :parent => :vm)       { cloud { true } }
   factory(:vm_infra,       :class => "VmInfra",       :parent => :vm)
   factory(:vm_server,      :class => "VmServer",      :parent => :vm)
@@ -38,7 +38,7 @@ FactoryBot.define do
     vendor { "openstack" }
   end
 
-  factory :miq_template do
+  factory :miq_template, :class => "ManageIQ::Providers::Vmware::InfraManager::Template" do
     name { "ubuntu-16.04-stable" }
     location { "Minneapolis, MN" }
     vendor { "openstack" }

--- a/spec/models/miq_report/generator_spec.rb
+++ b/spec/models/miq_report/generator_spec.rb
@@ -73,10 +73,12 @@ RSpec.describe MiqReport::Generator do
         FactoryBot.create(:template) # filtered out by report.where_clause
         vm = FactoryBot.create(:vm, :vendor => "redhat")
 
+        expect(vm.type).to match(/Vm/)
+
         rpt = FactoryBot.create(
           :miq_report,
           :db           => "VmOrTemplate",
-          :where_clause => ["vms.type = ?", "Vm"],
+          :where_clause => ["vms.type = ?", vm.type],
           :col_order    => %w[id name host.name vendor]
         )
         rpt.generate_table(:userid => @user.userid, :where_clause => {"vms.vendor" => "redhat"})

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe VmOrTemplate do
     end
 
     context "with attrs template => true, ems_id => nil, host_id => nil" do
-      let(:attrs) { {:template => true, :ems_id => nil, :host_id => nil} }
+      subject     { FactoryBot.create(:miq_template, attrs) }
+      let(:attrs) { {:ems_id => nil, :host_id => nil} }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
       it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
@@ -64,7 +65,8 @@ RSpec.describe VmOrTemplate do
     end
 
     context "with attrs if template => true, ems_id => nil, host_id => [ID]" do
-      let(:attrs) { {:template => true, :ems_id => nil, :host_id => host.id} }
+      subject     { FactoryBot.create(:miq_template, attrs) }
+      let(:attrs) { {:ems_id => nil, :host_id => host.id} }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
       it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
@@ -72,7 +74,8 @@ RSpec.describe VmOrTemplate do
     end
 
     context "with attrs if template => true, ems_id => [ID], host_id => nil" do
-      let(:attrs) { {:template => true, :ems_id => ems.id, :host_id => nil} }
+      subject     { FactoryBot.create(:miq_template, attrs) }
+      let(:attrs) { {:ems_id => ems.id, :host_id => nil} }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
       it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
@@ -80,7 +83,8 @@ RSpec.describe VmOrTemplate do
     end
 
     context "with attrs if template => true, ems_id => [ID], host_id => [ID]" do
-      let(:attrs) { {:template => true, :ems_id => ems.id, :host_id => host.id} }
+      subject     { FactoryBot.create(:miq_template, attrs) }
+      let(:attrs) { {:ems_id => ems.id, :host_id => host.id} }
 
       it("is #registered?")            { expect(subject.registered?).to be true }
       it("is in registered_vms")       { expect(registered_vms).to include subject }


### PR DESCRIPTION
Does it make sense to not use Vm/VmOrTemplate abstract classes for out tests?

Maybe we need to push/flush out dummy providers first?

## Why

I was working on https://github.com/ManageIQ/manageiq/pull/23604 and was getting weird errors around a `Vm` in the database. It seemed odd to me that we would do this.

TODO:

- [x] Prevent creating DummyProvider entries in production (done)
- [ ] add dummy provider to gems, and add factories
- [ ] point `factory :vm_infra` to `Dummy::Vm`
- [ ] change specs to point `:vm_or_template` and `:vm` to `:vm_dummy`
- [ ] change `factory :vm*` to only allow leafs. (Thinking we want to allow `:vm_infra`). This is similar to ems factories


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
