### PR TITLE
Drop lockfile printing in CI

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -85,10 +85,6 @@ module ManageIQ
       else
         system!("bundle update --jobs=3", :chdir => root)
       end
-      return unless ci?
-
-      lockfile_contents = File.read(root.join("Gemfile.lock"))
-      puts "===== Begin Gemfile.lock =====\n\n#{lockfile_contents}\n\n===== End Gemfile.lock ====="
     end
 
     def self.create_database(root = APP_ROOT)


### PR DESCRIPTION
This is no longer needed because CI already prints the lockfile as part of setup-ruby action.

@jrafanie Please review. It's just overly verbose and is no longer necessary.