### PR TITLE
Add miq_provision_configuration_script_dialog factory

### DIFF
--- a/spec/factories/miq_dialog.rb
+++ b/spec/factories/miq_dialog.rb
@@ -32,4 +32,9 @@ FactoryBot.define do
     name        { "miq_provision_configured_system_foreman_dialogs" }
     dialog_type { "MiqProvisionConfiguredSystemWorkflow" }
   end
+
+  factory :miq_provision_configuration_script_dialog, :parent => :miq_dialog do
+    name        { "miq_provision_configuration_script_dialogs" }
+    dialog_type { "MiqProvisionConfigurationScriptWorkflow" }
+  end
 end


### PR DESCRIPTION
This is helpful for testing `ProvisionWorkflow` and `prov_get_form_vars`

Required for:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/9728
* https://github.com/ManageIQ/manageiq-providers-awx/pull/51
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
