### PR TITLE
Fix ProviderTagMapping removal leaving Classifications

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,6 +1,5 @@
 class Classification < ApplicationRecord
   acts_as_tree
-  include ReadOnlyMixin
 
   belongs_to :tag
 


### PR DESCRIPTION
A read-only Classification does not mean that it should not be deleted. Classifications that are seeded from fixtures aren't read_only which would be the only reason why we would want to prevent read_only deletion.

When you try to delete a Tag Mapping you get an error:
<img width="462" height="155" alt="image" src="https://github.com/user-attachments/assets/93a2151c-466c-4a71-a435-021d1287925d" />

And the Classification and Tag are still present:

```
vmdb(dev)> Classification.find(196)
=> #<Classification:0x00007f05fa7103c0 id: 196, description: "amazon:vm|company", icon: nil, read_only: true, syntax: "string", single_value: true, example_text: nil, tag_id: 198, parent_id: nil, show: true, default: nil, perf_by_tag: nil>vmdb(dev)> Classification.find(196).tag
=> #<Tag:0x00007f05fa5a1a48 id: 198, name: "/managed/amazon:vm:company"> 
```

Related https://github.com/ManageIQ/manageiq/pull/22232
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
