### PR TITLE
Cleanup get_description override for Configuration Scripts Provisioning

### DIFF
--- a/app/models/miq_provision_configuration_script_task.rb
+++ b/app/models/miq_provision_configuration_script_task.rb
@@ -1,4 +1,2 @@
 class MiqProvisionConfigurationScriptTask < MiqRequestTask
-  def self.get_description(*)
-  end
 end


### PR DESCRIPTION
I had to add this override at some point during my testing but I tried dropping it and everything still works so we can clean this up.

Follow-up to: https://github.com/ManageIQ/manageiq/pull/23542
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
