### PR TITLE
Fix sporadic `worker_deployment_name.length` failure when `MiqServer.compressed_id` is over 100

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -105,11 +105,15 @@ class MiqWorker
       "#{MiqServer.my_server.compressed_id}-"
     end
 
+    def deployment_base_name
+      minimal_class_name.sub("Manager", "").underscore.dasherize.tr("/", "-")
+    end
+
     def worker_deployment_name
       @worker_deployment_name ||= begin
-        deployment_name = abbreviated_class_name.dup.chomp("Worker").sub("Manager", "").sub(/^Miq/, "")
+        deployment_name = deployment_base_name.dup
         deployment_name << "-#{ApplicationRecord.split_id(ems_id).last}" if respond_to?(:ems_id) && ems_id.present?
-        "#{deployment_prefix}#{deployment_name.underscore.dasherize.tr("/", "-")}"
+        "#{deployment_prefix}#{deployment_name}"
       end
     end
 

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -137,7 +137,8 @@ RSpec.describe MiqWorker::ContainerCommon do
       #   so we buffer 5 characters
       MiqWorkerType.seed
       MiqWorkerType.pluck(:worker_type).each do |klass|
-        expect(klass.constantize.new.worker_deployment_name.length + 5).to be <= 63
+        worker_deployment_name = klass.constantize.new.worker_deployment_name
+        expect(worker_deployment_name.length + 5).to be <= 63, "Expected \"#{worker_deployment_name}\".length + 5 <= 63"
       end
     end
 

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -131,16 +131,18 @@ RSpec.describe MiqWorker::ContainerCommon do
       test_cases.each { |test| expect(test[:subject].worker_deployment_name).to eq(test[:name]) }
     end
 
+  end
+
+  describe "#deployment_base_name" do
+    before { MiqWorkerType.seed }
+
     it "no worker deployment names are over 63 characters", :providers_common => true do
       # OpenShift does not allow deployment names over 63 characters
       # We also want to leave some room for the compressed region number (e.g. 10r99)
-      #   so we buffer 6 characters (e.g. 10r99-).
-      MiqWorkerType.seed
+      # and an ems_id so we buffer 9 characters.
       MiqWorkerType.pluck(:worker_type).each do |klass|
-        # Strip off the current miq_server compressed_id prefix so that we can compare the base
-        # worker_deployment_name to a longer compressed_id prefix like 10r99-.
-        worker_deployment_name = klass.constantize.new.worker_deployment_name.split("-", 2).last
-        expect(worker_deployment_name.length + 6).to be <= 63, "Expected \"10r99-#{worker_deployment_name}\".length <= 63"
+        deployment_base_name = klass.constantize.new.deployment_base_name
+        expect(deployment_base_name.length + 9).to be <= 63, "Expected \"10r99-#{deployment_base_name}-10\".length <= 63"
       end
     end
 

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -134,11 +134,13 @@ RSpec.describe MiqWorker::ContainerCommon do
     it "no worker deployment names are over 63 characters", :providers_common => true do
       # OpenShift does not allow deployment names over 63 characters
       # We also want to leave some room for the compressed region number (e.g. 10r99)
-      #   so we buffer 5 characters
+      #   so we buffer 6 characters (e.g. 10r99-).
       MiqWorkerType.seed
       MiqWorkerType.pluck(:worker_type).each do |klass|
-        worker_deployment_name = klass.constantize.new.worker_deployment_name
-        expect(worker_deployment_name.length + 5).to be <= 63, "Expected \"#{worker_deployment_name}\".length + 5 <= 63"
+        # Strip off the current miq_server compressed_id prefix so that we can compare the base
+        # worker_deployment_name to a longer compressed_id prefix like 10r99-.
+        worker_deployment_name = klass.constantize.new.worker_deployment_name.split("-", 2).last
+        expect(worker_deployment_name.length + 6).to be <= 63, "Expected \"10r99-#{worker_deployment_name}\".length <= 63"
       end
     end
 


### PR DESCRIPTION
Strip the leading `deployment_prefix` since the `MiqServer.my_server.compressed_id` for the miq_server created by the factory can have an excessively large ID (e.g. `70r1192` seen below).  Since this prefix isn't a consistent length it causes the spec tests to fail sporadically.

Also I update the worker_deployment_name length spec to print the worker_deployment_name that failed, not just that 64 > 63 which isn't helpful in figuring out what is wrong.

Before:
```

  1) MiqWorker::ContainerCommon#worker_deployment_name no worker deployment names are over 63 characters
     Failure/Error: expect(klass.constantize.new.worker_deployment_name.length + 5).to be <= 63

       expected: <= 63
            got:    64
```

After:
```
Failures:

  1) MiqWorker::ContainerCommon#worker_deployment_name no worker deployment names are over 63 characters
     Failure/Error: expect(worker_deployment_name.length + 5).to be <= 63, "Expected #{worker_deployment_name}.length + 5 <= 63"
       Expected 70r1192-ibm-cloud-power-virtual-servers-cloud-event-catcher.length + 5 <= 63
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
