### PR TITLE
[WIP] Drop the generic_ style of AWX/AAP provisioning

### DIFF
--- a/app/models/service_template_awx.rb
+++ b/app/models/service_template_awx.rb
@@ -6,15 +6,6 @@ class ServiceTemplateAwx < ServiceTemplateAutomation
   alias job_template configuration_script
   alias job_template= configuration_script=
 
-  def create_subtasks(_parent_service_task, _parent_service)
-    if prov_type.start_with?("generic_")
-      # no sub task is needed for this service
-      []
-    else
-      super
-    end
-  end
-
   def self.create_catalog_item(options, _auth_user = nil)
     transaction do
       create_from_options(options).tap do |service_template|
@@ -37,18 +28,6 @@ class ServiceTemplateAwx < ServiceTemplateAutomation
       r.reload if r.persisted?
       r.destroy if r.resource.blank?
     end
-  end
-
-  def self.default_provisioning_entry_point(_service_type)
-    '/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision/CatalogItemInitialization'
-  end
-
-  def self.default_reconfiguration_entry_point
-    nil
-  end
-
-  def self.default_retirement_entry_point
-    nil
   end
 
   def self.validate_config_info(options)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-awx/pull/62
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/341

TODO:
- [ ] Determine what methods in `ServiceTemplateAwx` and `ServiceAwx` are still required, a lot will have been to support the Automate/Generic provisioning.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
