### PR TITLE
Rails 8: Use pool's with_connnection since establish_connection returns a pool

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -88,13 +88,12 @@ module ArPglogicalMigrationHelper
     end
 
     def restart_subscription
-      c = SubscriptionHelper.establish_connection.connection.raw_connection
-      rep_client = PG::LogicalReplication::Client.new(c)
+      SubscriptionHelper.establish_connection.with_connection do |c|
+        rep_client = PG::LogicalReplication::Client.new(c.raw_connection)
 
-      rep_client.disable_subscription(subscription.id)
-      rep_client.enable_subscription(subscription.id)
-    ensure
-      SubscriptionHelper.remove_connection
+        rep_client.disable_subscription(subscription.id)
+        rep_client.enable_subscription(subscription.id)
+      end
     end
   end
 end

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ArPglogicalMigrationHelper do
       include_context "with a dummy version"
       let(:helper_class) { Class.new(ActiveRecord::Base) { include ActiveRecord::IdRegions } }
       let(:other_region_number) { helper_class.my_region_number + rand(1..50) }
-      let(:subscription) { double("Subscription", :enable => nil, :disable => nil, :provider_region => other_region_number) }
+      let(:subscription) { double("Subscription", :enable => nil, :id => 1, :disable => nil, :provider_region => other_region_number) }
 
       subject do
         described_class.new(subscription, version).tap do |s|
@@ -75,7 +75,9 @@ RSpec.describe ArPglogicalMigrationHelper do
         end
 
         it "waits for the migration to be added" do
-          allow(subject).to receive(:restart_subscription)
+          rep_client = double("PG::LogicalReplication::Client", :disable_subscription => nil, :enable_subscription => nil)
+          require 'pg-logical_replication'
+          allow(PG::LogicalReplication::Client).to receive(:new).and_return(rep_client)
           expect(ArPglogicalMigrationHelper.discover_schema_migrations_ran_class.unscoped.where(:version => version).exists?).to eq(false)
 
           allow(subject).to receive(:wait_for_migration?).and_wrap_original do |m, _args|


### PR DESCRIPTION
Note, we only get to this failing code in rake db:migrate if you have replication enabled with a remote region that needs to be migrated.

From the output below, you can see the global is waiting on the remote:

```
== Migrating database ==
** Enabling rack session debug logger
** ManageIQ master, codename: Uhlmann
Waiting for remote region 1 to run migration 20260415170724.bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

undefined method `connection' for an instance of ActiveRecord::ConnectionAdapters::ConnectionPool

Caused by:
NoMethodError: undefined method `connection' for an instance of ActiveRecord::ConnectionAdapters::ConnectionPool (NoMethodError)

      c = SubscriptionHelper.establish_connection.connection.raw_connection
```

Similar problem as https://github.com/ManageIQ/manageiq-appliance_console/pull/284
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
