### PR TITLE
Handle a `ServiceTemplateAwx` without explicit zone

### DIFF
--- a/app/models/service_template_awx.rb
+++ b/app/models/service_template_awx.rb
@@ -61,7 +61,11 @@ class ServiceTemplateAwx < ServiceTemplateAutomation
   end
 
   def my_zone
-    zone&.name || job_template.manager.try(:my_zone)
+    # Determine the zone from either the Service directly, a ConfigurationScript in the service_resources (deprecated type),
+    # or a MiqRequest in the service_resources.
+    zone&.name ||
+      job_template&.manager.try(:my_zone) ||
+      service_resources.find_by(:resource_type => 'MiqRequest')&.resource&.my_zone
   end
 
   private

--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -144,5 +144,52 @@ RSpec.describe ServiceTemplateAnsibleTower do
         expect(service_template.my_zone).to eq(nil)
       end
     end
+
+    context 'with an explicit zone set on the service template' do
+      let!(:server_zone) { EvmSpecHelper.local_miq_server.zone }
+      let(:explicit_zone) { FactoryBot.create(:zone, :name => 'explicit_zone') }
+      let(:service_template_with_zone) { FactoryBot.create(:service_template_ansible_tower, :zone => explicit_zone) }
+
+      it 'returns the explicit zone even when it differs from MiqServer.my_zone' do
+        expect(service_template_with_zone.my_zone).to eq(explicit_zone.name)
+        expect(explicit_zone.name).not_to eq(server_zone.name)
+      end
+    end
+
+    context 'with no zone, no job_template, and no MiqRequest in service_resources' do
+      it 'returns nil' do
+        service_template = FactoryBot.create(:service_template_ansible_tower)
+        expect(service_template.my_zone).to be_nil
+      end
+    end
+
+    context 'with a MiqRequest in service_resources' do
+      let!(:zone) { EvmSpecHelper.local_miq_server.zone }
+      let(:miq_request) { FactoryBot.create(:automation_request) }
+      let(:service_template_no_job_template) { FactoryBot.create(:service_template_ansible_tower) }
+
+      before do
+        service_template_no_job_template.service_resources.create!(:resource => miq_request)
+      end
+
+      it 'takes the zone from the MiqRequest' do
+        expect(service_template_no_job_template.my_zone).to eq(zone.name)
+      end
+    end
+
+    context 'with a MiqRequest in service_resources and a job template without a manager' do
+      let!(:zone) { EvmSpecHelper.local_miq_server.zone }
+      let(:job_template_no_manager) { FactoryBot.create(:configuration_script, :manager => nil) }
+      let(:service_template_no_manager) { FactoryBot.create(:service_template_ansible_tower, :job_template => job_template_no_manager) }
+      let(:miq_request) { FactoryBot.create(:automation_request) }
+
+      before do
+        service_template_no_manager.service_resources.create!(:resource => miq_request)
+      end
+
+      it 'falls back to the MiqRequest zone when job_template manager is absent' do
+        expect(service_template_no_manager.my_zone).to eq(zone.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
If a zone isn't set on the `ServiceTemplate` we fall back to using the zone from the source.

In the case of `AWX`/`AAP` the source can be in `service_resources` directly as a `job_template` in the deprecated case, or as part of a `MiqProvisionConfigurationScriptRequest` in the current case.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
