### PR TITLE
Cleanup `inactive (dead)` systemd services

### DIFF
--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -24,6 +24,9 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     super
 
     cleanup_failed_systemd_services
+    cleanup_dead_systemd_services
+
+    systemd_manager.Reload
   end
 
   def cleanup_failed_systemd_services
@@ -37,6 +40,14 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     MiqWorker.find_current_or_starting.where(:system_uid => service_names).each do |w|
       w.update!(:status => MiqWorker::STATUS_STOPPED)
     end
+  end
+
+  def cleanup_dead_systemd_services
+    service_names = dead_miq_services.pluck(:name)
+    return if service_names.empty?
+
+    _log.info("Disabling inactive (dead) unit files: [#{service_names.join(", ")}]")
+    systemd_stop_services(service_names)
   end
 
   private
@@ -107,6 +118,10 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
 
   def failed_miq_services
     miq_services.select { |service| service[:active_state] == "failed" }
+  end
+
+  def dead_miq_services
+    miq_services.select { |s| s[:active_state] == "inactive" && s[:sub_state] == "dead" }
   end
 
   def failed_miq_service_names

--- a/app/models/miq_server/worker_management/systemd.rb
+++ b/app/models/miq_server/worker_management/systemd.rb
@@ -23,9 +23,11 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
   def cleanup_failed_workers
     super
 
-    cleanup_failed_systemd_services
-    cleanup_dead_systemd_services
+    # Cleanup any failed or inactive/dead MIQ services.
+    return unless cleanup_failed_systemd_services || cleanup_dead_systemd_services
 
+    # If we ended up cleaning any failed services from disk instruct
+    # systemd to reload all services from the filesystem.
     systemd_manager.Reload
   end
 
@@ -40,6 +42,8 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
     MiqWorker.find_current_or_starting.where(:system_uid => service_names).each do |w|
       w.update!(:status => MiqWorker::STATUS_STOPPED)
     end
+
+    service_names
   end
 
   def cleanup_dead_systemd_services
@@ -48,6 +52,8 @@ class MiqServer::WorkerManagement::Systemd < MiqServer::WorkerManagement
 
     _log.info("Disabling inactive (dead) unit files: [#{service_names.join(", ")}]")
     systemd_stop_services(service_names)
+
+    service_names
   end
 
   private

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -11,62 +11,52 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     allow(systemd_manager).to receive(:units).and_return(units)
   end
 
-  context "#cleanup_failed_systemd_services" do
+  context "#cleanup_failed_workers" do
+    let!(:generic_worker) { FactoryBot.create(:miq_generic_worker, :guid => "68400a7e-1747-4f10-be2a-d0fc91b705ca", :miq_server => server) }
+    let(:service_name) { "manageiq-generic@#{generic_worker.guid}.service" }
+
     before { server.worker_manager.sync_from_system }
 
-    context "with no failed services" do
-      let(:units) { [{:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
+    context "with no failed or dead services" do
+      let(:units) { [{:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
 
       it "doesn't call DisableUnitFiles" do
         expect(systemd_manager).not_to receive(:DisableUnitFiles)
-        server.worker_manager.cleanup_failed_systemd_services
+        server.worker_manager.cleanup_failed_workers
+      end
+
+      it "doesn't call Reload" do
+        expect(systemd_manager).not_to receive(:Reload)
+        server.worker_manager.cleanup_failed_workers
       end
     end
 
     context "with failed services" do
-      let(:service_name) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
       let(:units) { [{:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "failed", :sub_state => "plugged", :job_id => 0, :job_type => "", :job_object_path => "/"}] }
-      let!(:worker) { FactoryBot.create(:miq_generic_worker, :miq_server => server, :status => "creating", :system_uid => service_name) }
+      let!(:starting_worker) { FactoryBot.create(:miq_generic_worker, :miq_server => server, :status => "creating", :system_uid => service_name) }
 
       it "calls DisableUnitFiles with the service name" do
         expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
         expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
         expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name], false)
+        expect(systemd_manager).to receive(:Reload)
 
-        server.worker_manager.cleanup_failed_systemd_services
+        server.worker_manager.cleanup_failed_workers
       end
 
       it "marks any active workers as stopped" do
         expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
         expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
         expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name], false)
+        expect(systemd_manager).to receive(:Reload)
 
-        server.worker_manager.cleanup_failed_systemd_services
+        server.worker_manager.cleanup_failed_workers
 
-        expect(worker.reload.status).to eq("stopped")
-      end
-    end
-  end
-
-  context "#cleanup_dead_systemd_services" do
-    before { server.worker_manager.sync_from_system }
-
-    context "with no dead services" do
-      let(:units) do
-        [
-          {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "running", :job_id => 0, :job_type => "", :job_object_path => "/"},
-          {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service", :description => "ManageIQ UI Worker", :load_state => "loaded", :active_state => "failed", :sub_state => "failed", :job_id => 0, :job_type => "", :job_object_path => "/"}
-        ]
-      end
-
-      it "doesn't call DisableUnitFiles" do
-        expect(systemd_manager).not_to receive(:DisableUnitFiles)
-        server.worker_manager.cleanup_dead_systemd_services
+        expect(starting_worker.reload.status).to eq("stopped")
       end
     end
 
     context "with dead services" do
-      let(:service_name) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
       let(:units) do
         [
           {:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"}
@@ -77,48 +67,49 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
         expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
         expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
         expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name], false)
+        expect(systemd_manager).to receive(:Reload)
 
-        server.worker_manager.cleanup_dead_systemd_services
+        server.worker_manager.cleanup_failed_workers
       end
     end
 
     context "with multiple dead services" do
-      let(:service_name_1) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
       let(:service_name_2) { "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service" }
       let(:units) do
         [
-          {:name => service_name_1, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"},
+          {:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"},
           {:name => service_name_2, :description => "ManageIQ UI Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"}
         ]
       end
 
       it "calls DisableUnitFiles with all dead service names" do
-        expect(systemd_manager).to receive(:StopUnit).with(service_name_1, "replace")
-        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name_1)
+        expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
         expect(systemd_manager).to receive(:StopUnit).with(service_name_2, "replace")
         expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name_2)
-        expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name_1, service_name_2], false)
+        expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name, service_name_2], false)
+        expect(systemd_manager).to receive(:Reload)
 
-        server.worker_manager.cleanup_dead_systemd_services
+        server.worker_manager.cleanup_failed_workers
       end
     end
 
     context "with mixed service states" do
-      let(:dead_service) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
       let(:units) do
         [
-          {:name => dead_service, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"},
+          {:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"},
           {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service", :description => "ManageIQ UI Worker", :load_state => "loaded", :active_state => "active", :sub_state => "running", :job_id => 0, :job_type => "", :job_object_path => "/"},
           {:name => "manageiq-event_catcher@abc123.service", :description => "ManageIQ Event Catcher", :load_state => "loaded", :active_state => "failed", :sub_state => "failed", :job_id => 0, :job_type => "", :job_object_path => "/"}
         ]
       end
 
       it "only disables dead services" do
-        expect(systemd_manager).to receive(:StopUnit).with(dead_service, "replace")
-        expect(systemd_manager).to receive(:ResetFailedUnit).with(dead_service)
-        expect(systemd_manager).to receive(:DisableUnitFiles).with([dead_service], false)
+        expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
+        expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name], false)
+        expect(systemd_manager).to receive(:Reload)
 
-        server.worker_manager.cleanup_dead_systemd_services
+        server.worker_manager.cleanup_failed_workers
       end
     end
   end

--- a/spec/models/miq_server/worker_management/systemd_spec.rb
+++ b/spec/models/miq_server/worker_management/systemd_spec.rb
@@ -48,6 +48,81 @@ RSpec.describe MiqServer::WorkerManagement::Systemd do
     end
   end
 
+  context "#cleanup_dead_systemd_services" do
+    before { server.worker_manager.sync_from_system }
+
+    context "with no dead services" do
+      let(:units) do
+        [
+          {:name => "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service", :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "active", :sub_state => "running", :job_id => 0, :job_type => "", :job_object_path => "/"},
+          {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service", :description => "ManageIQ UI Worker", :load_state => "loaded", :active_state => "failed", :sub_state => "failed", :job_id => 0, :job_type => "", :job_object_path => "/"}
+        ]
+      end
+
+      it "doesn't call DisableUnitFiles" do
+        expect(systemd_manager).not_to receive(:DisableUnitFiles)
+        server.worker_manager.cleanup_dead_systemd_services
+      end
+    end
+
+    context "with dead services" do
+      let(:service_name) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
+      let(:units) do
+        [
+          {:name => service_name, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"}
+        ]
+      end
+
+      it "calls DisableUnitFiles with the service name" do
+        expect(systemd_manager).to receive(:StopUnit).with(service_name, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name)
+        expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name], false)
+
+        server.worker_manager.cleanup_dead_systemd_services
+      end
+    end
+
+    context "with multiple dead services" do
+      let(:service_name_1) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
+      let(:service_name_2) { "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service" }
+      let(:units) do
+        [
+          {:name => service_name_1, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"},
+          {:name => service_name_2, :description => "ManageIQ UI Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"}
+        ]
+      end
+
+      it "calls DisableUnitFiles with all dead service names" do
+        expect(systemd_manager).to receive(:StopUnit).with(service_name_1, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name_1)
+        expect(systemd_manager).to receive(:StopUnit).with(service_name_2, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(service_name_2)
+        expect(systemd_manager).to receive(:DisableUnitFiles).with([service_name_1, service_name_2], false)
+
+        server.worker_manager.cleanup_dead_systemd_services
+      end
+    end
+
+    context "with mixed service states" do
+      let(:dead_service) { "manageiq-generic@68400a7e-1747-4f10-be2a-d0fc91b705ca.service" }
+      let(:units) do
+        [
+          {:name => dead_service, :description => "ManageIQ Generic Worker", :load_state => "loaded", :active_state => "inactive", :sub_state => "dead", :job_id => 0, :job_type => "", :job_object_path => "/"},
+          {:name => "manageiq-ui@cfe2c489-5c93-4b77-8620-cf6b1d3ec595.service", :description => "ManageIQ UI Worker", :load_state => "loaded", :active_state => "active", :sub_state => "running", :job_id => 0, :job_type => "", :job_object_path => "/"},
+          {:name => "manageiq-event_catcher@abc123.service", :description => "ManageIQ Event Catcher", :load_state => "loaded", :active_state => "failed", :sub_state => "failed", :job_id => 0, :job_type => "", :job_object_path => "/"}
+        ]
+      end
+
+      it "only disables dead services" do
+        expect(systemd_manager).to receive(:StopUnit).with(dead_service, "replace")
+        expect(systemd_manager).to receive(:ResetFailedUnit).with(dead_service)
+        expect(systemd_manager).to receive(:DisableUnitFiles).with([dead_service], false)
+
+        server.worker_manager.cleanup_dead_systemd_services
+      end
+    end
+  end
+
   context "#sync_from_system" do
     before { server.worker_manager.sync_from_system }
 


### PR DESCRIPTION
If a MIQ worker isn't shutdown cleanly the config directory isn't removed leading to an accumulation of these directories on disk.

Add a check for `inactive (dead)` services in the monitor_workers method.

Fixes https://github.com/ManageIQ/manageiq/issues/23889

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
