### PR TITLE
Add KubeVirt VNC remote console client adapter

### DIFF
--- a/lib/remote_console/client_adapter.rb
+++ b/lib/remote_console/client_adapter.rb
@@ -13,6 +13,8 @@ module RemoteConsole
         WebMKSLegacy.new(record, socket)
       when 'kube_exec'
         KubeExec.new(record, socket)
+      when 'kubevirt_vnc'
+        KubeVirtVnc.new(record, socket)
       else
         raise NotImplementedError, "Support for #{record.protocol} remote consoles is not implemented!"
       end

--- a/lib/remote_console/client_adapter.rb
+++ b/lib/remote_console/client_adapter.rb
@@ -11,6 +11,8 @@ module RemoteConsole
         WebMKS.new(record, socket)
       when 'webmks-uint8utf8'
         WebMKSLegacy.new(record, socket)
+      when 'kubevirt_vnc'
+        KubeVirtVnc.new(record, socket)
       else
         raise NotImplementedError, "Support for #{record.protocol} remote consoles is not implemented!"
       end

--- a/lib/remote_console/client_adapter/kube_virt_vnc.rb
+++ b/lib/remote_console/client_adapter/kube_virt_vnc.rb
@@ -1,4 +1,4 @@
-require 'websocket/driver'
+require "websocket/driver"
 
 module RemoteConsole
   module ClientAdapter
@@ -7,20 +7,27 @@ module RemoteConsole
 
       def initialize(record, socket)
         super
-        @url = URI::Generic.build(:scheme => 'wss',
-                                  :host   => @record.host_name,
-                                  :port   => @record.port,
-                                  :path   => path).to_s
-        @driver = WebSocket::Driver.client(self, :protocols => %w[plain.kubevirt.io])
-        @driver.set_header('Authorization', "Bearer #{bearer_token}")
+
+        @url = @record.url
+
+        @driver = WebSocket::Driver.client(
+          self,
+          :protocols => %w[plain.kubevirt.io]
+        )
+
+        @driver.set_header(
+          "Authorization",
+          "Bearer #{bearer_token}"
+        )
+
         @driver.on(:close) { socket.close unless socket.closed? }
+
         @driver.start
       end
 
       def fetch(length)
-        if @driver.listeners(:message).empty?
-          @driver.on(:message) { |msg| yield(msg.data) }
-        end
+        @driver.on(:message) { |msg| yield(msg.data) } if @driver.listeners(:message).empty?
+
         data = @ssl.send(:sysread_nonblock, length, :exception => false)
         @driver.parse(data) if data != :wait_readable
       end
@@ -36,21 +43,18 @@ module RemoteConsole
       private
 
       def bearer_token
-        @record.vm.ext_management_system.authentication_token('bearer')
-      end
-
-      def path
-        vm = @record.vm
-        "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/#{vm.name}/vnc"
+        @record.vm.ext_management_system.authentication_token("bearer")
       end
 
       def setup_ssl
         context = OpenSSL::SSL::SSLContext.new
         context.ssl_version = :SSLv23
         context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
         ssl = OpenSSL::SSL::SSLSocket.new(@sock, context)
         ssl.sync_close = true
         ssl.hostname = @record.host_name if ssl.respond_to?(:hostname=)
+
         ssl
       end
     end

--- a/lib/remote_console/client_adapter/kube_virt_vnc.rb
+++ b/lib/remote_console/client_adapter/kube_virt_vnc.rb
@@ -1,0 +1,58 @@
+require 'websocket/driver'
+
+module RemoteConsole
+  module ClientAdapter
+    class KubeVirtVnc < SSLSocket
+      attr_accessor :url
+
+      def initialize(record, socket)
+        super
+        @url = URI::Generic.build(:scheme => 'wss',
+                                  :host   => @record.host_name,
+                                  :port   => @record.port,
+                                  :path   => path).to_s
+        @driver = WebSocket::Driver.client(self, :protocols => %w[plain.kubevirt.io])
+        @driver.set_header('Authorization', "Bearer #{bearer_token}")
+        @driver.on(:close) { socket.close unless socket.closed? }
+        @driver.start
+      end
+
+      def fetch(length)
+        if @driver.listeners(:message).empty?
+          @driver.on(:message) { |msg| yield(msg.data) }
+        end
+        data = @ssl.send(:sysread_nonblock, length, :exception => false)
+        @driver.parse(data) if data != :wait_readable
+      end
+
+      def issue(data)
+        @driver.binary(data)
+      end
+
+      def write(data)
+        @ssl.syswrite(data)
+      end
+
+      private
+
+      def bearer_token
+        @record.vm.ext_management_system.authentication_token('bearer')
+      end
+
+      def path
+        vm = @record.vm
+        "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/#{vm.name}/vnc"
+      end
+
+      def setup_ssl
+        context = OpenSSL::SSL::SSLContext.new
+        context.ssl_version = :SSLv23
+        context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        ssl = OpenSSL::SSL::SSLSocket.new(@sock, context)
+        ssl.sync_close = true
+        ssl.hostname = @record.host_name if ssl.respond_to?(:hostname=)
+        ssl
+      end
+    end
+  end
+end

--- a/lib/remote_console/client_adapter/kube_virt_vnc.rb
+++ b/lib/remote_console/client_adapter/kube_virt_vnc.rb
@@ -49,7 +49,7 @@ module RemoteConsole
       def setup_ssl
         context = OpenSSL::SSL::SSLContext.new
         context.ssl_version = :SSLv23
-        context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        context.verify_depth = OpenSSL::SSL::VERIFY_NONE
 
         ssl = OpenSSL::SSL::SSLSocket.new(@sock, context)
         ssl.sync_close = true


### PR DESCRIPTION
# Purpose

Add a new remote console client adapter for KubeVirt Virtualization.

The adapter proxies the WebSocket connection between the browser and the KubeVirt API server while authenticating using the provider bearer token.

## Changes
- Add RemoteConsole::ClientAdapter::KubevirtVnc
- Support WebSocket proxying for KubeVirt VNC.
- Handle bearer token authentication.
- Forward WebSocket traffic between browser and KubeVirt API.
- Register the adapter in RemoteConsole::ClientAdapter.

## Notes

This adapter is responsible only for backend proxying. Rendering continues to use the standard HTML5 VNC (noVNC) client.

## Testing
- Verified successful WebSocket connection.
- Verified console proxy communication.
- Verified interactive VM console access.

<img width="1849" height="853" alt="image" src="https://github.com/user-attachments/assets/370f4260-5c82-41ef-afd4-54130171f417" />

<img width="1854" height="916" alt="image" src="https://github.com/user-attachments/assets/8d3fc4a6-4132-4f0a-a446-5acde0f3f09e" />



## Depends On
- https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/327
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10204

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/268