### PR TITLE
Delete c3 chart local

### DIFF
--- a/lib/manageiq/reporting/formatter/c3_helper.rb
+++ b/lib/manageiq/reporting/formatter/c3_helper.rb
@@ -16,16 +16,6 @@ module ManageIQ
             EOJ
         end
 
-        def c3chart_local(data, opts = {})
-          chart_id = opts[:id] || ('chart' + rand(10**8).to_s)
-
-          content_tag(:div, '', :id => chart_id) +
-            javascript_tag(<<~EOJ)
-              var data = #{data.to_json};
-              var chart = c3.generate(chartData('#{data[:miqChart]}', data, { bindto: "##{chart_id}" }));
-              ManageIQ.charts.c3["#{chart_id}"] = chart;
-            EOJ
-        end
       end
     end
   end


### PR DESCRIPTION
Deleting the c3chart_local function as it is not needed as a follow up to this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/9969