### PR TITLE
Retry messaging health check before restarting the server

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -620,9 +620,9 @@ class MiqServer < ApplicationRecord
     broker = MiqQueue.messaging_client("health_check")
     return if broker.nil?
 
-    # CALO-PATCH-MSG-HEALTH-RETRY: tolerate transient broker transport blips before bouncing evm
+    # tolerate transient broker transport blips before bouncing evm
     max_attempts = 3
-    retry_delay = 2  # seconds
+    retry_delay = 2 # seconds
     attempts = 0
 
     begin
@@ -638,7 +638,11 @@ class MiqServer < ApplicationRecord
         shutdown_and_exit(1)
       end
     ensure
-      broker.close rescue nil
+      begin
+        broker.close
+      rescue
+        nil
+      end
     end
   end
 end # class MiqServer

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -620,14 +620,25 @@ class MiqServer < ApplicationRecord
     broker = MiqQueue.messaging_client("health_check")
     return if broker.nil?
 
+    # CALO-PATCH-MSG-HEALTH-RETRY: tolerate transient broker transport blips before bouncing evm
+    max_attempts = 3
+    retry_delay = 2  # seconds
+    attempts = 0
+
     begin
-      # Fail health check if list of topics can't be retrieved
       broker.topics
     rescue => err
-      _log.error("Messaging health check failed: #{err}")
-      shutdown_and_exit(1)
+      attempts += 1
+      if attempts < max_attempts
+        _log.warn("Messaging health check attempt #{attempts}/#{max_attempts} failed: #{err}. Retrying in #{retry_delay}s...")
+        sleep(retry_delay)
+        retry
+      else
+        _log.error("Messaging health check failed after #{max_attempts} attempts: #{err}")
+        shutdown_and_exit(1)
+      end
     ensure
-      broker.close
+      broker.close rescue nil
     end
   end
 end # class MiqServer

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -621,8 +621,8 @@ class MiqServer < ApplicationRecord
     return if broker.nil?
 
     # tolerate transient broker transport blips before bouncing evm
-    max_attempts = 3
-    retry_delay = 2 # seconds
+    max_attempts = ::Settings.server.server_messaging_max_attempts
+    retry_delay = ::Settings.server.server_messaging_retry_delay # seconds
     attempts = 0
 
     begin

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -622,7 +622,7 @@ class MiqServer < ApplicationRecord
 
     # tolerate transient broker transport blips before bouncing evm
     max_attempts = ::Settings.server.server_messaging_max_attempts
-    retry_delay = ::Settings.server.server_messaging_retry_delay # seconds
+    retry_delay = ::Settings.server.server_messaging_retry_delay.to_i_with_method
     attempts = 0
 
     begin

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -939,7 +939,7 @@
   :server_log_frequency: 5.minutes
   :server_log_timings_threshold: 1.second
   :server_messaging_max_attempts: 3
-  :server_messaging_retry_delay: 2 # seconds
+  :server_messaging_retry_delay: 2.seconds
   :server_monitor_frequency: 60.seconds
   :server_role_monitor_frequency: 15.seconds
   :session_store: cache

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -938,6 +938,8 @@
   :server_dequeue_frequency: 5.seconds
   :server_log_frequency: 5.minutes
   :server_log_timings_threshold: 1.second
+  :server_messaging_max_attempts: 3
+  :server_messaging_retry_delay: 2 # seconds
   :server_monitor_frequency: 60.seconds
   :server_role_monitor_frequency: 15.seconds
   :session_store: cache

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -419,4 +419,84 @@ RSpec.describe MiqServer do
       expect(described_class.audit_details).to include(:vms => 1, :hosts => 1, :services => {:active => 1, :inactive => 1}, :service_catalog_items => {:active => 1, :archived => 1})
     end
   end
+
+  describe "#messaging_health_check" do
+    let(:broker)     { double("broker") }
+    let(:miq_server) { FactoryBot.create(:miq_server) }
+
+    context "when broker is nil" do
+      before { allow(MiqQueue).to receive(:messaging_client).with("health_check").and_return(nil) }
+
+      it "returns early without error" do
+        expect(miq_server).not_to receive(:shutdown_and_exit)
+        expect { miq_server.send(:messaging_health_check) }.not_to raise_error
+      end
+    end
+
+    context "when broker is available" do
+      before do
+        allow(MiqQueue).to receive(:messaging_client).with("health_check").and_return(broker)
+      end
+
+      it "succeeds on first attempt and closes broker" do
+        expect(broker).to receive(:topics).once
+        expect(broker).to receive(:close).once
+        expect(miq_server).not_to receive(:shutdown_and_exit)
+
+        miq_server.send(:messaging_health_check)
+      end
+
+      it "retries on failure and succeeds on second attempt" do
+        call_count = 0
+        allow(broker).to receive(:topics) do
+          call_count += 1
+          raise "Connection error" if call_count == 1
+        end
+
+        expect(broker).to receive(:close).once
+        expect(miq_server).not_to receive(:shutdown_and_exit)
+        expect(miq_server).to receive(:sleep).with(2).once
+
+        miq_server.send(:messaging_health_check)
+      end
+
+      it "retries on failure and succeeds on third attempt" do
+        call_count = 0
+        allow(broker).to receive(:topics) do
+          call_count += 1
+          raise "connection error" if call_count < 3
+        end
+        expect(broker).to receive(:close).once
+        expect(miq_server).not_to receive(:shutdown_and_exit)
+        expect(miq_server).to receive(:sleep).with(2).twice
+
+        miq_server.send(:messaging_health_check)
+      end
+
+      it "shuts down after max retry attempts" do
+        allow(broker).to receive(:topics).and_raise("Connection error")
+        expect(broker).to receive(:close).once
+        expect(miq_server).to receive(:shutdown_and_exit).with(1)
+        expect(miq_server).to receive(:sleep).with(2).twice
+
+        miq_server.send(:messaging_health_check)
+      end
+
+      it "ignores errors when closing broker" do
+        allow(broker).to receive(:topics)
+        allow(broker).to receive(:close).and_raise("Close error")
+
+        expect { miq_server.send(:messaging_health_check) }.not_to raise_error
+      end
+
+      it "closes broker even when topics raises error" do
+        allow(broker).to receive(:topics).and_raise("Connection error")
+        expect(broker).to receive(:close).once
+        allow(miq_server).to receive(:shutdown_and_exit)
+        allow(miq_server).to receive(:sleep)
+
+        miq_server.send(:messaging_health_check)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What this PR does

`MiqServer#messaging_health_check` currently makes a single `broker.topics` call and, on **any** exception, immediately calls `shutdown_and_exit(1)`, which exits the server process and restarts `evm`. A momentary broker transport blip (e.g. a brief Kafka broker/network interruption that clears within seconds) is therefore indistinguishable from a sustained outage and forces a full `evm` restart — bouncing all workers and disrupting in-flight work. In practice this bounces `evm` a couple of times per day with no underlying broker outage.

This PR wraps the `broker.topics` check in a bounded retry with backoff (3 attempts, 2s apart) and only calls `shutdown_and_exit(1)` after the final attempt fails, so transient blips are tolerated while a genuinely unreachable broker still triggers a restart. It also makes the `ensure` close defensive (`broker.close rescue nil`) so a close failure on an already-broken transport can't mask the original error.

**Before:** one failed `broker.topics` on any monitor cycle → `shutdown_and_exit(1)` → `evm` restart.
**After:** up to 3 attempts (~4s of tolerance) → server only restarts if all consecutive attempts fail.

We have been running this patch and it eliminates the transient-blip restarts while still restarting on a sustained broker outage.

Fixes #23919 

@miq-bot add-label enhancement
@miq-bot add-reviewer @agrare