### PR TITLE
Add `https://` to AnsibleTower::Provider factory url

### DIFF
--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
 
   factory :provider_openstack, :class => "ManageIQ::Providers::Openstack::Provider", :parent => :provider
   factory(:provider_ansible_tower, :class => "ManageIQ::Providers::AnsibleTower::Provider", :parent => :provider) do
-    sequence(:url) { |n| "example_#{seq_padded_for_sorting(n)}.com" }
+    sequence(:url) { |n| "https://example_#{seq_padded_for_sorting(n)}.com" }
     trait(:with_authentication) do
       after(:create) do |x|
         x.authentications << FactoryBot.create(:authentication)


### PR DESCRIPTION
Related:
* https://github.com/ManageIQ/manageiq-providers-awx/pull/50
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
