### PR TITLE
Fix `_object_details.href` missing `/api/` path in Context for Workflow driven MiqProvisionTask and MiqRetireTasks

### DIFF
--- a/app/models/mixins/configuration_script_context_source_details_mixin.rb
+++ b/app/models/mixins/configuration_script_context_source_details_mixin.rb
@@ -3,7 +3,7 @@ module ConfigurationScriptContextSourceDetailsMixin
 
   def configuration_script_context
     remote_ws_url = MiqRegion.my_region.remote_ws_url
-    api_base_url  = URI.join(remote_ws_url, "api") if remote_ws_url
+    api_base_url  = File.join(remote_ws_url, "api") if remote_ws_url
 
     source_details = {
       :id      => source.id,
@@ -11,7 +11,7 @@ module ConfigurationScriptContextSourceDetailsMixin
       :ems_ref => source.respond_to?(:manager_ref) ? source.manager_ref : source.ems_ref
     }
 
-    source_details[:href] = URI.join(api_base_url, source.href_slug).to_s if api_base_url
+    source_details[:href] = File.join(api_base_url, source.href_slug) if api_base_url
 
     evm_owner = source.evm_owner if source.respond_to?(:evm_owner)
     if evm_owner
@@ -21,7 +21,7 @@ module ConfigurationScriptContextSourceDetailsMixin
         :name   => evm_owner.name,
         :email  => evm_owner.email
       }
-      source_details[:owner][:href] = URI.join(api_base_url, evm_owner.href_slug).to_s if api_base_url
+      source_details[:owner][:href] = File.join(api_base_url, evm_owner.href_slug) if api_base_url
     end
 
     service = source.service if source.respond_to?(:service)
@@ -30,7 +30,7 @@ module ConfigurationScriptContextSourceDetailsMixin
         :id   => service.id,
         :name => service.name
       }
-      source_details[:service][:href] = URI.join(api_base_url, service.href_slug).to_s if api_base_url
+      source_details[:service][:href] = File.join(api_base_url, service.href_slug) if api_base_url
     end
 
     super.merge(:_object_details => source_details)

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -218,11 +218,11 @@ RSpec.describe ServiceRetireTask do
                       :id      => vm.id,
                       :name    => vm.name,
                       :ems_ref => vm.ems_ref,
-                      :href    => "https://#{ip}/instances/#{vm.id}",
+                      :href    => "https://#{ip}/api/instances/#{vm.id}",
                       :service => {
                         :id   => service.id,
                         :name => service.name,
-                        :href => "https://#{ip}/services/#{service.id}"
+                        :href => "https://#{ip}/api/services/#{service.id}"
                       }
                     }
                   )


### PR DESCRIPTION
When including the API URL in the context for configuration_script contexts the `/api` component of the URL was missing causing 404 errors when trying to retrieve the object from the API.

```
 "Execution"=>
  {"Id"=>"80085f9d-2671-4d5d-91eb-3dd0c5f78732",
   "_object_id"=>185,
   "_object_type"=>"VmRetireTask",
   "_object_details"=>{"id"=>1581, "href"=>"http://localhost:3000/vms/1581", "name"=>"ag_prov_test_servicenow0034", "owner"=>{"id"=>1, "href"=>"http://localhost:3000/users/1", "name"=>"Administrator", "email"=>nil, "userid"=>"admin"}, "ems_ref"=>"vm-186", "service"=>{"id"=>53, "href"=>"http://localhost:3000/services/53", "name"=>"VMware x ServiceNow-20260615-152646"}},
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
