### PR TITLE
Add targeted refresh to Service::LinkingWorkflow

### DIFF
--- a/app/models/service/linking_workflow.rb
+++ b/app/models/service/linking_workflow.rb
@@ -53,10 +53,10 @@ class Service
 
       found_vms = linking_targets
       not_found_vms = options[:uid_ems_array] - found_vms.pluck(:uid_ems)
+      service = linking_service
 
       _log.warn("VMs not found for linking to service ID [#{service.id}], name [#{service.name}]: #{not_found_vms}") if not_found_vms.present?
 
-      service = linking_service
       found_vms.each { |vm| service.add_resource!(vm) }
       signal(:finish, "linking VMs to service is complete", "ok")
     rescue => err

--- a/app/models/service/linking_workflow.rb
+++ b/app/models/service/linking_workflow.rb
@@ -53,6 +53,7 @@ class Service
 
       found_vms = linking_targets
       not_found_vms = options[:uid_ems_array] - found_vms.pluck(:uid_ems)
+
       _log.warn("VMs not found for linking to service ID [#{service.id}], name [#{service.name}]: #{not_found_vms}") if not_found_vms.present?
 
       service = linking_service
@@ -61,6 +62,20 @@ class Service
     rescue => err
       _log.log_backtrace(err)
       signal(:abort, err.message, "error")
+    end
+
+    def refresh_target
+      ems = target_entity
+      return ems unless ems&.allow_targeted_refresh?
+
+      # Create targeted refresh for specific VMs
+      options[:uid_ems_array].map do |uid_ems|
+        InventoryRefresh::Target.new(
+          :manager     => ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => uid_ems}
+        )
+      end
     end
 
     private

--- a/spec/models/service/linking_workflow_spec.rb
+++ b/spec/models/service/linking_workflow_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe Service::LinkingWorkflow do
     subject { job.run_native_op }
 
     it 'raises an error if service is not found' do
-      options[:service_id] = 999
-      expect(job).to receive(:signal).with(:abort, "Job [#{job.id}] [#{job.name}] aborted: didn't find service ID: [999] to link to", "error")
+      options[:service_id] = -1
+      expect(job).to receive(:signal).with(:abort, "Job [#{job.id}] [#{job.name}] aborted: didn't find service ID: [-1] to link to", "error")
       subject
     end
 
     it 'raises an error if provider is not found' do
-      options[:target_id] = 999
-      msg = "Job [#{job.id}] [#{job.name}] aborted: didn't find provider class: [#{provider.class.name}] ID: [999] to refresh"
+      options[:target_id] = -1
+      msg = "Job [#{job.id}] [#{job.name}] aborted: didn't find provider class: [#{provider.class.name}] ID: [-1] to refresh"
       expect(job).to receive(:signal).with(:abort, msg, "error")
       subject
     end
@@ -92,7 +92,7 @@ RSpec.describe Service::LinkingWorkflow do
 
     context 'when provider record doesn\'t exist' do
       before do
-        options[:target_id] = 999
+        options[:target_id] = -1
       end
 
       it 'returns nil' do

--- a/spec/models/service/linking_workflow_spec.rb
+++ b/spec/models/service/linking_workflow_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Service::LinkingWorkflow do
   let(:service)  { FactoryBot.create(:service) }
-  let(:provider) { FactoryBot.create(:ems_vmware) }
+  let(:provider) { FactoryBot.create(:ems_infra) }
   let(:uid_ems_array) { ["423c9963-378c-813f-1dbd-630e464d59d4", "423cf3e2-e319-3953-993f-fd8513db951d"] }
   let(:options) do
     {
@@ -11,6 +11,11 @@ RSpec.describe Service::LinkingWorkflow do
     }
   end
   let(:job) { described_class.create_job(options) }
+
+  before do
+    allow(ExtManagementSystem).to receive(:find_by).and_call_original
+    allow(ExtManagementSystem).to receive(:find_by).with(:id => provider.id).and_return(provider)
+  end
 
   context 'run_native_op' do
     subject { job.run_native_op }
@@ -47,6 +52,52 @@ RSpec.describe Service::LinkingWorkflow do
       uid_ems_array.each { |uid| FactoryBot.create(:vm_vmware, :uid_ems => uid, :ems_id => provider.id) }
       subject
       expect(service.vms.count).to eq(2)
+    end
+  end
+
+  context '#refresh_target' do
+    subject { job.refresh_target }
+
+    context 'when provider supports targeted refresh' do
+      before do
+        allow(provider).to receive(:allow_targeted_refresh?).and_return(true)
+      end
+
+      it 'creates InventoryRefresh::Target for each VM UID' do
+        expect(subject).to all(be_a(InventoryRefresh::Target))
+
+        subject.each_with_index do |target, index|
+          expect(target.manager).to eq(provider)
+          expect(target.association).to eq(:vms)
+          expect(target.manager_ref).to eq(:ems_ref => uid_ems_array[index])
+        end
+      end
+
+      it 'handles single VM UID' do
+        options[:uid_ems_array] = ["single-vm-uid"]
+        expect(subject.size).to eq(1)
+        expect(subject.first.manager_ref).to eq(:ems_ref => "single-vm-uid")
+      end
+    end
+
+    context 'when provider does not support targeted refresh' do
+      before do
+        allow(provider).to receive(:allow_targeted_refresh?).and_return(false)
+      end
+
+      it 'returns the EMS provider for full refresh' do
+        expect(subject).to eq(provider)
+      end
+    end
+
+    context 'when provider record doesn\'t exist' do
+      before do
+        options[:target_id] = 999
+      end
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
     end
   end
 

--- a/spec/models/service/linking_workflow_spec.rb
+++ b/spec/models/service/linking_workflow_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Service::LinkingWorkflow do
       subject
       expect(service.vms.count).to eq(2)
     end
+
+    it 'finishes even if not all vms are found' do
+      FactoryBot.create(:vm_vmware, :uid_ems => uid_ems_array.first, :ems_id => provider.id)
+      subject
+      expect(service.vms.count).to eq(1)
+    end
   end
 
   context '#refresh_target' do


### PR DESCRIPTION
The `Service#add_provider_vms` method creates a `Job` based state-machine to refresh providers and find new vms that should be linked to a service.  This is useful in non-standard service provisioning where e.g. the customer provisions the VMs outside of MIQ but wants to link the newly created vms to the service.

The `Service::LinkingWorkflow` refresh_target was always the EMS which meant that full refreshes were being done.

We can easily build a `InventoryRefresh::Target` array with the new vm uuids and perform targeted refreshes where supported and drastically improve the performance.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
