### PR TITLE
Add Pod Log feature 

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4491,6 +4491,10 @@
       :description: Show Capacity & Utilization data of Pods
       :feature_type: view
       :identifier: container_group_perf
+    - :name: Logs
+      :description: Logs of this Pod
+      :feature_type: control
+      :identifier: container_group_logs
   - :name: Operate
     :description: Perform Operations on Pods
     :feature_type: control
@@ -4508,7 +4512,6 @@
       :description: Check Compliance of Last Known Configuration
       :feature_type: control
       :identifier: container_group_check_compliance
-
 # ContainerNode
 - :name: Nodes
   :description: Everything under Container Nodes


### PR DESCRIPTION
## Purpose

Add support for viewing Kubernetes/OpenShift pod logs from ManageIQ.

Depends On:

- https://github.com/ManageIQ/manageiq-ui-classic/pull/10201
- https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/567
- https://github.com/ManageIQ/manageiq-api/pull/1339
