### PR TITLE
Cleanup awesome_spawn usage

### DIFF
--- a/lib/tasks/test_security_helper.rb
+++ b/lib/tasks/test_security_helper.rb
@@ -73,9 +73,7 @@ class TestSecurityHelper
     # For engines, use core's configuration file if it exists
     if defined?(ENGINE_ROOT)
       config = Rails.root.join(".bundler-audit.yml")
-      if File.exist?(config)
-        options << "--config" << config.to_s
-      end
+      options << {:config => config.to_s} if config.exist?
     end
 
     if format == "json"


### PR DESCRIPTION
@jrafanie Please review - very minor cleanup of awesome_spawn / Pathname usage for consistency.

- Use Pathname#exist?
- Use Symbol/Hash for CLI flag

(Technically, you don't need the .to_s on the Pathname either, but the other usages of Pathname in this function use it, so I left that in for consistency)

EDIT: Followup to #23867
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
