### PR TITLE
Show worker deployment name in length check failure message

### DIFF
--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -137,7 +137,8 @@ RSpec.describe MiqWorker::ContainerCommon do
       #   so we buffer 5 characters
       MiqWorkerType.seed
       MiqWorkerType.pluck(:worker_type).each do |klass|
-        expect(klass.constantize.new.worker_deployment_name.length + 5).to be <= 63
+        worker_deployment_name = klass.constantize.new.worker_deployment_name
+        expect(worker_deployment_name.length + 5).to(be <= 63, "#{worker_deployment_name.inspect} is too long")
       end
     end
 


### PR DESCRIPTION
@agrare Please review.

When a worker fails this check it's hard to know which one it is, so this adds it in.

Example before with the missing detail.

```
  1) MiqWorker::ContainerCommon#worker_deployment_name no worker deployment names are over 63 characters
     Failure/Error: expect(klass.constantize.new.worker_deployment_name.length + 5).to be <= 63

       expected: <= 63
            got:    64
     # ./spec/models/miq_worker/container_common_spec.rb:140:in `block (4 levels) in <top (required)>'
     # ./spec/models/miq_worker/container_common_spec.rb:139:in `each'
     # ./spec/models/miq_worker/container_common_spec.rb:139:in `block (3 levels) in <top (required)>'
```