### PR TITLE
Nuage - Clean up leftover code

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -313,11 +313,6 @@ FactoryBot.define do
           :class   => "ManageIQ::Providers::Openstack::NetworkManager",
           :parent  => :ems_network
 
-  factory :ems_nuage_network,
-          :aliases => ["manageiq/providers/nuage/network_manager"],
-          :class   => "ManageIQ::Providers::Nuage::NetworkManager",
-          :parent  => :ems_network
-
   factory :ems_nsxt_network,
           :aliases => ["manageiq/providers/nsxt/network_manager"],
           :class   => "ManageIQ::Providers::Nsxt::NetworkManager",


### PR DESCRIPTION
Nuage network provider was dropped in [PR](https://github.com/ManageIQ/manageiq/pull/23792). So this PR cleans up the leftover code.

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
