### PR TITLE
Stricter deployment name lengths

### DIFF
--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -131,12 +131,13 @@ RSpec.describe MiqWorker::ContainerCommon do
       test_cases.each { |test| expect(test[:subject].worker_deployment_name).to eq(test[:name]) }
     end
 
-    it "no worker deployment names are over 60 characters", :providers_common => true do
+    it "no worker deployment names are over 63 characters", :providers_common => true do
       # OpenShift does not allow deployment names over 63 characters
-      # We also want to leave some for the ems_id so we compare against 60 to be safe
+      # We also want to leave some room for the compressed region number (e.g. 10r99)
+      #   so we buffer 5 characters
       MiqWorkerType.seed
       MiqWorkerType.pluck(:worker_type).each do |klass|
-        expect(klass.constantize.new.worker_deployment_name.length).to be <= 60
+        expect(klass.constantize.new.worker_deployment_name.length + 5).to be <= 63
       end
     end
 


### PR DESCRIPTION
@agrare Please review. I increased the compressed region size in this test from 3 to 5. A 2 digit region id is not uncommon, and it's unusual but not impossible to have 2 digit ems_ids (e.g. `1r99`, `10r99`, or even `1r100`. This seems a bit safer to assume 5 character buffer in the test vs 3.

I also made the test description and check more explicit about the max size, instead of encoding the math.

I think this would have caught the length in https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/577 avoiding https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/580

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
