### PR TITLE
On bootc appliances, /lib is not writable, prefer the /etc directory

### DIFF
--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -86,7 +86,7 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   end
 
   def systemd_unit_dir
-    Pathname.new("/lib/systemd/system")
+    Pathname.new("/etc/systemd/system")
   end
 
   def manageiq_service?(unit)

--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -16,7 +16,7 @@ class MiqWorker
       end
 
       def systemd_unit_dir
-        Pathname.new("/lib/systemd/system")
+        Pathname.new("/etc/systemd/system")
       end
     end
 


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/23737
