### PR TITLE
[WIP] Request purger now ignores live provision requests

### DIFF
--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -166,4 +166,14 @@ class MiqProvisionRequest < MiqRequest
   def my_records
     "#{SOURCE_CLASS_NAME}:#{source_id.inspect}"
   end
+
+  def self.active_provision_requests
+    MiqProvision.where(:destination_type => "VmOrTemplate")
+                .joins("INNER JOIN vms ON vms.id = miq_request_tasks.destination_id")
+                .where.not(:miq_request_id => nil)
+                .where(:miq_request_id => select(:id))
+                .where.not(:vms => {:ems_id => nil})
+                .distinct
+                .select(:miq_request_id)
+  end
 end

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -168,12 +168,10 @@ class MiqProvisionRequest < MiqRequest
   end
 
   def self.active_provision_requests
-    MiqProvision.where(:destination_type => "VmOrTemplate")
-                .joins("INNER JOIN vms ON vms.id = miq_request_tasks.destination_id")
-                .where.not(:miq_request_id => nil)
+    MiqProvision.with_destination('VmOrTemplate')
+                .having_request
                 .where(:miq_request_id => select(:id))
-                .where.not(:vms => {:ems_id => nil})
+                .merge(Vm.active)
                 .distinct
-                .select(:miq_request_id)
   end
 end

--- a/app/models/miq_request/purging.rb
+++ b/app/models/miq_request/purging.rb
@@ -13,11 +13,35 @@ class MiqRequest
       end
 
       def purge_scope(older_than)
-        MiqRequest.where(arel_table[:created_on].lt(older_than))
+        old_requests = MiqRequest.where(arel_table[:created_on].lt(older_than))
+
+        # Find all MiqRequest subclasses that implement active_provision_requests
+        provision_request_types = MiqRequest.descendants.select do |klass|
+          klass.respond_to?(:active_provision_requests)
+        end
+
+        purgeable_provision_requests = provision_request_types.flat_map do |request_class|
+          purgeable_requests_for_class(request_class, older_than)
+        end
+
+        old_requests.where.not(:type => provision_request_types.map(&:name))
+                    .or(old_requests.where(:id => purgeable_provision_requests))
       end
 
       def purge_method
         :destroy
+      end
+
+      private
+
+      def purgeable_requests_for_class(request_class, older_than)
+        old_requests = request_class.where(MiqRequest.arel_table[:created_on].lt(older_than))
+
+        if request_class.respond_to?(:active_provision_requests)
+          old_requests.where.not(:id => request_class.active_provision_requests)
+        else
+          old_requests.select(:id)
+        end
       end
     end
   end

--- a/app/models/miq_request/purging.rb
+++ b/app/models/miq_request/purging.rb
@@ -38,7 +38,7 @@ class MiqRequest
         old_requests = request_class.where(MiqRequest.arel_table[:created_on].lt(older_than))
 
         if request_class.respond_to?(:active_provision_requests)
-          old_requests.where.not(:id => request_class.active_provision_requests)
+          old_requests.where.not(:id => request_class.active_provision_requests.select(:miq_request_id))
         else
           old_requests.select(:id)
         end

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -10,6 +10,13 @@ class MiqRequestTask < ApplicationRecord
   belongs_to :miq_request_task
   belongs_to :tenant
 
+  scope :with_destination, lambda { |type|
+    table_name = type.constantize.table_name
+    where(:destination_type => type)
+      .joins(sanitize_sql_array(["INNER JOIN %s ON %s.id = miq_request_tasks.destination_id", table_name, table_name]))
+  }
+  scope :having_request, -> { where.not(:miq_request_id => nil) }
+
   serialize   :phase_context, :type => Hash
   serialize   :options,       :type => Hash
 

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -34,6 +34,7 @@ class PhysicalServer < ApplicationRecord
   has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy, :inverse_of => :resource
 
   scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
+  scope :active, -> { where.not(:ems_id => nil) }
 
   virtual_column :v_availability, :type => :string, :uses => :host
   virtual_column :v_host_os, :type => :string, :uses => :host

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -35,12 +35,10 @@ class PhysicalServerProvisionRequest < MiqRequest
   end
 
   def self.active_provision_requests
-    PhysicalServerProvisionTask.where(:destination_type => "PhysicalServer")
-                               .joins("INNER JOIN physical_servers ON physical_servers.id = miq_request_tasks.destination_id")
-                               .where.not(:miq_request_id => nil)
+    PhysicalServerProvisionTask.with_destination('PhysicalServer')
+                               .having_request
                                .where(:miq_request_id => select(:id))
-                               .where.not(:physical_servers => {:ems_id => nil})
+                               .merge(PhysicalServer.active)
                                .distinct
-                               .select(:miq_request_id)
   end
 end

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -33,4 +33,14 @@ class PhysicalServerProvisionRequest < MiqRequest
       raise MiqException::MiqProvisionError, "Source PhysicalServer with id [#{source_id}] has no EMS, unable to provision" if source.ext_management_system.nil?
     end
   end
+
+  def self.active_provision_requests
+    PhysicalServerProvisionTask.where(:destination_type => "PhysicalServer")
+                               .joins("INNER JOIN physical_servers ON physical_servers.id = miq_request_tasks.destination_id")
+                               .where.not(:miq_request_id => nil)
+                               .where(:miq_request_id => select(:id))
+                               .where.not(:physical_servers => {:ems_id => nil})
+                               .distinct
+                               .select(:miq_request_id)
+  end
 end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -95,4 +95,13 @@ class ServiceTemplateProvisionRequest < MiqRequest
   def process_on_create?
     false
   end
+
+  def self.active_provision_requests
+    ServiceTemplateProvisionTask.where(:destination_type => "Service")
+                                .joins("INNER JOIN services ON services.id = miq_request_tasks.destination_id")
+                                .where.not(:miq_request_id => nil)
+                                .where(:miq_request_id => select(:id))
+                                .distinct
+                                .select(:miq_request_id)
+  end
 end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -97,11 +97,9 @@ class ServiceTemplateProvisionRequest < MiqRequest
   end
 
   def self.active_provision_requests
-    ServiceTemplateProvisionTask.where(:destination_type => "Service")
-                                .joins("INNER JOIN services ON services.id = miq_request_tasks.destination_id")
-                                .where.not(:miq_request_id => nil)
+    ServiceTemplateProvisionTask.with_destination('Service')
+                                .having_request
                                 .where(:miq_request_id => select(:id))
                                 .distinct
-                                .select(:miq_request_id)
   end
 end

--- a/spec/models/miq_request/purging_spec.rb
+++ b/spec/models/miq_request/purging_spec.rb
@@ -2,34 +2,166 @@ RSpec.describe MiqRequest do
   let(:user) { FactoryBot.create(:user) }
   context "::Purging" do
     describe ".purge_by_date" do
-      before do
+      let!(:old_request) do
         Timecop.freeze(7.months.ago) do
-          @old_request = FactoryBot.create(:vm_migrate_request, :requester => user)
-          FactoryBot.create(:miq_request_task, :miq_request => @old_request)
-          parent_task = FactoryBot.create(:miq_request_task, :miq_request => @old_request)
-          FactoryBot.create(:miq_request_task, :miq_request_task => parent_task)
-          FactoryBot.create(:miq_approval, :miq_request => @old_request)
-          FactoryBot.create(:request_log, :resource => @old_request)
-        end
-
-        Timecop.freeze(6.days.ago) do
-          @new_request = FactoryBot.create(:vm_migrate_request, :requester => user)
-          @new_parent_task = FactoryBot.create(:miq_request_task, :miq_request => @new_request)
-          @new_child_task = FactoryBot.create(:miq_request_task, :miq_request_task => @new_parent_task)
-          FactoryBot.create(:miq_approval, :miq_request => @new_request)
-          FactoryBot.create(:request_log, :resource => @new_request)
+          FactoryBot.create(:vm_migrate_request, :requester => user)
         end
       end
 
+      let!(:old_request_task) { FactoryBot.create(:miq_request_task, :miq_request => old_request) }
+      let!(:old_parent_task)  { FactoryBot.create(:miq_request_task, :miq_request => old_request) }
+      let!(:old_child_task)   { FactoryBot.create(:miq_request_task, :miq_request_task => old_parent_task) }
+      let!(:old_approval)     { FactoryBot.create(:miq_approval, :miq_request => old_request) }
+      let!(:old_request_log)  { FactoryBot.create(:request_log, :resource => old_request) }
+
+      let!(:new_request) do
+        Timecop.freeze(6.days.ago) do
+          FactoryBot.create(:vm_migrate_request, :requester => user)
+        end
+      end
+
+      let!(:new_parent_task) { FactoryBot.create(:miq_request_task, :miq_request => new_request) }
+      let!(:new_child_task)  { FactoryBot.create(:miq_request_task, :miq_request_task => new_parent_task) }
+      let!(:new_approval)    { FactoryBot.create(:miq_approval, :miq_request => new_request) }
+      let!(:new_request_log) { FactoryBot.create(:request_log, :resource => new_request) }
+
       it "deletes rows and associated table rows, leaving only newer rows" do
-        expect(described_class.all).to match_array([@old_request, @new_request])
+        expect(described_class.all).to match_array([old_request, new_request])
         expect(MiqRequestTask.count).to eq(5)
         described_class.purge_by_date(described_class.purge_date)
 
-        expect(described_class.all).to match_array([@new_request])
-        expect(MiqRequestTask.all.pluck(:id)).to match_array([@new_parent_task.id, @new_child_task.id])
-        expect(MiqApproval.all.pluck(:id)).to match_array(@new_request.reload.miq_approval_ids) # there's a default approval created for each request, so just check ids
-        expect(RequestLog.all.pluck(:id)).to eq(@new_request.request_log_ids)
+        expect(described_class.all).to match_array([new_request])
+        expect(MiqRequestTask.pluck(:id)).to match_array([new_parent_task.id, new_child_task.id])
+        expect(MiqApproval.pluck(:id)).to match_array(new_request.reload.miq_approval_ids) # there's a default approval created for each request, so just check ids
+        expect(RequestLog.pluck(:id)).to eq(new_request.request_log_ids)
+      end
+
+      def create_provision_task(request, destination = nil)
+        FactoryBot.create(:miq_request_task, :miq_request => request, :destination => destination).tap do |task|
+          task.update!(:type => "MiqProvision")
+        end
+      end
+
+      it "retains old provision requests with a live provisioned vm" do
+        protected_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          protected_request = FactoryBot.create(:miq_provision_request, :requester => user)
+          vm = FactoryBot.create(:vm_vmware, :ems_id => 1, :storage_id => 1)
+          create_provision_task(protected_request, vm)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(protected_request.id)).to be(true)
+      end
+
+      it "purges old provision requests whose provisioned vm is archived" do
+        purgeable_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          purgeable_request = FactoryBot.create(:miq_provision_request, :requester => user)
+          vm = FactoryBot.create(:vm_vmware, :ems_id => nil, :storage_id => nil)
+          create_provision_task(purgeable_request, vm)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(purgeable_request.id)).to be(false)
+      end
+
+      it "purges old provision requests whose provisioned vm is orphaned" do
+        purgeable_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          purgeable_request = FactoryBot.create(:miq_provision_request, :requester => user)
+          vm = FactoryBot.create(:vm_vmware, :ems_id => nil, :storage_id => 1)
+          create_provision_task(purgeable_request, vm)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(purgeable_request.id)).to be(false)
+      end
+
+      it "purges old provision requests without a provisioned vm" do
+        purgeable_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          purgeable_request = FactoryBot.create(:miq_provision_request, :requester => user)
+          create_provision_task(purgeable_request)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(purgeable_request.id)).to be(false)
+      end
+
+      def create_service_provision_task(request, destination = nil)
+        FactoryBot.create(:miq_request_task, :miq_request => request, :destination => destination).tap do |task|
+          task.update!(:type => "ServiceTemplateProvisionTask")
+        end
+      end
+
+      it "retains old service provision requests with a live provisioned service" do
+        protected_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          protected_request = FactoryBot.create(:service_template_provision_request, :requester => user)
+          service = FactoryBot.create(:service)
+          create_service_provision_task(protected_request, service)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(protected_request.id)).to be(true)
+      end
+
+      it "purges old service provision requests without a provisioned service" do
+        purgeable_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          purgeable_request = FactoryBot.create(:service_template_provision_request, :requester => user)
+          create_service_provision_task(purgeable_request)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(purgeable_request.id)).to be(false)
+      end
+
+      def create_physical_server_provision_task(request, destination = nil)
+        FactoryBot.create(:miq_request_task, :miq_request => request, :destination => destination).tap do |task|
+          task.update!(:type => "PhysicalServerProvisionTask")
+        end
+      end
+
+      it "retains old physical server provision requests with a live provisioned server" do
+        protected_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          protected_request = FactoryBot.create(:physical_server_provision_request, :requester => user)
+          physical_server = FactoryBot.create(:physical_server, :ems_id => 1)
+          create_physical_server_provision_task(protected_request, physical_server)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(protected_request.id)).to be(true)
+      end
+
+      it "purges old physical server provision requests whose provisioned server is orphaned" do
+        purgeable_request = nil
+
+        Timecop.freeze(7.months.ago) do
+          purgeable_request = FactoryBot.create(:physical_server_provision_request, :requester => user)
+          physical_server = FactoryBot.create(:physical_server, :ems_id => nil)
+          create_physical_server_provision_task(purgeable_request, physical_server)
+        end
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.exists?(purgeable_request.id)).to be(false)
       end
     end
 

--- a/spec/models/miq_request_task_spec.rb
+++ b/spec/models/miq_request_task_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe MiqRequestTask do
+  describe ".with_destination" do
+    it "filters by destination_type and joins destination table for VmOrTemplate" do
+      vm = FactoryBot.create(:vm_vmware)
+      service = FactoryBot.create(:service)
+
+      task_with_vm = FactoryBot.create(:miq_request_task, :destination => vm)
+      task_with_service = FactoryBot.create(:miq_request_task, :destination => service)
+      task_without_destination = FactoryBot.create(:miq_request_task)
+
+      result = described_class.with_destination('VmOrTemplate')
+
+      expect(result).to include(task_with_vm)
+      expect(result).not_to include(task_with_service)
+      expect(result).not_to include(task_without_destination)
+    end
+
+    it "works with Service type" do
+      service = FactoryBot.create(:service)
+      task_with_service = FactoryBot.create(:miq_request_task, :destination => service)
+      task_without_destination = FactoryBot.create(:miq_request_task)
+
+      result = described_class.with_destination('Service')
+
+      expect(result).to include(task_with_service)
+      expect(result).not_to include(task_without_destination)
+    end
+
+    it "works with PhysicalServer type" do
+      physical_server = FactoryBot.create(:physical_server)
+      task_with_server = FactoryBot.create(:miq_request_task, :destination => physical_server)
+      task_without_destination = FactoryBot.create(:miq_request_task)
+
+      result = described_class.with_destination('PhysicalServer')
+
+      expect(result).to include(task_with_server)
+      expect(result).not_to include(task_without_destination)
+    end
+  end
+
+  describe ".having_request" do
+    it "returns only tasks with a miq_request_id" do
+      request = FactoryBot.create(:miq_provision_request, :requester => FactoryBot.create(:user))
+      task_with_request = FactoryBot.create(:miq_request_task, :miq_request => request)
+      task_without_request = FactoryBot.create(:miq_request_task, :miq_request_id => nil)
+
+      result = described_class.having_request
+
+      expect(result).to include(task_with_request)
+      expect(result).not_to include(task_without_request)
+    end
+  end
+end

--- a/spec/models/physical_server_spec.rb
+++ b/spec/models/physical_server_spec.rb
@@ -50,4 +50,14 @@ RSpec.describe PhysicalServer do
       end
     end
   end
+
+  describe ".active" do
+    it "returns only servers with ems_id" do
+      active_server = FactoryBot.create(:physical_server, :ems_id => 1)
+      orphaned_server = FactoryBot.create(:physical_server, :ems_id => nil)
+
+      expect(described_class.active).to include(active_server)
+      expect(described_class.active).not_to include(orphaned_server)
+    end
+  end
 end


### PR DESCRIPTION
Prevent purging provision requests with active resources

The purger now checks for active provisioned resources before removing
provision requests. Each provision request type (VM, Service, Physical Server)
implements an active_provision_requests method that identifies requests with
live resources still managed by an EMS.

For VMs and Physical Servers, a resource is considered active if it has an
ems_id (not archived/orphaned). For Services, any existing service is
considered active.

This prevents accidentally removing provision requests and their associations
(most importantly the provision object) when there is an active resource
associated with that provision. The purger will now wait until the resource
becomes archived/retired before removing the request and all associated objects.

Related to https://github.com/ManageIQ/manageiq/issues/23776