### PR TITLE
Allow provider override of MiqRetireRequest

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -442,6 +442,14 @@ class ExtManagementSystem < ApplicationRecord
     self::ProvisionWorkflow
   end
 
+  def self.vm_retire_task_class
+    VmRetireTask
+  end
+
+  def self.orchestration_stack_retire_task_class
+    OrchestrationStackRetireTask
+  end
+
   BELONGS_TO_DESCENDANTS_CLASSES_BY_NAME = {
     'Network Manager' => 'ManageIQ::Providers::NetworkManager'
   }.freeze

--- a/app/models/miq_retire_request.rb
+++ b/app/models/miq_retire_request.rb
@@ -6,4 +6,39 @@ class MiqRetireRequest < MiqRequest
 
   def my_zone
   end
+
+  # Provider-specific task class support
+  def self.request_task_class_from(attribs)
+    source_id = MiqRequestMixin.get_option(:src_ids, nil, attribs["options"])
+    source    = find_source!(source_id)
+    ems_retire_task_class(source) || request_task_class
+  end
+
+  def self.new_request_task(attribs)
+    klass = request_task_class_from(attribs)
+    klass.new(attribs)
+  end
+
+  private_class_method def self.find_source!(source_id)
+    source_class = self::SOURCE_CLASS_NAME.constantize
+    source       = source_class.find_by(:id => source_id)
+    raise "Unable to find #{source_class.name} with id [#{source_id}]" if source.nil?
+
+    source
+  end
+
+  private_class_method def self.ems_retire_task_class(source)
+    ems = source.ext_management_system
+    return nil unless ems
+
+    ems.class.try(retire_task_class_method_name)
+  end
+
+  private_class_method def self.retire_task_class_method_name
+    # Convert source class name to method name
+    # Vm -> vm_retire_task_class
+    # OrchestrationStack -> orchestration_stack_retire_task_class
+    source_class_name = self::SOURCE_CLASS_NAME.underscore
+    "#{source_class_name}_retire_task_class"
+  end
 end

--- a/app/models/orchestration_stack_retire_task.rb
+++ b/app/models/orchestration_stack_retire_task.rb
@@ -11,6 +11,10 @@ class OrchestrationStackRetireTask < MiqRetireTask
     OrchestrationStackRetireTask
   end
 
+  def self.request_class
+    OrchestrationStackRetireRequest
+  end
+
   def self.model_being_retired
     OrchestrationStack
   end

--- a/app/models/service_retire_request.rb
+++ b/app/models/service_retire_request.rb
@@ -4,4 +4,8 @@ class ServiceRetireRequest < MiqRetireRequest
   ACTIVE_STATES     = %w[retired] + base_class::ACTIVE_STATES
 
   delegate :service_template, :to => :source, :allow_nil => true
+
+  def self.request_task_class_from(_attribs)
+    request_task_class
+  end
 end

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -112,7 +112,7 @@ class ServiceRetireTask < MiqRetireTask
   end
 
   def default_retire_task_class(resource_type)
-    (resource_type.base_class.name + "RetireTask").safe_constantize || (resource_type.name.demodulize + "RetireTask").safe_constantize
+    "#{resource_type.base_class.name}RetireTask".safe_constantize || "#{resource_type.name.demodulize}RetireTask".safe_constantize
   end
 
   def derive_request_type(task_type)

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -9,6 +9,10 @@ class ServiceRetireTask < MiqRetireTask
     Service
   end
 
+  def self.request_class
+    ServiceRetireRequest
+  end
+
   def update_and_notify_parent(*args)
     prev_state = state
     super
@@ -56,7 +60,7 @@ class ServiceRetireTask < MiqRetireTask
   end
 
   def create_task(svc_rsc, parent_service, nh, parent_task)
-    task_type = retire_task_type(svc_rsc.resource.class)
+    task_type = retire_task_type(svc_rsc.resource)
     task_type.new(nh).tap do |task|
       task.options.merge!(
         :src_ids             => [svc_rsc.resource.id],
@@ -68,7 +72,7 @@ class ServiceRetireTask < MiqRetireTask
       workflow_id = parent_service.retirement_resource_action&.configuration_script_id
       task.options[:configuration_script_payload_id] = workflow_id if workflow_id
 
-      task.request_type = task_type.name.underscore[0..-6]
+      task.request_type = derive_request_type(task_type)
       task.source       = svc_rsc.resource
 
       parent_task.miq_request_tasks << task
@@ -83,7 +87,41 @@ class ServiceRetireTask < MiqRetireTask
     !parent_svc.try(:retain_resources_on_retirement?)
   end
 
-  def retire_task_type(resource_type)
+  def retire_task_type(resource)
+    ems_retire_task_class(resource) || default_retire_task_class(resource.class)
+  end
+
+  def ems_retire_task_class(resource)
+    return nil unless resource.respond_to?(:ext_management_system)
+
+    ems = resource.ext_management_system
+    return nil unless ems
+
+    # Call the appropriate EMS method based on resource type
+    method_name = retire_task_class_method_name(resource.class)
+
+    ems.class.send(method_name)
+  end
+
+  def retire_task_class_method_name(resource_type)
+    # Convert resource class name to method name
+    # Vm -> vm_retire_task_class
+    # OrchestrationStack -> orchestration_stack_retire_task_class
+    resource_class_name = resource_type.base_model.name.underscore
+    "#{resource_class_name}_retire_task_class"
+  end
+
+  def default_retire_task_class(resource_type)
     (resource_type.base_class.name + "RetireTask").safe_constantize || (resource_type.name.demodulize + "RetireTask").safe_constantize
+  end
+
+  def derive_request_type(task_type)
+    # For provider-specific task classes, use the base model's request_type
+    # e.g., ManageIQ::Providers::EmbeddedTerraform::AutomationManager::Retire -> orchestration_stack_retire
+    if task_type.respond_to?(:base_model) && task_type.base_model != task_type
+      task_type.base_model.name.underscore[0..-6]
+    else
+      task_type.name.underscore[0..-6]
+    end
   end
 end

--- a/app/models/vm_retire_task.rb
+++ b/app/models/vm_retire_task.rb
@@ -15,6 +15,10 @@ class VmRetireTask < MiqRetireTask
     VmRetireTask
   end
 
+  def self.request_class
+    VmRetireRequest
+  end
+
   def self.model_being_retired
     Vm
   end

--- a/spec/models/miq_retire_request_spec.rb
+++ b/spec/models/miq_retire_request_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe MiqRetireRequest do
+  let!(:ems)     { FactoryBot.create(:ems_vmware) }
+  let!(:vm)      { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+  let!(:service) { FactoryBot.create(:service) }
+
+  describe ".request_task_class_from" do
+    context "when source has no EMS" do
+      let(:request_class) { ServiceRetireRequest }
+
+      it "returns the default task class" do
+        attribs = {'options' => {:src_ids => [service.id]}}
+        expect(request_class.request_task_class_from(attribs)).to eq(ServiceRetireTask)
+      end
+    end
+
+    context "when source has EMS with custom task class" do
+      let(:request_class)     { VmRetireRequest }
+      let(:custom_task_class) { Class.new(VmRetireTask) }
+
+      before do
+        stub_const("ManageIQ::Providers::InfraManager::Retire", custom_task_class)
+        allow(ems.class).to receive(:vm_retire_task_class).and_return(custom_task_class)
+      end
+
+      it "returns the custom task class from the EMS" do
+        attribs = {'options' => {:src_ids => [vm.id]}}
+        expect(request_class.request_task_class_from(attribs)).to eq(ManageIQ::Providers::InfraManager::Retire)
+      end
+    end
+
+    context "when source is not found" do
+      let(:request_class) { VmRetireRequest }
+
+      it "raises an exception" do
+        attribs = {'options' => {:src_ids => [-1]}}
+        expect { request_class.request_task_class_from(attribs) }
+          .to raise_error(RuntimeError, /Unable to find Vm/)
+      end
+    end
+
+    context "with src_ids option" do
+      let(:request_class) { VmRetireRequest }
+
+      it "handles src_ids option" do
+        attribs = {'options' => {:src_ids => [vm.id]}}
+        expect { request_class.request_task_class_from(attribs) }.not_to raise_error
+      end
+    end
+  end
+
+  describe ".new_request_task" do
+    let(:request_class) { VmRetireRequest }
+
+    it "creates a task with the correct class" do
+      attribs = {
+        'options'     => {:src_ids => [vm.id]},
+        'source_id'   => vm.id,
+        'source_type' => 'Vm'
+      }
+
+      task = request_class.new_request_task(attribs)
+      expect(task).to be_a(VmRetireTask)
+      expect(task.source_id).to eq(vm.id)
+    end
+  end
+end

--- a/spec/models/orchestration_stack_retire_request_spec.rb
+++ b/spec/models/orchestration_stack_retire_request_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe OrchestrationStackRetireRequest do
+  let(:ems) { FactoryBot.create(:ems_openstack) }
+  let(:stack) { FactoryBot.create(:orchestration_stack_openstack, :ext_management_system => ems) }
+
+  describe ".request_task_class_from" do
+    context "with default EMS" do
+      it "returns OrchestrationStackRetireTask" do
+        attribs = {'options' => {:src_ids => [stack.id]}}
+        expect(described_class.request_task_class_from(attribs)).to eq(OrchestrationStackRetireTask)
+      end
+    end
+
+    context "with custom EMS retire task class" do
+      let(:custom_task_class) { Class.new(OrchestrationStackRetireTask) }
+
+      before do
+        allow(ems.class).to receive(:orchestration_stack_retire_task_class).and_return(custom_task_class)
+      end
+
+      it "returns the custom task class" do
+        attribs = {'options' => {:src_ids => [stack.id]}}
+        expect(described_class.request_task_class_from(attribs)).to eq(custom_task_class)
+      end
+    end
+
+    context "with stack that has no EMS" do
+      let(:stack_no_ems) { FactoryBot.create(:orchestration_stack, :ext_management_system => nil) }
+
+      it "returns OrchestrationStackRetireTask" do
+        attribs = {'options' => {:src_ids => [stack_no_ems.id]}}
+        expect(described_class.request_task_class_from(attribs)).to eq(OrchestrationStackRetireTask)
+      end
+    end
+
+    context "with src_ids option" do
+      it "handles src_ids option" do
+        attribs = {'options' => {:src_ids => [stack.id]}}
+        expect { described_class.request_task_class_from(attribs) }.not_to raise_error
+        expect(described_class.request_task_class_from(attribs)).to eq(OrchestrationStackRetireTask)
+      end
+    end
+
+    context "when stack is not found" do
+      it "raises an exception" do
+        attribs = {'options' => {:src_ids => [-1]}}
+        expect { described_class.request_task_class_from(attribs) }
+          .to raise_error(RuntimeError, /Unable to find OrchestrationStack/)
+      end
+    end
+  end
+
+  describe ".new_request_task" do
+    it "creates a task with the correct class" do
+      attribs = {
+        'options'     => {:src_ids => [stack.id]},
+        'source_id'   => stack.id,
+        'source_type' => 'OrchestrationStack'
+      }
+
+      task = described_class.new_request_task(attribs)
+      expect(task).to be_a(OrchestrationStackRetireTask)
+      expect(task.source_id).to eq(stack.id)
+    end
+
+    context "with custom EMS retire task class" do
+      let(:custom_task_class) { Class.new(OrchestrationStackRetireTask) }
+
+      before do
+        allow(ems.class).to receive(:orchestration_stack_retire_task_class).and_return(custom_task_class)
+      end
+
+      it "creates a task with the custom class" do
+        attribs = {
+          'options'     => {:src_ids => [stack.id]},
+          'source_id'   => stack.id,
+          'source_type' => 'OrchestrationStack'
+        }
+
+        task = described_class.new_request_task(attribs)
+        expect(task).to be_a(custom_task_class)
+        expect(task.source_id).to eq(stack.id)
+      end
+    end
+  end
+end

--- a/spec/models/service_retire_request_spec.rb
+++ b/spec/models/service_retire_request_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe ServiceRetireRequest do
+  let!(:service) { FactoryBot.create(:service) }
+
+  describe ".request_task_class_from" do
+    it "returns ServiceRetireTask (no EMS support)" do
+      attribs = {'options' => {:src_ids => [service.id]}}
+      expect(described_class.request_task_class_from(attribs)).to eq(ServiceRetireTask)
+    end
+
+    context "with src_ids option" do
+      it "handles src_ids option" do
+        attribs = {'options' => {:src_ids => [service.id]}}
+        expect { described_class.request_task_class_from(attribs) }.not_to raise_error
+        expect(described_class.request_task_class_from(attribs)).to eq(ServiceRetireTask)
+      end
+    end
+  end
+
+  describe ".new_request_task" do
+    it "creates a task with the correct class" do
+      attribs = {
+        'options'     => {:src_ids => [service.id]},
+        'source_id'   => service.id,
+        'source_type' => 'Service'
+      }
+
+      task = described_class.new_request_task(attribs)
+      expect(task).to be_a(ServiceRetireTask)
+      expect(task.source_id).to eq(service.id)
+    end
+  end
+end

--- a/spec/models/vm_retire_request_spec.rb
+++ b/spec/models/vm_retire_request_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe VmRetireRequest do
+  let!(:ems) { FactoryBot.create(:ems_vmware) }
+  let!(:vm) { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+
+  describe ".request_task_class_from" do
+    context "with custom EMS retire task class" do
+      let(:custom_task_class) { Class.new(VmRetireTask) }
+
+      before do
+        stub_const("ManageIQ::Providers::InfraManager::Retire", custom_task_class)
+        allow(ems.class).to receive(:vm_retire_task_class).and_return(custom_task_class)
+      end
+
+      it "returns the custom task class" do
+        attribs = {'options' => {:src_ids => [vm.id]}}
+        expect(described_class.request_task_class_from(attribs)).to eq(custom_task_class)
+      end
+    end
+
+    context "with VM that has no EMS" do
+      let!(:vm_no_ems) { FactoryBot.create(:vm_vmware, :ext_management_system => nil) }
+
+      it "returns VmRetireTask" do
+        attribs = {'options' => {:src_ids => [vm_no_ems.id]}}
+        expect(described_class.request_task_class_from(attribs)).to eq(VmRetireTask)
+      end
+    end
+
+    context "when VM is not found" do
+      it "raises an exception" do
+        attribs = {'options' => {:src_ids => [-1]}}
+        expect { described_class.request_task_class_from(attribs) }
+          .to raise_error(RuntimeError, /Unable to find Vm/)
+      end
+    end
+  end
+
+  describe ".new_request_task" do
+    it "creates a task with the correct class" do
+      attribs = {
+        'options'     => {:src_ids => [vm.id]},
+        'source_id'   => vm.id,
+        'source_type' => 'Vm'
+      }
+
+      task = described_class.new_request_task(attribs)
+      expect(task).to be_a(VmRetireTask)
+      expect(task.source_id).to eq(vm.id)
+    end
+
+    context "with custom EMS retire task class" do
+      let(:custom_task_class) { Class.new(VmRetireTask) }
+
+      before do
+        stub_const("ManageIQ::Providers::InfraManager::Retire", custom_task_class)
+        allow(ems.class).to receive(:vm_retire_task_class).and_return(custom_task_class)
+      end
+
+      it "creates a task with the custom class" do
+        attribs = {
+          'options'     => {:src_ids => [vm.id]},
+          'source_id'   => vm.id,
+          'source_type' => 'Vm'
+        }
+
+        task = described_class.new_request_task(attribs)
+        expect(task).to be_a(custom_task_class)
+        expect(task.source_id).to eq(vm.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->

~~Very WIP right now, I've live tested VM retirement.~~

The goal here is to allow for providers to override the `MiqRetireTask` specifically the `StateMachine` methods, this will make it easier for e.g. EmbeddedTerraform to requeue if the `Terraform::Runner` is unavailable similar to `MiqProvisionTask`

Required for:
* https://github.com/ManageIQ/manageiq-providers-embedded_terraform/pull/134