### PR TITLE
Add orchestration_stack_retiring notification type

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -159,6 +159,11 @@
   :expires_in: 24.hours
   :level: :warning
   :audience: global
+- :name: orchestration_stack_retiring
+  :message: Orchestration Stack %{subject} has started retirement.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
 - :name: orchestration_stack_retired
   :message: Orchestration Stack %{subject} has been retired.
   :expires_in: 7.days


### PR DESCRIPTION
Currently Stack retirement uses the `:vm_retiring` notification type, however there is an `:orchestration_stack_retired` notification.

Required for:
* https://github.com/ManageIQ/manageiq-content/pull/777
* https://github.com/ManageIQ/manageiq/pull/23660

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
