### PR TITLE
Apache will set strict/HSTS for rails in production

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -3,7 +3,9 @@ if defined?(SecureHeaders)
   # - https://github.com/ManageIQ/manageiq-appliance/blob/master/COPY/etc/httpd/conf.d/manageiq-https-application.conf
   # - https://github.com/ManageIQ/manageiq-pods/blob/master/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
   SecureHeaders::Configuration.default do |config|
-    config.hsts = "max-age=#{20.years.to_i}"
+    # Only set HSTS in development/test where Apache isn't fronting Rails
+    # In production, Apache sets HSTS (see manageiq-https-application.conf line 15)
+    config.hsts = Rails.env.production? ? SecureHeaders::OPT_OUT : "max-age=#{20.years.to_i}"
     # X-Frame-Options
     config.x_frame_options = 'SAMEORIGIN'
     # X-Content-Type-Options


### PR DESCRIPTION
This avoids setting the same header value twice.

CP4AIOPS-25657

See:
https://github.com/ManageIQ/manageiq-appliance/pull/402
https://github.com/ManageIQ/manageiq-pods/pull/1347

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
