### PR TITLE
Update ansible-runner bats tests

### DIFF
--- a/spec/lib/ansible/runner_execution_spec.bats
+++ b/spec/lib/ansible/runner_execution_spec.bats
@@ -116,7 +116,7 @@ exec_ansible_runner_cli_role() {
 
   run exec_ansible_runner_cli vmware.yml
   assert_failure # We expect to this to fail due to connecting to an unknown vcenter
-  assert_output --partial '"msg": "Unknown error while connecting to vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
 }
 
 @test "[ansible-runner] aws collection" {
@@ -188,7 +188,7 @@ exec_ansible_runner_role() {
 
   run exec_ansible_runner vmware.yml
   assert_failure # We expect to this to fail due to connecting to an unknown vcenter
-  assert_output --partial '"msg": "Unknown error while connecting to vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
 }
 
 @test "[Ansible::Runner#run] aws collection" {
@@ -260,7 +260,7 @@ exec_ansible_runner_role_async() {
 
   run exec_ansible_runner_async vmware.yml
   assert_failure # We expect to this to fail due to connecting to an unknown vcenter
-  assert_output --partial '"msg": "Unknown error while connecting to vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
 }
 
 @test "[Ansible::Runner#run_async] aws collection" {

--- a/spec/lib/ansible/runner_execution_spec.bats
+++ b/spec/lib/ansible/runner_execution_spec.bats
@@ -4,10 +4,17 @@
 # that the real installation is working as expected. It is a duplicate of the tests
 # in runner_execution_spec.rb but without the rspec and rspec-rails overhead.
 #
-# This test requires the Bats test framework to be installed
+# These tests should be run on an appliance or container using
+#
+#   bin/test_ansible_runner_execution
+#
+# which will setup the Bats test framework, plugins, and ensure the test files
+# are present. This can also be used to run locally, but if you prefer to
+# install Bats and the plugins yourself, you can do the following manually:
+#
 #   macOS: brew install bats-core
 #   appliance: dnf install bats
-# as well as the bats-support and bats-assert plugins installed
+#
 #   git clone https://github.com/bats-core/bats-support ~/.bats/libs/bats-support
 #   git clone https://github.com/bats-core/bats-assert ~/.bats/libs/bats-assert
 


### PR DESCRIPTION
After the update in ManageIQ/manageiq-rpm_build#655, the vmware collection updated to vcf-sdk>=9.0.0.0. This change had a small text change in the error message the test was depending on. This commit updates the test to the new expected text.

I've also update the instructions to make it clearer what to run on a container/appliance vs locally, while still keeping the manual instructions (some devs didn't want the script to be invasive and install stuff).

@bdunne Please review.