### PR TITLE
Add `connect_to_service!` to base StateMachine

### DIFF
--- a/app/models/manageiq/providers/automation_manager/provision.rb
+++ b/app/models/manageiq/providers/automation_manager/provision.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::AutomationManager::Provision < MiqProvisionTask
+  include StateMachine
+
   def self.request_class
     MiqProvisionConfigurationScriptRequest
   end

--- a/app/models/manageiq/providers/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/automation_manager/provision/state_machine.rb
@@ -1,0 +1,11 @@
+module ManageIQ::Providers::AutomationManager::Provision::StateMachine
+  private
+
+  def connect_to_service!(stack, options = {})
+    service&.add_resource!(stack, options)
+  end
+
+  def service
+    @service ||= Service.find_by(:guid => options[:service_guid])
+  end
+end


### PR DESCRIPTION
Add some common methods to the base `AutomationManager::Provision::StateMachine`

This is a step that all of the AutomationManager StateMachine steps need to do, as we go we can continue to add common code here.

Dependents:
* https://github.com/ManageIQ/manageiq-providers-terraform_enterprise/pull/33
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/120

https://github.com/ManageIQ/manageiq/issues/23775
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
