### PR TITLE
Remove generator ruby-versions logic into Ruby code

### DIFF
--- a/lib/generators/manageiq/plugin/plugin_generator.rb
+++ b/lib/generators/manageiq/plugin/plugin_generator.rb
@@ -136,6 +136,18 @@ module ManageIQ
       @plugin_description ||= "#{plugin_short_name.titleize} plugin for #{Vmdb::Appliance.PRODUCT_NAME}."
     end
 
+    def ruby_versions
+      @ruby_versions ||= core_ci_yaml.dig("jobs", "ci", "strategy", "matrix", "ruby-version").to_a
+    end
+
+    def core_ci_yaml
+      @core_ci_yaml ||= YAML.load_file(core_ci_yaml_path)
+    end
+
+    def core_ci_yaml_path
+      Rails.root.join(".github/workflows/ci.yaml")
+    end
+
     def node_version
       @node_version ||= package_json.dig("engines", "node")
     end

--- a/lib/generators/manageiq/plugin/templates/.github/workflows/ci.yaml
+++ b/lib/generators/manageiq/plugin/templates/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-<%= YAML.load_file(Rails.root.join(".github/workflows/ci.yaml")).dig("jobs", "ci", "strategy", "matrix", "ruby-version").to_a.map { |r| "- '#{r}'".indent(8) }.join("\n") %>
+        <%= ruby_versions.to_yaml[3..].indent(8).strip %>
     services:
       postgres:
         image: manageiq/postgresql:13


### PR DESCRIPTION
This moves the logic into the plugin generator itself to avoid overcomplicating the yaml template. The ruby side focuses on getting the version numbers, the yaml side focuses on the yaml formatting only.

@agrare Please review - minor refactoring.