### PR TITLE
Temporarily ignore websocket-driver CVEs

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -2,3 +2,7 @@
 ignore:
 - CVE-2026-38969 # TODO: Remove when webrick is released, see: https://github.com/ruby/webrick/issues/198 and https://github.com/ruby/webrick/pull/199; False positive - puma is our configured rails server; webrick is an indirect dev dependency pulled in from: rails → railties → rackup → webrick. It allows running a rails server with a webrick server, which we never do.
 - CVE-2026-54163 # TODO: Remove when secure_headers is upgraded to 7.3.0';
+- CVE-2026-54463 # TODO: Remove when websocket-driver is updated to >=0.8.1
+- CVE-2026-54464 # TODO: Remove when websocket-driver is updated to >=0.8.1
+- CVE-2026-54465 # TODO: Remove when websocket-driver is updated to >=0.8.1
+- GHSA-2x63-gw47-w4mm # TODO: Remove when websocket-driver is updated to >=0.8.2


### PR DESCRIPTION
@agrare Please review. This will get master back to green for now until #23905 is merged.