### PR TITLE
[WIP] Support datastores without free_space/uncommitted metrics

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1021,7 +1021,9 @@ class MiqRequestWorkflow
 
   def storage_to_hash_struct(ci)
     storage_clusters = ci.storage_clusters.blank? ? nil : ci.storage_clusters.collect(&:name).join(', ')
-    build_ci_hash_struct(ci, [:name, :free_space, :total_space, :storage_domain_type]).tap do |hs|
+    attrs = [:name, :total_space, :storage_domain_type]
+    attrs << :free_space if ci.supports?(:free_space)
+    build_ci_hash_struct(ci, attrs).tap do |hs|
       hs.storage_clusters = storage_clusters
     end
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -70,6 +70,9 @@ class Storage < ApplicationRecord
 
   SUPPORTED_STORAGE_TYPES = %w[VSAN VMFS NAS NFS NFS41 ISCSI DIR FCP CSVFS NTFS GLUSTERFS].freeze
 
+  supports :free_space
+  supports :uncommitted
+
   supports :smartstate_analysis do
     if !ext_management_system&.class&.supports?(:smartstate_analysis)
       _("Smartstate Analysis cannot be performed on selected Datastore")
@@ -581,7 +584,9 @@ class Storage < ApplicationRecord
   alias_method :v_used_space, :used_space
 
   def used_space_percent_of_total
-    total_space.to_i.zero? ? 0.0 : (used_space.to_f / total_space * 1000.0).round / 10.0
+    return nil unless supports?(:free_space) && total_space.to_i > 0
+
+    (used_space.to_f / total_space * 1000.0).round / 10.0
   end
   alias_method :v_used_space_percent_of_total, :used_space_percent_of_total
 
@@ -638,7 +643,11 @@ class Storage < ApplicationRecord
   end
 
   def v_total_provisioned
-    used_space + uncommitted.to_i
+    if supports?(:uncommitted) && supports?(:free_space)
+      used_space + uncommitted.to_i
+    else
+      total_space.to_i
+    end
   end
 
   def v_provisioned_percent_of_total

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -531,4 +531,75 @@ RSpec.describe Storage do
       expect(storage.storage_type_supported_for_ssa?).to eq(true)
     end
   end
+
+  describe "supports :free_space and :uncommitted defaults" do
+    let(:storage) { FactoryBot.build(:storage) }
+
+    it "supports :free_space by default" do
+      expect(storage.supports?(:free_space)).to be(true)
+    end
+
+    it "supports :uncommitted by default" do
+      expect(storage.supports?(:uncommitted)).to be(true)
+    end
+  end
+
+  describe "#used_space_percent_of_total" do
+    context "when :free_space is supported" do
+      let(:storage) { FactoryBot.build(:storage, :total_space => 1000, :free_space => 400) }
+
+      it "returns the used space percentage" do
+        expect(storage.used_space_percent_of_total).to eq(60.0)
+      end
+
+      it "returns nil when total_space is zero" do
+        storage.total_space = 0
+        expect(storage.used_space_percent_of_total).to be_nil
+      end
+    end
+
+    context "when :free_space is not supported" do
+      let(:storage) { FactoryBot.build(:storage, :total_space => 1000, :free_space => 0) }
+
+      before { allow(storage).to receive(:supports?).and_call_original }
+      before { allow(storage).to receive(:supports?).with(:free_space).and_return(false) }
+
+      it "returns nil" do
+        expect(storage.used_space_percent_of_total).to be_nil
+      end
+    end
+  end
+
+  describe "#v_total_provisioned" do
+    context "when both :free_space and :uncommitted are supported" do
+      let(:storage) { FactoryBot.build(:storage, :total_space => 1000, :free_space => 400, :uncommitted => 200) }
+
+      it "returns used_space plus uncommitted" do
+        # used_space = total_space - free_space = 600; uncommitted = 200 => 800
+        expect(storage.v_total_provisioned).to eq(800)
+      end
+    end
+
+    context "when :free_space is not supported" do
+      let(:storage) { FactoryBot.build(:storage, :total_space => 1000, :free_space => 0, :uncommitted => nil) }
+
+      before { allow(storage).to receive(:supports?).and_call_original }
+      before { allow(storage).to receive(:supports?).with(:free_space).and_return(false) }
+
+      it "returns total_space" do
+        expect(storage.v_total_provisioned).to eq(1000)
+      end
+    end
+
+    context "when :uncommitted is not supported" do
+      let(:storage) { FactoryBot.build(:storage, :total_space => 1000, :free_space => 400, :uncommitted => 200) }
+
+      before { allow(storage).to receive(:supports?).and_call_original }
+      before { allow(storage).to receive(:supports?).with(:uncommitted).and_return(false) }
+
+      it "returns total_space" do
+        expect(storage.v_total_provisioned).to eq(1000)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add supports :free_space and :uncommitted feature flags to Storage so that providers like KubeVirt StorageClasses can opt out of metrics they do not expose.

- Return nil from used_space_percent_of_total when :free_space is unsupported or total_space is zero
- Return total_space from v_total_provisioned when either :free_space or :uncommitted is unsupported, falling back to the full calculation only when both are available
- Omit free_space from the provision workflow hash struct when unsupported so expression-based placement filters do not falsely disqualify datastores with free_space == 0

**Related PRs:** 
- https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/330
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10289

@miq-bot add-label enhancement
@miq-bot add-reviewer @agrare
@miq-bot assign @agrare
