### PR TITLE
Add request log purging

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -133,6 +133,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "MiqReportResult", :method_name => "purge_timer", :zone => nil)
   end
 
+  def request_log_purge_timer
+    queue_work(:class_name => "RequestLog", :method_name => "purge_timer", :zone => nil)
+  end
+
   def archived_entities_purge_timer
     queue_work(:class_name => "Container", :method_name => "purge_timer", :zone => nil)
     queue_work(:class_name => "ContainerNode", :method_name => "purge_timer", :zone => nil)

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -255,6 +255,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:notification_purge_timer)
     end
 
+    # Schedule - Purging of request logs
+    scheduler.schedule_every(
+      :request_log_purge_timer,
+      worker_settings[:request_logs_purge_interval]
+    ) do
+      enqueue(:request_log_purge_timer)
+    end
+
     # Schedule - Purging of tasks
     scheduler.schedule_every(
       :task_purge_timer,

--- a/app/models/request_log.rb
+++ b/app/models/request_log.rb
@@ -1,4 +1,6 @@
 class RequestLog < ApplicationRecord
+  include RequestLog::Purging
+
   validates :severity, :inclusion => {:in => Logger::Severity.constants.map(&:to_s)}
 
   belongs_to :resource, :class_name => "MiqRequest"

--- a/app/models/request_log/purging.rb
+++ b/app/models/request_log/purging.rb
@@ -1,0 +1,20 @@
+class RequestLog < ApplicationRecord
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.request_logs.history.keep_request_logs.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.request_logs.history.purge_window_size
+      end
+
+      def purge_scope(older_than)
+        where(arel_table[:created_at].lt(older_than))
+      end
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -893,6 +893,10 @@
   :use_sql_view: false
 :repository_scanning:
   :defaultsmartproxy:
+:request_logs:
+  :history:
+    :keep_request_logs: 6.months
+    :purge_window_size: 1000
 :server:
   :asynchronous_notifications: true
   :case_sensitive_name_search: false
@@ -1122,6 +1126,7 @@
       :poll: 15.seconds
       :queue_timeout_interval: 15.seconds
       :report_result_purge_interval: 1.week
+      :request_logs_purge_interval: 1.day
       :server_log_stats_interval: 5.minutes
       :server_stats_interval: 60.seconds
       :service_retired_interval: 10.minutes

--- a/spec/factories/request_log.rb
+++ b/spec/factories/request_log.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :request_log do
+    message { "Test log message" }
+    severity { "INFO" }
+  end
+end

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -131,4 +131,17 @@ RSpec.describe MiqScheduleWorker::Jobs do
       end
     end
   end
+
+  describe "#request_log_purge_timer" do
+    it "queues RequestLog.purge_timer" do
+      allow(MiqServer).to receive(:my_zone)
+      described_class.new.request_log_purge_timer
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => "RequestLog",
+        :method_name => "purge_timer",
+        :zone        => nil,
+        :priority    => MiqQueue::MEDIUM_PRIORITY
+      )
+    end
+  end
 end

--- a/spec/models/request_log/purging_spec.rb
+++ b/spec/models/request_log/purging_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe RequestLog do
+  context "::Purging" do
+    let(:settings) do
+      {
+        :request_logs => {
+          :history => {
+            :keep_request_logs => "6.months",
+            :purge_window_size => 1000
+          }
+        }
+      }
+    end
+
+    before do
+      stub_settings(settings)
+    end
+
+    describe ".purge_by_date" do
+      let(:created_on) { 6.months.ago }
+
+      before do
+        @old_log        = FactoryBot.create(:request_log, :created_at => created_on - 1.day)
+        @purge_date_log = FactoryBot.create(:request_log, :created_at => created_on - 1.second)
+        @new_log        = FactoryBot.create(:request_log, :created_at => created_on + 1.day)
+      end
+
+      it "purges old request logs" do
+        expect(described_class.count).to eq(3)
+
+        described_class.purge_by_date(created_on)
+
+        expect(described_class.count).to eq(1)
+        expect(described_class.first.id).to eq(@new_log.id)
+      end
+
+      it "purges with a window" do
+        callbacks = []
+
+        settings.store_path(:request_logs, :history, :purge_window_size, 1)
+        stub_settings(settings)
+
+        expect(described_class.count).to eq(3)
+
+        described_class.purge(created_on) { |count, total| callbacks << [count, total] }
+
+        expect(described_class.count).to eq(1)
+        expect(described_class.first.id).to eq(@new_log.id)
+        expect(callbacks).to eq([[1, 1], [1, 2]])
+      end
+    end
+
+    describe ".purge_timer" do
+      it "queues the correct purge method" do
+        EvmSpecHelper.local_miq_server
+        described_class.purge_timer
+        q = MiqQueue.first
+        expect(q).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, we implemented MiqRequest purging in https://github.com/ManageIQ/manageiq/pull/21577

This was reverted in https://github.com/ManageIQ/manageiq/pull/23828 because
MiqProvisionRequestTemplate and MiqProvisionConfigurationScriptRequestTemplate are
types of requests that contain options needed for the life of the associated
service template. We also found that MiqProvisionRequest also needed to remain
as long as the VM associated with its provision was still active.

That leaves several other MiqRequest descendant classes also at risk if they
persist metadata in their row that is needed by another association at some point
after the request is purged.

Therefore, we reverted MiqRequest purging and instead are targeting
purging of request_logs here.

CP4AIOPS-29035