### PR TITLE
Fix chart data

### DIFF
--- a/lib/manageiq/reporting/formatter/c3.rb
+++ b/lib/manageiq/reporting/formatter/c3.rb
@@ -151,18 +151,26 @@ module ManageIQ
           mri.chart[:axis][:x] = {:type => 'timeseries', :tick => {}}
           # set flag for performance chart
           mri.chart[:miq][:performance_chart] = true
-          # this conditions are taken from build_performance_chart_area method from chart_commons.rb
-          if mri.db.include?("Daily") || (mri.where_clause && mri.where_clause.include?("daily"))
-            # set format for parsing
-            mri.chart[:data][:xFormat] = '%m/%d'
-            # set format for labels
-            mri.chart[:axis][:x][:tick][:format] = '%m/%d'
-          elsif mri.extras[:realtime] == true
-            mri.chart[:data][:xFormat] = '%H:%M:%S'
-            mri.chart[:axis][:x][:tick][:format] = '%H:%M:%S'
-          else
-            mri.chart[:data][:xFormat] = '%H:%M'
-            mri.chart[:axis][:x][:tick][:format] = '%H:%M'
+          # these conditions are taken from build_performance_chart_area method from chart_commons.rb
+          fmt = if mri.db.include?("Daily") || (mri.where_clause && mri.where_clause.include?("daily"))
+                  '%m/%d'
+                elsif mri.extras[:realtime] == true
+                  '%H:%M:%S'
+                else
+                  '%H:%M'
+                end
+          # set format for parsing and for axis labels
+          mri.chart[:data][:xFormat] = fmt
+          mri.chart[:axis][:x][:tick][:format] = fmt
+          # The x column contains values that were passed through add_axis_category_text
+          # → slice_legend, which converts Time objects to ISO 8601 strings via .iso8601(3).
+          # Those ISO strings cannot be parsed by C3 using the short xFormat (e.g. '%m/%d').
+          # Re-parse each value and reformat it to match xFormat so C3 can read it.
+          x_col = mri.chart[:data][:columns].first # ['x', "2024-06-17T00:00:00.000Z", ...]
+          x_col.map!.with_index do |v, i|
+            next v if i.zero?
+            time = v.respond_to?(:strftime) ? v : Time.parse(v)
+            time.strftime(fmt)
           end
         end
 

--- a/lib/manageiq/reporting/formatter/c3.rb
+++ b/lib/manageiq/reporting/formatter/c3.rb
@@ -162,15 +162,14 @@ module ManageIQ
           # set format for parsing and for axis labels
           mri.chart[:data][:xFormat] = fmt
           mri.chart[:axis][:x][:tick][:format] = fmt
-          # The x column contains values that were passed through add_axis_category_text
-          # → slice_legend, which converts Time objects to ISO 8601 strings via .iso8601(3).
-          # Those ISO strings cannot be parsed by C3 using the short xFormat (e.g. '%m/%d').
-          # Re-parse each value and reformat it to match xFormat so C3 can read it.
-          x_col = mri.chart[:data][:columns].first # ['x', "2024-06-17T00:00:00.000Z", ...]
-          x_col.map!.with_index do |v, i|
-            next v if i.zero?
-            time = v.respond_to?(:strftime) ? v : Time.parse(v)
-            time.strftime(fmt)
+          # The x column contains ISO 8601 strings produced by slice_legend via .iso8601(3).
+          # C3 cannot parse those with the short '%m/%d' xFormat, so reformat them here.
+          if fmt == '%m/%d'
+            x_col = mri.chart[:data][:columns].first # ['x', "2024-06-17T00:00:00.000Z", ...]
+            x_col.map!.with_index do |v, i|
+              next v if i.zero?
+              Time.parse(v).strftime(fmt)
+            end
           end
         end
 

--- a/spec/lib/manageiq/reporting/formatter/c3_spec.rb
+++ b/spec/lib/manageiq/reporting/formatter/c3_spec.rb
@@ -105,7 +105,7 @@ describe ManageIQ::Reporting::Formatter::C3 do
 
     it "has right data" do
       expect(report.chart[:data][:columns][0].count).to eq(report.table.data.count + 1)
-      expect(report.chart[:data][:columns][0]).to eq(["x", "2017-08-19T00:00:00.000Z", "2017-08-20T00:00:00.000Z"])
+      expect(report.chart[:data][:columns][0]).to eq(["x", "08/19", "08/20"])
       expect(report.chart[:data][:columns][1]).to eq(["1", 19_986.0, 205_632.0])
       expect(report.chart[:data][:columns][2]).to eq(["2", 41_584.0, 41_584.0])
     end
@@ -132,7 +132,7 @@ describe ManageIQ::Reporting::Formatter::C3 do
 
     it "has right data" do
       expect(report.chart[:data][:columns][0].count).to eq(report.table.data.count + 1)
-      expect(report.chart[:data][:columns][0]).to eq(["x", "2017-08-19T00:00:00.000Z", "2017-08-20T00:00:00.000Z"])
+      expect(report.chart[:data][:columns][0]).to eq(["x", "08/19", "08/20"])
       expect(report.chart[:data][:columns][1]).to eq(["1", 19_986.0, 205_632.0])
       expect(report.chart[:data][:columns][2]).to eq(["2", 41_584.0, 41_584.0])
     end


### PR DESCRIPTION
Fix chart data for utilization and capacity charts. Utilization chart data is currently throwing errors
`Failed to parse x '2024-06-17T00:00:00.000Z' to Date object`, this PR fixes the data to be in the correct format. The actual chart and data are still displayed the same, the only difference is the console errors are now fixed.

Before:
<img width="1143" height="750" alt="Screenshot 2026-09-01 at 11 50 27 AM" src="https://github.com/user-attachments/assets/00a49532-5d63-4c63-a4c6-07ead105a8da" />

After:
<img width="1156" height="728" alt="Screenshot 2026-09-01 at 11 51 58 AM" src="https://github.com/user-attachments/assets/0a219731-28a9-4d7a-8edf-b21432d53047" />


