### PR TITLE
Fix sporadic failure in AWX workflow_job_spec

### DIFF
--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :configuration_script_base do
     sequence(:name) { |n| "Configuration_script_base_#{seq_padded_for_sorting(n)}" }
-    sequence(:manager_ref) { SecureRandom.random_number(100) }
+    sequence(:manager_ref)
     variables { {:instance_ids => ['i-3434']} }
   end
 


### PR DESCRIPTION
AWX/AnsibleTower has a spec where a configuration_script is used for the response in a mocked API call, and the name is matched to the "raw_job" which has the template.name.

Because the `ConfigurationScript` factory has a `manager_ref` with a total number of possible values of 100 it is possible for a manager_ref to be reused causing a name mismatch with the expected value.

Example failure: https://github.com/ManageIQ/manageiq-providers-ansible_tower/actions/runs/33085525009/job/98563992666#step:7:102

Tested by adding `1000.times {}` around the whole refresh_ems context which was reliably able to get that spec to fail.  Since there is no reason why there can be only 100 manager refs I don't see why we don't leave this as a simple sequence ensuring that this is never reused.

```
diff --git a/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb b/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
index 079fdf8..0dfee1b 100644
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/workflow_job_spec.rb
@@ -79,6 +79,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob do
       end
     end
 
+    1000.times do
     context "#refresh_ems" do
       before do
         allow_any_instance_of(ManageIQ::Providers::AnsibleTower::Provider).to receive_messages(:connect => connection)
@@ -162,6 +163,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob do
         end
       end
     end
+    end
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
