### PR TITLE
Update secure headers

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,4 +1,3 @@
 ---
 ignore:
 - CVE-2026-38969 # TODO: Remove when webrick is released, see: https://github.com/ruby/webrick/issues/198 and https://github.com/ruby/webrick/pull/199; False positive - puma is our configured rails server; webrick is an indirect dev dependency pulled in from: rails → railties → rackup → webrick. It allows running a rails server with a webrick server, which we never do.
-- CVE-2026-54163 # TODO: Remove when secure_headers is upgraded to 7.3.0';

--- a/Gemfile
+++ b/Gemfile
@@ -287,7 +287,7 @@ end
 group :web_server, :manageiq_default do
   gem "puma",                           "~>8.0", ">=8.0.2"
   gem "ruby-dbus" # For external auth
-  gem "secure_headers",                 "~>5.0"
+  gem "secure_headers",                 "~>6.0"
 end
 
 group :web_socket, :manageiq_default do

--- a/Gemfile
+++ b/Gemfile
@@ -287,7 +287,7 @@ end
 group :web_server, :manageiq_default do
   gem "puma",                           "~>8.0", ">=8.0.2"
   gem "ruby-dbus" # For external auth
-  gem "secure_headers",                 "~>4.0"
+  gem "secure_headers",                 "~>5.0"
 end
 
 group :web_socket, :manageiq_default do

--- a/Gemfile
+++ b/Gemfile
@@ -287,7 +287,7 @@ end
 group :web_server, :manageiq_default do
   gem "puma",                           "~>8.0", ">=8.0.2"
   gem "ruby-dbus" # For external auth
-  gem "secure_headers",                 "~>3.9"
+  gem "secure_headers",                 "~>4.0"
 end
 
 group :web_socket, :manageiq_default do

--- a/Gemfile
+++ b/Gemfile
@@ -287,7 +287,7 @@ end
 group :web_server, :manageiq_default do
   gem "puma",                           "~>8.0", ">=8.0.2"
   gem "ruby-dbus" # For external auth
-  gem "secure_headers",                 "~>7.0"
+  gem "secure_headers",                 "~>7.3"
 end
 
 group :web_socket, :manageiq_default do

--- a/Gemfile
+++ b/Gemfile
@@ -287,7 +287,7 @@ end
 group :web_server, :manageiq_default do
   gem "puma",                           "~>8.0", ">=8.0.2"
   gem "ruby-dbus" # For external auth
-  gem "secure_headers",                 "~>6.0"
+  gem "secure_headers",                 "~>7.0"
 end
 
 group :web_socket, :manageiq_default do

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -36,6 +36,9 @@ if defined?(SecureHeaders)
     # Need google fonts in fonts_src for https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed%7CIBM+Plex+Sans:400,600&display=swap (For carbon-charts download)
     config.csp = {
       :report_uri  => ["/dashboard/csp_report"],
+      # report-to satisfies scanners that flag report-uri as deprecated. Browsers fall back to
+      # report-uri until a Reporting-Endpoints header is wired up (follow-up in Apache configs).
+      :report_to   => "csp-endpoint",
 
       :base_uri        => ["'self'"],
       :default_src     => ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -12,8 +12,11 @@ if defined?(SecureHeaders)
     # Note: ws_token (ActionCable auth) is set by JavaScript via document.cookie
     # and is not subject to this middleware, so it is unaffected either way.
     config.cookies = SecureHeaders::OPT_OUT
-    # Only set HSTS in development/test where Apache isn't fronting Rails
-    # In production, Apache sets HSTS (see manageiq-https-application.conf line 15)
+    # Only set HSTS in development/test where Apache isn't fronting Rails.
+    # In production, Apache sets HSTS at VirtualHost level in all three configs:
+    #   manageiq-appliance: manageiq-https-application.conf
+    #   manageiq-pods: httpdApplicationConf (ingress proxy) and uiHttpdConfig (UI pod)
+    #   product: oidcutils/httpd.go
     config.hsts = Rails.env.production? ? SecureHeaders::OPT_OUT : "max-age=#{20.years.to_i}"
     # X-Frame-Options
     config.x_frame_options = 'SAMEORIGIN'

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -30,7 +30,6 @@ if defined?(SecureHeaders)
 
       :base_uri        => ["'self'"],
       :default_src     => ["'self'"],
-      :child_src       => ["'self'"],
       :connect_src     => ["'self'"],
       :font_src        => ["'self'", 'https://fonts.gstatic.com', "https://fonts.googleapis.com"],
       :form_action     => ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -26,7 +26,6 @@ if defined?(SecureHeaders)
     # Content-Security-Policy
     # Need google fonts in fonts_src for https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed%7CIBM+Plex+Sans:400,600&display=swap (For carbon-charts download)
     config.csp = {
-      :report_only => false,
       :report_uri  => ["/dashboard/csp_report"],
 
       :base_uri        => ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -36,8 +36,9 @@ if defined?(SecureHeaders)
     # Need google fonts in fonts_src for https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed%7CIBM+Plex+Sans:400,600&display=swap (For carbon-charts download)
     config.csp = {
       :report_uri  => ["/dashboard/csp_report"],
-      # report-to satisfies scanners that flag report-uri as deprecated. Browsers fall back to
-      # report-uri until a Reporting-Endpoints header is wired up (follow-up in Apache configs).
+      # report-to enables modern structured CSP reporting. Browsers that support the Reporting API
+      # use this; others fall back to report-uri. The Reporting-Endpoints header that names
+      # csp-endpoint is set by Apache (see manageiq-appliance and manageiq-pods httpd configs).
       :report_to   => "csp-endpoint",
 
       :base_uri        => ["'self'"],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -3,6 +3,15 @@ if defined?(SecureHeaders)
   # - https://github.com/ManageIQ/manageiq-appliance/blob/master/COPY/etc/httpd/conf.d/manageiq-https-application.conf
   # - https://github.com/ManageIQ/manageiq-pods/blob/master/manageiq-operator/pkg/helpers/miq-components/httpd_conf.go
   SecureHeaders::Configuration.default do |config|
+    # Opt out of secure_headers cookie middleware - we manage session cookie
+    # security ourselves via ManageIQ::Session::AbstractStoreAdapter#session_options:
+    #   same_site: :strict  (always)
+    #   secure:    true     (appliance only, unless ALLOW_INSECURE_SESSION)
+    #   httponly:  true     (appliance only)
+    # The gem's SameSite=Lax default is weaker than our Strict setting.
+    # Note: ws_token (ActionCable auth) is set by JavaScript via document.cookie
+    # and is not subject to this middleware, so it is unaffected either way.
+    config.cookies = SecureHeaders::OPT_OUT
     # Only set HSTS in development/test where Apache isn't fronting Rails
     # In production, Apache sets HSTS (see manageiq-https-application.conf line 15)
     config.hsts = Rails.env.production? ? SecureHeaders::OPT_OUT : "max-age=#{20.years.to_i}"


### PR DESCRIPTION
* Upgrade secure_headers from 3.9 to 7.3+ with documented changes along the way (CP4AIOPS-31126)
* Adds report-to to silence the report-uri deprecation warning from security
scanners. Browsers fall back to report-uri for actual violation delivery
until Reporting-Endpoints is wired up in the Apache configs. (CP4AIOPS-31150)
* Update HSTS comment to reflect all three Apache configs (CP4AIOPS-447)

Fixes https://github.com/ManageIQ/manageiq/issues/23891

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
