### PR TITLE
Remove redundant X-XSS-Protection default_headers entry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -118,9 +118,6 @@ module Vmdb
     # See for probable culprit https://www.github.com/rails/rails/pull/47747
     config.active_record.marshalling_format_version = 6.1
 
-    # TODO: this is the only change we had from defaults in 7.0.  See secure_headers.rb.  It's 0 in defaults.
-    config.action_dispatch.default_headers["X-XSS-Protection"] = "1; mode=block"
-
     # TODO: If disabled, causes cross repo test failures in content, ui-classic and amazon provider
     config.active_record.partial_inserts = true
 


### PR DESCRIPTION
#23912 upgraded secure_headers to v7.x. Since v7.1.0, secure_headers lowercases all emitted header names. Its Railtie also explicitly strips any conflicting key from action_dispatch.default_headers by downcasing each key and deleting it if it matches one of its own header names -- so the title-case "X-XSS-Protection" entry was already being silently deleted on every boot before it could reach any response.

The header is already set correctly via `config.x_xss_protection` in config/initializers/secure_headers.rb.

Related to https://www.github.com/github/secure_headers/pull/533
Followup to #23912

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
