### PR TITLE
ConnectionPool v3.0 introduces breaking changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "bundler",                          "~> 2.2", ">= 2.2.15", *("!= 2.5.0".."!=
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>5.1",             :require => false
-gem "connection_pool",                                       :require => false # For Dalli
+gem "connection_pool",                  "~>2.5",             :require => false # For Dalli
 gem "dalli",                            "~>3.2.3",           :require => false
 gem "default_value_for",                "~>4.0"
 gem "docker-api",                       "~>1.33.6",          :require => false


### PR DESCRIPTION
Dalli does not use kwargs for creating a connection pool object which throws an ArgumentError exception:

```
ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)
~/.gem/ruby/3.3.0/gems/connection_pool-3.0.1/lib/connection_pool.rb:48:in `initialize'
~/.gem/ruby/3.3.0/gems/dalli-3.2.8/lib/rack/session/dalli.rb:142:in `new'
~/.gem/ruby/3.3.0/gems/dalli-3.2.8/lib/rack/session/dalli.rb:142:in `build_data_source'
~/.gem/ruby/3.3.0/gems/dalli-3.2.8/lib/rack/session/dalli.rb:70:in `initialize'
```

https://rubygems.org/gems/connection_pool/versions/3.0.0
https://github.com/mperham/connection_pool/blob/main/Changes.md#300
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
