### PR TITLE
Bump surro-gate to fix incompatible pointer warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -298,7 +298,7 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
-  gem "surro-gate",                     "~>1.0.5",           :require => false
+  gem "surro-gate",                     "~>1.0.6",           :require => false
   gem "websocket-driver",               "~>0.6.3",           :require => false
 end
 


### PR DESCRIPTION
Bump surro-gate to v1.0.6 to pull in https://github.com/skateman/surro-gate/pull/29 to fix an incompatible pointer error while compiling native extensions.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
