### PR TITLE
Fix `get_source_and_targets` error when the selected folder is deleted

### DIFF
--- a/app/models/manageiq/providers/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/infra_manager/provision_workflow.rb
@@ -52,7 +52,7 @@ class ManageIQ::Providers::InfraManager::ProvisionWorkflow < MiqProvisionVirtWor
     if result[:folder_id].nil?
       add_target(:placement_dc_name, :datacenter, EmsFolder, result)
     else
-      result[:datacenter] = find_datacenter_for_ci(result[:folder], get_ems_metadata_tree(result))
+      result[:datacenter] = find_datacenter_for_ci(result[:folder], get_ems_metadata_tree(result)) unless result[:folder].nil?
       result[:datacenter_id] = result[:datacenter].id unless result[:datacenter].nil?
     end
 


### PR DESCRIPTION
If a ServiceTemplate's selected folder has been deleted then when you click on the ServiceTemplate in the UI it throws an undefined method exception trying to find the base class of `NilClass`.

<img width="1080" height="370" alt="image" src="https://github.com/user-attachments/assets/ca8d77b9-016e-4a81-b67c-3d641ee66450" />

```
[----] F, [2026-01-29T15:25:52.743165#299629:f72d8] FATAL -- : Error caught: [NoMethodError] undefined method `base_class' for class NilClass
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request_workflow.rb:875:in `load_ems_node'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request_workflow.rb:949:in `find_class_above_ci'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_request_workflow.rb:931:in `find_datacenter_for_ci'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/infra_manager/provision_workflow.rb:56:in `get_source_and_targets'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_provision_virt_workflow.rb:403:in `get_source_vm'
/home/grare/adam/src/manageiq/manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb:119:in `update_field_visibility'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_provision_virt_workflow.rb:40:in `initialize'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/miq_request_mixin.rb:160:in `new'
/home/grare/adam/src/manageiq/manageiq/app/models/mixins/miq_request_mixin.rb:160:in `workflow'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/controllers/application_controller/miq_request_methods.rb:876:in `prov_set_show_vars'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:1910:in `get_node_info_handle_leaf_node'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:1985:in `get_node_info'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:2301:in `replace_right_cell'
/home/grare/adam/src/manageiq/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:164:in `tree_select'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
