### PR TITLE
Replace MiqServer#has_vix_disk_lib with #capabilities

### DIFF
--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -14,7 +14,7 @@ module MiqServer::ServerSmartProxy
   end
 
   def is_vix_disk?
-    has_vix_disk_lib? && has_active_role?(:SmartProxy)
+    !!capabilities["vix_disk_lib"] && has_active_role?(:SmartProxy)
   end
 
   def vm_scan_host_affinity?
@@ -89,7 +89,7 @@ module MiqServer::ServerSmartProxy
       ost.config = OpenStruct.new(
         :vmdb               => true,
         :forceFleeceDefault => true,
-        :capabilities       => {:vixDisk => has_vix_disk_lib?}
+        :capabilities       => {:vixDisk => capabilities["vix_disk_lib"]}
       )
 
       target.perform_metadata_scan(ost)

--- a/spec/models/miq_server/server_smart_proxy_spec.rb
+++ b/spec/models/miq_server/server_smart_proxy_spec.rb
@@ -4,12 +4,16 @@ RSpec.describe "MiqServer::ServerSmartProxy" do
 
   describe "#is_vix_disk?" do
     it "is false without the smartproxy role" do
-      server.update(:has_vix_disk_lib => true)
+      server.capabilities["vix_disk_lib"] = true
+      server.save!
+
       expect(server.is_vix_disk?).to be_falsey
     end
 
     it "is true with smartproxy and vix disk lib" do
-      server.update(:has_vix_disk_lib => true)
+      server.capabilities["vix_disk_lib"] = true
+      server.save!
+
       server.role = "smartproxy"
       server.assigned_server_roles.update(:active => true)
 

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe VmScan do
   context "A single VM Scan Job," do
-    let(:server) { EvmSpecHelper.local_miq_server(:has_vix_disk_lib => true) }
+    let(:server) { EvmSpecHelper.local_miq_server(:capabilities => {"vix_disk_lib" => true}) }
     let(:user) { FactoryBot.create(:user_with_group, :userid => "tester") }
     let(:ems) { FactoryBot.create(:ems_infra, :zone => server.zone) }
     let(:vm) { FactoryBot.create(:vm_infra, :ext_management_system => ems, :host => host, :miq_group => user.current_group, :evm_owner => user) }
@@ -106,34 +106,34 @@ RSpec.describe VmScan do
   context "A VM Scan job in multiple zones" do
     before do
       # local zone
-      @server1 = EvmSpecHelper.local_miq_server(:has_vix_disk_lib => true)
-      @user      = FactoryBot.create(:user_with_group, :userid => "tester")
-      @ems       = FactoryBot.create(:ems_vmware_with_authentication, :name => "Test EMS", :zone => @server1.zone,
-                                      :tenant => FactoryBot.create(:tenant))
-      @storage   = FactoryBot.create(:storage, :name => "test_storage", :store_type => "VMFS")
-      @host      = FactoryBot.create(:host, :name => "test_host", :hostname => "test_host",
-                                      :state => 'on', :ext_management_system => @ems)
-      @vm        = FactoryBot.create(:vm_vmware, :name => "test_vm", :location => "abc/abc.vmx",
-                                      :raw_power_state       => 'poweredOn',
-                                      :host                  => @host,
-                                      :ext_management_system => @ems,
-                                      :miq_group             => @user.current_group,
-                                      :evm_owner             => @user,
-                                      :storage               => @storage)
+      @server1 = EvmSpecHelper.local_miq_server(:capabilities => {"vix_disk_lib" => true})
+      @user    = FactoryBot.create(:user_with_group, :userid => "tester")
+      @ems     = FactoryBot.create(:ems_vmware_with_authentication, :name => "Test EMS", :zone => @server1.zone,
+                                   :tenant => FactoryBot.create(:tenant))
+      @storage = FactoryBot.create(:storage, :name => "test_storage", :store_type => "VMFS")
+      @host    = FactoryBot.create(:host, :name => "test_host", :hostname => "test_host",
+                                   :state => 'on', :ext_management_system => @ems)
+      @vm      = FactoryBot.create(:vm_vmware, :name => "test_vm", :location => "abc/abc.vmx",
+                                   :raw_power_state       => 'poweredOn',
+                                   :host                  => @host,
+                                   :ext_management_system => @ems,
+                                   :miq_group             => @user.current_group,
+                                   :evm_owner             => @user,
+                                   :storage               => @storage)
 
       # remote zone
-      @server2 = EvmSpecHelper.remote_miq_server(:has_vix_disk_lib => true)
-      @user2     = FactoryBot.create(:user_with_group, :userid => "tester2")
-      @storage2  = FactoryBot.create(:storage, :name => "test_storage2", :store_type => "VMFS")
-      @host2     = FactoryBot.create(:host, :name => "test_host2", :hostname => "test_host2",
-                                      :state => 'on', :ext_management_system => @ems)
-      @vm2       = FactoryBot.create(:vm_vmware, :name => "test_vm2", :location => "abc2/abc2.vmx",
-                                      :raw_power_state       => 'poweredOn',
-                                      :host                  => @host2,
-                                      :ext_management_system => @ems,
-                                      :miq_group             => @user2.current_group,
-                                      :evm_owner             => @user2,
-                                      :storage               => @storage2)
+      @server2  = EvmSpecHelper.remote_miq_server(:capabilities => {"vix_disk_lib" => true})
+      @user2    = FactoryBot.create(:user_with_group, :userid => "tester2")
+      @storage2 = FactoryBot.create(:storage, :name => "test_storage2", :store_type => "VMFS")
+      @host2    = FactoryBot.create(:host, :name => "test_host2", :hostname => "test_host2",
+                                    :state => 'on', :ext_management_system => @ems)
+      @vm2      = FactoryBot.create(:vm_vmware, :name => "test_vm2", :location => "abc2/abc2.vmx",
+                                    :raw_power_state       => 'poweredOn',
+                                    :host                  => @host2,
+                                    :ext_management_system => @ems,
+                                    :miq_group             => @user2.current_group,
+                                    :evm_owner             => @user2,
+                                    :storage               => @storage2)
 
       allow(MiqEventDefinition).to receive_messages(:find_by => true)
       allow(@server1).to receive(:has_active_role?).with('automate').and_return(true) # set automate role in local zone


### PR DESCRIPTION
Improve the pluggability of MiqServer capabilities without having to add a new column for every capability that we want to track.

Other examples of a capability might be "has a docker image for a worker been pulled"

Depends on:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/827

Co-dependent:
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/960

Cross-repo-test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1015
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
