### PR TITLE
Add a common ServiceTemplateAutomation parent class

### DIFF
--- a/app/models/service_automation.rb
+++ b/app/models/service_automation.rb
@@ -1,0 +1,2 @@
+class ServiceAutomation < Service
+end

--- a/app/models/service_awx.rb
+++ b/app/models/service_awx.rb
@@ -1,4 +1,4 @@
-class ServiceAwx < Service
+class ServiceAwx < ServiceAutomation
   include AnsibleExtraVarsMixin
   include ServiceConfigurationMixin
   include ServiceOrchestrationOptionsMixin

--- a/app/models/service_template_automation.rb
+++ b/app/models/service_template_automation.rb
@@ -1,0 +1,3 @@
+class ServiceTemplateAutomation < ServiceTemplate
+  include ServiceTemplateAutomationMixin
+end

--- a/app/models/service_template_awx.rb
+++ b/app/models/service_template_awx.rb
@@ -1,6 +1,5 @@
-class ServiceTemplateAwx < ServiceTemplate
+class ServiceTemplateAwx < ServiceTemplateAutomation
   include ServiceConfigurationMixin
-  include ServiceTemplateAutomationMixin
 
   before_update :remove_invalid_resource
 

--- a/spec/factories/service_template.rb
+++ b/spec/factories/service_template.rb
@@ -2,9 +2,10 @@ FactoryBot.define do
   factory :service_template do
     sequence(:name) { |n| "service_template_#{seq_padded_for_sorting(n)}" }
   end
+  factory :service_template_automation, :class => 'ServiceTemplateAutomation', :parent => :service_template
   factory :service_template_orchestration, :class => 'ServiceTemplateOrchestration', :parent => :service_template
   factory :service_template_ansible_playbook, :class => 'ServiceTemplateAnsiblePlaybook', :parent => :service_template
-  factory :service_template_ansible_tower, :class => 'ServiceTemplateAnsibleTower', :parent => :service_template
+  factory :service_template_ansible_tower, :class => 'ServiceTemplateAnsibleTower', :parent => :service_template_automation
   factory :service_template_container_template, :class => 'ServiceTemplateContainerTemplate', :parent => :service_template
 
   trait :with_provision_resource_action_and_dialog do


### PR DESCRIPTION
Add a common parent class that Awx/AnsibleTower/TerraformEnterprise can inherit from.

Required for:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/9915
* https://github.com/ManageIQ/manageiq-providers-terraform_enterprise/pull/32

Cross-repo Tests:
* https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1044

Related:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/120
* https://github.com/ManageIQ/manageiq-ui-classic/pull/9869
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
