### PR TITLE
Drop sys-filesystem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ gem "ruport",                           "~>1.8.0"
 gem "snmp",                             "~>1.3.0",           :require => false
 gem "sprockets",                        "~>3.7.2",           :require => false
 gem "sync",                             "~>0.5",             :require => false
-gem "sys-filesystem",                   "~>1.4.3"
 gem "terminal",                                              :require => false
 gem "wim_parser",                       "~>1.0",             :require => false
 


### PR DESCRIPTION
sys-filesystem was introduced in #18785 in the VmdbDatabase model, but that model was dropped in #20148. I've also [searched the org](https://github.com/search?q=org%3AManageIQ%20Sys%3A%3AFilesystem&type=code) and there are no more callers of Sys::Filesystem.

Replaces #23758

@jrafanie Please review.
