### PR TITLE
Remove react-ui-components pot file

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -190,8 +190,7 @@ namespace :locale do
 
     checkout_branch = ENV['BRANCH'].presence || 'master'
     extra_pots = [
-      "https://raw.githubusercontent.com/ManageIQ/ui-components/#{checkout_branch}/locale/ui-components.pot",
-      "https://raw.githubusercontent.com/ManageIQ/react-ui-components/#{checkout_branch}/locale/react-ui-components.pot"
+      "https://raw.githubusercontent.com/ManageIQ/ui-components/#{checkout_branch}/locale/ui-components.pot"
     ]
 
     tmp_dir = Rails.root.join('locale/tmp')


### PR DESCRIPTION
[react-ui-components](https://github.com/ManageIQ/react-ui-components) is archved and the content was moved into the ui-classic repo a long time ago. This should no longer be needed for i18n.

@jrafanie Please review.
