### PR TITLE
[WIP] Require URI ~>1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,9 +87,9 @@ gem "wim_parser",                       "~>1.0",             :require => false
 
 # gems to resolve security issues
 gem "cgi",  "~> 0.4.2"  # CVE-2025-27219: https://github.com/advisories/GHSA-gh9q-2xrm-x6qv
+gem "thor", ">= 1.4.0"  # CVE-2025-54314: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
 gem "time", "~> 0.2.2"  # CVE-2023-28756: https://github.com/advisories/GHSA-fg7x-g82r-94qc; ruby 3.1.4+
 gem "uri",  "~> 1.0.4"  # CVE-2025-61594: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
-gem "thor", ">= 1.4.0"  # CVE-2025-54314: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
 
 # Custom gem that replaces mime-types in order to redirect mime-types calls to mini_mime
 #   Source is located at https://github.com/ManageIQ/mime-types-redirector

--- a/Gemfile
+++ b/Gemfile
@@ -88,9 +88,8 @@ gem "wim_parser",                       "~>1.0",             :require => false
 # gems to resolve security issues
 gem "cgi",  "~> 0.4.2"  # CVE-2025-27219: https://github.com/advisories/GHSA-gh9q-2xrm-x6qv
 gem "time", "~> 0.2.2"  # CVE-2023-28756: https://github.com/advisories/GHSA-fg7x-g82r-94qc; ruby 3.1.4+
-gem "uri",  "~> 0.13.3" # CVE-2025-61594: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
-                        # Avoid URI 1.0.0 for now due to: https://github.com/ruby/uri/issues/125
-gem "thor", ">= 1.4.0"   # CVE-2025-54314: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
+gem "uri",  "~> 1.0.4"  # CVE-2025-61594: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
+gem "thor", ">= 1.4.0"  # CVE-2025-54314: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
 
 # Custom gem that replaces mime-types in order to redirect mime-types calls to mini_mime
 #   Source is located at https://github.com/ManageIQ/mime-types-redirector


### PR DESCRIPTION
Replaces #23261

Merge AFTER 0.13.x / 1.x compatible change:
  - [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/580
  - [x] [qpid_proton release with uri fix](https://github.com/apache/qpid-proton/commit/346c7792a1fb74f16f406d37bfaae7ba59abc628) and related [issue](https://issues.apache.org/jira/browse/PROTON-2777)
    - [x] [qpid_proton 0.40.0 was released](https://rubygems.org/gems/qpid_proton/versions/0.40.0) 🎉 
  - [ ] Need libqpid-proton11-dev at 0.40.0 in system packages, el10 seems to have 0.40.0.  el9 still has 0.37.0.
  - [ ] [Cross repo test](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/996)


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
