### PR TITLE
Update to forked pg v1.6.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "more_core_extensions"                                                     #
 gem "net-ping",                         "~>1.7.4",           :require => false
 gem "openscap",                         "~>0.4.8",           :require => false
 gem "optimist",                         "~>3.0",             :require => false
-gem "pg",                               ">=1.4.1",           :require => false
+gem "pg",                               ">=1.6.3.1",         :require => false, :source => "https://rubygems.manageiq.org"
 gem "pg-dsn_parser",                    "~>0.1.1",           :require => false
 gem "prism",                            ">=0.25.0",          :require => false # Used by DescendantLoader
 gem "psych",                            ">=3.1",             :require => false # 3.1 safe_load changed positional to kwargs like aliases: true: https://github.com/ruby/psych/commit/4d4439d6d0adfcbd211ea295779315f1baa7dadd


### PR DESCRIPTION
This fixes RPM build issues on PPC and likely s390x as well

Error:
```
+ /usr/lib/rpm/check-rpaths ******************************************************************************* *
* WARNING: 'check-rpaths' detected a broken RPATH OR RUNPATH and will cause
*          'rpmbuild' to fail. To ignore these errors, you can set the
*          '$QA_RPATHS' environment variable which is a bitmask allowing the
*          values below. The current value of QA_RPATHS is 0x0000.
*
*    0x0001 ... standard RPATHs (e.g. /usr/lib); such RPATHs are a minor
*               issue but are introducing redundant searchpaths without
*               providing a benefit. They can also cause errors in multilib
*               environments.
*    0x0002 ... invalid RPATHs; these are RPATHs which are neither absolute
*               nor relative filenames and can therefore be a SECURITY risk
*    0x0004 ... insecure RPATHs; these are relative RPATHs which are a
*               SECURITY risk
*    0x0008 ... the special '$ORIGIN' RPATHs are appearing after other
*               RPATHs; this is just a minor issue but usually unwanted
*    0x0010 ... the RPATH is empty; there is no reason for such RPATHs
*               and they cause unneeded work while loading libraries
*    0x0020 ... an RPATH references '..' of an absolute path; this will break
*               the functionality when the path before '..' is a symlink
*
*
* Examples:
* - to ignore standard and empty RPATHs, execute 'rpmbuild' like
*   $ QA_RPATHS=$(( 0x0001|0x0010 )) rpmbuild my-package.src.rpm
* - to check existing files, set $RPM_BUILD_ROOT and execute check-rpaths like
*   $ RPM_BUILD_ROOT=<top-dir> /usr/lib/rpm/check-rpaths
*
*******************************************************************************
ERROR   0001: file '/opt/IBM/infrastructure-management-gemset/extensions/powerpc64le-linux/3.3.0/pg-1.6.3/pg_ext.so' contains a standard rpath '/usr/lib64' in [/usr/lib64]
error: Bad exit status from /var/tmp/rpm-tmp.KMyTi3 (%install)

RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.KMyTi3 (%install)

```

Fix PR: https://github.com/ged/ruby-pg/pull/699
Original upstream issue: https://github.com/ged/ruby-pg/issues/183
Our fork: https://github.com/ManageIQ/ruby-pg/tree/v1.6.3.1