### PR TITLE
feat: store PowerVS instance health state and reason in dedicated vms columns

### DIFF
--- a/db/migrate/20250901000000_add_health_state_to_vms.rb
+++ b/db/migrate/20250901000000_add_health_state_to_vms.rb
@@ -1,0 +1,6 @@
+class AddHealthStateToVms < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vms, :health_state,   :string
+    add_column :vms, :health_details, :string
+  end
+end


### PR DESCRIPTION
IBM Cloud Power VS returns a health object per instance alongside the power status:
"health": {
  "lastUpdate": "2026-09-10T14:26:37.759526",
  "reason": "rmc_state - inactive",
  "status": "WARNING"
}

To capture this health information, two new columns are added to the vms table:

health_state — stores health.status ("OK", "WARNING", "CRITICAL")
health_details — stores health.reason ("rmc_state - inactive")
