### PR TITLE
Handle missing ServiceTemplate MiqRequest resource

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -567,11 +567,13 @@ class ServiceTemplate < ApplicationRecord
 
   def construct_config_info
     config_info = {}
-
-    miq_request_resource = service_resources.find_by(:resource_type => 'MiqRequest')
-    config_info.merge!(miq_request_resource.resource.options.compact) if miq_request_resource
-
+    config_info.merge!(miq_request_info)
     config_info.merge!(resource_actions_info)
+  end
+
+  def miq_request_info
+    miq_request = service_resources.find_by(:resource_type => 'MiqRequest')&.resource
+    miq_request&.options&.compact || {}
   end
 
   def resource_actions_info


### PR DESCRIPTION
If a ServiceTemplate is missing its `MiqRequest` referenced by a `ServiceResource` we still need to be able to render the config_info so the UI can edit the resource to fix it.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
