### PR TITLE
Fix `Vmdb::Loggers.contents` with a `BroadcastLogger`

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -107,7 +107,7 @@ module Vmdb
 
     def self.contents(log, last = 1000)
       log = log.instance_variable_get(:@logdev)&.filename.to_s if log.kind_of?(Logger)
-      return "" unless File.file?(log)
+      return "" unless (log.kind_of?(String) || log.kind_of?(Pathname)) && File.file?(log)
 
       if last.nil?
         contents = File.readlines(log, :mode => "rb", :chomp => true)

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -329,6 +329,12 @@ RSpec.describe Vmdb::Loggers do
       expect(described_class.contents(log)).to eq(ascii_log_content)
     end
 
+    it "with ActiveSupport::BroadcastLogger" do
+      log = described_class.send(:create_wrapper_logger, "test", ManageIQ::Loggers::Base, ManageIQ::Loggers::Base.new($stdout))
+
+      expect(described_class.contents(log)).to eq("")
+    end
+
     context "with evm log snippet with invalid utf8 byte sequence data" do
       let(:logfile) { Pathname.new(__dir__).join("data/redundant_utf8_byte_sequence.log") }
 


### PR DESCRIPTION
If `Vmdb::Loggers.contents` is passed an
`ActiveSupport::BroadcastLogger` it was passing that directly to `File.file?` since it wasn't a `Logger`

This updates the `.contents` method to check that the `log` variable is a String or Pathname before checking that it represents the path to a file.

```
[TypeError] no implicit conversion of ActiveSupport::BroadcastLogger into String
/var/www/miq/vmdb/lib/vmdb/loggers.rb:110:in `file?'
/var/www/miq/vmdb/lib/vmdb/loggers.rb:110:in `contents'
```

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/10028
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
