### PR TITLE
Reduce queries in MiqWidget#contents_for_user

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -372,19 +372,23 @@ class MiqWidget < ApplicationRecord
   def contents_for_user(user)
     user = self.class.get_user(user)
     timezone = timezone_matters? ? user.get_timezone : "UTC"
-    conditions = {:miq_group_id => user.current_group.id}
-    conditions[:user_id] = user.id
-    conditions[:timezone] = timezone
-    contents = miq_widget_contents.find_by(conditions)
+    group_id = user.current_group.id
 
-    conditions.delete(:user_id)
-    contents ||= miq_widget_contents.find_by(conditions)
+    # Fetch all possible content records in a single query
+    possible_contents = miq_widget_contents.where(:miq_group_id => group_id)
 
+    # Try to find exact match (user + timezone)
+    contents = possible_contents.detect { |c| c.user_id == user.id && c.timezone == timezone }
+
+    # Fallback to group + timezone (no specific user)
+    contents ||= possible_contents.detect { |c| c.user_id.nil? && c.timezone == timezone }
+
+    # Fallback to any timezone for this group
     if contents.nil?
       _log.warn("No contents found for Widget: '#{title}' Group: #{user.current_group.description} in Timezone '#{timezone}'. Attempting to get widget's contents from any Timezone ...")
-      conditions.delete(:timezone)
-      contents = miq_widget_contents.find_by(conditions)
+      contents = possible_contents.detect { |c| c.user_id.nil? }
     end
+
     contents
   end
 


### PR DESCRIPTION
### Before:

```
vmdb(dev)> MiqWidget.first.contents_for_user(User.first)
  ...
  MiqWidgetContent Load (0.5ms)  SELECT "miq_widget_contents".* FROM "miq_widget_contents" WHERE "miq_widget_contents"."miq_widget_id" = $1 AND "miq_widget_contents"."miq_group_id" = $2 AND "miq_widget_contents"."user_id" = $3 AND "miq_widget_contents"."timezone" = $4 LIMIT $5  [["miq_widget_id", 1], ["miq_group_id", 1], ["user_id", 1], ["timezone", "UTC"], ["LIMIT", 1]]
  MiqWidgetContent Load (0.4ms)  SELECT "miq_widget_contents".* FROM "miq_widget_contents" WHERE "miq_widget_contents"."miq_widget_id" = $1 AND "miq_widget_contents"."miq_group_id" = $2 AND "miq_widget_contents"."timezone" = $3 LIMIT $4  [["miq_widget_id", 1], ["miq_group_id", 1], ["timezone", "UTC"], ["LIMIT", 1]]
  MiqWidgetContent Load (0.4ms)  SELECT "miq_widget_contents".* FROM "miq_widget_contents" WHERE "miq_widget_contents"."miq_widget_id" = $1 AND "miq_widget_contents"."miq_group_id" = $2 LIMIT $3  [["miq_widget_id", 1], ["miq_group_id", 1], ["LIMIT", 1]]
```

### After:

```
vmdb(dev)> MiqWidget.first.contents_for_user(User.first)
  ...
  MiqWidgetContent Load (0.5ms)  SELECT "miq_widget_contents".* FROM "miq_widget_contents" WHERE "miq_widget_contents"."miq_widget_id" = $1 AND "miq_widget_contents"."miq_group_id" = $2  [["miq_widget_id", 1], ["miq_group_id", 1]]
```

Note this doesn't eliminate the N+1 when called on multiple widgets, callers should use eager loading (.includes(:miq_widget_contents)) to fully eliminate N+1.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
