### PR TITLE
Drop color gem as it's not used.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem "bcrypt",                           "~> 3.1.10",         :require => false
 gem "bootsnap",                         ">= 1.8.1",          :require => false # for psych 3.3.2+ / 4 unsafe_load
 gem "bundler",                          ">= 2.5.20", "< 5",  :require => false
 gem "byebug",                                                :require => false
-gem "color",                            "~>1.8"
 gem "config",                           "~>5.1",             :require => false
 gem "connection_pool",                  "~>2.5",             :require => false # For Dalli
 gem "dalli",                            "~>3.2.3",           :require => false


### PR DESCRIPTION
This gem was added to the Gemfile because Ruport lazy loaded it but hadn't specified it in it's dependencies [[ref](https://github.com/ManageIQ/manageiq/pull/4306)]. However, the gem no longer seems used by Ruport.

From what I can tell the usage was dropped in https://github.com/ruport/ruport/commit/be4a8005cf6e731b205654dcc595b9f7421b1662 and released in 1.8.0

Replaces https://github.com/ManageIQ/manageiq/pull/23934

@agrare Please review.
@miq-bot cross-repo-test /all