### PR TITLE
Update minimum bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "awesome_spawn",                    "~>1.6",             :require => false
 gem "aws-sdk-s3",                       "~>1.0",             :require => false # For FileDepotS3
 gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load
-gem "bundler",                          "~> 2.2", ">= 2.2.15", *("!= 2.5.0".."!= 2.5.9"), "!= 2.5.19", :require => false
+gem "bundler",                          ">= 2.5.20", "< 5",  :require => false
 gem "byebug",                                                :require => false
 gem "color",                            "~>1.8"
 gem "config",                           "~>5.1",             :require => false


### PR DESCRIPTION
Now that we are only on Ruby 3.3+, we can update the minimum bundler to what comes with Ruby 3.3 (and then some to avoid the bad versions).

Additionally, open up the ability to use bundler 4

@jrafanie @agrare Please review.