### PR TITLE
Fix Alert Issue

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -731,7 +731,7 @@ class MiqAlert < ApplicationRecord
       return false
     end
 
-    status = target.miq_alert_statuses.first
+    status = target.miq_alert_statuses.find_by(:miq_alert_id => id)
     if status
       since_last_eval = (Time.now.utc - status.evaluated_on)
       eval_options[:starting_on] = if since_last_eval >= eval_options[:duration]

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -627,4 +627,48 @@ RSpec.describe MiqAlert do
       expect { alert.valid? }.not_to make_database_queries
     end
   end
+
+  describe "#evaluate_performance" do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    let(:alert_cpu_75) do
+      FactoryBot.create(
+        :miq_alert_vm,
+        :expression => {
+          :eval_method => "realtime_performance",
+          :mode        => "internal",
+          :options     => {:perf_column => "cpu_usage_rate_average", :value_threshold => 75, :operator => ">"}
+        }
+      )
+    end
+
+    let(:alert_cpu_90) do
+      FactoryBot.create(
+        :miq_alert_vm,
+        :expression => {
+          :eval_method => "realtime_performance",
+          :mode        => "internal",
+          :options     => {:perf_column => "cpu_usage_rate_average", :value_threshold => 90, :operator => ">"}
+        }
+      )
+    end
+
+    it "scopes the alert status lookup by miq_alert_id" do
+      cpu_75_evaluated = 2.minutes.ago.utc
+      cpu_90_evaluated = 30.minutes.ago.utc
+
+      vm.miq_alert_statuses.create!(:miq_alert => alert_cpu_75, :evaluated_on => cpu_75_evaluated, :result => true)
+      vm.miq_alert_statuses.create!(:miq_alert => alert_cpu_90, :evaluated_on => cpu_90_evaluated, :result => true)
+
+      eval_options_75 = {:interval_name => "realtime", :duration => 300, :column => "cpu_usage_rate_average", :value => 75, :operator => ">"}
+      eval_options_90 = {:interval_name => "realtime", :duration => 300, :column => "cpu_usage_rate_average", :value => 90, :operator => ">"}
+
+      allow(vm).to receive(:performances_maintains_value_for_duration?) do |opts|
+        opts[:starting_on] > cpu_75_evaluated
+      end
+
+      expect(alert_cpu_75.evaluate_performance(vm, eval_options_75)).to eq(true)
+      expect(alert_cpu_90.evaluate_performance(vm, eval_options_90)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->
When a VM / Host is configured with multiple performance alerts, for example, CPU utilization exceeding 75% and CPU utilization exceeding 90%. When evaluating  these performance alerts evaluate_performance queries miq_alert_statuses. The query was missing a filter on miq_alert_id. Because of this, when multiple alerts were configured for the same target, the query could pick up the alert status record belonging to a different alert on that target. This was causing one of the performance alerts to be evaluated incorrectly.

The fix is to include miq_alert_id in the query so that the evaluation considers only the status record associated with the specific alert being evaluated.
<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
@miq-bot add-label bug