### PR TITLE
Ignore false positive webrick audit warning

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,5 +1,6 @@
 ---
 ignore:
+- CVE-2026-38969 # TODO: Remove when webrick is released, see: https://github.com/ruby/webrick/issues/198 and https://github.com/ruby/webrick/pull/199; False positive - puma is our configured rails server; webrick is an indirect dev dependency pulled in from: rails → railties → rackup → webrick. It allows running a rails server with a webrick server, which we never do.
 - CVE-2026-47736 # TODO: Remove when puma is upgraded to 7.2.1+ or 8.0.2+; False positive - Only Puma servers using the following non-default config are affected: set_remote_address proxy_protocol: :v1 /  Workaround: * Disable PROXY protocol v1 parsing if it is not required
 - CVE-2026-47737 # TODO: Remove when puma is upgraded to 7.2.1+ or 8.0.2+; False positive - Only deployments that explicitly enable PROXY protocol v1 are affected: set_remote_address proxy_protocol: :v1 / Workaround: * Disable PROXY protocol v1 parsing if it is not required
 - CVE-2026-54163 # TODO: Remove when secure_headers is upgraded to 7.3.0';


### PR DESCRIPTION
While the CVE is real, the warning is not relevant to manageiq since it's
not configured to use webrick in development mode as we use puma.

webrick is an indirect dev dependency pulled in from: rails → railties → rackup → webrick

It allows running a rails server with a webrick server, which we never do.

See:
https://www.github.com/ruby/webrick/issues/198
https://www.github.com/ruby/webrick/pull/199

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
