### PR TITLE
Fix relationship_save_block clearing EMS -> root_folder

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -236,19 +236,6 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
-        def root_folder_relationship
-          skip_auto_inventory_attributes
-          skip_model_class
-
-          add_properties(
-            :custom_save_block => root_folder_relationship_save_block
-          )
-
-          add_dependency_attributes(
-            :ems_folders => [persister.collections[:ems_folders]]
-          )
-        end
-
         def parent_blue_folders
           skip_auto_inventory_attributes
           skip_model_class
@@ -282,20 +269,6 @@ module ManageIQ::Providers
         end
 
         private
-
-        def root_folder_relationship_save_block
-          lambda do |ems, inventory_collection|
-            folder_inv_collection = inventory_collection.dependency_attributes[:ems_folders]&.first
-            return if folder_inv_collection.nil?
-
-            # All folders must have a parent except for the root folder
-            root_folder_obj = folder_inv_collection.data.detect { |obj| obj.data[:parent].nil? }
-            return if root_folder_obj.nil?
-
-            root_folder = folder_inv_collection.model_class.find(root_folder_obj.id)
-            root_folder.with_relationship_type(:ems_metadata) { root_folder.parent = ems }
-          end
-        end
 
         def vm_template_infra_shared_properties
           add_inventory_attributes(%i[resource_pool])

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -38,13 +38,16 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     end
 
     def ext_management_system
-      skip_model_class
-
       add_properties(
         :manager_ref       => %i[guid],
+        :model_class       => ExtManagementSystem,
         :custom_save_block => lambda do |ems, inventory_collection|
-          ems_attrs = inventory_collection.data.first&.attributes
-          ems.update!(ems_attrs) if ems_attrs
+          inventory_object = inventory_collection.data.first
+          if inventory_object
+            ems_attrs = inventory_object.attributes
+            ems.update!(ems_attrs) if ems_attrs.present?
+            inventory_object.id = ems.id
+          end
         end
       )
     end
@@ -246,7 +249,6 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
             next unless obj.data.key?(relationship_key)
 
             parent = obj.data[relationship_key].try(&:load)
-
             if parent.nil?
               parent_by_child[collection.model_class][obj.id] = nil
             else


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/23888 introduced the ability for the `relationship_save_block` to clear a relationship if the value at the `relationship_key` (e.g. `:parent`) was `nil`.  Previously these were simply skipped.

This introduced an issue specifically with the "root folder" in a number of infrastructure providers due to the `parent` being split across two separate inventory collections.

The issue was that the root folder would eventually be added as a child of the `ExtManagementSystem` in the `root_folder_relationship` inventory collection, but the `root_folder.parent` was `nil` in the `parent_blue_folders` inventory collection.

This caused the `parent_blue_folders` inventory collection to see the `nil` parent and process that as a removal and call `ext_management_system.remove_children([root_folder])`.

Instead of setting adding the root folder to the EMS in its own inventory collection we can simply set the parent to the EMS in the same manner as the rest of the folder parents.  When this was originally written this was impractical because we didn't have an `ext_management_system` inventory collection, but since then this has been added in order to set attributes on the EMS like the `:api_version` so we can use this to reference the EMS in a way that `InventoryRefresh` understands.

Failing providers:
* [Nutanix](https://github.com/ManageIQ/manageiq-providers-nutanix/actions/runs/28991972010)
* [Ovirt](https://github.com/ManageIQ/manageiq-providers-ovirt/actions/runs/28992309395)
* [RHV](https://github.com/ManageIQ/manageiq-providers-red_hat_virtualization/actions/runs/28988432704)
* [SCVMM](https://github.com/ManageIQ/manageiq-providers-scvmm/actions/runs/28992397188)
* [VMware](https://github.com/ManageIQ/manageiq-providers-vmware/actions/runs/28990220388)


Dependents:
* https://github.com/ManageIQ/manageiq-providers-nutanix/pull/47
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/709
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/979
* https://github.com/ManageIQ/manageiq-providers-scvmm/pull/231

Alternative to: https://github.com/ManageIQ/manageiq/pull/23906
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
