### PR TITLE
[WIP] Switch ActsAsArModel to be QueryRelation based by default

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -16,22 +16,20 @@ class PglogicalSubscription < ActsAsArModel
     :provider_region_name => :string
   )
 
-  def self.find(*args)
-    case args.first
+  def self.search(mode, args)
+    case mode
     when :all then find_all
-    when :first, :last then find_one(args.first)
-    else find_id(args.first)
+    when :first, :last then find_one(mode)
+    else find_id(mode)
     end
   end
 
   def self.lookup_by_id(to_find)
-    find(to_find)
+    find_id(to_find)
   rescue ActiveRecord::RecordNotFound
     nil
   end
-
   singleton_class.send(:alias_method, :find_by_id, :lookup_by_id)
-  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_id => :lookup_by_id)
 
   def save!(reload_failover_monitor = true)
     assert_different_region!
@@ -73,7 +71,7 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def self.delete_all(list = nil)
-    (list.nil? ? find(:all) : list)&.each { |sub| sub.delete(false) }
+    (list.nil? ? all : list)&.each { |sub| sub.delete(false) }
     EvmDatabase.restart_failover_monitor_service_queue
     nil
   end
@@ -189,7 +187,7 @@ class PglogicalSubscription < ActsAsArModel
     subscriptions.each do |s|
       return new(subscription_to_columns(s)) if s.symbolize_keys[:subscription_name] == to_find
     end
-    raise ActiveRecord::RecordNotFound, "Coundn't find subscription with id #{to_find}"
+    raise ActiveRecord::RecordNotFound, "Couldn't find subscription with id #{to_find}"
   end
   private_class_method :find_id
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2660,7 +2660,7 @@ RSpec.describe Rbac::Filterer do
     end
 
     it "support aaarm object" do
-      expect(VimPerformanceTrend).to receive(:find).with(:all, {:include => {:a => {}}}).and_return([:good])
+      expect(VimPerformanceTrend).to receive(:search).with(:all, {:includes => {:a => {}}, :references => {:a => {}}}).and_return([:good])
       expect(described_class.filtered(VimPerformanceTrend, :include_for_find => {:a => {}}).to_a).to match_array([:good])
     end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -118,42 +118,35 @@ RSpec.describe PglogicalSubscription do
       expect(actual_attrs).to match_array(expected_attrs)
     end
 
-    it "supports find(:all) with records" do
-      with_records
-      actual_attrs = described_class.find(:all).map(&:attributes)
-      expect(actual_attrs).to match_array(expected_attrs)
-    end
-
     it "retrieves no records with no records" do
       with_no_records
       expect(described_class.all).to be_empty
-      expect(described_class.find(:all)).to be_empty
     end
   end
 
   describe ".first" do
     it "retrieves the first record with records" do
       with_records
-      rec = described_class.find(:first)
+      rec = described_class.first
       expect(rec.attributes).to eq(expected_attrs.first)
     end
 
     it "returns nil with no records" do
       with_no_records
-      expect(described_class.find(:first)).to be_nil
+      expect(described_class.first).to be_nil
     end
   end
 
   describe ".last" do
     it "retrieves the last record with :last" do
       with_records
-      rec = described_class.find(:last)
+      rec = described_class.last
       expect(rec.attributes).to eq(expected_attrs.last)
     end
 
     it "returns nil with :last" do
       with_no_records
-      expect(described_class.find(:last)).to be_nil
+      expect(described_class.last).to be_nil
     end
   end
 
@@ -264,7 +257,7 @@ RSpec.describe PglogicalSubscription do
       with_records
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
 
-      sub = described_class.find(:first)
+      sub = described_class.first
       sub.host = "other-host.example.com"
       allow(sub).to receive(:assert_different_region!)
 
@@ -289,7 +282,7 @@ RSpec.describe PglogicalSubscription do
     end
 
     it "deletes all subscriptions if no parameter passed" do
-      allow(described_class).to receive(:find).with(:all).and_return([subscription1, subscription2])
+      allow(described_class).to receive(:search).with(:all, {}).and_return([subscription1, subscription2])
       expect(subscription1).to receive(:delete)
       expect(subscription2).to receive(:delete)
       described_class.delete_all
@@ -368,7 +361,7 @@ RSpec.describe PglogicalSubscription do
   end
 
   describe "#delete" do
-    let(:sub) { described_class.find(:first) }
+    let(:sub) { described_class.first }
 
     it "drops the subscription" do
       allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first], [])
@@ -444,7 +437,7 @@ RSpec.describe PglogicalSubscription do
     it "validates existing subscriptions with new parameters" do
       allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first])
 
-      sub = described_class.find(:first)
+      sub = described_class.first
       expect(sub.host).to eq "example.com"
       expect(sub.port).to be_blank
       expect(sub.user).to eq "root"


### PR DESCRIPTION
This flips ActsAsArModel to be search-first (i.e. via QueryRelation) and deprecates the old-style find method that takes :all, :first, or :last (However, find with an id is still supported just like in Rails). This also deprecates the old-style find_by_id and find_all_by_id.

WIP: I think I should change the default implementation of `PglogicalSubscription#search` to handle `where :id` - right now it can't handle it.

cc @kbrock