### PR TITLE
Add back SCVMM provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -207,6 +207,10 @@ group :red_hat_virtualization, :manageiq_default do
   manageiq_plugin "manageiq-providers-red_hat_virtualization"
 end
 
+group :scvmm, :manageiq_default do
+  manageiq_plugin "manageiq-providers-scvmm"
+end
+
 group :terraform_enterprise, :manageiq_default do
   manageiq_plugin "manageiq-providers-terraform_enterprise"
 end


### PR DESCRIPTION
The SCVMM provider was removed by https://github.com/ManageIQ/manageiq/pull/22279 due to issues with building some required C libraries on EL8.

TODO:
- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/229

Cross-Repo Test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1050

Related:
* https://github.com/ManageIQ/manageiq-providers-scvmm/pull/227
* https://github.com/ManageIQ/manageiq-content/pull/784
* https://github.com/ManageIQ/manageiq-automation_engine/pull/585
* https://github.com/ManageIQ/manageiq-ui-classic/pull/9926

Follow-ups:
* Add SCVMM back to the capabilities_matrix

https://github.com/orgs/ManageIQ/discussions/23689
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
