### PR TITLE
Disable testing plugins with Gemfile.lock.release

### DIFF
--- a/bin/ci/setup_plugin_gemfile_lock
+++ b/bin/ci/setup_plugin_gemfile_lock
@@ -5,9 +5,10 @@ APP_ROOT=$ENGINE_ROOT/spec/manageiq
 
 # Gemfile.lock.release only applies to non-master branches and PRs to non-master branches
 if [[ "$GITHUB_REPOSITORY_OWNER" = "ManageIQ" && "$GITHUB_BASE_REF" != "master" && "$GITHUB_REF_NAME" != "master" && "$GITHUB_REF_NAME" != "revert-"* && "$GITHUB_REF_NAME" != "dependabot/"* && "$GITHUB_REF_NAME" != "renovate/"* ]]; then
-  echo "== Copying Gemfile.lock.release =="
-  cp -f "$APP_ROOT/Gemfile.lock.release" "$ENGINE_ROOT/Gemfile.lock"
-  echo "== Patching Gemfile.lock for plugin =="
-  $APP_ROOT/bin/ci/patch_plugin_gemfile_lock
+  # Temporarily disable testing plugins with Gemfile.lock.release
+  # echo "== Copying Gemfile.lock.release =="
+  # cp -f "$APP_ROOT/Gemfile.lock.release" "$ENGINE_ROOT/Gemfile.lock"
+  # echo "== Patching Gemfile.lock for plugin =="
+  # $APP_ROOT/bin/ci/patch_plugin_gemfile_lock
   echo
 fi


### PR DESCRIPTION
Temporarily disable this so we can get the `tal` release branches green.
This reverts back to the old behavior for plugin release branches which skips using the Gemfile.lock.release
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
