### PR TITLE
[WIP] Embedded ansible workflows provisioning

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -11,6 +11,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   end
 
   def self.catalog_types
-    {"generic_ansible_playbook" => N_("Ansible Playbook")}
+    {"generic_ansible_playbook" => N_("Ansible Playbook (deprecated)"), "embedded_ansible" => N_("Ansible Playbook")}
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/provision.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/provision.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Provision < ManageIQ::Providers::AutomationManager::Provision
+  include StateMachine
+
+  TASK_DESCRIPTION = N_("Ansible Playbook Provision")
+end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/provision/state_machine.rb
@@ -1,0 +1,66 @@
+module ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Provision::StateMachine
+  def run_provision
+    signal :provision
+  end
+
+  def provision
+    opts = %i[become_enabled cloud_credential_id credential_id execution_ttl extra_vars hosts network_credential_id vault_credential_id verbosity].to_h do |key|
+      [key, get_option(key)]
+    end
+
+    opts[:hosts] ||= %w[localhost]
+    stack = stack_klass.create_stack(source.parent, opts)
+
+    phase_context[:stack_id] = stack.id
+    connect_to_service!(stack, :name => "Provision")
+
+    save!
+
+    signal :check_provisioned
+  end
+
+  def check_provisioned
+    if running?
+      requeue_phase
+    else
+      signal :post_provision
+    end
+  end
+
+  def post_provision
+    if succeeded?
+      signal :mark_as_completed
+    else
+      abort_job("Failed to provision playbook", "error")
+    end
+  end
+
+  def abort_job(message, status)
+    update_and_notify_parent(:state => "finished", :status => status.capitalize, :message => message)
+  end
+
+  def running?
+    !stack.raw_status.completed?
+  end
+
+  def succeeded?
+    stack.raw_status.succeeded?
+  end
+
+  def mark_as_completed
+    update_and_notify_parent(:state => "finished", :message => "Playbook provision is complete")
+    signal :finish
+  end
+
+  def finish
+    mark_execution_servers
+  end
+
+  def stack_klass
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job
+  end
+
+  def stack
+    @stack ||= stack_klass.find(phase_context[:stack_id])
+  end
+end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/provision_workflow.rb
@@ -1,0 +1,50 @@
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ProvisionWorkflow < ManageIQ::Providers::AutomationManager::ProvisionWorkflow
+  def self.default_dialog_file
+    "miq_provision_configuration_script_embedded_ansible_dialogs".freeze
+  end
+
+  def dialog_name_from_automate(message = 'get_dialog_name', extra_attrs = {})
+    extra_attrs['platform'] ||= 'embedded_ansible'
+    super
+  end
+
+  def allowed_configuration_scripts(*_args)
+    self.class.module_parent::ConfigurationScript.all.map do |cs|
+      build_ci_hash_struct(cs, %w[name description manager_name])
+    end
+  end
+
+  def allowed_machine_credentials(*_args)
+    self.class.module_parent::MachineCredential.all.to_h do |mc|
+      [mc.id, mc.name]
+    end
+  end
+
+  def allowed_vault_credentials(*_args)
+    self.class.module_parent::VaultCredential.all.to_h do |vc|
+      [vc.id, vc.name]
+    end
+  end
+
+  def allowed_cloud_credential_types(*_args)
+    # If a cloud credential is selected then pre-populate the Cloud Type
+    cloud_credential_id = get_value(values[:cloud_credential_id])
+    if cloud_credential_id && cloud_credential_id != 0 # TODO: Why is <None> = 0 ??
+      # TODO why does self.class.module_parent::CloudCredential.find(id) not work?
+      cloud_credential = ::Authentication.find(cloud_credential_id)
+      {cloud_credential.class.to_s => cloud_credential.class::API_OPTIONS[:label]}
+    else
+      self.class.module_parent::CloudCredential.descendants.to_h do |klass|
+        [klass.to_s, klass::API_OPTIONS[:label]]
+      end
+    end
+  end
+
+  def allowed_cloud_credentials(*_args)
+    klass   = get_value(values[:cloud_credential_type])&.safe_constantize
+    klass ||= self.class.module_parent::CloudCredential
+    klass.all.to_h do |cc|
+      [cc.id, "#{cc.name} - #{cc.type}"]
+    end
+  end
+end

--- a/app/models/miq_provision_configuration_script_request_template.rb
+++ b/app/models/miq_provision_configuration_script_request_template.rb
@@ -4,7 +4,7 @@ class MiqProvisionConfigurationScriptRequestTemplate < MiqProvisionConfiguration
     scaling_min = 1
 
     _log.info("create_tasks_for_service ID #{service_task.id} SCALING : #{scaling_min}")
-    scaling_min.times.collect do |idx|
+    Array.new(scaling_min) do |idx|
       create_request_task(idx) do |req_task|
         req_task.miq_request_id = service_task.miq_request.id
         req_task.userid         = service_task.userid

--- a/app/models/miq_provision_configuration_script_workflow.rb
+++ b/app/models/miq_provision_configuration_script_workflow.rb
@@ -17,4 +17,13 @@ class MiqProvisionConfigurationScriptWorkflow < MiqProvisionWorkflow
 
   def get_source_and_targets(_refresh = false)
   end
+
+  def make_request(request, values, requester = nil, auto_approve = false)
+    if request
+      request = MiqRequest.find(request) unless request.kind_of?(MiqRequest)
+      request.source_id = get_value(values[:src_configuration_script_id])
+    end
+
+    super
+  end
 end

--- a/app/models/service_embedded_ansible.rb
+++ b/app/models/service_embedded_ansible.rb
@@ -1,0 +1,5 @@
+class ServiceEmbeddedAnsible < ServiceAutomation
+  def job(action = "Provision")
+    service_resources.find_by(:name => action, :resource_type => 'OrchestrationStack').try(:resource)
+  end
+end

--- a/app/models/service_template_embedded_ansible.rb
+++ b/app/models/service_template_embedded_ansible.rb
@@ -1,0 +1,2 @@
+class ServiceTemplateEmbeddedAnsible < ServiceTemplateAutomation
+end

--- a/product/dialogs/miq_dialogs/miq_provision_configuration_script_embedded_ansible_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_configuration_script_embedded_ansible_dialogs.yaml
@@ -1,0 +1,227 @@
+---
+:name: miq_provision_configuration_script_embedded_ansible_dialogs
+:description: Sample Configuration Script Embedded Ansible Provisioning Dialog
+:dialog_type: MiqProvisionConfigurationScriptWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :tag_ids:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags: []
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :provision:
+      :description: Provision
+      :fields:
+        :verbosity:
+          :description: Verbosity
+          :values:
+            0: Normal
+            1: Verbose
+            2: More Verbose
+            3: Debug
+            4: Connection Debug
+            5: WinRM Debug
+          :notes:
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :log_output:
+          :description: Log Output
+          :values:
+            on_error: On Error
+            always: Always
+            never: Never
+          :notes:
+          :required: false
+          :display: :edit
+          :default: on_error
+          :data_type: :string
+        :execution_ttl:
+          :description: Max TTL (mins)
+          :notes:
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :credential_id:
+          :values_from:
+            :method: :allowed_machine_credentials
+          :description: Machine Credential
+          :required: true
+          :display: :edit
+          :data_type: :integer
+        :vault_credential_id:
+          :values_from:
+            :method: :allowed_vault_credentials
+          :description: Vault Credential
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :cloud_credential_type:
+          :values_from:
+            :method: :allowed_cloud_credential_types
+          :description: Cloud Type
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :cloud_credential_id:
+          :values_from:
+            :method: :allowed_cloud_credentials
+          :description: Cloud Credential
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :src_configuration_script_id:
+          :values_from:
+            :method: :allowed_configuration_scripts
+          :description: Configuration Script
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :provision
+  - :schedule

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/provision_spec.rb
@@ -1,0 +1,253 @@
+describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Provision do
+  let(:user) { FactoryBot.create(:user_with_group) }
+  let(:manager) { FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first }
+  let(:playbook) { FactoryBot.create(:embedded_ansible_configuration_script, :manager => manager) }
+  let(:request) { FactoryBot.create(:miq_provision_configuration_script_request, :requester => user, :source => playbook) }
+  let(:provision) { described_class.create(:source => playbook, :miq_request => request, :userid => user.userid) }
+
+  before do
+    EvmSpecHelper.assign_embedded_ansible_role
+  end
+
+  describe "TASK_DESCRIPTION" do
+    it "returns the correct task description" do
+      expect(described_class::TASK_DESCRIPTION).to eq("Ansible Playbook Provision")
+    end
+  end
+
+  describe "#run_provision" do
+    it "signals provision" do
+      expect(provision).to receive(:signal).with(:provision)
+      provision.run_provision
+    end
+  end
+
+  describe "#provision" do
+    let(:job) { FactoryBot.create(:embedded_ansible_job, :ext_management_system => manager) }
+
+    before do
+      allow(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_stack).and_return(job)
+      allow(provision).to receive(:connect_to_service!)
+      allow(provision).to receive(:save!)
+      allow(provision).to receive(:signal)
+    end
+
+    it "creates a stack with the correct options" do
+      provision.options = {
+        :become_enabled      => true,
+        :credential_id       => 123,
+        :execution_ttl       => 3600,
+        :extra_vars          => {"key" => "value"},
+        :hosts               => ["host1", "host2"],
+        :vault_credential_id => 456,
+        :verbosity           => 2
+      }
+
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_stack).with(
+        playbook.parent,
+        hash_including(
+          :become_enabled      => true,
+          :credential_id       => 123,
+          :execution_ttl       => 3600,
+          :extra_vars          => {"key" => "value"},
+          :vault_credential_id => 456,
+          :verbosity           => 2
+        )
+      ).and_return(job)
+
+      provision.provision
+    end
+
+    it "defaults hosts to localhost if not provided" do
+      provision.options = {}
+
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_stack).with(
+        playbook.parent,
+        hash_including(:hosts => %w[localhost])
+      ).and_return(job)
+
+      provision.provision
+    end
+
+    it "stores the stack_id in phase_context" do
+      provision.provision
+      expect(provision.phase_context[:stack_id]).to eq(job.id)
+    end
+
+    it "connects the stack to the service" do
+      expect(provision).to receive(:connect_to_service!).with(job, :name => "Provision")
+      provision.provision
+    end
+
+    it "saves the provision" do
+      expect(provision).to receive(:save!).at_least(:once)
+      provision.provision
+    end
+
+    it "signals check_provisioned" do
+      expect(provision).to receive(:signal).with(:check_provisioned)
+      provision.provision
+    end
+  end
+
+  describe "#check_provisioned" do
+    let(:job) { FactoryBot.create(:embedded_ansible_job, :ext_management_system => manager) }
+
+    before do
+      provision.phase_context[:stack_id] = job.id
+    end
+
+    context "when the job is still running" do
+      before do
+        allow(provision).to receive(:running?).and_return(true)
+      end
+
+      it "requeues the phase" do
+        expect(provision).to receive(:requeue_phase)
+        provision.check_provisioned
+      end
+    end
+
+    context "when the job is finished" do
+      before do
+        allow(provision).to receive(:running?).and_return(false)
+      end
+
+      it "signals post_provision" do
+        expect(provision).to receive(:signal).with(:post_provision)
+        provision.check_provisioned
+      end
+    end
+  end
+
+  describe "#post_provision" do
+    let(:job) { FactoryBot.create(:embedded_ansible_job, :ext_management_system => manager) }
+
+    before do
+      provision.phase_context[:stack_id] = job.id
+    end
+
+    context "when the job succeeded" do
+      before do
+        allow(provision).to receive(:succeeded?).and_return(true)
+      end
+
+      it "signals mark_as_completed" do
+        expect(provision).to receive(:signal).with(:mark_as_completed)
+        provision.post_provision
+      end
+    end
+
+    context "when the job failed" do
+      before do
+        allow(provision).to receive(:succeeded?).and_return(false)
+      end
+
+      it "calls abort_job with error message" do
+        expect(provision).to receive(:abort_job).with("Failed to provision playbook", "error")
+        provision.post_provision
+      end
+    end
+  end
+
+  describe "#abort_job" do
+    it "updates parent with finished state and error status" do
+      expect(provision).to receive(:update_and_notify_parent).with(
+        :state   => "finished",
+        :status  => "Error",
+        :message => "Test error message"
+      )
+      provision.abort_job("Test error message", "error")
+    end
+
+    it "capitalizes the status" do
+      expect(provision).to receive(:update_and_notify_parent).with(
+        hash_including(:status => "Warn")
+      )
+      provision.abort_job("Test warning", "warn")
+    end
+  end
+
+  describe "#running?" do
+    let(:raw_status) { double("raw_status") }
+
+    before do
+      allow(provision).to receive(:stack).and_return(double("stack", :raw_status => raw_status))
+    end
+
+    it "returns true when the job is not completed" do
+      allow(raw_status).to receive(:completed?).and_return(false)
+      expect(provision.running?).to be true
+    end
+
+    it "returns false when the job is completed" do
+      allow(raw_status).to receive(:completed?).and_return(true)
+      expect(provision.running?).to be false
+    end
+  end
+
+  describe "#succeeded?" do
+    let(:raw_status) { double("raw_status") }
+
+    before do
+      allow(provision).to receive(:stack).and_return(double("stack", :raw_status => raw_status))
+    end
+
+    it "returns true when the job succeeded" do
+      allow(raw_status).to receive(:succeeded?).and_return(true)
+      expect(provision.succeeded?).to be true
+    end
+
+    it "returns false when the job failed" do
+      allow(raw_status).to receive(:succeeded?).and_return(false)
+      expect(provision.succeeded?).to be false
+    end
+  end
+
+  describe "#mark_as_completed" do
+    it "updates parent with finished state and completion message" do
+      expect(provision).to receive(:update_and_notify_parent).with(
+        :state   => "finished",
+        :message => "Playbook provision is complete"
+      )
+      provision.mark_as_completed
+    end
+
+    it "signals finish" do
+      allow(provision).to receive(:update_and_notify_parent)
+      expect(provision).to receive(:signal).with(:finish)
+      provision.mark_as_completed
+    end
+  end
+
+  describe "#finish" do
+    it "marks execution servers" do
+      expect(provision).to receive(:mark_execution_servers)
+      provision.finish
+    end
+  end
+
+  describe "#stack_klass" do
+    it "returns the correct Job class" do
+      expect(provision.stack_klass).to eq(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job)
+    end
+  end
+
+  describe "#stack" do
+    let(:job) { FactoryBot.create(:embedded_ansible_job, :ext_management_system => manager) }
+
+    before do
+      provision.phase_context[:stack_id] = job.id
+    end
+
+    it "returns the stack from phase_context" do
+      expect(provision.stack).to eq(job)
+    end
+
+    it "caches the stack" do
+      stack1 = provision.stack
+      stack2 = provision.stack
+      expect(stack1.object_id).to eq(stack2.object_id)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/provision_workflow_spec.rb
@@ -1,0 +1,114 @@
+describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ProvisionWorkflow do
+  let(:admin) { FactoryBot.create(:user_with_group) }
+  let(:manager) { FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first }
+  let(:workflow) { described_class.new({}, admin.userid) }
+
+  before do
+    EvmSpecHelper.assign_embedded_ansible_role
+    MiqDialog.seed_dialog(Rails.root.join("product/dialogs/miq_dialogs/miq_provision_configuration_script_embedded_ansible_dialogs.yaml"))
+  end
+
+  describe ".default_dialog_file" do
+    it "returns the correct dialog file name" do
+      expect(described_class.default_dialog_file).to eq("miq_provision_configuration_script_embedded_ansible_dialogs")
+    end
+  end
+
+  describe "#dialog_name_from_automate" do
+    it "sets platform to embedded_ansible by default" do
+      extra_attrs = {}
+      workflow.dialog_name_from_automate('get_dialog_name', extra_attrs)
+      expect(extra_attrs['platform']).to eq('embedded_ansible')
+    end
+
+    it "preserves existing platform if provided" do
+      extra_attrs = {'platform' => 'custom_platform'}
+      workflow.dialog_name_from_automate('get_dialog_name', extra_attrs)
+      expect(extra_attrs['platform']).to eq('custom_platform')
+    end
+  end
+
+  describe "#allowed_configuration_scripts" do
+    let!(:config_script1) { FactoryBot.create(:embedded_ansible_configuration_script, :manager => manager) }
+    let!(:config_script2) { FactoryBot.create(:embedded_ansible_configuration_script, :manager => manager) }
+
+    it "returns all configuration scripts" do
+      scripts = workflow.allowed_configuration_scripts
+      expect(scripts.count).to eq(2)
+      expect(scripts.map { |s| s[:id] }).to match_array([config_script1.id, config_script2.id])
+    end
+  end
+
+  describe "#allowed_machine_credentials" do
+    let!(:machine_cred1) { FactoryBot.create(:embedded_ansible_machine_credential, :manager => manager) }
+    let!(:machine_cred2) { FactoryBot.create(:embedded_ansible_machine_credential, :manager => manager) }
+
+    it "returns all machine credentials" do
+      credentials = workflow.allowed_machine_credentials
+      expect(credentials).to be_a(Hash)
+      expect(credentials.count).to eq(2)
+      expect(credentials.keys).to match_array([machine_cred1.id, machine_cred2.id])
+      expect(credentials.values).to match_array([machine_cred1.name, machine_cred2.name])
+    end
+  end
+
+  describe "#allowed_vault_credentials" do
+    let!(:vault_cred1) { FactoryBot.create(:embedded_ansible_vault_credential, :manager => manager) }
+    let!(:vault_cred2) { FactoryBot.create(:embedded_ansible_vault_credential, :manager => manager) }
+
+    it "returns all vault credentials" do
+      credentials = workflow.allowed_vault_credentials
+      expect(credentials).to be_a(Hash)
+      expect(credentials.count).to eq(2)
+      expect(credentials.keys).to match_array([vault_cred1.id, vault_cred2.id])
+      expect(credentials.values).to match_array([vault_cred1.name, vault_cred2.name])
+    end
+  end
+
+  describe "#allowed_cloud_credentials" do
+    let!(:amazon_cred1) { FactoryBot.create(:embedded_ansible_amazon_credential, :manager => manager) }
+    let!(:amazon_cred2) { FactoryBot.create(:embedded_ansible_amazon_credential, :manager => manager) }
+    let!(:azure_cred)   { FactoryBot.create(:embedded_ansible_azure_credential,  :manager => manager) }
+
+    it "returns all cloud credentials when no type is selected" do
+      credentials = workflow.allowed_cloud_credentials
+
+      expect(credentials).to be_a(Hash)
+      expect(credentials.count).to eq(3)
+      expect(credentials.keys).to match_array([amazon_cred1.id, amazon_cred2.id, azure_cred.id])
+    end
+
+    it "returns only credentials of the selected type" do
+      workflow.instance_variable_set(:@values, {:cloud_credential_type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential"})
+      credentials = workflow.allowed_cloud_credentials
+
+      expect(credentials).to be_a(Hash)
+      expect(credentials.count).to eq(2)
+      expect(credentials.keys).to match_array([amazon_cred1.id, amazon_cred2.id])
+    end
+  end
+
+  describe "#allowed_cloud_credential_types" do
+    let!(:amazon_cred) { FactoryBot.create(:embedded_ansible_amazon_credential, :manager => manager) }
+    let!(:azure_cred)  { FactoryBot.create(:embedded_ansible_azure_credential,  :manager => manager) }
+
+    it "returns all cloud credential types when no credential is selected" do
+      types = workflow.allowed_cloud_credential_types
+
+      expect(types).to be_a(Hash)
+      expect(types.keys).to include(
+        "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential",
+        "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential"
+      )
+    end
+
+    it "returns only the selected credential type when a credential is selected" do
+      workflow.instance_variable_set(:@values, {:cloud_credential_id => amazon_cred.id})
+      types = workflow.allowed_cloud_credential_types
+
+      expect(types).to be_a(Hash)
+      expect(types.count).to eq(1)
+      expect(types.keys).to include("ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential")
+    end
+  end
+end

--- a/spec/models/miq_provision_configuration_script_request_template_spec.rb
+++ b/spec/models/miq_provision_configuration_script_request_template_spec.rb
@@ -1,0 +1,112 @@
+describe MiqProvisionConfigurationScriptRequestTemplate do
+  let(:user) { FactoryBot.create(:user_with_group) }
+  let(:manager) { FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first }
+  let(:playbook1) { FactoryBot.create(:embedded_ansible_configuration_script, :manager => manager, :name => "Playbook 1") }
+  let(:playbook2) { FactoryBot.create(:embedded_ansible_configuration_script, :manager => manager, :name => "Playbook 2") }
+  let(:request_template) do
+    FactoryBot.create(
+      :miq_provision_configuration_script_request_template,
+      :requester => user,
+      :source    => playbook1,
+      :options   => {:src_configuration_script_id => playbook1.id}
+    )
+  end
+
+  before do
+    EvmSpecHelper.assign_embedded_ansible_role
+  end
+
+  describe "#sync_source_from_options" do
+    context "when options[:src_configuration_script_id] is updated" do
+      it "updates source_id to match" do
+        expect(request_template.source_id).to eq(playbook1.id)
+
+        request_template.options[:src_configuration_script_id] = playbook2.id
+        request_template.save!
+
+        expect(request_template.source_id).to eq(playbook2.id)
+        expect(request_template.source).to eq(playbook2)
+      end
+
+      it "handles array format for src_configuration_script_id" do
+        expect(request_template.source_id).to eq(playbook1.id)
+
+        request_template.options[:src_configuration_script_id] = [playbook2.id]
+        request_template.save!
+
+        expect(request_template.source_id).to eq(playbook2.id)
+        expect(request_template.source).to eq(playbook2)
+      end
+
+      it "does not update source_id if src_configuration_script_id is not present" do
+        original_source_id = request_template.source_id
+
+        request_template.options.delete(:src_configuration_script_id)
+        request_template.save!
+
+        expect(request_template.source_id).to eq(original_source_id)
+      end
+
+      it "does not update source_id if it already matches" do
+        expect(request_template.source_id).to eq(playbook1.id)
+
+        # Spy on the source_id= method to ensure it's not called unnecessarily
+        allow(request_template).to receive(:source_id=).and_call_original
+
+        request_template.options[:src_configuration_script_id] = playbook1.id
+        request_template.save!
+
+        expect(request_template).not_to have_received(:source_id=)
+        expect(request_template.source_id).to eq(playbook1.id)
+      end
+    end
+
+    context "when updating via service catalog item" do
+      let(:service_template) do
+        FactoryBot.create(
+          :service_template_embedded_ansible,
+          :name => "Test Service"
+        )
+      end
+
+      before do
+        service_template.add_resource!(request_template)
+      end
+
+      it "syncs source when service template config_info is updated" do
+        expect(request_template.source_id).to eq(playbook1.id)
+
+        # Simulate what happens when a service catalog item is edited
+        request_template.update!(
+          :options => request_template.options.merge(:src_configuration_script_id => playbook2.id)
+        )
+
+        expect(request_template.reload.source_id).to eq(playbook2.id)
+        expect(request_template.source).to eq(playbook2)
+      end
+    end
+  end
+
+  describe "TASK_DESCRIPTION" do
+    it "inherits from parent class" do
+      expect(described_class::TASK_DESCRIPTION).to eq("Automation Manager Provisioning")
+    end
+  end
+
+  describe "#execute" do
+    it "raises an error as templates should not be executed" do
+      expect { request_template.execute }.to raise_error(RuntimeError, /do not support the execute method/)
+    end
+  end
+
+  describe "#service_template_resource_copy" do
+    it "creates a duplicate of the request template" do
+      copy = request_template.service_template_resource_copy
+
+      expect(copy).to be_a(MiqProvisionConfigurationScriptRequestTemplate)
+      expect(copy.id).not_to eq(request_template.id)
+      expect(copy.source_id).to eq(request_template.source_id)
+      expect(copy.options).to eq(request_template.options)
+    end
+  end
+end


### PR DESCRIPTION
EmbeddedAnsible is the last automation manager that doesn't support provision with workflows.

TODO:
- [ ] Provision and Retirement tabs (Does Retirement need to create a separate MiqRequest Template?  A `MiqRetireRequestTemplate` possibly)
- [ ] Runner options (execution_ttl, verbosity, log_output)
- [ ] Playbook selection
- [ ] Machine Credential, Vault Credential, Cloud Type, Cloud Credential
- [ ] Hosts
- [ ] Input Vars

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23772
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/9921

https://github.com/ManageIQ/manageiq/issues/23775
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
