### PR TITLE
Add factory method: ems_oracle_cloud_with_authentication

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -335,6 +335,20 @@ FactoryBot.define do
           :class   => "ManageIQ::Providers::Google::NetworkManager",
           :parent  => :ems_network
 
+  factory :ems_oracle_cloud_with_authentication,
+          :aliases => ["manageiq/providers/oracle_cloud/cloud_manager_with_auth"],
+          :class   => "ManageIQ::Providers::OracleCloud::CloudManager",
+          :parent  => :ems_cloud do
+    after(:create) do |ems|
+      ems.authentications << FactoryBot.create(
+        :authentication,
+        :userid     => "ocid1.user.oc1..aaaaaaaafakeuserid",
+        :auth_key   => "fake-private-key-for-testing",
+        :public_key => "fake-public-key-for-testing"
+      )
+    end
+  end
+
   # Leaf classes for ems_container
 
   factory :ems_kubernetes,


### PR DESCRIPTION
PR to add `oracle_cloud` factory method that includes `public_key`

I'm kind of convinced by 🤖 that I need a new factory method since the existing [ems_oracle_cloud](https://github.com/ManageIQ/manageiq-providers-oracle_cloud/blob/master/spec/factories/ext_management_system.rb#L2C12-L2C28) doesn't create a public key, which is not the behavior I need. Happy to be proven wrong here. If there's already a factory that creates a public key, I'm all for using it I just wasn't able to find one

@miq-bot add-reviewer @Fryguy 
@miq-bot add-reviewer @jrafanie 
@miq-bot add-reviewer @agrare   
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
