### PR TITLE
Fix `configuration_script_context` for AutomationManagers

### DIFF
--- a/app/models/mixins/configuration_script_context_source_details_mixin.rb
+++ b/app/models/mixins/configuration_script_context_source_details_mixin.rb
@@ -4,16 +4,16 @@ module ConfigurationScriptContextSourceDetailsMixin
   def configuration_script_context
     remote_ws_url = MiqRegion.my_region.remote_ws_url
     api_base_url  = URI.join(remote_ws_url, "api") if remote_ws_url
-    evm_owner     = source.evm_owner
-    service       = source.service
 
     source_details = {
       :id      => source.id,
       :name    => source.name,
-      :ems_ref => source.ems_ref
+      :ems_ref => source.respond_to?(:manager_ref) ? source.manager_ref : source.ems_ref
     }
+
     source_details[:href] = URI.join(api_base_url, source.href_slug).to_s if api_base_url
 
+    evm_owner = source.evm_owner if source.respond_to?(:evm_owner)
     if evm_owner
       source_details[:owner] = {
         :id     => evm_owner.id,
@@ -24,6 +24,7 @@ module ConfigurationScriptContextSourceDetailsMixin
       source_details[:owner][:href] = URI.join(api_base_url, evm_owner.href_slug).to_s if api_base_url
     end
 
+    service = source.service if source.respond_to?(:service)
     if service
       source_details[:service] = {
         :id   => service.id,


### PR DESCRIPTION
AutomationManagers have a `ConfigurationScript` as the `source` of the `MiqRequestTask`.  This doesn't have `evm_owner`, `service`, or `ems_ref`.

This checks if `source` responds to service/evm_owner, and handles if `source` has an `ems_ref` or a `manager_ref`

Required for:
* https://github.com/ManageIQ/manageiq-providers-awx/pull/55
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
