### PR TITLE
Add AGENTS.md and agent guidance docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+This file provides guidance to agents working in this repository.
+
+## Product
+
+ManageIQ is an open source hybrid-cloud management platform — a single management plane for virtual, cloud, container, and physical infrastructure. Provider workers collect inventory/events/metrics from external systems into PostgreSQL (VMDB); all other features (RBAC, reporting, policy, automation, service catalog) operate on that normalized data. Operations are posted back to the native provider.
+
+Key domains: resource management, tagging, dashboards, reporting, chargeback, service catalog, policy (event-condition-action), automation (Automate Engine, Embedded Ansible, Embedded Terraform, Embedded Workflows), and auth/RBAC with multi-tenancy.
+
+See [`docs/agents/product.md`](docs/agents/product.md) when you need model names, feature details, or deployment topology.
+
+## Stack
+
+Ruby on Rails monolith (no frontend — controllers live in plugins/engines, not `app/controllers/`). Ruby 3.3.x required. PostgreSQL 16. The default integration branch is `master`.
+
+## Terminology
+
+- **VMDB** (Virtual Machine DataBase) — legacy name for the core ManageIQ database/application layer. Appears throughout the codebase in class names, rake tasks, and log prefixes.
+- **EVM** (Enterprise Virtualization Manager) — even older term for the same application layer as VMDB (e.g. `EvmSpecHelper`, `evm.rake`).
+- **C&U** (Capacity & Utilization) — the metrics collection, rollup, and reporting subsystem.
+
+## Commands
+
+```bash
+# Run all specs (equivalent to what CI runs)
+bundle exec rake
+
+# Run a single spec file / example
+bundle exec rspec spec/models/vm_or_template_spec.rb
+bundle exec rspec spec/models/vm_or_template_spec.rb:42
+
+# Lint
+bundle exec rubocop
+bundle exec haml-lint app/
+bundle exec yamllint .
+
+# Security suite
+bundle exec rake test:security
+
+# Dev environment bootstrap (SKIP_DATABASE_SETUP, SKIP_UI_UPDATE, SKIP_TEST_RESET)
+bin/setup
+```
+
+## Code Style
+
+- RuboCop inherits from `manageiq-style` gem; local overrides in `.rubocop_local.yml`. Do not edit `.rubocop.yml`.
+- Global logger variables (`$log`, `$audit_log`, etc.) are the project standard — see `.rubocop_local.yml` for the full list. `Rails.logger` is acceptable only for the Rails production/development log.
+- Internationalization uses FastGettext/Gettext (`_`, `n_`, `N_`). Translate the literal string first, then interpolate named placeholders. See [`docs/agents/coding.md`](docs/agents/coding.md).
+- HAML: line length max 160, `SpaceInsideHashAttributes: no_space`.
+- YAML: `indent-sequences: false`.
+
+## Architecture
+
+Key non-obvious constraints — read [`docs/agents/architecture.md`](docs/agents/architecture.md) before making structural changes:
+
+- **ID regions**: model IDs are region-scoped; never assume global uniqueness.
+- **RBAC**: use `Rbac.search` / `Rbac.filtered`, never raw `.where`, for user-facing queries.
+- **Settings**: read `Settings` at call time; persist via `Vmdb::Settings.save!` or `resource.add_settings_for_resource`.
+- **Workers**: `MiqWorker` subclasses are separate OS processes — no background threads in models.
+- **No HTTP/view/API layer here**: UI changes go in `manageiq-ui-classic`, API changes in `manageiq-api`.
+
+## Testing
+
+Tests use random order, transactional fixtures, and strict VCR. See [`docs/agents/testing.md`](docs/agents/testing.md) before writing or modifying specs.
+
+## Plugins / Engines
+
+- Plugin gems are loaded as Rails engines; engine factories are auto-added to FactoryBot.
+- Add plugin gems via `manageiq_plugin "plugin-name"` in the `Gemfile`.
+- On release branches (non-`master`), `Gemfile.lock.release` pins gem versions. If changing gems on a release branch, update both lockfiles.
+- See [`docs/agents/plugins.md`](docs/agents/plugins.md) for available plugins and development conventions.
+
+## Further reading
+
+Load these when the task requires it — do not load them speculatively:
+
+- **Product features / model names**: [`docs/agents/product.md`](docs/agents/product.md) — providers, resource management, service catalog, policy, automation, RBAC, deployment
+- **Making code changes**: [`docs/agents/coding.md`](docs/agents/coding.md) — non-obvious patterns, loggers, RuboCop, factory helpers
+- **Architecture / design questions**: [`docs/agents/architecture.md`](docs/agents/architecture.md) — RBAC, Settings, ID regions, workers, plugin model
+- **Working with RBAC or authorization**: [`docs/agents/rbac.md`](docs/agents/rbac.md) — data model, filter types, tenancy, feature flags, spec helpers
+- **Writing or modifying specs**: [`docs/agents/testing.md`](docs/agents/testing.md) — RSpec setup, FactoryBot, VCR, spec helpers
+- **Working in a plugin gem**: [`docs/agents/plugins.md`](docs/agents/plugins.md) — repo layout, bin/setup, engine, settings, spec structure
+- **Working in a provider plugin**: [`docs/agents/provider_plugins.md`](docs/agents/provider_plugins.md) — manager model, inventory pipeline, event collection, metrics collection, operations, workers, VCR cassettes
+- **Build and packaging**: [`docs/agents/build.md`](docs/agents/build.md) — RPM build, appliance images, container/pod deployment, release branches
+- **Public documentation**: [`docs/agents/documentation.md`](docs/agents/documentation.md) — manageiq-documentation repo, user guides, when to update docs

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,50 @@
+# Architecture
+
+## ID regions
+
+Every model ID is region-scoped via `ActiveRecord::IdRegions`. Records in different regions have IDs in non-overlapping numeric ranges — never assume IDs are globally unique across the database. Cross-region associations are by design. ID region assignment is set at record creation and cannot be changed.
+
+## RBAC
+
+RBAC is enforced by `Rbac::Filterer` (`lib/rbac/filterer.rb`) — it is **not** automatic. Use `Rbac.search` or `Rbac.filtered` instead of raw `.where` for any user-facing record retrieval. See [`rbac.md`](rbac.md) for the full reference (data model, filter types, tenancy strategy, feature flags, and spec helpers).
+
+Key non-obvious rules:
+
+- For tag-based RBAC to apply to a class, add it to both `Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC` and ensure the model includes `acts_as_miq_taggable`.
+- Belongsto filters force Ruby-side filtering — SQL `LIMIT` cannot be applied when they are active.
+- Tenant access strategy (which tenants can see which resources) is defined per-model in `TENANT_ACCESS_STRATEGY` in `Rbac::Filterer`.
+
+## Settings
+
+`Settings` is a live `Config::Options` tree managed by `lib/vmdb/settings.rb` — it is not a static hash or Rails config.
+
+- **Read**: access `Settings` directly at call time. Do not cache values in class-level constants — settings are hot-reloadable at runtime.
+- **Persist** (production code): use `Vmdb::Settings.save!(resource, hash)` or the model-level convenience `resource.add_settings_for_resource(hash)` (available on models that include `ConfigurationManagementMixin`). Do not assign to `Settings` directly.
+- **Stub** (specs): use `stub_settings(hash)` or `stub_settings_merge(hash)` from `spec/support/settings_helper.rb`.
+
+## Workers
+
+Each worker type is a subclass of `MiqWorker` and runs as a separate OS process — not a thread. Do not use background threads in models. Start individual workers in development via:
+
+```bash
+lib/workers/bin/run_single_worker.rb <WorkerClassName>
+```
+
+Architecture must not rely on in-process shared state between workers.
+
+## Plugin / provider model
+
+Provider code (AWS, VMware, OpenStack, etc.) lives in separate gems (e.g. `manageiq-providers-vmware`) loaded as Rails engines at boot. Core models define abstract base classes (e.g. `ExtManagementSystem`, `VmOrTemplate`); providers subclass them. New features added to base classes automatically propagate to all providers.
+
+Add plugin gems via the `manageiq_plugin "plugin-name"` helper in the `Gemfile`.
+
+## Internationalization
+
+ManageIQ uses **FastGettext/Gettext** for translations — not the standard Rails i18n (`I18n.t`) system. A very small portion of the codebase does use Rails i18n, but the overwhelming convention is the Gettext helpers (`_`, `n_`, `N_`). See [`docs/agents/coding.md`](coding.md) for usage details.
+
+## No HTTP / view / API layer in this repo
+
+This repo is a backend model/service layer. There is no `app/controllers/` or `app/views/`. Any work touching API endpoints, views, or controller logic requires changes in separate repos:
+
+- UI: [`manageiq-ui-classic`](https://github.com/ManageIQ/manageiq-ui-classic)
+- REST API: [`manageiq-api`](https://github.com/ManageIQ/manageiq-api)

--- a/docs/agents/build.md
+++ b/docs/agents/build.md
@@ -1,0 +1,28 @@
+# Build and Packaging
+
+ManageIQ ships as both an appliance (virtual-machine image) and a container (Kubernetes/OpenShift pod). The build pipeline lives in four separate repositories; this repository (`manageiq`) is the application source that all of them consume.
+
+## Build repositories
+
+| Repository | Purpose |
+|---|---|
+| [`manageiq-rpm_build`](https://github.com/ManageIQ/manageiq-rpm_build) | Produces RPM packages for all ManageIQ components and their dependencies. Drives the nightly and release RPM build pipeline. |
+| [`manageiq-appliance-build`](https://github.com/ManageIQ/manageiq-appliance-build) | Assembles virtual-machine appliance images (QCOW2, OVA, VHD, etc.) from the RPMs produced by `manageiq-rpm_build`. |
+| [`manageiq-appliance`](https://github.com/ManageIQ/manageiq-appliance) | OS-level configuration and firstboot scripts that run inside the appliance image — service units, network configuration, initial database setup, etc. |
+| [`manageiq-pods`](https://github.com/ManageIQ/manageiq-pods) | Kubernetes/OpenShift deployment manifests and operator for running ManageIQ as a containerised workload. |
+
+## Relationship to this repository
+
+Changes to `manageiq` (and its plugin gems) flow into builds as follows:
+
+1. **RPM build** — `manageiq-rpm_build` pulls gem sources, installs them into a build root, and packages them as RPMs. Version pins and gem sources are controlled there.
+2. **Appliance image** — `manageiq-appliance-build` installs the RPMs from step 1 into a base OS image, then applies the configuration layer from `manageiq-appliance`.
+3. **Container image** — `manageiq-pods` builds OCI images by installing the same RPMs from step 1 into a container base image, then provides the Kubernetes manifests and operator to deploy them.
+
+When making changes that affect startup, required OS packages, or service configuration, coordinate with the `manageiq-appliance` and `manageiq-pods` repositories in addition to this one.
+
+## Branches and release cadence
+
+- The `master` branch of this repository tracks the next release.
+- Named release branches correspond to stable releases; branches are named after chess grandmasters (e.g., `spassky`, `tal`). The build repositories have matching branches.
+- On release branches, `Gemfile.lock.release` pins gem versions; update both `Gemfile.lock` and `Gemfile.lock.release` when changing gem dependencies on a release branch.

--- a/docs/agents/coding.md
+++ b/docs/agents/coding.md
@@ -1,0 +1,19 @@
+# Coding
+
+## Non-obvious patterns
+
+- **No `app/controllers/`** — this repo is a model/service layer. Controller code lives in plugin engines. See [`docs/agents/architecture.md`](architecture.md) for details.
+- **`Rbac.search` / `Rbac.filtered`** instead of raw `.where` for any user-facing record retrieval. See [`docs/agents/architecture.md`](architecture.md) for the full RBAC requirements.
+- **ID regions**: all model IDs are region-scoped. Never assume IDs are globally unique across the database. See [`docs/agents/architecture.md`](architecture.md).
+- **Settings**: do not assign to `Settings` directly — use `Vmdb::Settings.save!` or `add_settings_for_resource`. See [`docs/agents/architecture.md`](architecture.md) for the full Settings API.
+- **Global loggers**: the project uses global logger variables (`$log`, `$audit_log`, etc.) for application-level logging — see `.rubocop_local.yml` for the full allowed list. Plugin gems define their own additional loggers. `Rails.logger` is acceptable when specifically targeting the Rails production/development log.
+- **Worker isolation**: each worker type is a subclass of `MiqWorker` running as a separate OS process. Do not use background threads in models.
+- **RuboCop base config** comes from the `manageiq-style` gem. Run `bundle exec rubocop` to validate. Do not edit `.rubocop.yml` — use `.rubocop_local.yml` for local overrides.
+- **Factories use padded sequences**: use `seq_padded_for_sorting(n)` when adding sequence-based name attributes to factories. See [`docs/agents/testing.md`](testing.md).
+- **VCR cassettes are strict**: all HTTP in specs must be cassette-recorded or explicitly stubbed. See [`docs/agents/testing.md`](testing.md).
+
+## Internationalization
+
+- Use FastGettext/Gettext helpers for user-visible strings: `_` for simple strings, `n_` for plurals, and `N_` when a string must be marked for translation now but translated later. See existing usage throughout `app/` and [`lib/postponed_translation.rb`](../../lib/postponed_translation.rb).
+- Translate the literal string first and then interpolate named placeholders, e.g. `_("...") % {:name => value}`. Do not build English strings with interpolation before translation.
+- Locale discovery is filesystem-driven from `locale/` directories and optional plugin `config/supported_locales.yml` files. Human locale names come from [`config/human_locale_names.yaml`](../../config/human_locale_names.yaml) via [`Vmdb::FastGettextHelper`](../../lib/vmdb/fast_gettext_helper.rb).

--- a/docs/agents/documentation.md
+++ b/docs/agents/documentation.md
@@ -1,0 +1,15 @@
+# Documentation
+
+Public-facing ManageIQ documentation is maintained in a dedicated repository separate from the application source.
+
+## Documentation repository
+
+| Repository | Purpose |
+|---|---|
+| [`manageiq-documentation`](https://github.com/ManageIQ/manageiq-documentation) | Source for all public ManageIQ docs — installation guides, user guides, API reference, and release notes. Written in Markdown and published to the ManageIQ docs site. |
+
+## Scope
+
+- User-facing feature documentation, installation guides, and how-to articles belong in `manageiq-documentation`, not in this repository.
+- Code-level documentation (RDoc / YARD comments, `AGENTS.md`, `docs/agents/`) lives here alongside the code.
+- When implementing a new user-visible feature, consider whether `manageiq-documentation` needs a corresponding update.

--- a/docs/agents/plugins.md
+++ b/docs/agents/plugins.md
@@ -1,0 +1,112 @@
+# Plugin Development
+
+This document covers the structure and conventions for ManageIQ plugin gems — gems loaded as Rails engines that extend core functionality. Plugins are not standalone applications; they run mounted inside the core ManageIQ repository (checked out at `spec/manageiq/`), which provides all core models, workers, RBAC, settings, and helpers. The plugin only defines what it adds or overrides on top of core. Provider plugins have additional conventions; see [`provider_plugins.md`](provider_plugins.md).
+
+## Available plugins
+
+### Core plugins
+
+| Plugin | Purpose |
+|---|---|
+| [`manageiq-api`](https://github.com/ManageIQ/manageiq-api) | REST API layer (JSON-API); changes to API endpoints belong here |
+| [`manageiq-automation_engine`](https://github.com/ManageIQ/manageiq-automation_engine) | Automate Engine — event-driven automation, state machines, and method execution |
+| [`manageiq-consumption`](https://github.com/ManageIQ/manageiq-consumption) | Chargeback / showback — cost allocation models and reporting |
+| [`manageiq-content`](https://github.com/ManageIQ/manageiq-content) | Seed data: default automate domains, reports, roles, scan profiles, etc. |
+| [`manageiq-decorators`](https://github.com/ManageIQ/manageiq-decorators) | View decorators shared between the UI and API |
+| [`manageiq-schema`](https://github.com/ManageIQ/manageiq-schema) | Database migrations and schema definitions shared across the application |
+| [`manageiq-ui-classic`](https://github.com/ManageIQ/manageiq-ui-classic) | Rails engine delivering the classic (PatternFly/jQuery) web UI; controller code lives here |
+
+### Fundamental provider plugins
+
+These behave less like external-system connectors and more like built-in platform capabilities:
+
+| Plugin | Purpose |
+|---|---|
+| [`manageiq-providers-embedded_terraform`](https://github.com/ManageIQ/manageiq-providers-embedded_terraform) | Embedded Terraform runner — executes Terraform templates as a service; provides the `EmbeddedTerraform` manager and related workers directly within the platform |
+| [`manageiq-providers-workflows`](https://github.com/ManageIQ/manageiq-providers-workflows) | Embedded Workflows engine (based on AWS States Language / Floe); provides the `Workflows` manager that orchestrates multi-step automation workflows natively in the platform |
+
+### External-system provider plugins
+
+`manageiq-providers-<provider_name>` gems implement the inventory/events/metrics/operations pipeline for a specific external system. They follow the standard provider structure described in [`provider_plugins.md`](provider_plugins.md). See [all provider plugins](https://github.com/ManageIQ?q=manageiq-providers-) for the full list.
+
+### Non-plugin repositories
+
+These repositories are part of the ManageIQ ecosystem but are **not** Rails engines and are not loaded as plugins:
+
+| Repository | Kind | Purpose |
+|---|---|---|
+| [`manageiq-gems-pending`](https://github.com/ManageIQ/manageiq-gems-pending) | Ruby gem | Low-level utilities extracted from the old `gems/pending` directory — encoding, process helpers, XML, exceptions, etc. Declared directly in `Gemfile`; not a Rails engine. |
+| [`manageiq-ui-service`](https://github.com/ManageIQ/manageiq-ui-service) | JavaScript app | Self-service portal UI (AngularJS/PatternFly). Standalone Node.js application; communicates with `manageiq-api` over REST. Has no presence in this repo's `Gemfile`. |
+
+## Repo layout
+
+```
+app/          # Models, helpers, and other Rails autoloaded code (if any)
+config/       # settings.yml (plugin-specific defaults) and secrets.defaults.yml
+lib/          # Engine definition, rake tasks, and version file
+locale/       # Gettext translation catalogs
+spec/
+  factories/  # FactoryBot factories for this plugin's models
+  manageiq/   # Full copy / symlink of the core ManageIQ app — never edit here
+  support/    # Shared spec helpers for this plugin
+  *_spec.rb   # Specs
+```
+
+`spec/manageiq` is populated by `bin/setup` — either cloned from GitHub or symlinked from a local checkout via the `$MANAGEIQ_REPO` environment variable. It is excluded from RuboCop, yamllint, and the RSpec run (see `.rspec` and `.yamllint`).
+
+## Setup and update
+
+```bash
+# Clone/symlink core and initialise the database
+bin/setup
+
+# Update dependencies and run any plugin-specific update steps.
+# Also pulls the latest core manageiq if spec/manageiq is a clone (not a symlink).
+bin/update
+```
+
+## Commands
+
+```bash
+# Run all specs
+bundle exec rake
+
+# Run a single spec file or example
+bundle exec rspec spec/models/my_model_spec.rb
+bundle exec rspec spec/models/my_model_spec.rb:42
+
+# Lint
+bundle exec rubocop
+bundle exec haml-lint app/
+bundle exec yamllint .
+```
+
+## Gemfile structure
+
+The plugin `Gemfile` delegates almost everything to core:
+
+```ruby
+gemspec
+eval_gemfile(File.expand_path("spec/manageiq/Gemfile", __dir__))
+```
+
+Runtime and development dependencies are declared in the `.gemspec`. Plugin-specific bundler overrides go in `bundler.d/` (gitignored except for `.keep`).
+
+## Engine and settings
+
+- The Rails engine is defined in `lib/<plugin_path>/engine.rb`.
+- Plugin-specific `Settings` defaults live in `config/settings.yml` and are merged into the global `Settings` tree at boot.
+- Read `Settings` at call time; never cache in a constant. Persist via `Vmdb::Settings.save!`. See `spec/manageiq/docs/agents/architecture.md`.
+
+## Code style and conventions
+
+All core conventions apply — see `spec/manageiq/AGENTS.md` and the docs it references. Plugin-specific notes:
+
+- Plugins can bring their own UI (custom button forms, menu structures, pages), but prefer application-agnostic implementations first — provider/plugin-specific UI should only be added when a generic solution isn't feasible. API changes go in `manageiq-api`.
+- Plugin factories belong in `spec/factories/`.
+- Plugin shared spec helpers belong in `spec/support/`.
+- i18n: user-visible strings use `_()` / `n_()`.
+
+## Factories
+
+Plugin factories belong in `spec/factories/`. For the non-obvious rules around what belongs in core vs. a provider plugin, see the [Factories section in `provider_plugins.md`](provider_plugins.md#factories).

--- a/docs/agents/product.md
+++ b/docs/agents/product.md
@@ -1,0 +1,150 @@
+# Product Overview
+
+ManageIQ is an open source hybrid-cloud management platform that provides a single management plane for virtual, cloud, container, and physical infrastructure.
+
+- Website: https://manageiq.org
+- GitHub org: https://github.com/ManageIQ
+
+## High-level architecture
+
+```
+Providers → collect inventory / events / metrics
+         → normalize into PostgreSQL (VMDB)
+         → all features read from VMDB
+         → operations posted back to native provider
+```
+
+Provider workers run as `MiqWorker` subclasses (separate OS processes). Many providers support event-streaming for near real-time collection. All domain objects (VMs, hosts, clusters, networks, etc.) are stored as ActiveRecord models and shared across all features.
+
+## Key database tables
+
+Some tables are central to understanding how ManageIQ works. An agent should know these exist even if it doesn't know the full schema:
+
+| Table / model | Purpose |
+|---|---|
+| `ext_management_systems` / `ExtManagementSystem` | All providers (VMs, containers, physical, cloud, etc.) |
+| `vms` / `VmOrTemplate` | VMs and templates across all infra/cloud providers |
+| `miq_queue` / `MiqQueue` | Async work queue — almost all background work is enqueued here |
+| `miq_tasks` / `MiqTask` | Tracks long-running operations triggered by users |
+| `miq_requests` / `MiqRequest` | Lifecycle requests (provision, retire, reconfigure, etc.) |
+| `metrics` / `Metric` | Realtime C&U data |
+| `metric_rollups` / `MetricRollup` | Hourly/daily rolled-up C&U data |
+| `miq_workers` / `MiqWorker` | Active worker process records |
+| `users`, `miq_groups`, `miq_user_roles`, `miq_product_features` | RBAC — see [`architecture.md`](architecture.md) |
+| `tenants` / `Tenant` | Multi-tenancy scoping |
+| `ems_events` / `EmsEvent` | Provider events (power on/off, create, etc.) |
+
+## Providers
+
+Providers are the integration point with external systems. Each provider type has an abstract base class in this repo; the concrete implementation lives in a separate gem (`manageiq-providers-<name>`). Provider plugins have their own development conventions; see [`provider_plugins.md`](provider_plugins.md).
+
+The system supports several types of providers: Infrastructure, Cloud, Containers, Physical, Network, Storage, Automation, and Configuration.
+
+See [all provider plugins](https://github.com/ManageIQ?q=manageiq-providers-) for the full list of concrete provider implementations.
+
+## Resource management
+
+Agents working on resource management features should be aware of the following:
+
+- **Managed object types**: VMs, instances, containers (pods/nodes/projects), hosts, clusters, datastores, networks, physical servers, etc. Each is a separate model hierarchy rooted in an abstract base class.
+- **Operations** (power on/off, shutdown guest, reset, pause, suspend): implemented as `supports` flags + provider-specific methods. The `Supports` concern (`app/models/concerns/supports/`) gates which operations are available for a given object.
+- **Lifecycle**: Provision, Clone, Reconfigure, Delete, Retirement. Provisioning goes through `MiqProvisionRequest` / `MiqProvision`; retirement through `RetirementManager`.
+- **VM console access**: VNC/SPICE/WebMKS/HTML5 console support; protocol varies by provider.
+- **Monitoring**: utilization data collected via metrics workers into `Metric` / `MetricRollup`; event timelines via `EmsEvent`.
+- **SmartState Analysis**: deep introspection of VM/template filesystems. Extracts files, packages, services, accounts, Windows registry entries. Implemented via `VmScan` / `JobProxyDispatcher`.
+- **Optimization / right-sizing**: recommendations based on utilization rollups stored in `MetricRollup`.
+- **Custom buttons and dialogs**: `CustomButton` / `CustomButtonSet` attach to any object type; dialog authoring is in `Dialog` / `DialogField` models. Fields can be dynamic (backed by Automate methods).
+
+## Tagging
+
+Tags are first-class citizens. Nearly every managed object supports tagging.
+
+- `Tag` and `Tagging` models; the `acts_as_miq_taggable` concern wires an object into the system.
+- Tag taxonomy: `Classification` (categories) → `Tag` (entries).
+- Tag mapping: provider-native tags (e.g. AWS labels) are mapped to ManageIQ tags via `TagMapping`.
+- Tag-based RBAC is enforced by `Rbac::Filterer` — see [`architecture.md`](architecture.md).
+
+## Dashboards and reporting
+
+- **Dashboards**: `MiqDashboard` model; widgets (`MiqWidget`) are reusable tiles (charts, reports, RSS). Dashboards can be group-owned or user-owned.
+- **Reports**: `MiqReport` covers any database entity and its relationships; supports scheduling (`MiqSchedule`), email delivery, and export to PDF/CSV/TXT. Report results stored in `MiqReportResult`.
+- **Utilization reports**: rolled-up C&U data from `MetricRollup`.
+- **Dashboard widgets**: `MiqWidget` can render a chart, a report table, or an RSS feed inside a dashboard.
+
+## Chargeback
+
+- **Rate cards**: `ChargebackRate` with `ChargebackRateDetail` entries for CPU, memory, storage, and network.
+- **Rate assignment**: `ChargebackRateDetailMeasure` + tag/resource assignments connect rate cards to groups of resources.
+- **Reports**: `ChargebackVm`, `ChargebackContainerProject`, etc. aggregate cost data; generated and stored like standard `MiqReport` results.
+
+## Service catalog
+
+The service catalog provides end-user self-service ordering. Key models:
+
+- `ServiceTemplate` — a catalog item definition; subclassed per type (VM provision, Ansible playbook, Terraform template, orchestration, etc.).
+- `ServiceTemplateProvisionRequest` / `ServiceTemplateProvisionTask` — the lifecycle of an order.
+- `Service` — a deployed service instance; can own resources (VMs, etc.).
+- `Dialog` / `DialogField` — custom ordering forms; fields can be dynamic (backed by Automate).
+- `ServiceTemplateCatalog` — groups `ServiceTemplate` records for UI presentation.
+- **Catalog item types**:
+  - Cloud/infra VM templates
+  - Ansible Playbook jobs
+  - Orchestration templates (CloudFormation, Azure ARM, OpenStack Heat, vCloud vApp, VMware OVF)
+  - Generic (custom Automate-backed)
+- **Catalog bundles**: `ServiceTemplate` with child items; supports sequenced provisioning of multiple items in a single order.
+- **Service lifecycle**: provisioning → reconfigure → retirement; each phase has request/task pairs and Automate entry points.
+
+## Policy (Event-Condition-Action)
+
+- `MiqPolicy` — defines a control or compliance policy.
+- `MiqPolicySet` — a named set of policies assigned to objects via tags.
+- **Control policies**: fire an `MiqAction` when an `MiqEvent` matches and `MiqCondition`s are satisfied.
+- **Compliance policies**: evaluate conditions and mark objects `compliant` / `non_compliant` via `ComplianceDetail`.
+- **Alerts**: `MiqAlert` watches metric thresholds and trends; fires `MiqAlertStatus` records and can trigger actions.
+- **Actions** (`MiqAction`): run an Automate method, perform a provider operation, send email, create an incident, etc.
+- **Policy simulation**: test which policies would fire for a given object/event without side effects.
+
+## Automation
+
+### Embedded Automate Engine
+
+- Domain/namespace/class/method hierarchy stored in `MiqAeDomain`, `MiqAeNamespace`, `MiqAeClass`, `MiqAeMethod`.
+- Methods are Ruby or Ansible; called from policy actions, service lifecycle, custom buttons, or directly via API.
+- Entry points resolved by the Automate path (e.g. `/ManageIQ/System/Process/request`).
+- The `MiqAeEngine` drives execution; workspace state passed via `MiqAeWorkspace`.
+- Reference: _Mastering CloudForms Automation_ (Peter McGowan) for in-depth engine internals.
+
+### Embedded Ansible
+
+- Runs `ansible-cli` as a subprocess without requiring an external AWX/Tower provider.
+- Playbooks imported from Git repositories (`ConfigurationScriptSource`).
+- Execution tracked via `ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job`.
+
+### Embedded Terraform
+
+- Runs `terraform` CLI as a subprocess.
+- Templates imported from Git repositories (`ConfigurationScriptSource` with type `ManageIQ::Providers::EmbeddedTerraform::...`).
+
+### Embedded Workflows
+
+- Custom workflow engine using Amazon States Language (ASL).
+- Built on the [`floe`](https://github.com/ManageIQ/floe) open source gem.
+- Workflows stored as `ManageIQ::Providers::EmbeddedWorkflows::...` records; execution tracked via `Floe::Workflow`.
+
+## Authentication and authorization
+
+- **RBAC**: `User`, `MiqGroup`, `MiqUserRole`, `MiqProductFeature`. Access checked via `Rbac::Filterer`; see [`rbac.md`](rbac.md) for details.
+- **Multi-tenancy**: `Tenant` model; every group belongs to a tenant; resources are scoped by tenant ownership.
+- **External auth**: OIDC, SAML, LDAP, Active Directory, IPA (with AD Trust and 2FA). Configured via `MiqServer` settings. External groups mapped to ManageIQ groups via `ExternalAuthenticationSettings` / group-mapping configuration.
+- **Audit logging**: `AuditEvent` model; written via `$audit_log` global. All significant user/system actions should produce an audit event.
+
+## Deployment
+
+Understanding deployment helps when working on multi-region, worker, or settings-related code.
+
+- **Appliance**: one or more VMs each running the full stack (UI, workers, database). Multiple appliances can be added to an installation for horizontal scaling.
+- **Podified** (Operator-based): Kubernetes deployment via the [`manageiq-operator`](https://github.com/ManageIQ/manageiq-operator). Each component (UI, API, workers) runs as a separate pod.
+- **Installation / Region**: a ManageIQ installation is a *region* — one or more appliances sharing a single PostgreSQL database. Multiple regions can replicate into a *Global Region* (also called a *super-region*) for centralized reporting. `MiqRegion`, `MiqRegionRemote`, and the `ActiveRecord::IdRegions` concern handle cross-region identity.
+- **High availability**: active/passive failover for the application tier; PostgreSQL HA via external tooling.
+- **MiqServer**: the in-process server record (`MiqServer`) tracks zone/region membership, active roles (server roles), and worker lifecycle.
+- **Zones**: logical groupings of servers (`MiqServer`) within a region; used to direct work to specific sets of workers.

--- a/docs/agents/provider_plugins.md
+++ b/docs/agents/provider_plugins.md
@@ -1,0 +1,128 @@
+# Provider Plugin Development
+
+This document covers the architecture and conventions specific to ManageIQ provider plugins. Read [`plugins.md`](plugins.md) first for the general plugin conventions that also apply here.
+
+## Manager model
+
+Every provider has a top-level manager class that inherits from one of the abstract base classes in core:
+
+| Manager type | Core base class |
+|---|---|
+| `CloudManager` | `ManageIQ::Providers::CloudManager` |
+| `InfraManager` | `ManageIQ::Providers::InfraManager` |
+| `ContainerManager` | `ManageIQ::Providers::ContainerManager` |
+| `PhysicalInfraManager` | `ManageIQ::Providers::PhysicalInfraManager` |
+| `NetworkManager` | `ManageIQ::Providers::NetworkManager` |
+| `StorageManager` | `ManageIQ::Providers::StorageManager` |
+| `AutomationManager` | `ManageIQ::Providers::AutomationManager` |
+| `ConfigurationManager` | `ManageIQ::Providers::ConfigurationManager` |
+
+All inventory objects (VMs, hosts, networks, etc.) are associated to the manager via `ems_id`. The root base class for all managers is `ExtManagementSystem` (`app/models/ext_management_system.rb` in core).
+
+### Parent/child managers and the Provider record
+
+Many providers decompose into a hierarchy:
+
+- **`Provider`** (optional) — a top-level credential/connection record that owns one or more managers. For example, `ManageIQ::Providers::Openstack::Provider` holds credentials shared by its `CloudManager`, `NetworkManager`, and `StorageManager`.
+- **Parent manager** — the primary manager (e.g. `CloudManager`); it handles refresh and credentials.
+- **Child managers** — subordinate managers (e.g. `NetworkManager`, `StorageManager`) that are created automatically under the parent and share the parent's connection. They are associated via `parent_ems_id`.
+
+Not every provider uses all three levels — simple providers may have only a single manager with no `Provider` record and no child managers.
+
+## Inventory pipeline: Refresher → Collector → Parser → Persister
+
+The `Refresher` class is the entrypoint for inventory collection. It is invoked by the `RefreshWorker` and orchestrates the full pipeline. Base classes for all pipeline stages live in core under `app/models/manageiq/providers/inventory/`.
+
+### Refresh targets: full vs. targeted
+
+Every refresh is driven by a target:
+
+- **Full refresh** — a `ManagerRefresh::Target` that covers all objects managed by the EMS.
+- **Targeted refresh** — a `TargetCollection` of specific `InventoryRefresh::Target` objects (each identified by an association name + `manager_ref`). The `Collector` uses this collection to narrow the API calls it makes; the `Persister` uses it to define the *targeted scope*, which prevents deletion of records that were not part of this refresh.
+
+### Pipeline stages
+
+| Stage | Base class (core) | Responsibility |
+|---|---|---|
+| `Refresher` | `ManageIQ::Providers::BaseManager::Refresher` | Entrypoint; receives targets, builds the pipeline, drives Collector → Parser → Persister |
+| `Collector` | `ManageIQ::Providers::Inventory::Collector` | Fetch raw data from the provider API; cache it for the parser; respects targeted scope |
+| `Parser` | `ManageIQ::Providers::Inventory::Parser` | Map raw data to ManageIQ inventory object hashes |
+| `Persister` | `ManageIQ::Providers::Inventory::Persister` | Declares a set of `InventoryCollection`s; drives upsert/disconnect/deletion |
+
+### InventoryCollection
+
+Each `InventoryCollection` represents either a Rails association (e.g. `:vms`, `:hosts`) or a custom save block. The persister uses them to perform upsert, disconnect, and deletion of stale records in a single pass. Base classes live in core at `app/models/manageiq/providers/inventory/persister/builder.rb` and `lib/manageiq/providers/inventory/persister/`.
+
+## Event collection
+
+The `EventCatcher::Runner` subclass streams events from the provider and feeds them to core. It must implement:
+
+| Method | Responsibility |
+|---|---|
+| `monitor_events` | Open the provider event stream; push raw events onto `@queue` or call `process_event` directly |
+| `stop_event_monitor` | Shut down the event stream connection |
+| `queue_event(event)` | Convert the raw event to a hash and call `EmsEvent.add_queue("add", @ems.id, event_hash)` |
+| `filtered?(event)` | (optional) Return `true` to drop an event before queuing |
+| `event_dedup_key(event)` † | Key used for flood-prevention deduplication |
+| `event_dedup_descriptor(event)` † | Human-readable event description for flood-prevention logging |
+
+† Only required when the `:flooding_monitor_enabled` setting is `true`. Currently only VMware implements the flooding monitor.
+
+The event hash must include `:event_type` and any resource references (`vm_ems_ref`, `host_ems_ref`, etc.) so core can correlate the event to existing inventory. Event groups for policy and alerting are declared in the provider's settings YAML under `ems.<provider_key>.event_handling.event_groups`.
+
+## Metrics collection
+
+The `MetricsCapture` class (one per provider, inheriting from `ManageIQ::Providers::<ManagerType>::MetricsCapture`) handles C&U data collection. It must implement:
+
+| Method | Responsibility |
+|---|---|
+| `perf_collect_metrics(interval_name, start_time, end_time)` | Fetch raw metrics from the provider; return `[counters_by_ems_ref, counter_values_by_ems_ref_and_ts]` |
+| `capture_ems_targets(options = {})` | Return the objects (`Host`, `Vm`, `Storage`, etc.) eligible for capture |
+
+Core processes the returned data into `Metric` records (realtime) and `MetricRollup` records (hourly/daily). Resources must declare `supports :capture` to be included in targeting.
+
+## Operations
+
+Provider operations (power actions, resize, snapshot, etc.) are dispatched as `MiqQueue` messages with role `ems_operations` and routed to the provider's `OperationsWorker` via `queue_name_for_ems_operations`. The pattern for each operation is:
+
+1. Declare support with `supports :operation_name` (or `supports(:operation_name) { reason_unsupported }`) on the model.
+2. Implement `raw_<operation>` on the model to make the actual provider API call; raise `NotImplementedError` in the base class to require provider implementation.
+3. The `<operation>_queue` wrapper (provided by core mixins) enqueues the `raw_<operation>` call via `run_command_via_queue`.
+
+Override `queue_name_for_ems_operations` on the manager class to return the provider-specific queue name (defaults to `"generic"` until an `OperationsWorker` is defined).
+
+## Workers
+
+Each worker is a separate OS process — a `MiqWorker` subclass. Do not use background threads. Worker base classes live in core.
+
+| Worker | Core base class | Purpose |
+|---|---|---|
+| `RefreshWorker` | `ManageIQ::Providers::BaseManager::RefreshWorker` | Polls for full and targeted inventory refreshes |
+| `EventCatcher` | `ManageIQ::Providers::BaseManager::EventCatcher` | Streams real-time events from the provider; creates `EmsEvent` records |
+| `MetricsCollectorWorker` | `ManageIQ::Providers::BaseManager::MetricsCollectorWorker` | Collects performance metrics; feeds `Metric` records |
+| `OperationsWorker` | `ManageIQ::Providers::BaseManager::OperationsWorker` | Executes provider operations queued with role `ems_operations` |
+
+Each worker has a `Runner` inner class that contains the process loop. Workers are registered with systemd via `.service` / `.target` units in the `systemd/` directory of the plugin gem.
+
+## VCR cassettes
+
+HTTP interactions with the provider API are recorded as cassettes and replayed in specs. The configuration is strict — see `spec/manageiq/docs/agents/testing.md` for the full rules.
+
+Provider-specific setup:
+
+- Cassettes live in `spec/vcr_cassettes/`.
+- Credentials and other secrets used as cassette placeholders are declared in `spec/config/secrets.defaults.yml` (committed, contains only placeholder names) and `spec/config/secrets.yml` (gitignored, contains real values for recording).
+- Placeholders are registered via `VcrSecrets.define_all_cassette_placeholders` in `spec/spec_helper.rb`.
+
+To re-record a cassette, delete the cassette file and re-run the spec with real credentials in `spec/config/secrets.yml`. VCR will record a new cassette on the next run.
+
+## spec/models layout
+
+Provider specs that exercise model classes go under `spec/models/<plugin_path>/`, mirroring the `app/models/<plugin_path>/` tree.
+
+## Factories
+
+- **Core** (`manageiq/spec/factories/`) — factories shared across providers or needed by core specs. Examples: `:ems_infra`, `:vm_or_template`, `:vm_cloud`.
+- **Provider** (`spec/factories/`) — factories for models specific to that one provider.
+
+Rule of thumb: if any spec outside this plugin would ever need the factory, define it in core.

--- a/docs/agents/rbac.md
+++ b/docs/agents/rbac.md
@@ -1,0 +1,108 @@
+# RBAC (Role-Based Access Control)
+
+ManageIQ enforces authorization at the data-retrieval layer via `Rbac::Filterer` (`lib/rbac/filterer.rb`). It is **not** automatic — you must call it explicitly for any user-facing query.
+
+## The golden rule
+
+Never use raw `.where` for user-facing record retrieval. Always go through:
+
+```ruby
+Rbac.search(class: VmOrTemplate, user: current_user)   # returns [records, attrs]
+Rbac.filtered(VmOrTemplate.all, user: current_user)    # returns records
+Rbac.filtered_object(vm, user: current_user)           # returns object or nil
+```
+
+`Rbac.search` is the full entry point (supports paging, counts, filters). `Rbac.filtered` and `Rbac.filtered_object` are convenience wrappers that call `search` internally.
+
+## Data model
+
+```mermaid
+erDiagram
+    User }o--o{ MiqGroup : "via Entitlement"
+    MiqGroup ||--|| MiqUserRole : "has one"
+    MiqUserRole }o--o{ MiqProductFeature : "via miq_roles_features"
+    MiqGroup }o--|| Tenant : "belongs to"
+    MiqGroup ||--o{ Entitlement : "has one"
+    Entitlement {
+        string managed_filters
+        string belongsto_filters
+    }
+    MiqProductFeature {
+        string identifier
+        string feature_type
+    }
+    Tenant {
+        int parent_id "tree via ancestry"
+    }
+```
+
+- **`User`** — a person or service account. Belongs to one or more `MiqGroup`s; one group is the *current group* that determines active permissions.
+- **`MiqGroup`** — links a user to a role and a tenant. Carries the managed/belongsto filter assignments (`Entitlement`).
+- **`MiqUserRole`** — defines what actions are allowed. Has many `MiqProductFeature` records via the join table `miq_roles_features`.
+- **`MiqProductFeature`** — a tree of feature identifiers (e.g. `"vm_explorer"`, `"vm_power_on"`). The root feature `"everything"` is the super-admin grant. Roles are checked with `role.allows?(identifier:)`, which walks up the feature tree.
+- **`Entitlement`** — the join model between `MiqGroup` and `MiqUserRole`; also stores the group's managed and belongsto filter expressions.
+
+## Tenancy
+
+Every `MiqGroup` belongs to a `Tenant`. Tenants form a tree; child tenants can see resources owned by their ancestors (and vice-versa for some resource types). The `TENANT_ACCESS_STRATEGY` hash in `Rbac::Filterer` defines the traversal direction per model:
+
+| Strategy | Meaning |
+|---|---|
+| `:descendant_ids` | All child tenants can see the resource (e.g. `Vm`) |
+| `:ancestor_ids` | All parent tenants can see the resource (e.g. `ExtManagementSystem`, `ServiceTemplate`) |
+| `nil` | Only the owning tenant can see the resource (e.g. `OrchestrationStack`) |
+
+Models not in `TENANT_ACCESS_STRATEGY` are not tenant-scoped.
+
+## Filter types
+
+Filters live on the group's `Entitlement` and are stored as `MiqExpression` or tag-path arrays. `Rbac::Filterer` evaluates all active filters and intersects/unions the resulting ID sets.
+
+### Managed filters (tag-based)
+
+Restrict records to those carrying specific tag categories/values. Only classes listed in `TAGGABLE_FILTER_CLASSES` (a superset of `CLASSES_THAT_PARTICIPATE_IN_RBAC`) are subject to managed filters.
+
+### Belongsto filters (tree-based)
+
+Restrict records to those that belong to a given infrastructure node — a datacenter, cluster, host, resource pool, or infrastructure folder. Only classes in `BELONGSTO_FILTER_CLASSES` are subject to belongsto filters. Note: belongsto filters force Ruby-side filtering (SQL LIMIT cannot be applied), which has performance implications on large datasets.
+
+### Self-service / ownership filters
+
+Roles can be marked as *self-service* (see `MiqUserRole#self_service?`) to restrict users to objects they own (`OwnershipMixin`) or that belong to their group. This is combined with other filters via union.
+
+## Adding a class to RBAC
+
+For tag-based RBAC to apply to a new class, **both** of the following must be true:
+
+1. The class is listed in `Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC`
+2. The model includes `acts_as_miq_taggable`
+
+If the class should also be subject to belongsto filters, add it to `BELONGSTO_FILTER_CLASSES`.
+
+If the class should be tenant-scoped, add an entry in `TENANT_ACCESS_STRATEGY`.
+
+## Feature-flag checks (UI/API access)
+
+Checking whether a user can perform an action is separate from the data-retrieval filter:
+
+```ruby
+current_user.role_allows?(:identifier => "vm_power_on")
+```
+
+Feature identifiers are seeded from `db/fixtures/miq_product_features.yml` (and per-plugin equivalents). The tree is hierarchical — granting a parent feature implicitly grants all its children.
+
+## Specs
+
+Use the `:user` factory with a `features:` transient, or the `stub_user` helper from `spec/support/auth_helper.rb`. For data-scoping tests use `Rbac.filtered` directly rather than mocking the filterer.
+
+```ruby
+# create a user whose role allows specific features
+let(:user) { FactoryBot.create(:user, :features => %w[vm_explorer]) }
+
+# super-admin shortcut
+let(:admin) { FactoryBot.create(:user_admin) }
+
+# controller/request specs — stubs User.current_user and session
+stub_user(:features => %w[vm_power_on])
+stub_admin   # equivalent to stub_user(:features => :all)
+```

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,38 @@
+# Testing
+
+## RSpec setup
+
+- Tests run with `--order random`. Caches are reset between examples via `EvmSpecHelper.clear_caches`.
+- `MiqRegion.seed` runs before the suite — tests can assume a default region exists.
+- `EvmSpecHelper.local_miq_server` creates/finds a local server record; use it when a test needs server role assignment.
+- Specs that create DB rows must use `use_transactional_fixtures` isolation — avoid shared mutable state at class level in specs. `parallel_tests` can be configured locally to speed up the suite but is not used by CI.
+
+## FactoryBot
+
+Factory files live in `spec/factories/`. Use `FactoryBot.create(:factory_name)` patterns. When adding a sequence-based name attribute to a factory, use the `seq_padded_for_sorting(n)` helper, which pads to 13 digits for consistent sort ordering.
+
+## VCR cassettes
+
+Cassettes live in `spec/vcr_cassettes/`. The configuration is strict:
+
+- `allow_http_connections_when_no_cassette: false` — all outbound HTTP in specs must be cassette-recorded or explicitly stubbed.
+- `allow_unused_http_interactions: false` — cassettes with interactions that are never replayed will fail the spec.
+
+## Spec helpers
+
+Key helpers in `spec/support/`:
+
+| Helper | Purpose |
+|---|---|
+| `evm_spec_helper.rb` | Suite-wide setup, cache clearing, `local_miq_server` |
+| `settings_helper.rb` | `stub_settings(hash)`, `stub_settings_merge(hash)` |
+| `supports_helper.rb` | `stub_supports`, `stub_supports_not` for feature support flags |
+
+Check these before assuming standard RSpec helpers cover a given concern.
+
+## CI test suites
+
+CI runs two suites, controlled by the `TEST_SUITE` env var:
+
+- `TEST_SUITE=vmdb` — full spec suite (`bundle exec rake test:vmdb`)
+- `TEST_SUITE=security` — security audit suite (`bundle exec rake test:security`)

--- a/lib/generators/manageiq/plugin/plugin_generator.rb
+++ b/lib/generators/manageiq/plugin/plugin_generator.rb
@@ -25,14 +25,15 @@ module ManageIQ
 
     def create_plugin_files
       template "%plugin_name%.gemspec"
+      template ".github/workflows/ci.yaml"
       template ".gitignore"
       template ".rspec"
       template ".rspec_ci"
       template ".rubocop.yml"
       template ".rubocop_local.yml", :skip => true
-      template ".github/workflows/ci.yaml"
       template ".whitesource"
       template ".yamllint"
+      template "AGENTS.md"
       template "Gemfile"
       template "LICENSE.txt"
       template "Rakefile"

--- a/lib/generators/manageiq/plugin/templates/AGENTS.md
+++ b/lib/generators/manageiq/plugin/templates/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — <%= class_name %>
+
+`<%= plugin_description %>`
+
+This is a ManageIQ plugin — a Rails engine gem that extends the core ManageIQ platform. Plugins are not standalone applications; they run mounted inside the core ManageIQ repository, which is checked out at `spec/manageiq/` for testing purposes. Core models, workers, RBAC, settings, and helpers are all provided by that core checkout.
+
+- Gem name: `<%= plugin_name %>`
+- Engine: `lib/<%= plugin_path %>/engine.rb`
+
+## Further reading
+
+Load these when the task requires it — do not load them speculatively:
+
+- **Core ManageIQ conventions** (RBAC, Settings, workers, logging, testing, i18n): `spec/manageiq/AGENTS.md`
+- **Plugin repo layout, setup, commands, code style**: `spec/manageiq/docs/agents/plugins.md`

--- a/lib/generators/manageiq/provider/provider_generator.rb
+++ b/lib/generators/manageiq/provider/provider_generator.rb
@@ -34,11 +34,44 @@ module ManageIQ
         "[#{match}, 'app:test:providers_common']"
       end
 
+      append_provider_agents_md
+
       create_scaffolding if options[:scaffolding]
       create_vcr         if options[:vcr]
     end
 
     private
+
+    def append_provider_agents_md
+      content = <<~AGENTS_MD
+
+        ## Provider architecture
+
+        For the full provider architecture guide (manager model, inventory pipeline,
+        workers, VCR cassettes) see:
+        `spec/manageiq/docs/agents/provider_plugins.md`
+      AGENTS_MD
+
+      if options[:scaffolding]
+        content += <<~AGENTS_MD
+
+          ### Class paths for this provider
+
+          | Class | Path |
+          |---|---|
+          | Manager | `app/models/#{plugin_path}/#{manager_path}.rb` |
+          | Refresher | `app/models/#{plugin_path}/#{manager_path}/refresher.rb` |
+          | RefreshWorker | `app/models/#{plugin_path}/#{manager_path}/refresh_worker.rb` |
+          | EventCatcher | `app/models/#{plugin_path}/#{manager_path}/event_catcher.rb` |
+          | MetricsCollectorWorker | `app/models/#{plugin_path}/#{manager_path}/metrics_collector_worker.rb` |
+          | Collector | `app/models/#{plugin_path}/inventory/collector/#{manager_path}.rb` |
+          | Parser | `app/models/#{plugin_path}/inventory/parser/#{manager_path}.rb` |
+          | Persister | `app/models/#{plugin_path}/inventory/persister/#{manager_path}.rb` |
+        AGENTS_MD
+      end
+
+      append_to_file "AGENTS.md", content
+    end
 
     # The short name of the provider
     #


### PR DESCRIPTION
- Add top-level AGENTS.md with agent coding rules, commands, code style, architecture constraints, and testing notes
- Add docs/agents/ subtree with detailed pages for product overview, coding patterns (including i18n), architecture, testing, plugins, and provider plugins
- Add AGENTS.md templates to the plugin and provider plugin generators so new engines start with agent-ready documentation

AGENTS.md is kept short deliberately. Agents load it on every task, so bloating it wastes context. It covers only the mistakes most likely to slip through — wrong logger, raw .where instead of Rbac.search, etc.

The docs/agents/ pages are on-demand. The "Further reading" section explicitly tells agents not to load them speculatively — only when the task requires it. Simple tasks stay lean; complex ones get full detail.

The detail pages convey non-obvious constraints that aren't visible from reading the source (why Rbac.search, why Settings must be read at call time, how ID regions work) rather than enumerating methods agents can already find themselves.

---

@ManageIQ/core-admins  Please review.
@agrare Can you read the providers section - there were details in there I wasn't 100% sure about.

This is intended to be an initial first draft. I assume we will expand on this as necessary.
Separately, I intend to blast out the plugin AGENTS.md files after this is merged. After that, we can update any plugin-specific AGENTS.md files with repo specific details.