### PR TITLE
Clarify that the permissions are intentionally 644 octal

### DIFF
--- a/app/models/miq_remote_console_worker.rb
+++ b/app/models/miq_remote_console_worker.rb
@@ -23,7 +23,7 @@ class MiqRemoteConsoleWorker < MiqWorker
     super
 
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "remote-console-httpd-config", :mountPath => "/etc/httpd/conf.d"}
-    definition[:spec][:template][:spec][:volumes] << {:name => "remote-console-httpd-config", :configMap => {:name => "remote-console-httpd-configs", :defaultMode => 420}}
+    definition[:spec][:template][:spec][:volumes] << {:name => "remote-console-httpd-config", :configMap => {:name => "remote-console-httpd-configs", :defaultMode => 0o644}}
 
     if ENV["REMOTE_CONSOLE_SSL_SECRET_NAME"].present?
       definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "remote-console-httpd-ssl", :mountPath => "/etc/pki/tls"}

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -49,7 +49,7 @@ class MiqUiWorker < MiqWorker
     super
 
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "ui-httpd-configs", :mountPath => "/etc/httpd/conf.d"}
-    definition[:spec][:template][:spec][:volumes] << {:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 420}}
+    definition[:spec][:template][:spec][:volumes] << {:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 0o644}}
 
     if ENV["UI_SSL_SECRET_NAME"].present?
       definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "ui-httpd-ssl", :mountPath => "/etc/pki/tls"}

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -34,7 +34,7 @@ class MiqWebServiceWorker < MiqWorker
     super
 
     definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "api-httpd-config", :mountPath => "/etc/httpd/conf.d"}
-    definition[:spec][:template][:spec][:volumes] << {:name => "api-httpd-config", :configMap => {:name => "api-httpd-configs", :defaultMode => 420}}
+    definition[:spec][:template][:spec][:volumes] << {:name => "api-httpd-config", :configMap => {:name => "api-httpd-configs", :defaultMode => 0o644}}
 
     if ENV["API_SSL_SECRET_NAME"].present?
       definition[:spec][:template][:spec][:containers].first[:volumeMounts] << {:name => "api-httpd-ssl", :mountPath => "/etc/pki/tls"}

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       it "adds the ui_httpd_configs volume mount" do
         expect(kubeclient).to receive(:create_deployment) do |deployment|
           expect(deployment.fetch_path(:spec, :template, :spec, :containers, 0, :volumeMounts)).to include({:name => "ui-httpd-configs", :mountPath => "/etc/httpd/conf.d"})
-          expect(deployment.fetch_path(:spec, :template, :spec, :volumes)).to include({:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 420}})
+          expect(deployment.fetch_path(:spec, :template, :spec, :volumes)).to include({:name => "ui-httpd-configs", :configMap => {:name => "ui-httpd-configs", :defaultMode => 0o644}})
         end
 
         expect(ui_worker).to receive(:scale_deployment)


### PR DESCRIPTION
The bug in https://github.com/ManageIQ/manageiq/pull/23930 made it appear like the octal permission was used, but
it was actually decimal. In the cases of these files, 0o644 is actually
what we want (meaning 420 decimal is correct), but we are changing to
octal to better clarify that.

@bdunne Please review.