### PR TITLE
Remove extra space from cluster memory menu name

### DIFF
--- a/product/reports/750_Trending - Clusters/050_Cluster memory trend  6 months.yaml
+++ b/product/reports/750_Trending - Clusters/050_Cluster memory trend  6 months.yaml
@@ -8,7 +8,7 @@ conditions:
 updated_on: 2009-10-19 22:09:11.300000 Z
 order: Ascending
 graph:
-menu_name: "Cluster memory trend  6 months"
+menu_name: "Cluster memory trend 6 months"
 rpt_group: Custom
 priority: 110
 col_order: []


### PR DESCRIPTION
This PR removes an extra space from the Cluster Memory report menu name. This error is causing the Cypress tests in this PR to fail: https://github.com/ManageIQ/manageiq-ui-classic/pull/9806