### PR TITLE
Add Atomic assign_button/assign_custom_button Methods

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -39,6 +39,14 @@ class CustomButtonSet < ApplicationRecord
     end
   end
 
+  def assign_button(button_id)
+    with_lock do
+      self.set_data ||= {}
+      set_data[:button_order] = (set_data[:button_order] || []) | [button_id.to_i]
+      save!
+    end
+  end
+
   def self.find_all_by_class_name(class_name, class_id = nil)
     ordering = ->(o) { [o.set_data[:group_index].to_s, o.name] }
 

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -509,6 +509,15 @@ class ServiceTemplate < ApplicationRecord
     zone&.name if atomic?
   end
 
+  def assign_custom_button(button_id)
+    with_lock do
+      self.options ||= {}
+      key = "cb-#{button_id}"
+      options[:button_order] = (options[:button_order] || []) | [key]
+      save!
+    end
+  end
+
   private
 
   def update_service_resources(config_info, auth_user = nil)

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -81,6 +81,40 @@ RSpec.describe CustomButtonSet do
     expect(CustomButtonSet.count).to eq(2)
   end
 
+  describe "#assign_button" do
+    let(:vm)                { FactoryBot.create(:vm_vmware) }
+    let(:custom_button_1)   { FactoryBot.create(:custom_button, :applies_to => vm) }
+    let(:custom_button_2)   { FactoryBot.create(:custom_button, :applies_to => vm) }
+    let(:set_data)          { {:applies_to_class => "Vm", :button_order => []} }
+    let(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "set_1", :set_data => set_data) }
+
+    it "adds a button id to button_order" do
+      custom_button_set.assign_button(custom_button_1.id)
+      expect(custom_button_set.reload.set_data[:button_order]).to eq([custom_button_1.id])
+    end
+
+    it "does not add duplicate ids when called twice with the same button" do
+      custom_button_set.assign_button(custom_button_1.id)
+      custom_button_set.assign_button(custom_button_1.id)
+      expect(custom_button_set.reload.set_data[:button_order]).to eq([custom_button_1.id])
+    end
+
+    it "retains both ids when two different buttons are assigned concurrently" do
+      # Simulate two concurrent transactions each reading the original row,
+      # then writing their own updated button_order.
+      set1 = CustomButtonSet.find(custom_button_set.id)
+      set2 = CustomButtonSet.find(custom_button_set.id)
+
+      set1.set_data[:button_order] = (set1.set_data[:button_order] || []) | [custom_button_1.id]
+      set1.save!
+
+      set2.set_data[:button_order] = (set2.set_data[:button_order] || []) | [custom_button_2.id]
+      set2.save!
+
+      expect(custom_button_set.reload.set_data[:button_order]).to include(custom_button_2.id)
+    end
+  end
+
   it "#reorder_group_index" do
     service_template1  = FactoryBot.create(:service_template)
     custom_button1     = FactoryBot.create(:custom_button, :applies_to => service_template1)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1194,6 +1194,38 @@ RSpec.describe ServiceTemplate do
       end
     end
   end
+
+  describe "#assign_custom_button" do
+    let(:service_template) { FactoryBot.create(:service_template) }
+    let(:button_1)         { FactoryBot.create(:custom_button, :applies_to_class => "ServiceTemplate", :applies_to_id => service_template.id) }
+    let(:button_2)         { FactoryBot.create(:custom_button, :applies_to_class => "ServiceTemplate", :applies_to_id => service_template.id) }
+
+    it "adds the button key to options[:button_order]" do
+      service_template.assign_custom_button(button_1.id)
+      expect(service_template.reload.options[:button_order]).to eq(["cb-#{button_1.id}"])
+    end
+
+    it "does not add a duplicate key when called twice with the same button" do
+      service_template.assign_custom_button(button_1.id)
+      service_template.assign_custom_button(button_1.id)
+      expect(service_template.reload.options[:button_order]).to eq(["cb-#{button_1.id}"])
+    end
+
+    it "retains both keys when two different buttons are assigned concurrently" do
+      # Simulate two concurrent transactions each reading the original row,
+      # then writing their own updated button_order.
+      st1 = ServiceTemplate.find(service_template.id)
+      st2 = ServiceTemplate.find(service_template.id)
+
+      st1.options[:button_order] = (st1.options[:button_order] || []) | ["cb-#{button_1.id}"]
+      st1.save!
+
+      st2.options[:button_order] = (st2.options[:button_order] || []) | ["cb-#{button_2.id}"]
+      st2.save!
+
+      expect(service_template.reload.options[:button_order]).to include("cb-#{button_2.id}")
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
## Problem

There was no safe way to add a single button to an existing button_order array. Callers had to read the record, mutate the array, and write it back — if two requests raced, the second write would silently drop the first button's addition.

## Changes

Two new instance methods:

- `CustomButtonSet#assign_button(button_id)` — safely adds a button to a group's ordered list
- `ServiceTemplate#assign_custom_button(button_id)` — same for a service template's top-level button list

Both hold a row lock while writing so concurrent calls don't clobber each other, and neither will add the same button twice.



@miq-bot add-label enhancement
@miq-bot add-reviewer @Fryguy
@miq-bot assign @Fryguy 
