### PR TITLE
[TAL] Bump rugged to 1.9.4 for security updates in libgit2

### DIFF
--- a/Gemfile.lock.release
+++ b/Gemfile.lock.release
@@ -1328,7 +1328,7 @@ GEM
     rufus-lru (1.0.7)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
-    rugged (1.9.0)
+    rugged (1.9.4)
     ruport (1.8.0)
       prawn (~> 2.4.0)
       prawn-table (~> 0.2.0)


### PR DESCRIPTION
Namely https://github.com/libgit2/libgit2/releases/tag/v1.9.2

@agrare Please review.