### PR TITLE
Support /mnt/log_collection mount point for log collection

### DIFF
--- a/tools/collect_logs/README.md
+++ b/tools/collect_logs/README.md
@@ -1,2 +1,4 @@
-To collect logs manually, please use the collect_archive_logs.sh and/or collect_current_logs.sh scripts within this collect_logs directory depending on the information that is requested.  
+To collect logs manually, please use the collect_archive_logs.sh and/or collect_current_logs.sh scripts within this collect_logs directory depending on the information that is requested.
 Use the exclude_files file to add any files you don't want included in log collection.
+
+If you need NFS, Samba, or some other type of shared storage to collect logs, you can mount the storage to the /mnt/log_collection directory, and we will use that instead of the /var/www/miq/vmdb/log directory.

--- a/tools/collect_logs/collect_all_logs
+++ b/tools/collect_logs/collect_all_logs
@@ -4,13 +4,16 @@ require File.expand_path("../../config/environment", __dir__)
 require "optimist"
 require "awesome_spawn"
 require "manageiq-ssh-util"
+require "pathname"
 
 class CollectAllLogs
   def initialize(opts = {})
     @remote_user     = opts.fetch(:remote_user, "root")
     @remote_password = opts.fetch(:remote_password, nil)
-    @vmdb_log_dir    = Rails.root.join("log")
-    @target_log_dir  = vmdb_log_dir.join("evm_current_region_#{MiqRegion.my_region&.id}_#{Time.now.utc.strftime("%Y%m%d_%H%M%S")}")
+
+    log_collection_mount = Pathname.new("/mnt/log_collection")
+    @base_log_dir = log_collection_mount.mountpoint? ? log_collection_mount.join("log") : Rails.root.join("log")
+    @target_log_dir = @base_log_dir.join("evm_current_region_#{MiqRegion.my_region&.id}_#{Time.now.utc.strftime("%Y%m%d_%H%M%S")}")
   end
 
   def self.collect_all_logs!(opts = {})
@@ -19,7 +22,7 @@ class CollectAllLogs
 
   def collect_all_logs
     # Create the directory to copy all log bundles into
-    target_log_dir.mkdir
+    target_log_dir.mkpath
 
     active_miq_servers = MiqServer.active_miq_servers
 
@@ -38,7 +41,7 @@ class CollectAllLogs
     abort("Collecting logs from [#{active_miq_servers.count}] servers in #{MiqRegion.my_region.description}...Failed") if results.none?(&:success?)
 
     # Tar up all of the logs we have collected from the servers
-    `cd #{vmdb_log_dir} && tar cfJ #{target_log_dir.basename}.tar.xz #{target_log_dir.basename} 2>&1`
+    `cd #{base_log_dir} && tar cfJ #{target_log_dir.basename}.tar.xz #{target_log_dir.basename} 2>&1`
 
     # Cleanup the directory that we created the tar from
     FileUtils.rm_r(target_log_dir)
@@ -48,7 +51,7 @@ class CollectAllLogs
 
   private
 
-  attr_reader :remote_user, :remote_password, :target_log_dir, :vmdb_log_dir
+  attr_reader :remote_user, :remote_password, :target_log_dir, :base_log_dir
 
   def collect_logs(miq_server)
     server_ident = miq_server.hostname || miq_server.ipaddress

--- a/tools/collect_logs/collect_archive_logs.sh
+++ b/tools/collect_logs/collect_archive_logs.sh
@@ -3,14 +3,19 @@
 # save directory from which command is initiated
 collect_logs_directory=$(pwd)
 
-# make the vmdb/log directory the current directory
-vmdb_logs_directory="/var/www/miq/vmdb"
-pushd ${vmdb_logs_directory}
+# determine where to write the logs to
+if mountpoint /mnt/log_collection >/dev/null; then
+    base_log_dir="/mnt/log_collection"
+else
+    base_log_dir="/var/www/miq/vmdb"
+fi
+pushd ${base_log_dir}
+mkdir -p log
 
-# eliminiate any prior collected logs to make sure that only one collection is current
+# eliminate any prior collected logs to make sure that only one collection is current
 rm -f log/evm_full_archive_$(uname -n)* log/evm_archived_$(uname -n)*
 
-#Source in the file so that we can call postgresql functions
+# Source in the file so that we can call postgresql functions
 source /etc/default/evm
 
 tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
@@ -18,7 +23,7 @@ tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/log" ]]; then
     echo "This ManageIQ appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files BUILD GUID VERSION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/log/* $APPLIANCE_PG_DATA/postgresql.conf
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse --warning=no-file-changed -X $collect_logs_directory/exclude_files BUILD GUID VERSION log/* config/* /var/log/* log/apache/* $APPLIANCE_PG_DATA/log/* $APPLIANCE_PG_DATA/postgresql.conf
 else
     echo "This ManageIQ appliance is not a Database server"
     echo " Log collection starting:"
@@ -29,4 +34,4 @@ fi
 popd
 
 # let the user know where the archive is
-echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"
+echo "Archive Written To: ${base_log_dir}/${tarball}"

--- a/tools/collect_logs/collect_current_logs.sh
+++ b/tools/collect_logs/collect_current_logs.sh
@@ -3,14 +3,19 @@
 # save directory from which command is initiated
 collect_logs_directory=$(pwd)
 
-# make the vmdb/log directory the current directory
-vmdb_logs_directory="/var/www/miq/vmdb"
-pushd ${vmdb_logs_directory}
+# determine where to write the logs to
+if mountpoint /mnt/log_collection >/dev/null; then
+    base_log_dir="/mnt/log_collection"
+else
+    base_log_dir="/var/www/miq/vmdb"
+fi
+pushd ${base_log_dir}
+mkdir -p log
 
-# eliminiate any prior collected logs to make sure that only one collection is current
+# eliminate any prior collected logs to make sure that only one collection is current
 rm -f log/evm_full_archive_$(uname -n)* log/evm_current_$(uname -n)*
 
-#Source in the file so that we can call postgresql functions
+# Source in the file so that we can call postgresql functions
 source /etc/default/evm
 
 tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
@@ -29,4 +34,4 @@ fi
 popd
 
 # let the user know where the archive is
-echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"
+echo "Archive Written To: ${base_log_dir}/${tarball}"


### PR DESCRIPTION
This will allow us to remove the need to mount FileDepot instances for log collection, because now the user has the option to manually mount storage of whatever type they'd like in the appliance.

@agrare Please review.