### PR TITLE
Rename `MiqRequestTask#workflow_inputs`

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -117,7 +117,7 @@ class MiqProvision < MiqProvisionTask
     end
   end
 
-  def workflow_inputs
+  def configuration_script_inputs
     options
   end
 


### PR DESCRIPTION
Rename `workflow_inputs` to the more generic `configuration_script_inputs` as well as other local variables that reference `workflows` directly.

Follow-up to https://github.com/ManageIQ/manageiq/pull/23680#issuecomment-3715852281
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
