### PR TITLE
Remove the unncessary local server

### DIFF
--- a/spec/factories/small_environment.rb
+++ b/spec/factories/small_environment.rb
@@ -4,9 +4,6 @@ FactoryBot.define do
     sequence(:description)  { |n| "Small Environment #{seq_padded_for_sorting(n)}" }
 
     after(:create) do |z|
-      # Hackery: Due to ntp reload occurring on save,
-      #          we need to add the servers after saving the zone.
-      EvmSpecHelper.local_miq_server(:is_master => true, :zone => z)
       FactoryBot.create_list(:ems_vmware, 1, :zone => z) do |ems|
         FactoryBot.create(:host, :with_ref, :vmm_product => "Workstation", :ext_management_system => ems) do |host|
           FactoryBot.create_list(:vm_with_ref, 2, :ext_management_system => ems, :host => host)

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe EmsEvent do
     let(:vm) { FactoryBot.create(:vm_openstack, :ems_ref => "vm1") }
     before do
       @zone = FactoryBot.create(:small_environment)
+      EvmSpecHelper.local_miq_server(:is_master => true, :zone => @zone)
       @ems  = @zone.ext_management_systems.first
       @availability_zone = FactoryBot.create(:availability_zone_openstack, :ems_ref => "az1")
     end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -328,15 +328,15 @@ RSpec.describe ExtManagementSystem do
     end
 
     it "refresh_all_ems_timer will refresh for all emses in zone1" do
+      EvmSpecHelper.local_miq_server(:is_master => true, :zone => @zone1)
       @ems1 = @zone1.ext_management_systems.first
-      allow(MiqServer).to receive(:my_server).and_return(@zone1.miq_servers.first)
       expect(described_class).to receive(:refresh_ems).with([@ems1.id], true)
       described_class.refresh_all_ems_timer
     end
 
     it "refresh_all_ems_timer will refresh for all emses in zone2" do
       @ems2 = @zone2.ext_management_systems.first
-      allow(MiqServer).to receive(:my_server).and_return(@zone2.miq_servers.first)
+      EvmSpecHelper.local_miq_server(:is_master => true, :zone => @zone2)
       expect(described_class).to receive(:refresh_ems).with([@ems2.id], true)
       described_class.refresh_all_ems_timer
     end


### PR DESCRIPTION
There are only a few usages of it and it's easily replaced where needed.

TODO:

- [x] 💚 [cross repo tests](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1034)

This passes locally:
```
bundle exec rspec `git grep -l small_environment spec/models`
```

Note, the stubbing of the local server fails when you try to use this factory through cypress.  We could try to fix this or just remove it, with the latter being much easier if we're not using it.

This was mentioned in https://github.com/ManageIQ/manageiq-ui-classic/pull/9633