### PR TITLE
Use worker_settings starting_timeout readiness probe

### DIFF
--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -33,7 +33,7 @@ class MiqWorker
     end
 
     def add_readiness_probe(container_definition)
-      starting_timeout = self.class.worker_settings[:starting_timeout]
+      starting_timeout = self.class.worker_settings[:starting_timeout] || 3
 
       container_definition[:readinessProbe] = {
         :httpGet             => {:path => "/ping", :port => HEALTH_PORT},

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -33,10 +33,12 @@ class MiqWorker
     end
 
     def add_readiness_probe(container_definition)
+      starting_timeout = self.class.worker_settings[:starting_timeout]
+
       container_definition[:readinessProbe] = {
         :httpGet             => {:path => "/ping", :port => HEALTH_PORT},
         :initialDelaySeconds => 60,
-        :timeoutSeconds      => 3
+        :timeoutSeconds      => starting_timeout
       }
     end
 

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -50,45 +50,61 @@ RSpec.describe MiqWorker::ContainerCommon do
     let(:kubeclient)             { double("Kubeclient::Client") }
 
     before do
+      expect(ContainerOrchestrator).to  receive(:new).at_least(:once).and_return(container_orchestrator)
       expect(container_orchestrator).to receive(:my_node_affinity_arch_values).and_return(["amd64", "arm64"])
-      allow(ContainerOrchestrator).to receive(:new).and_return(container_orchestrator)
       expect(container_orchestrator).to receive(:my_namespace).and_return("my-namespace")
       expect(container_orchestrator).to receive(:raw_connect).and_return(kubeclient)
     end
 
-    it "MiqUiWorker adds the ui_httpd_configs volume mount" do
-      expect(kubeclient).to receive(:create_deployment) do |deployment|
-        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts)).to include({:name => "ui-httpd-configs", :mountPath => "/etc/httpd/conf.d"})
-        expect(deployment.fetch_path(:spec, :template, :spec, :volumes)).to include({:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 420}})
-      end
+    context "MiqUiWorker" do
+      let(:ui_worker) { MiqUiWorker.new }
 
-      ui_worker = MiqUiWorker.new
-      expect(ui_worker).to receive(:scale_deployment)
-      ui_worker.create_container_objects
+      it "adds the ui_httpd_configs volume mount" do
+        expect(kubeclient).to receive(:create_deployment) do |deployment|
+          expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts)).to include({:name => "ui-httpd-configs", :mountPath => "/etc/httpd/conf.d"})
+          expect(deployment.fetch_path(:spec, :template, :spec, :volumes)).to include({:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 420}})
+        end
+
+        expect(ui_worker).to receive(:scale_deployment)
+        ui_worker.create_container_objects
+      end
     end
 
-    it "Service workers use httpGet liveness and readiness probes" do
-      expect(kubeclient).to receive(:create_deployment) do |deployment|
-        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :ports)).to match_array([{:containerPort => 3000}, {:containerPort => 4000}])
-        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :livenessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 240, :periodSeconds => 15, :timeoutSeconds => 10)
-        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 60, :timeoutSeconds => 600)
+    context "Service workers" do
+      let(:worker) { MiqWebServiceWorker.new }
+
+      it "use httpGet liveness and readiness probes" do
+        expect(kubeclient).to receive(:create_deployment) do |deployment|
+          expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :ports)).to match_array([{:containerPort => 3000}, {:containerPort => 4000}])
+          expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :livenessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 240, :periodSeconds => 15, :timeoutSeconds => 10)
+          expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 60, :timeoutSeconds => 600)
+        end
+
+        expect(worker).to receive(:scale_deployment)
+        worker.create_container_objects
       end
 
-      worker = MiqWebServiceWorker.new
-      expect(worker).to receive(:scale_deployment)
-      worker.create_container_objects
-    end
+      it "respect custom starting_timeout setting" do
+        stub_settings_merge(:workers => {:worker_base => {:web_service_worker => {:starting_timeout => 120}}})
 
-    it "Service workers respect custom starting_timeout setting" do
-      stub_settings_merge(:workers => {:worker_base => {:web_service_worker => {:starting_timeout => 120}}})
+        expect(kubeclient).to receive(:create_deployment) do |deployment|
+          expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe, :timeoutSeconds)).to eq(120)
+        end
 
-      expect(kubeclient).to receive(:create_deployment) do |deployment|
-        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe, :timeoutSeconds)).to eq(120)
+        expect(worker).to receive(:scale_deployment)
+        worker.create_container_objects
       end
 
-      worker = MiqWebServiceWorker.new
-      expect(worker).to receive(:scale_deployment)
-      worker.create_container_objects
+      it "defaults to 3 seconds if starting_timeout is nil" do
+        stub_settings_merge(:workers => {:worker_base => {:web_service_worker => {:starting_timeout => nil}}})
+
+        expect(kubeclient).to receive(:create_deployment) do |deployment|
+          expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe, :timeoutSeconds)).to eq(3)
+        end
+
+        expect(worker).to receive(:scale_deployment)
+        worker.create_container_objects
+      end
     end
   end
 

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -43,16 +43,20 @@ RSpec.describe MiqWorker::ContainerCommon do
 
       expect(test_deployment.dig(:spec, :template, :spec).keys).not_to include(:nodeSelector)
     end
+  end
 
-    it "MiqUiWorker adds the ui_httpd_configs volume mount" do
-      container_orchestrator = ContainerOrchestrator.new
+  describe "#create_container_objects" do
+    let(:container_orchestrator) { ContainerOrchestrator.new }
+    let(:kubeclient)             { double("Kubeclient::Client") }
+
+    before do
       expect(container_orchestrator).to receive(:my_node_affinity_arch_values).and_return(["amd64", "arm64"])
-      kubeclient = double("Kubeclient::Client")
-
       allow(ContainerOrchestrator).to receive(:new).and_return(container_orchestrator)
       expect(container_orchestrator).to receive(:my_namespace).and_return("my-namespace")
       expect(container_orchestrator).to receive(:raw_connect).and_return(kubeclient)
+    end
 
+    it "MiqUiWorker adds the ui_httpd_configs volume mount" do
       expect(kubeclient).to receive(:create_deployment) do |deployment|
         expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts)).to include({:name => "ui-httpd-configs", :mountPath => "/etc/httpd/conf.d"})
         expect(deployment.fetch_path(:spec, :template, :spec, :volumes)).to include({:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 420}})
@@ -64,14 +68,6 @@ RSpec.describe MiqWorker::ContainerCommon do
     end
 
     it "Service workers use httpGet liveness and readiness probes" do
-      container_orchestrator = ContainerOrchestrator.new
-      expect(container_orchestrator).to receive(:my_node_affinity_arch_values).and_return(["amd64", "arm64"])
-      kubeclient = double("Kubeclient::Client")
-
-      allow(ContainerOrchestrator).to receive(:new).and_return(container_orchestrator)
-      expect(container_orchestrator).to receive(:my_namespace).and_return("my-namespace")
-      expect(container_orchestrator).to receive(:raw_connect).and_return(kubeclient)
-
       expect(kubeclient).to receive(:create_deployment) do |deployment|
         expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :ports)).to match_array([{:containerPort => 3000}, {:containerPort => 4000}])
         expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :livenessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 240, :periodSeconds => 15, :timeoutSeconds => 10)
@@ -85,14 +81,6 @@ RSpec.describe MiqWorker::ContainerCommon do
 
     it "Service workers respect custom starting_timeout setting" do
       stub_settings_merge(:workers => {:worker_base => {:web_service_worker => {:starting_timeout => 120}}})
-
-      container_orchestrator = ContainerOrchestrator.new
-      expect(container_orchestrator).to receive(:my_node_affinity_arch_values).and_return(["amd64", "arm64"])
-      kubeclient = double("Kubeclient::Client")
-
-      allow(ContainerOrchestrator).to receive(:new).and_return(container_orchestrator)
-      expect(container_orchestrator).to receive(:my_namespace).and_return("my-namespace")
-      expect(container_orchestrator).to receive(:raw_connect).and_return(kubeclient)
 
       expect(kubeclient).to receive(:create_deployment) do |deployment|
         expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe, :timeoutSeconds)).to eq(120)

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -75,7 +75,27 @@ RSpec.describe MiqWorker::ContainerCommon do
       expect(kubeclient).to receive(:create_deployment) do |deployment|
         expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :ports)).to match_array([{:containerPort => 3000}, {:containerPort => 4000}])
         expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :livenessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 240, :periodSeconds => 15, :timeoutSeconds => 10)
-        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 60, :timeoutSeconds => 3)
+        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe)).to eq(:httpGet => {:path => "/ping", :port => 4000}, :initialDelaySeconds => 60, :timeoutSeconds => 600)
+      end
+
+      worker = MiqWebServiceWorker.new
+      expect(worker).to receive(:scale_deployment)
+      worker.create_container_objects
+    end
+
+    it "Service workers respect custom starting_timeout setting" do
+      stub_settings_merge(:workers => {:worker_base => {:web_service_worker => {:starting_timeout => 120}}})
+
+      container_orchestrator = ContainerOrchestrator.new
+      expect(container_orchestrator).to receive(:my_node_affinity_arch_values).and_return(["amd64", "arm64"])
+      kubeclient = double("Kubeclient::Client")
+
+      allow(ContainerOrchestrator).to receive(:new).and_return(container_orchestrator)
+      expect(container_orchestrator).to receive(:my_namespace).and_return("my-namespace")
+      expect(container_orchestrator).to receive(:raw_connect).and_return(kubeclient)
+
+      expect(kubeclient).to receive(:create_deployment) do |deployment|
+        expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :readinessProbe, :timeoutSeconds)).to eq(120)
       end
 
       worker = MiqWebServiceWorker.new


### PR DESCRIPTION
Allow the user to change the worker settings and control the starting timeout for the readiness probe of service workers.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
