### PR TITLE
[TAL] Bump jwt for CVE-2026-45363

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -896,7 +896,7 @@ GEM
       addressable (>= 2.4)
     jsonpath (1.1.5)
       multi_json
-    jwt (2.10.2)
+    jwt (2.10.3)
       base64
     kubeclient (4.13.0)
       http (>= 3.0, < 6.0)


### PR DESCRIPTION
@agrare Please review - security suite is failing on this one

https://github.com/jwt/ruby-jwt/blob/v2.10.3/CHANGELOG.md#v2103-2026-05-22