### PR TITLE
Move FileDepotMixin to be exclusively for PxeServer

### DIFF
--- a/app/models/pxe_server/file_depot_mixin.rb
+++ b/app/models/pxe_server/file_depot_mixin.rb
@@ -1,7 +1,7 @@
 require 'uri'
 require 'mount/miq_generic_mount_session'
 
-module FileDepotMixin
+module PxeServer::FileDepotMixin
   extend ActiveSupport::Concern
   SUPPORTED_DEPOTS = {
     'smb'   => 'Samba',


### PR DESCRIPTION
@bdunne Please review. Now that the only thing left using FileDepot is PxeServer, isolating it to the PxeServer model will make it's usage clearer. (Note the file rename in addition to the module change).