### PR TITLE
[WIP] Move default server roles out of Settings

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -48,12 +48,14 @@ module MiqServer::RoleManagement
   end
 
   def sync_assigned_roles
-    self.role = ::Settings.server.role
+    self.role = ::Settings.server.role if ::Settings.server.role
   end
 
   def ensure_default_roles
-    MiqServer.my_server.add_settings_for_resource(:server => {:role => ENV["MIQ_SERVER_DEFAULT_ROLES"]}) if role.blank? && ENV["MIQ_SERVER_DEFAULT_ROLES"].present?
-    sync_assigned_roles
+    return if role.present?
+
+    self.server_role_names = ServerRole.default_roles.pluck(:name)
+    add_settings_for_resource(:server => {:role => server_role_names.join(",")})
   end
 
   def deactivate_all_roles

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -4,6 +4,7 @@ class ServerRole < ApplicationRecord
 
   validates :name, :presence => true, :uniqueness_when_changed => true
 
+  scope :default_roles,  -> { where(:default => true).order(:name) }
   scope :database_roles, -> { where(:role_scope => 'database').order(:name) }
   scope :region_roles,   -> { where(:role_scope => 'region').order(:name) }
   scope :zone_roles,     -> { where(:role_scope => 'zone').order(:name) }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -947,7 +947,7 @@
     :ui_login:
       :limit: 5
       :period: 20.seconds
-  :role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,ems_metrics_collector,ems_metrics_coordinator,ems_metrics_processor,notifier,user_interface,remote_console,web_services,automate
+  :role:
   :server_dequeue_frequency: 5.seconds
   :server_log_frequency: 5.minutes
   :server_log_timings_threshold: 1.second

--- a/db/fixtures/server_roles.csv
+++ b/db/fixtures/server_roles.csv
@@ -1,21 +1,21 @@
-name,description,max_concurrent,external_failover,role_scope
-automate,Automation Engine,0,false,region
-database_operations,Database Operations,0,false,region
-database_owner,Database Owner,1,false,database
-embedded_ansible,Embedded Ansible,0,false,region
-ems_inventory,Provider Inventory,1,false,zone
-ems_metrics_collector,Capacity & Utilization Data Collector,0,false,zone
-ems_metrics_coordinator,Capacity & Utilization Coordinator,1,false,zone
-ems_metrics_processor,Capacity & Utilization Data Processor,0,false,zone
-ems_operations,Provider Operations,0,false,zone
-event,Event Monitor,1,false,zone
-git_owner,Git Repositories Owner,1,false,zone
-internet_connectivity,Internet Connectivity,0,false,region
-notifier,Notifier,1,false,region
-reporting,Reporting,0,false,region
-scheduler,Scheduler,1,false,region
-smartproxy,SmartProxy,0,false,zone
-smartstate,SmartState Analysis,0,false,zone
-user_interface,User Interface,0,false,region
-remote_console,Remote Consoles,0,false,region
-web_services,Web Services,0,false,region
+name,description,max_concurrent,external_failover,role_scope,default
+automate,Automation Engine,0,false,region,true
+database_operations,Database Operations,0,false,region,true
+database_owner,Database Owner,1,false,database,false
+embedded_ansible,Embedded Ansible,0,false,region,false
+ems_inventory,Provider Inventory,1,false,zone,true
+ems_metrics_collector,Capacity & Utilization Data Collector,0,false,zone,true
+ems_metrics_coordinator,Capacity & Utilization Coordinator,1,false,zone,true
+ems_metrics_processor,Capacity & Utilization Data Processor,0,false,zone,true
+ems_operations,Provider Operations,0,false,zone,true
+event,Event Monitor,1,false,zone,event
+git_owner,Git Repositories Owner,1,false,zone,false
+internet_connectivity,Internet Connectivity,0,false,region,false
+notifier,Notifier,1,false,region,true
+reporting,Reporting,0,false,region,true
+scheduler,Scheduler,1,false,region,true
+smartproxy,SmartProxy,0,false,zone,false
+smartstate,SmartState Analysis,0,false,zone,true
+user_interface,User Interface,0,false,region,true
+remote_console,Remote Consoles,0,false,region,true
+web_services,Web Services,0,false,region,true


### PR DESCRIPTION
Add a `:default` column to `ServerRole` so that we do not need to use `Settings.server.role` to indicate if a role should be enabled by default or not.

This allows for plugins to bring default server roles.

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/829

Related:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/114
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
