### PR TITLE
Fix MiqRequestTask tenant access strategy to :descendant_ids

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -141,7 +141,7 @@ module Rbac
       'MiqAeNamespace'         => :ancestor_ids,
       'MiqGroup'               => :descendant_ids,
       'MiqRequest'             => :descendant_ids,
-      'MiqRequestTask'         => nil, # tenant only
+      'MiqRequestTask'         => :descendant_ids,
       'MiqTemplate'            => :ancestor_ids,
       'NetworkPort'            => :descendant_ids,
       'NetworkRouter'          => :descendant_ids,

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -857,7 +857,7 @@ RSpec.describe Rbac::Filterer do
         end
       end
 
-      context "with accessible_tenant_ids filtering (strategy = nil aka tenant only)" do
+      context "with accessible_tenant_ids filtering (strategy = :descendant_ids)" do
         it "can see tenant's request task" do
           task = FactoryBot.create(:miq_request_task, :tenant => owner_tenant)
           results = described_class.search(:class => "MiqRequestTask", :miq_group => owner_group).first
@@ -870,10 +870,10 @@ RSpec.describe Rbac::Filterer do
           expect(results).to match_array []
         end
 
-        it "can't see descendant tenant's request task" do
-          _task = FactoryBot.create(:miq_request_task, :tenant => child_tenant)
+        it "can see descendant tenant's request task" do
+          task = FactoryBot.create(:miq_request_task, :tenant => child_tenant)
           results = described_class.search(:class => "MiqRequestTask", :miq_group => owner_group).first
-          expect(results).to match_array []
+          expect(results).to match_array [task]
         end
       end
 


### PR DESCRIPTION
MiqRequestTask was using nil (tenant only), while MiqRequest uses :descendant_ids. This means a parent tenant user could see and approve child tenant requests but could not see the underlying request tasks that fulfill them.

History:
- PR #4425 added both MiqRequest and MiqRequestTask with nil (tenant only), which was the original design.
- PR #7055 changed MiqRequest to :descendant_ids so parent tenant users could approve child tenant requests. MiqRequestTask was not updated at the same time.

MiqRequestTask records always belong to the requesting user's tenant (tenant_id is set from get_user.current_tenant at task creation time). Without :descendant_ids, a parent tenant administrator can see the request but not the tasks that execute it, making cross-tenant request approval incomplete.

This is a functionality bug, not a security issue. The :descendant_ids strategy only exposes records downward in the tenant tree (parent sees children), consistent with the existing MiqRequest behavior.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
