### PR TITLE
Update parallel_tests to v5 and open version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -323,7 +323,7 @@ group :development, :test do
   gem "database_cleaner",               "~>2.1",    :require => false # Used by cypress-on-rails.
   gem "factory_bot_rails",              "~>6.5.1",  :require => false # Used by cypress-on-rails.
 
-  gem "parallel_tests",                 "~>4.4",    :require => false
+  gem "parallel_tests",                 "~>5.6",    :require => false
   gem "routes_lazy_routes"
   gem "rspec-rails",                    "~>7.0"
 end


### PR DESCRIPTION
`parallel_tests` updated to v5 (breaking changes dropping ruby 3.0 and 3.1)

https://github.com/grosser/parallel_tests/blob/v5.0.0/CHANGELOG.md#500---2025-03-01

We also don't need to lock down to patch versions only.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
