### PR TITLE
Remove owner_load_ldap from dialogs

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -514,22 +514,6 @@ class MiqRequestWorkflow
     end
   end
 
-  def retrieve_ldap(_options = {})
-    email = get_value(@values[:owner_email])
-    if email.present?
-      l = MiqLdap.new
-      if l.bind_with_default == true
-        raise _("No information returned for %{email}") % {:email => email} if (d = l.get_user_info(email, "mail")).nil?
-
-        [:first_name, :last_name, :address, :city, :state, :zip, :country, :title, :company,
-         :department, :office, :phone, :phone_mobile, :manager, :manager_mail, :manager_phone].each do |prop|
-          @values["owner_#{prop}".to_sym] = d[prop].try(:dup)
-        end
-        @values[:sysprep_organization] = d[:company].try(:dup)
-      end
-    end
-  end
-
   def default_schedule_time(options = {})
     # TODO: Added support for "default_from", like values_from, that gets called once after dialog creation
     # Update VM description
@@ -759,11 +743,7 @@ class MiqRequestWorkflow
 
     if get_value(@values[:owner_email]).blank? && @requester.email.present?
       @values[:owner_email] = @requester.email
-      retrieve_ldap if MiqLdap.using_ldap?
     end
-
-    show_flag = MiqLdap.using_ldap? ? :show : :hide
-    show_fields(show_flag, [:owner_load_ldap])
   end
 
   def set_request_values(values)
@@ -1464,16 +1444,6 @@ class MiqRequestWorkflow
     _log.info("data:<#{data.inspect}>")
     values[:auto_approve] = data.delete(:auto_approve) == 'true'
     data.delete(:user_name)
-
-    # get owner values from LDAP if configured
-    if data[:owner_email].present? && MiqLdap.using_ldap?
-      email = data[:owner_email]
-      unless email.include?('@')
-        email = "#{email}@#{::Settings.authentication.user_suffix}"
-      end
-      values[:owner_email] = email
-      retrieve_ldap rescue nil
-    end
 
     dlg_keys = dlg_fields.keys
     data.keys.each do |key|

--- a/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_configuration_script_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_configuration_script_dialogs.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/physical_server_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/physical_server_provision_dialogs.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test2_miq_provision_dialogs_template.yaml
+++ b/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test2_miq_provision_dialogs_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template.yaml
+++ b/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template.yaml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false

--- a/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template_modified.yml
+++ b/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template_modified.yml
@@ -70,13 +70,6 @@
           :required: false
           :display: :hide
           :data_type: :string
-        :owner_load_ldap:
-          :pressed:
-            :method: :retrieve_ldap
-          :description: Look Up LDAP Email
-          :required: false
-          :display: :show
-          :data_type: :button
         :owner_manager_phone:
           :description: Phone
           :required: false


### PR DESCRIPTION
owner_load_ldap depends on MiqLdap which is no longer supported. Additionally drop retrieve_ldap, as that function's purpose is to implement owner_load_ldap.

Part of (and extracted from) ManageIQ/manageiq#21127

Co-depends on
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/9909

Depends on
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/580
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/68
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/149
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/322
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/299
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/938
- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/124
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/705
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/965