### PR TITLE
Allow non generic awx service provisioning

### DIFF
--- a/app/models/service_template_awx.rb
+++ b/app/models/service_template_awx.rb
@@ -6,6 +6,15 @@ class ServiceTemplateAwx < ServiceTemplateAutomation
   alias job_template configuration_script
   alias job_template= configuration_script=
 
+  def create_subtasks(_parent_service_task, _parent_service)
+    if prov_type.start_with?("generic_")
+      # no sub task is needed for this service
+      []
+    else
+      super
+    end
+  end
+
   def self.create_catalog_item(options, _auth_user = nil)
     transaction do
       create_from_options(options).tap do |service_template|
@@ -30,11 +39,6 @@ class ServiceTemplateAwx < ServiceTemplateAutomation
     end
   end
 
-  def create_subtasks(_parent_service_task, _parent_service)
-    # no sub task is needed for this service
-    []
-  end
-
   def self.default_provisioning_entry_point(_service_type)
     '/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision/CatalogItemInitialization'
   end
@@ -57,7 +61,7 @@ class ServiceTemplateAwx < ServiceTemplateAutomation
   end
 
   def my_zone
-    job_template.manager.try(:my_zone)
+    zone&.name || job_template.manager.try(:my_zone)
   end
 
   private


### PR DESCRIPTION
This fixes a short-term issue where we need to support the automate-based/generic service provisioning and the miq_provision_task state-machine style.  Awx/AnsibleTower use the same ServiceTemplate/Service subclasses for both, the generic prov_type doesn't create any subtasks while the non-generic prov_type does.

The other option would be to rename the generic service classes and a data migration to update those types.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23772

https://github.com/ManageIQ/manageiq/issues/23775
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
