### PR TITLE
Add adjustable timeout to Service::LinkingWorkflow

### DIFF
--- a/app/models/manageiq/providers/ems_refresh_workflow.rb
+++ b/app/models/manageiq/providers/ems_refresh_workflow.rb
@@ -59,6 +59,10 @@ class ManageIQ::Providers::EmsRefreshWorkflow < Job
     super(*args, :role => role, :priority => priority, :deliver_on => deliver_on)
   end
 
+  def current_job_timeout(_timeout_adjustment = 1)
+    options[:timeout] || super
+  end
+
   alias_method :initializing, :dispatch_start
   alias_method :start,        :run_native_op
   alias_method :finish,       :process_finished

--- a/app/models/service/resource_linking.rb
+++ b/app/models/service/resource_linking.rb
@@ -1,7 +1,7 @@
 module Service::ResourceLinking
   extend ActiveSupport::Concern
 
-  def add_provider_vms(provider, uid_ems_array)
+  def add_provider_vms(provider, uid_ems_array, timeout: nil)
     vm_uid_array = Array(uid_ems_array).compact.uniq
     raise _("no uid_ems_array defined for linking to service") if vm_uid_array.blank?
 
@@ -13,7 +13,8 @@ module Service::ResourceLinking
       :userid        => evm_owner.userid,
       :sync_key      => guid,
       :service_id    => id,
-      :zone          => my_zone
+      :zone          => my_zone,
+      :timeout       => timeout
     }
 
     _log.info("NAME [#{options[:name]}] for user #{evm_owner.userid}")

--- a/spec/models/service/resource_linking_spec.rb
+++ b/spec/models/service/resource_linking_spec.rb
@@ -15,5 +15,17 @@ RSpec.describe Service do
       end.and_return(double(:signal_start => nil))
       service.add_provider_vms(provider, uid_ems_array)
     end
+
+    it 'sets Job options timeout' do
+      job = service.add_provider_vms(provider, uid_ems_array, :timeout => 600)
+
+      expect(job.current_job_timeout(nil)).to eq(600)
+    end
+
+    it 'defaults to base Job class default timeout' do
+      job = service.add_provider_vms(provider, uid_ems_array)
+
+      expect(job.current_job_timeout(nil)).to eq(Job::DEFAULT_TIMEOUT)
+    end
   end
 end


### PR DESCRIPTION
The default timeout for any `::Job` is 5 minutes, it is possible that some large `EmsRefresh` full refreshes can exceed that and there is currently no way to extend the `Service::LinkingWorkflow` timeout.

Dependents:
* https://github.com/ManageIQ/manageiq-api/pull/1315

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
