### PR TITLE
Update websocket-driver to v0.8.2 for CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -292,7 +292,7 @@ end
 
 group :web_socket, :manageiq_default do
   gem "surro-gate",                     "~>1.0.6",           :require => false
-  gem "websocket-driver",               "~>0.6.3",           :require => false
+  gem "websocket-driver",               "~>0.8", ">=0.8.2",  :require => false
 end
 
 group :appliance, :optional => true do

--- a/lib/remote_console/server_adapter/websocket_binary.rb
+++ b/lib/remote_console/server_adapter/websocket_binary.rb
@@ -29,7 +29,7 @@ module RemoteConsole
       # into this method.
       def fetch(length)
         # This callback should be set just once, yielding with the parsed message
-        @driver.on(:message) { |msg| yield(msg.data.pack('C*')) } if @driver.listeners(:message).length.zero?
+        @driver.on(:message) { |msg| yield(msg.data) } if @driver.listeners(:message).length.zero?
 
         data = @sock.read_nonblock(length) # Read from the socket
         @driver.parse(data) # Parse the incoming data, run the callback from above

--- a/lib/remote_console/server_adapter/websocket_uint8_utf8.rb
+++ b/lib/remote_console/server_adapter/websocket_uint8_utf8.rb
@@ -1,14 +1,6 @@
 module RemoteConsole
   module ServerAdapter
     class WebsocketUint8Utf8 < WebsocketBinary
-      # See the explanation of WebsocketBinary#fetch
-      def fetch(length)
-        @driver.on(:message) { |msg| yield(msg.data) } if @driver.listeners(:message).length.zero?
-
-        data = @sock.read_nonblock(length)
-        @driver.parse(data)
-      end
-
       def issue(data)
         @driver.frame(data)
       end

--- a/spec/lib/remote_console/client_adapter/web_mks_legacy_spec.rb
+++ b/spec/lib/remote_console/client_adapter/web_mks_legacy_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RemoteConsole::ClientAdapter::WebMKSLegacy do
   subject { described_class.new(record, nil) }
 
   before do
-    ssl = double
+    ssl = instance_double(OpenSSL::SSL::SSLSocket)
     allow(OpenSSL::SSL::SSLSocket).to receive(:new).and_return(ssl)
     allow(OpenSSL::X509::Certificate).to receive(:new)
     allow(OpenSSL::PKey::RSA).to receive(:new)
@@ -11,7 +11,7 @@ RSpec.describe RemoteConsole::ClientAdapter::WebMKSLegacy do
     allow(ssl).to receive(:sync_close=)
     allow(ssl).to receive(:connect)
 
-    driver = double
+    driver = instance_double(WebSocket::Driver::Client)
     allow(WebSocket::Driver).to receive(:client).and_return(driver)
     allow(driver).to receive(:start)
     allow(driver).to receive(:on)

--- a/spec/lib/remote_console/client_adapter/web_mks_spec.rb
+++ b/spec/lib/remote_console/client_adapter/web_mks_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RemoteConsole::ClientAdapter::WebMKS do
   subject { described_class.new(record, nil) }
 
   before do
-    ssl = double
+    ssl = instance_double(OpenSSL::SSL::SSLSocket)
     allow(OpenSSL::SSL::SSLSocket).to receive(:new).and_return(ssl)
     allow(OpenSSL::X509::Certificate).to receive(:new)
     allow(OpenSSL::PKey::RSA).to receive(:new)
@@ -11,7 +11,7 @@ RSpec.describe RemoteConsole::ClientAdapter::WebMKS do
     allow(ssl).to receive(:sync_close=)
     allow(ssl).to receive(:connect)
 
-    driver = double
+    driver = instance_double(WebSocket::Driver::Client)
     allow(WebSocket::Driver).to receive(:client).and_return(driver)
     allow(driver).to receive(:start)
     allow(driver).to receive(:on)

--- a/spec/lib/remote_console/server_adapter/websocket_binary_spec.rb
+++ b/spec/lib/remote_console/server_adapter/websocket_binary_spec.rb
@@ -1,0 +1,121 @@
+RSpec.describe RemoteConsole::ServerAdapter::WebsocketBinary do
+  let(:env) do
+    {
+      'HTTP_HOST'       => 'localhost:3000',
+      'REQUEST_URI'     => '/ws/console/test',
+      'rack.url_scheme' => 'http'
+    }
+  end
+  let(:sock) { instance_double(IO) }
+  let(:driver) { instance_double(WebSocket::Driver::Server) }
+
+  subject { described_class.new(env, sock) }
+
+  before do
+    allow(WebSocket::Driver).to receive(:rack).and_return(driver)
+    allow(driver).to receive(:on)
+    allow(driver).to receive(:start)
+  end
+
+  describe '#initialize' do
+    it 'creates a websocket driver with binary protocol' do
+      expect(WebSocket::Driver).to receive(:rack).with(
+        anything,
+        hash_including(:protocols => ['binary'])
+      ).and_return(driver)
+
+      described_class.new(env, sock)
+    end
+
+    it 'sets up close handler' do
+      expect(driver).to receive(:on).with(:close)
+      described_class.new(env, sock)
+    end
+
+    it 'starts the driver' do
+      expect(driver).to receive(:start)
+      described_class.new(env, sock)
+    end
+  end
+
+  describe '#fetch' do
+    let(:binary_data) { "\x00\x01\x02\x03".b }
+    let(:websocket_frame) { "websocket_frame_data" }
+
+    before do
+      allow(sock).to receive(:read_nonblock).and_return(websocket_frame)
+      allow(driver).to receive(:parse)
+      allow(driver).to receive(:listeners).with(:message).and_return([])
+    end
+
+    it 'reads from socket and parses through driver' do
+      expect(sock).to receive(:read_nonblock).with(1024).and_return(websocket_frame)
+      expect(driver).to receive(:parse).with(websocket_frame)
+
+      subject.fetch(1024) { |_data| nil }
+    end
+
+    it 'yields binary string data from websocket-driver 0.8+' do
+      # Simulate websocket-driver 0.8+ behavior where msg.data is a binary string
+      allow(driver).to receive(:on).with(:message) do |&block|
+        msg = double('message', :data => binary_data)
+        block.call(msg)
+      end
+
+      yielded_data = nil
+      subject.fetch(1024) { |data| yielded_data = data }
+
+      expect(yielded_data).to eq(binary_data)
+      expect(yielded_data.encoding).to eq(Encoding::BINARY)
+    end
+
+    it 'only sets up message callback once' do
+      # First call sets up the callback (listeners returns empty array)
+      allow(driver).to receive(:listeners).with(:message).and_return([])
+      subject.fetch(1024) { |_data| nil }
+
+      # Second call should not set up callback again (listeners returns non-empty array)
+      allow(driver).to receive(:listeners).with(:message).and_return([double])
+      expect(driver).not_to receive(:on).with(:message)
+      subject.fetch(1024) { |_data| nil }
+    end
+  end
+
+  describe '#issue' do
+    it 'sends binary data through driver' do
+      data = "\x00\x01\x02\x03".b
+      expect(driver).to receive(:binary).with(data)
+
+      subject.issue(data)
+    end
+  end
+
+  describe '#write' do
+    it 'writes data to socket' do
+      data = "frame_data"
+      expect(sock).to receive(:write_nonblock).with(data)
+
+      subject.write(data)
+    end
+  end
+
+  describe '#url' do
+    it 'constructs websocket URL from env' do
+      expect(subject.url).to eq('ws://localhost:3000/ws/console/test')
+    end
+
+    context 'with SSL' do
+      let(:env) do
+        {
+          'HTTP_HOST'       => 'example.com',
+          'REQUEST_URI'     => '/ws/console/secure',
+          'rack.url_scheme' => 'https'
+        }
+      end
+
+      it 'uses wss scheme' do
+        expect(subject.url).to eq('wss://example.com/ws/console/secure')
+      end
+    end
+  end
+end

--- a/spec/lib/remote_console/server_adapter/websocket_uint8_utf8_spec.rb
+++ b/spec/lib/remote_console/server_adapter/websocket_uint8_utf8_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe RemoteConsole::ServerAdapter::WebsocketUint8Utf8 do
+  let(:env) do
+    {
+      'HTTP_HOST'       => 'localhost:3000',
+      'REQUEST_URI'     => '/ws/console/test',
+      'rack.url_scheme' => 'http'
+    }
+  end
+  let(:sock) { instance_double(IO) }
+  let(:driver) { instance_double(WebSocket::Driver::Server) }
+
+  subject { described_class.new(env, sock) }
+
+  before do
+    allow(WebSocket::Driver).to receive(:rack).and_return(driver)
+    allow(driver).to receive(:on)
+    allow(driver).to receive(:start)
+  end
+
+  describe '#initialize' do
+    it 'creates a websocket driver with uint8utf8 protocol' do
+      expect(WebSocket::Driver).to receive(:rack).with(
+        anything,
+        hash_including(:protocols => ['uint8utf8'])
+      ).and_return(driver)
+
+      described_class.new(env, sock)
+    end
+  end
+
+  describe '#fetch' do
+    let(:text_data) { "console output text" }
+    let(:websocket_frame) { "websocket_frame_data" }
+
+    before do
+      allow(sock).to receive(:read_nonblock).and_return(websocket_frame)
+      allow(driver).to receive(:parse)
+      allow(driver).to receive(:listeners).with(:message).and_return([])
+    end
+
+    it 'reads from socket and parses through driver' do
+      expect(sock).to receive(:read_nonblock).with(1024).and_return(websocket_frame)
+      expect(driver).to receive(:parse).with(websocket_frame)
+
+      subject.fetch(1024) { |_data| nil }
+    end
+
+    it 'yields data directly from websocket-driver' do
+      # For uint8utf8 protocol, data is used directly without transformation
+      allow(driver).to receive(:on).with(:message) do |&block|
+        msg = double('message', :data => text_data)
+        block.call(msg)
+      end
+
+      yielded_data = nil
+      subject.fetch(1024) { |data| yielded_data = data }
+
+      expect(yielded_data).to eq(text_data)
+    end
+
+    it 'only sets up message callback once' do
+      # First call sets up the callback (listeners returns empty array)
+      allow(driver).to receive(:listeners).with(:message).and_return([])
+      subject.fetch(1024) { |_data| nil }
+
+      # Second call should not set up callback again (listeners returns non-empty array)
+      allow(driver).to receive(:listeners).with(:message).and_return([double])
+      expect(driver).not_to receive(:on).with(:message)
+      subject.fetch(1024) { |_data| nil }
+    end
+  end
+
+  describe '#issue' do
+    it 'sends data through driver frame method' do
+      data = "text to send"
+      expect(driver).to receive(:frame).with(data)
+
+      subject.issue(data)
+    end
+  end
+
+  describe '#write' do
+    it 'writes data to socket' do
+      data = "frame_data"
+      expect(sock).to receive(:write_nonblock).with(data)
+
+      subject.write(data)
+    end
+  end
+end


### PR DESCRIPTION
- 0.8.2
  - https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm
- 0.8.1:
  - CVE-2026-54463: https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-ghhp-3qvg-889p
  - CVE-2026-54464: https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-33ph-fccm-39pj
  - CVE-2026-54465: https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-8j3g-f24p-4mpw

In websocket-driver 0.8.0+, binary messages are emitted as strings with Encoding::BINARY instead of arrays. Remove the .pack('C*') call in WebsocketBinary#fetch since msg.data is already a binary string. Add comprehensive specs for WebsocketBinary and WebsocketUint8Utf8 server adapters to ensure proper handling of the new binary format.

@agrare Please review. This should get the master security suite back to green.

I'm not sure how to test this. websocket-driver is primarily used by the remote consoles (See https://github.com/search?q=org%3AManageIQ+WebSocket%3A%3ADriver&type=code), but the unit tests stub all the interactions with fake drivers. If we know of particular providers that go through this code we could test these.
