### PR TITLE
Workaround puma CVE false positive

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,4 @@
+---
+ignore:
+- CVE-2026-47736 # TODO: Remove when puma is upgraded to 7.2.1+ or 8.0.2+; False positive - Only Puma servers using the following non-default config are affected: set_remote_address proxy_protocol: :v1 /  Workaround: * Disable PROXY protocol v1 parsing if it is not required
+- CVE-2026-47737 # TODO: Remove when puma is upgraded to 7.2.1+ or 8.0.2+; False positive - Only deployments that explicitly enable PROXY protocol v1 are affected: set_remote_address proxy_protocol: :v1 / Workaround: * Disable PROXY protocol v1 parsing if it is not required

--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -69,6 +69,15 @@ class TestSecurityHelper
     puts "** Running bundle-audit in #{Dir.pwd}"
 
     options = [:update, :verbose]
+
+    # For engines, use core's configuration file if it exists
+    if defined?(ENGINE_ROOT)
+      config = Rails.root.join(".bundler-audit.yml")
+      if File.exist?(config)
+        options << "--config" << config.to_s
+      end
+    end
+
     if format == "json"
       options << {
         :format => "json",


### PR DESCRIPTION
    Ignore CVEs because we don't use puma proxy protocol v1

    From: https://github.com/puma/puma/security/advisories/GHSA-qpgp-93vx-g8v8

    Only Puma servers using the following non-default config are affected:

       set_remote_address proxy_protocol: :v1

    We don't enable this non-default configuration so we aren't impacted.

    Ultimately, we should upgrade to puma 7.2.1+ or 8.0.2+ but it's not required
    for this issue.