### PR TITLE
Use rails 8.0 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -111,9 +111,9 @@ module Vmdb
 
     config.autoload_paths += config.eager_load_paths
 
-    # FYI, this is where load_defaults is defined as of 7.2:
-    # https://github.com/rails/rails/blob/d437ae311f1b9dc40b442e40eb602e020cec4e49/railties/lib/rails/application/configuration.rb#L92
-    config.load_defaults 7.2
+    # FYI, this is where load_defaults is defined as of 8.0:
+    # https://github.com/rails/rails/blob/624fe3cdb9ab774ff598af29f408425178da6677/railties/lib/rails/application/configuration.rb#L337-L348
+    config.load_defaults 8.0
     # ensure MiqReport#extras will marshal/dump back out. 7.1 is default (and has better performance)
     # See for probable culprit https://www.github.com/rails/rails/pull/47747
     config.active_record.marshalling_format_version = 6.1


### PR DESCRIPTION
Followup to #23670

These are set here:
https://github.com/rails/rails/blob/624fe3cdb9ab774ff598af29f408425178da6677/railties/lib/rails/application/configuration.rb#L337-L348

* to_time_preserves_timezone: https://dev.to/lightflight/rails-8-new-activesupport-timezone-defaults-321c
* strict_freshness (etag header takes predence) https://www.github.com/rails/rails/pull/52274

* Regexp.timeout ||= 1 https://www.github.com/rails/rails/pull/53490

- [x] 💚 [cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1022)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
