### PR TITLE
Upgrade uri to 0.13.3 for CVE-2025-61594

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem "wim_parser",                       "~>1.0",             :require => false
 # gems to resolve security issues
 gem "cgi",  "~> 0.4.2"  # CVE-2025-27219: https://github.com/advisories/GHSA-gh9q-2xrm-x6qv
 gem "time", "~> 0.2.2"  # CVE-2023-28756: https://github.com/advisories/GHSA-fg7x-g82r-94qc; ruby 3.1.4+
-gem "uri",  "~> 0.13.2" # CVE-2025-27221: https://github.com/advisories/GHSA-22h5-pq3x-2gf2
+gem "uri",  "~> 0.13.3" # CVE-2025-61594: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
                         # Avoid URI 1.0.0 for now due to: https://github.com/ruby/uri/issues/125
 gem "thor", ">= 1.4.0"   # CVE-2025-54314: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
https://jsw.ibm.com/browse/CP4AIOPS-283
