### PR TITLE
Bump manageiq-smartstate to v0.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -270,7 +270,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.12",            :require => false
+  gem "manageiq-smartstate",            "~>0.13",            :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Pull in the update to drop glusterfs support from RHV/oVirt SSA due to missing EL10 packages

Related:
* https://github.com/ManageIQ/manageiq-smartstate/pull/241
* https://github.com/ManageIQ/manageiq-rpm_build/pull/630#discussion_r2949549362
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
