### PR TITLE
Replace Automation Manager strings with Automation Provider

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::EmbeddedAnsible::Provider < Provider
 
   def ensure_managers
     build_automation_manager unless automation_manager
-    automation_manager.name = _("%{name} Automation Provider") % {:name => name}
+    automation_manager.name = _("%{name} Automation Manager") % {:name => name}
     if zone_id_changed?
       automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
       automation_manager.zone_id = zone_id

--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::EmbeddedAnsible::Provider < Provider
 
   def ensure_managers
     build_automation_manager unless automation_manager
-    automation_manager.name = _("%{name} Automation Manager") % {:name => name}
+    automation_manager.name = _("%{name} Automation Provider") % {:name => name}
     if zone_id_changed?
       automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
       automation_manager.zone_id = zone_id

--- a/app/models/miq_provision_configuration_script_request.rb
+++ b/app/models/miq_provision_configuration_script_request.rb
@@ -1,7 +1,7 @@
 class MiqProvisionConfigurationScriptRequest < MiqRequest
   delegate :my_zone, :to => :source
 
-  TASK_DESCRIPTION  = N_('Automation Manager Provisioning')
+  TASK_DESCRIPTION  = N_('Automation Provider Provisioning')
   SOURCE_CLASS_NAME = 'ConfigurationScript'
 
   default_value_for(:source_id)   { |r| r.get_option(:src_configuration_script_id) }

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -82,7 +82,7 @@ class MiqRequest < ApplicationRecord
         :provision_via_foreman => N_("%{config_mgr_type} Provision") % {:config_mgr_type => ui_lookup(:ui_title => 'foreman')}
       },
       :MiqProvisionConfigurationScriptRequest => {
-        :provision_via_automation_manager => N_("Automation Manager Provision")
+        :provision_via_automation_manager => N_("Automation Provider Provision")
       },
       :MiqProvisionRequest                 => {
         :template          => N_("VM Provision"),

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5128,9 +5128,9 @@
       :feature_type: control
       :identifier: configured_system_console
 
-# Embedded Automation Manager
-- :name: Embedded Automation Manager
-  :description: Everything under Automation Manager
+# Embedded Automation Provider
+- :name: Embedded Automation Provider
+  :description: Everything under Automation Provider
   :feature_type: node
   :identifier: embedded_automation_manager
   :children:
@@ -5161,11 +5161,11 @@
         :feature_type: admin
         :identifier: embedded_configuration_script_source_delete
       - :name: Refresh Repositories
-        :description: Automation Manager Repositories Refresh
+        :description: Automation Provider Repositories Refresh
         :feature_type: control
         :identifier: embedded_configuration_script_source_refresh
       - :name: Edit Tags
-        :description: Edit Tags for the selected Automation Manager Repositories
+        :description: Edit Tags for the selected Automation Provider Repositories
         :feature_type: control
         :identifier: embedded_configuration_script_source_tag
   - :name: Configuration Scripts
@@ -5234,11 +5234,11 @@
         :feature_type: control
         :identifier: embedded_automation_manager_credentials_refresh
       - :name: Edit Tags
-        :description: Edit Tags for the selected Automation Manager Credentials
+        :description: Edit Tags for the selected Automation Provider Credentials
         :feature_type: control
         :identifier: embedded_automation_manager_credential_tag
 
-# Automation Manager
+# Automation Provider
 - :name: Ansible Tower
   :description: Everything under Providers
   :feature_type: node

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1455,9 +1455,9 @@ en:
       LdapRegion:                     LDAP Region
       LdapServer:                     LDAP Server
       LoadBalancer:                   Load Balancer
-      ManageIQ::Providers::AutomationManager:                                             Automation Manager
+      ManageIQ::Providers::AutomationManager:                                             Automation Provider
       ManageIQ::Providers::BaseManager:                                                   Provider
-      ManageIQ::Providers::EmbeddedAutomationManager:                                     Embedded Automation Manager
+      ManageIQ::Providers::EmbeddedAutomationManager:                                     Embedded Automation Provider
       ManageIQ::Providers::EmbeddedAutomationManager::Authentication:                     Credential
       ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource:          Repository
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential:          Credential (Amazon)
@@ -1480,7 +1480,7 @@ en:
       ManageIQ::Providers::Workflows::AutomationManager::Credential:                      Credential (Embedded Workflows)
       ManageIQ::Providers::Workflows::AutomationManager::ScmCredential:                   Credential (SCM)
       ManageIQ::Providers::Workflows::AutomationManager::WorkflowCredential:              Credential (Workflow)
-      ManageIQ::Providers::ExternalAutomationManager:                                     Automation Manager
+      ManageIQ::Providers::ExternalAutomationManager:                                     Automation Provider
       ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript:                Template
       ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack:                 Automation Job
       ManageIQ::Providers::AutomationManager::Authentication:                             Credential
@@ -1494,7 +1494,7 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential:         Credential (Satellite)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential:                Credential (SCM)
       ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential:             Credential (VMware)
-      ManageIQ::Providers::AnsibleTower::AutomationManager:                               Automation Manager (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::AutomationManager:                               Automation Provider (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript:          Job Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow:        Workflow Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook:                     Playbook (Ansible Tower)
@@ -1509,7 +1509,7 @@ en:
       ManageIQ::Providers::Awx::AutomationManager::Satellite6Credential:                  Credential (Satellite)
       ManageIQ::Providers::Awx::AutomationManager::ScmCredential:                         Credential (SCM)
       ManageIQ::Providers::Awx::AutomationManager::VmwareCredential:                      Credential (VMware)
-      ManageIQ::Providers::Awx::AutomationManager:                                        Automation Manager (AWX)
+      ManageIQ::Providers::Awx::AutomationManager:                                        Automation Provider (AWX)
       ManageIQ::Providers::Awx::AutomationManager::ConfigurationScript:                   Job Template (AWX)
       ManageIQ::Providers::Awx::AutomationManager::ConfigurationWorkflow:                 Workflow Template (AWX)
       ManageIQ::Providers::Awx::AutomationManager::Playbook:                              Playbook (AWX)
@@ -1759,8 +1759,8 @@ en:
       container_templates:         Templates
       custom_button:               Button
       custom_button_set:           Button Group
-      ems_automation:              Automation Manager
-      ems_automations:             Automation Managers
+      ems_automation:              Automation Provider
+      ems_automations:             Automation Providers
       ems_block_storage:           Block Storage Manager
       ems_block_storages:          Block Storage Managers
       ems_cloud:                   Cloud Provider

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MiqRequest do
         :ServiceRetireRequest                           => {:service_retire                   => "Service Retire"},
         :OrchestrationStackRetireRequest                => {:orchestration_stack_retire       => "Orchestration Stack Retire"},
         :AutomationRequest                              => {:automation                       => "Automation"},
-        :MiqProvisionConfigurationScriptRequest         => {:provision_via_automation_manager => "Automation Manager Provision"},
+        :MiqProvisionConfigurationScriptRequest         => {:provision_via_automation_manager => "Automation Provider Provision"},
         :MiqProvisionConfigurationScriptRequestTemplate => {:provision_via_automation_manager => "Configuration Script Template"},
         :ServiceTemplateProvisionRequest                => {:clone_to_service                 => "Service Provision"},
         :ServiceReconfigureRequest                      => {:service_reconfigure              => "Service Reconfigure"},


### PR DESCRIPTION
Replace Automation Manager strings with Automation Provider

Relevant PRs:
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10162
- https://github.com/ManageIQ/manageiq-ui-service/pull/2110
- https://github.com/ManageIQ/manageiq-content/pull/793
- https://github.com/ManageIQ/manageiq-documentation/pull/1905
- https://github.com/ManageIQ/manageiq-providers-awx/pull/65
- https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/344
- https://github.com/ManageIQ/manageiq-api-client/pull/165