### PR TITLE
Expand test_ansible_runner_execution to run in GHA

### DIFF
--- a/bin/test_ansible_runner_execution
+++ b/bin/test_ansible_runner_execution
@@ -48,4 +48,9 @@ fi
 
 # Run the tests
 echo -e "\033[1;34mRunning tests...\033[0m"
-exec bats ./spec/lib/ansible/runner_execution_spec.bats
+bats_args=()
+if [ -n "${BATS_FILTER}" ]; then
+    echo -e "\033[1;33mFiltering tests by: ${BATS_FILTER}\033[0m"
+    bats_args+=(--filter "${BATS_FILTER}")
+fi
+exec bats "${bats_args[@]}" ./spec/lib/ansible/runner_execution_spec.bats

--- a/bin/test_ansible_runner_execution
+++ b/bin/test_ansible_runner_execution
@@ -13,6 +13,9 @@ if [ ! -x "$(command -v bats)" ]; then
     if [ "$APPLIANCE" == "true" ]; then
         echo -e "\033[1;34mInstalling bats...\033[0m"
         dnf install -y bats
+    elif [ -n "$CI" ]; then
+        echo -e "\033[1;34mInstalling bats...\033[0m"
+        sudo npm install -g bats
     else
         echo -e "\033[1;31mERROR: Unable to find the bats test framework.\033[0m"
         exit 1

--- a/spec/lib/ansible/runner_execution_spec.bats
+++ b/spec/lib/ansible/runner_execution_spec.bats
@@ -123,7 +123,7 @@ exec_ansible_runner_cli_role() {
 
   run exec_ansible_runner_cli vmware.yml
   assert_failure # We expect to this to fail due to connecting to an unknown vcenter
-  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -'
 }
 
 @test "[ansible-runner] aws collection" {
@@ -195,7 +195,7 @@ exec_ansible_runner_role() {
 
   run exec_ansible_runner vmware.yml
   assert_failure # We expect to this to fail due to connecting to an unknown vcenter
-  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -'
 }
 
 @test "[Ansible::Runner#run] aws collection" {
@@ -267,7 +267,7 @@ exec_ansible_runner_role_async() {
 
   run exec_ansible_runner_async vmware.yml
   assert_failure # We expect to this to fail due to connecting to an unknown vcenter
-  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -2] Name or service not known"'
+  assert_output --partial '"msg": "Unknown error while connecting to the vCenter or ESXi API at vcenter_hostname:443 : [Errno -'
 }
 
 @test "[Ansible::Runner#run_async] aws collection" {


### PR DESCRIPTION
This opens up running the tests in CI, while still preserving running the tests on an appliances.
- Install bats via npm on GHA since it's ubuntu
- Add filtering capability to ansible runner bats tests: This is needed since we may not have the Rails code available, so in those cases we can filter to just the `ansible-runner` CLI based tests.
- Fix vmware collection bats tests on Ubuntu: This is needed because the DNS resolution message from the OS is different. In practice we don't care about the actual message, just that it failed inside of the vmware collection, which is evident by the prefix.

Needed by https://github.com/ManageIQ/manageiq-rpm_build/pull/686 (https://github.com/ManageIQ/manageiq-rpm_build/actions/runs/29032288030/job/86169750013#step:4:783)

@jrafanie Please review.