### PR TITLE
[WIP] Use installed libqpid-proton version for the gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -217,7 +217,9 @@ group :terraform_enterprise, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.37.0",          :require => false
+  qpid_major, qpid_minor, qpid_point = `egrep 'PN_VERSION_MAJOR|PN_VERSION_MINOR|PN_VERSION_POINT' /usr/include/proton/version.h  | awk '{print $3}'`.split("\n")
+
+  gem "qpid_proton", "~>#{qpid_major}.#{qpid_minor}.#{qpid_point}", :require => false
 end
 
 group :systemd, :optional => true do


### PR DESCRIPTION
Allow use of different qpid-proton gem versions based on what is installed.

The Qpid Proton gem has to match the libqpid-proton11 library version otherwise it'll fail. 
This would allow us to use for example 0.40.0 on EL10 but still use 0.37.0 on the latest ubuntu GHA runners.

Very early, no error handling, but want to start the discussion.

```
#define PN_VERSION_MAJOR 0
#define PN_VERSION_MINOR 37
#define PN_VERSION_POINT 0
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
