### PR TITLE
add missing statemachine_task_status method in OrchestrationStackRetireTask

### DIFF
--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -88,4 +88,12 @@ class MiqRetireTask < MiqRequestTask
   def self.display_name(number = 1)
     n_('Retire Task', 'Retire Tasks', number)
   end
+
+  def statemachine_task_status
+    if state == "finished"
+      status.to_s.downcase == "error" ? "error" : "ok"
+    else
+      "retry"
+    end
+  end
 end

--- a/app/models/orchestration_stack_retire_task.rb
+++ b/app/models/orchestration_stack_retire_task.rb
@@ -14,12 +14,4 @@ class OrchestrationStackRetireTask < MiqRetireTask
   def self.model_being_retired
     OrchestrationStack
   end
-
-  def statemachine_task_status
-    if state == "finished"
-      status.to_s.downcase == "error" ? "error" : "ok"
-    else
-      "retry"
-    end
-  end
 end

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -9,14 +9,6 @@ class ServiceRetireTask < MiqRetireTask
     Service
   end
 
-  def statemachine_task_status
-    if state == "finished"
-      status.to_s.downcase == "error" ? "error" : "ok"
-    else
-      "retry"
-    end
-  end
-
   def update_and_notify_parent(*args)
     prev_state = state
     super

--- a/app/models/vm_retire_task.rb
+++ b/app/models/vm_retire_task.rb
@@ -18,12 +18,4 @@ class VmRetireTask < MiqRetireTask
   def self.model_being_retired
     Vm
   end
-
-  def statemachine_task_status
-    if state == "finished"
-      status.to_s.downcase == "error" ? "error" : "ok"
-    else
-      "retry"
-    end
-  end
 end


### PR DESCRIPTION

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
